### PR TITLE
Voice crashfix, Properly getting data for large servers.

### DIFF
--- a/src/Discord.Net.Audio/Net/VoiceSocket.cs
+++ b/src/Discord.Net.Audio/Net/VoiceSocket.cs
@@ -407,7 +407,7 @@ namespace Discord.Net.WebSockets
             WebSocketMessage msg;
             using (var reader = new JsonTextReader(new StringReader(json)))
                 msg = _serializer.Deserialize(reader, typeof(WebSocketMessage)) as WebSocketMessage;
-            
+
             var opCode = (OpCodes)msg.Operation;
             switch (opCode)
             {
@@ -418,7 +418,11 @@ namespace Discord.Net.WebSockets
                             var payload = (msg.Payload as JToken).ToObject<ReadyEvent>(_serializer);
                             _heartbeatInterval = payload.HeartbeatInterval;
                             _ssrc = payload.SSRC;
-                            string hostname = Host.Substring(0, Host.IndexOf('?')).Replace("wss://", "");
+                            string hostname;
+                            if (Host.Contains("?"))
+                                hostname = Host.Substring(0, Host.IndexOf('?')).Replace("wss://", "");
+                            else
+                                hostname = Host.Replace("wss://", "");
                             var address = (await Dns.GetHostAddressesAsync(hostname).ConfigureAwait(false)).FirstOrDefault();
                             _endpoint = new IPEndPoint(address, payload.Port);
 

--- a/src/Discord.Net/DiscordClient.cs
+++ b/src/Discord.Net/DiscordClient.cs
@@ -540,7 +540,7 @@ namespace Discord
                                         while (largeServersCount < batchSize && _largeServers.TryDequeue(out serverIds[largeServersCount++])) { }
                                         if (largeServersCount > 0)
                                         {
-                                            Logger.Warning($"Downloading data for {largeServersCount} large servers.");
+                                            Logger.Verbose($"Downloading data for {largeServersCount} large servers.");
                                             cancelToken.ThrowIfCancellationRequested();
                                             GatewaySocket.SendRequestMembers(serverIds, "", 0);
                                             await Task.Delay(1500, cancelToken);

--- a/src/Discord.Net/DiscordClient.cs
+++ b/src/Discord.Net/DiscordClient.cs
@@ -529,23 +529,23 @@ namespace Discord
                                 try
                                 {
                                     ulong serverId;
-                                    ulong[] serverIds = new ulong[50];
-                                    int i = 0;
 
+                                    const short batchSize = 50;
+                                    int largeServersCount = 0;
                                     await Task.Delay(2500, cancelToken);
-                                    while (true)
+                                    do
                                     {
-                                        while (_largeServers.TryDequeue(out serverId) && i < 50)
-                                            serverIds[i++] = serverId;
-                                        if (i > 0)
+                                        largeServersCount = 0;
+                                        ulong[] serverIds = new ulong[batchSize];
+                                        while (largeServersCount < batchSize && _largeServers.TryDequeue(out serverIds[largeServersCount++])) { }
+                                        if (largeServersCount > 0)
                                         {
+                                            Logger.Warning($"Downloading data for {largeServersCount} large servers.");
                                             cancelToken.ThrowIfCancellationRequested();
                                             GatewaySocket.SendRequestMembers(serverIds, "", 0);
                                             await Task.Delay(1500, cancelToken);
                                         }
-                                        if (i < 50)
-                                            break;
-                                    }
+                                    } while (largeServersCount == batchSize);
                                     await Task.Delay(2500, cancelToken);
                                     EndConnect();
                                 }


### PR DESCRIPTION
- Voice connection no longer throws an error if there is no "?" in the Host string.
- Resetting the counter and clearing the array of large servers. (in order to get them all, not just first 50)
- Moved counter check for large servers before dequeuing the server. (like this you won't skip every 50th server, since it will dequeue first and check later right now)

Managed to get my bot working with these changes, although after some time I get 4003 and unknown opcode 9 errors (probably unrelated to this)