### PR TITLE
split management into server- and user-; wrote docs for server/user

### DIFF
--- a/docs/features/management.rst
+++ b/docs/features/management.rst
@@ -1,4 +1,0 @@
-|stub| Server Management
-========================
-
-|stub-desc|

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,8 @@ This Documentation is **currently undergoing a rewrite**. Some pages (marked wit
 
    getting_started
    features/logging
-   features/management
+   features/server-management
+   features/user-management
    features/permissions
    features/commands
    features/voice

--- a/test/Discord.Net.Tests/Discord.Net.Tests.csproj
+++ b/test/Discord.Net.Tests/Discord.Net.Tests.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DiscordBot\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Discord.Net.Tests/Tests.cs
+++ b/test/Discord.Net.Tests/Tests.cs
@@ -42,7 +42,7 @@ namespace Discord.Tests
 			//Create new server and invite the other bots to it
 			_testServer = _hostClient.CreateServer("Discord.Net Testing", _hostClient.Regions.First()).Result;
 			_testServerChannel = _testServer.DefaultChannel;
-			Invite invite = _testServer.CreateInvite(60, 1, false, false).Result;
+			var invite = _testServer.CreateInvite(60, 2, false, false).Result;
 			WaitAll(
 				_targetBot.GetInvite(invite.Code).Result.Accept(),
                 _observerBot.GetInvite(invite.Code).Result.Accept());
@@ -121,6 +121,8 @@ namespace Discord.Tests
 				_targetBot.Disconnect(),
 				_observerBot.Disconnect());
 		}
+
+        // Unit Test Helpers
 
 		private static void AssertEvent<TArgs>(string msg, Func<Task> action, Action<EventHandler<TArgs>> addEvent, Action<EventHandler<TArgs>> removeEvent, Func<object, TArgs, bool> test = null)
 		{

--- a/test/Discord.Net.Tests/packages.config
+++ b/test/Discord.Net.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Bumped Newtonsoft.Json to 8.0.2 in Discord.Net.Docs;
Added a comment somewhere, changed an invite limit -- shouldn't affect much as unit tests aren't used anyways, was leftover from my attempt at updating unit tests.