### PR TITLE
[docs] split management into server- and user-; wrote docs for server/user

### DIFF
--- a/docs/features/management.rst
+++ b/docs/features/management.rst
@@ -1,4 +1,0 @@
-|stub| Server Management
-========================
-
-|stub-desc|

--- a/docs/features/server-management.rst
+++ b/docs/features/server-management.rst
@@ -1,0 +1,53 @@
+Server Management
+=================
+
+Discord.Net will allow you to manage most settings of a Discord server.
+
+Usage
+-----
+
+You can create Channels, Invites, and Roles on a server using the CreateChannel, CreateInvite, and CreateRole function of a Server, respectively.
+
+You may also edit a server's name, icon, and region.
+
+.. code-block:: c#
+
+    // Create a Channel and retrieve the Channel object
+    var _channel = await _server.CreateChannel("announcements", ChannelType.Text);
+
+    // Create an Invite and retrieve the Invite object
+    var _invite = await _server.CreateInvite(maxAge: null, maxUses: 25, tempMembership: false, withXkcd: false);
+
+    // Create a Role and retrieve the Role object
+    var _role = await _server.CreateRole(name: "Bots", permissions: null, color: Color.DarkMagenta, isHoisted: false);
+
+    // Edit a server
+    var _ioStream = new System.IO.StreamReader("clock-0500-1952.png").BaseStream
+    _server.Edit(name: "19:52 | UTC-05:00", region: "east", icon: _ioStream, iconType: ImageType.Png);
+
+    // Prune Users
+    var _pruneCount = await _server.PruneUsers(30, true);
+
+Invite Parameters
+-----------------
+
+maxAge: The time (in seconds) until the invite expires. Use null for infinite.
+maxUses: The maximum amount of uses the invite has before it expires.
+tempMembership: Whether or not to kick a user when they disconnect.
+withXkcd: Generate the invite with an XKCD 936 style URL
+
+Role Parameters
+---------------
+
+name: The name of the role
+permissions: A set of ServerPermissions for the role to use by default
+color: The color of the role, recommended to use Discord.Color
+isHoisted: Whether a role's users should be displayed separately from other users in the user list.
+
+Edit Parameters
+---------------
+
+name: The server's name
+region: The region the voice server is hosted in
+icon: A System.IO.Stream that will read an image file
+iconType: The type of image being sent (png/jpeg).

--- a/docs/features/user-management.rst
+++ b/docs/features/user-management.rst
@@ -1,0 +1,22 @@
+User Management
+===============
+
+Banning
+-------
+
+To ban a user, invoke the Ban function on a Server object.
+
+.. code-block:: c#
+
+    _server.Ban(_user, 30);
+
+The pruneDays parameter, which defaults to 0, will remove all messages from a user dating back to the specified amount of days.
+
+Kicking
+-------
+
+To kick a user, invoke the Kick function on the User.
+
+.. code-block:: c#
+
+    _user.Kick();

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,8 @@ This Documentation is **currently undergoing a rewrite**. Some pages (marked wit
 
    getting_started
    features/logging
-   features/management
+   features/server-management
+   features/user-management
    features/permissions
    features/commands
    features/voice

--- a/test/Discord.Net.Tests/Discord.Net.Tests.csproj
+++ b/test/Discord.Net.Tests/Discord.Net.Tests.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DiscordBot\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Discord.Net.Tests/Tests.cs
+++ b/test/Discord.Net.Tests/Tests.cs
@@ -42,7 +42,7 @@ namespace Discord.Tests
 			//Create new server and invite the other bots to it
 			_testServer = _hostClient.CreateServer("Discord.Net Testing", _hostClient.Regions.First()).Result;
 			_testServerChannel = _testServer.DefaultChannel;
-			Invite invite = _testServer.CreateInvite(60, 1, false, false).Result;
+			var invite = _testServer.CreateInvite(60, 2, false, false).Result;
 			WaitAll(
 				_targetBot.GetInvite(invite.Code).Result.Accept(),
                 _observerBot.GetInvite(invite.Code).Result.Accept());
@@ -121,6 +121,8 @@ namespace Discord.Tests
 				_targetBot.Disconnect(),
 				_observerBot.Disconnect());
 		}
+
+        // Unit Test Helpers
 
 		private static void AssertEvent<TArgs>(string msg, Func<Task> action, Action<EventHandler<TArgs>> addEvent, Action<EventHandler<TArgs>> removeEvent, Func<object, TArgs, bool> test = null)
 		{

--- a/test/Discord.Net.Tests/packages.config
+++ b/test/Discord.Net.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Reference Pull #36, amended the commit to include the new documentation pages.