### PR TITLE
Help command changes

### DIFF
--- a/src/Discord.Net.Commands/CommandBuilder.cs
+++ b/src/Discord.Net.Commands/CommandBuilder.cs
@@ -74,9 +74,9 @@ namespace Discord.Commands
 		private void Build()
 		{
 			_command.SetParameters(_params.ToArray());
-			foreach (var alias in _command.Aliases)
+            _service.AddCommand(_command);
+            foreach (var alias in _command.Aliases)
 				_service.Map.AddCommand(alias, _command);
-			_service.AddCommand(_command);
 		}
 
 		internal static string AppendPrefix(string prefix, string cmd)


### PR DESCRIPTION
Hopefully I set the PR up correctly this time.

The help command will now display top level commands and aliases, and will display subcommands and parameters for the requested command.

Also changed the order of commands/aliases being added, and removed a duplicate adding of commands.