### PR TITLE
Add `User.IsBot` field, bump version number to 0.9.1

### DIFF
--- a/src/Discord.Net/API/Client/Common/UserReference.cs
+++ b/src/Discord.Net/API/Client/Common/UserReference.cs
@@ -13,5 +13,7 @@ namespace Discord.API.Client
         public ushort? Discriminator { get; set; }
         [JsonProperty("avatar")]
         public string Avatar { get; set; }
+        [JsonProperty("bot")]
+        public bool? Bot { get; set; }
     }
 }

--- a/src/Discord.Net/Models/User.cs
+++ b/src/Discord.Net/Models/User.cs
@@ -164,7 +164,6 @@ namespace Discord
 				AvatarId = model.Avatar;
             if (model.Bot != null)
                 IsBot = model.Bot.Value;
-            if (model.Bot == null) IsBot = false;
 
 		}
 		internal void Update(APIMember model)

--- a/src/Discord.Net/Models/User.cs
+++ b/src/Discord.Net/Models/User.cs
@@ -62,6 +62,8 @@ namespace Discord
         public string AvatarId { get; private set; }
         /// <summary> Gets the name of the game this user is currently playing. </summary>
         public string CurrentGame { get; internal set; }
+        /// <summary> Determines whether this user is a Bot account. </summary>
+        public bool IsBot { get; internal set; }
         /// <summary> Gets the current status for this user. </summary>
         public UserStatus Status { get; internal set; }
         /// <summary> Gets the datetime that this user joined this server. </summary>
@@ -160,6 +162,10 @@ namespace Discord
 				Discriminator = model.Discriminator.Value;
 			if (model.Avatar != null)
 				AvatarId = model.Avatar;
+            if (model.Bot != null)
+                IsBot = model.Bot.Value;
+            if (model.Bot == null) IsBot = false;
+
 		}
 		internal void Update(APIMember model)
 		{

--- a/src/Discord.Net/project.json
+++ b/src/Discord.Net/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.0-rc3-3",
+  "version": "0.9.1",
   "description": "An unofficial .Net API wrapper for the Discord client.",
   "authors": [
     "RogueException"


### PR DESCRIPTION
A few users requested an IsBot field for marking Bot Accounts;

Bumping Version number because it has been 0.9-rc3 forever and that's caused a bit of confusion in the channel with what version users are on.