### PR TITLE
Added SelfBot Functionality by Config

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -80,7 +80,13 @@ namespace Discord.Commands
             client.MessageReceived += async (s, e) =>
             {
                 if (_allCommands.Count == 0)  return;
-                if (e.Message.User == null || e.Message.User.Id == Client.CurrentUser.Id) return;
+
+                if (Config.IsSelfBot)
+                {
+                    if (e.Message.User == null || e.Message.User.Id != Client.CurrentUser.Id) return; // Will only listen to Self
+                }
+                else
+                    if (e.Message.User == null || e.Message.User.Id == Client.CurrentUser.Id) return; // Normal expected behavior for bots
 
                 string msg = e.Message.RawText;
                 if (msg.Length == 0) return;

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -15,7 +15,7 @@ namespace Discord.Commands
         /// </summary>
         public Func<Message, int> CustomPrefixHandler { get; set; } = null;
         /// <summary>
-        /// Changing this to <see cref="true"/> makes the bot ignore all messages, except when the messages are from its own account.
+        /// Changing this to true makes the bot ignore all messages, except when the messages are from its own account.
         /// This is desired behavior for "Self Bots" only, so unless this bot is being run under a normal user's account, leave it alone!!
         /// </summary>
         public bool IsSelfBot { get; set; } = false;

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -14,6 +14,11 @@ namespace Discord.Commands
         /// and a negative value if the message should be ignored.
         /// </summary>
         public Func<Message, int> CustomPrefixHandler { get; set; } = null;
+        /// <summary>
+        /// Changing this to <see cref="true"/> makes the bot ignore all messages, except when the messages are from its own account.
+        /// This is desired behavior for "Self Bots" only, so unless this bot is being run under a normal user's account, leave it alone!!
+        /// </summary>
+        public bool IsSelfBot { get; set; } = false;
 
         /// <summary> Gets or sets whether a help function should be automatically generated. </summary>
 		public HelpMode HelpMode { get; set; } = HelpMode.Disabled;
@@ -28,9 +33,10 @@ namespace Discord.Commands
     }
     public class CommandServiceConfig
     {
-		public char? PrefixChar { get; }
+        public char? PrefixChar { get; }
         public bool AllowMentionPrefix { get; }
         public Func<Message, int> CustomPrefixHandler { get; }
+        public bool IsSelfBot { get; }
 
         /// <summary> Gets or sets whether a help function should be automatically generated. </summary>
 		public HelpMode HelpMode { get; set; } = HelpMode.Disabled;
@@ -41,6 +47,7 @@ namespace Discord.Commands
             AllowMentionPrefix = builder.AllowMentionPrefix;
             CustomPrefixHandler = builder.CustomPrefixHandler;
             HelpMode = builder.HelpMode;
+            IsSelfBot = builder.IsSelfBot;
         }
     }
 }


### PR DESCRIPTION
Adds `CommandConfigBuilder.IsSelfBot`, default as false
When true, the bot ignores everyone but itself, as far as commands. This is the behavior expected of SelfBots, as inferred from the Discord stance.