### PR TITLE
Removed ArgumentNullException from FindChannels

### DIFF
--- a/src/Discord.Net/Models/Server.cs
+++ b/src/Discord.Net/Models/Server.cs
@@ -270,7 +270,6 @@ namespace Discord
         public IEnumerable<Channel> FindChannels(string name, ChannelType type = null, bool exactMatch = false)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
-            if (type == null) throw new ArgumentNullException(nameof(type));
 
             return _channels.Select(x => x.Value).Find(name, type, exactMatch);
         }


### PR DESCRIPTION
Removed the exception because it will default to text if not specified, and it already was an optional parameter, which didn't make sense if its going to throw on null.

Hopefuly i got the PR right this time.