### PR TITLE
Support Role Mentions

### DIFF
--- a/src/Discord.Net/API/Client/Common/Role.cs
+++ b/src/Discord.Net/API/Client/Common/Role.cs
@@ -19,5 +19,7 @@ namespace Discord.API.Client
         public uint? Color { get; set; }
         [JsonProperty("managed")]
         public bool? Managed { get; set; }
+        [JsonProperty("mentionable")]
+        public bool? Mentionable { get; set; }
     }
 }

--- a/src/Discord.Net/API/Client/Rest/UpdateRole.cs
+++ b/src/Discord.Net/API/Client/Rest/UpdateRole.cs
@@ -18,6 +18,8 @@ namespace Discord.API.Client.Rest
         public uint Permissions { get; set; }
         [JsonProperty("hoist")]
         public bool IsHoisted { get; set; }
+        [JsonProperty("mentionable")]
+        public bool IsMentionable { get; set; }
         [JsonProperty("color")]
         public uint Color { get; set; }
 

--- a/src/Discord.Net/Models/Role.cs
+++ b/src/Discord.Net/Models/Role.cs
@@ -28,6 +28,8 @@ namespace Discord
         public int Position { get; private set; }
         /// <summary> Gets whether this role is managed by server (e.g. for Twitch integration) </summary>
         public bool IsManaged { get; private set; }
+        /// <summary> Gets whether this role is mentionable by anyone. </summary>
+        public bool IsMentionable { get; private set; }
         /// <summary> Gets the the permissions given to this role. </summary>
         public ServerPermissions Permissions { get; private set; }
         /// <summary> Gets the color of this role. </summary>
@@ -41,7 +43,7 @@ namespace Discord
         public IEnumerable<User> Members => IsEveryone ? Server.Users : Server.Users.Where(x => x.HasRole(this));
 
         /// <summary> Gets the string used to mention this role. </summary>
-        public string Mention => IsEveryone ? "@everyone" : "";
+        public string Mention => IsMentionable ? $"<@&{Id}>" : "";
 
 		internal Role(ulong id, Server server)
 		{
@@ -60,6 +62,8 @@ namespace Discord
 				IsHoisted = model.Hoist.Value;
 			if (model.Managed != null)
 				IsManaged = model.Managed.Value;
+			if (model.Mentionable != null)
+				IsMentionable = model.Mentionable.Value;
 			if (model.Position != null && !IsEveryone)
 				Position = model.Position.Value;
 			if (model.Color != null)
@@ -75,14 +79,15 @@ namespace Discord
             }
 		}
         
-        public async Task Edit(string name = null, ServerPermissions? permissions = null, Color color = null, bool? isHoisted = null, int? position = null)
+        public async Task Edit(string name = null, ServerPermissions? permissions = null, Color color = null, bool? isHoisted = null, int? position = null, bool? isMentionable = null)
         {
             var updateRequest = new UpdateRoleRequest(Server.Id, Id)
             {
                 Name = name ?? Name,
                 Permissions = (permissions ?? Permissions).RawValue,
                 Color = (color ?? Color).RawValue,
-                IsHoisted = isHoisted ?? IsHoisted
+                IsHoisted = isHoisted ?? IsHoisted,
+                IsMentionable = isMentionable ?? IsMentionable
             };
 
             var updateResponse = await Client.ClientAPI.Send(updateRequest).ConfigureAwait(false);

--- a/src/Discord.Net/Models/Role.cs
+++ b/src/Discord.Net/Models/Role.cs
@@ -43,7 +43,7 @@ namespace Discord
         public IEnumerable<User> Members => IsEveryone ? Server.Users : Server.Users.Where(x => x.HasRole(this));
 
         /// <summary> Gets the string used to mention this role. </summary>
-        public string Mention => IsMentionable ? $"<@&{Id}>" : "";
+        public string Mention => IsEveryone ? "@everyone" : IsMentionable ? $"<@&{Id}>" : "";
 
 		internal Role(ulong id, Server server)
 		{

--- a/src/Discord.Net/Models/Server.cs
+++ b/src/Discord.Net/Models/Server.cs
@@ -366,7 +366,7 @@ namespace Discord
         }
 
         /// <summary> Creates a new role. </summary>
-        public async Task<Role> CreateRole(string name, ServerPermissions? permissions = null, Color color = null, bool isHoisted = false)
+        public async Task<Role> CreateRole(string name, ServerPermissions? permissions = null, Color color = null, bool isHoisted = false, bool isMentionable = false)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
 
@@ -380,7 +380,8 @@ namespace Discord
                 Name = name,
                 Permissions = (permissions ?? role.Permissions).RawValue,
                 Color = (color ?? Color.Default).RawValue,
-                IsHoisted = isHoisted
+                IsHoisted = isHoisted,
+                IsMentionable = isMentionable
             };
             var editResponse = await Client.ClientAPI.Send(editRequest).ConfigureAwait(false);
             role.Update(editResponse, true);


### PR DESCRIPTION
`Message.MentionedRoles` is now populated properly with roles.
`Role.IsMentionable` has been added to determine whether
`Role.Mention` now mentions roles that are `IsMentionable` as expected (otherwise returns empty string)
`Role.Edit` now takes parameter `bool? isMentionable`
`Server.CreateRole` now takes parameter `bool isMentionable`
`IsMentionable` added to `UpdateRoleRequest`