### PR TITLE
BulkMessageDelete Exception

### DIFF
--- a/src/Discord.Net/Models/Channel.cs
+++ b/src/Discord.Net/Models/Channel.cs
@@ -204,11 +204,14 @@ namespace Discord
 
         public async Task DeleteMessages(ulong[] messageIds)
         {
-            if (messageIds.Count() < 2 || messageIds.Count() > 100)
+            if (messageIds.Count() > 100)
                 throw new ArgumentOutOfRangeException("messageIds",
-                    "You must provide no more than 100 and no less than 2 Messages or Message Ids");
-
-            await Client.ClientAPI.Send(new BulkMessageDelete(Id, messageIds));
+                    "You must provide no more than 100 Messages or Message Ids");
+                    
+            if (messageIds.Count() == 1)
+                await Client.ClientAPI.Send(new DeleteMessageRequest(Id, messageIds.First()));
+            else if (messageIds.Any())
+                await Client.ClientAPI.Send(new BulkMessageDelete(Id, messageIds));
         }
 
         public async Task Delete()

--- a/src/Discord.Net/Models/Channel.cs
+++ b/src/Discord.Net/Models/Channel.cs
@@ -204,7 +204,9 @@ namespace Discord
 
         public async Task DeleteMessages(ulong[] messageIds)
         {
-            if (messageIds.Count() < 2) throw new ArgumentOutOfRangeException("messageIds", "You must provide at least 2 Messages or Message Ids");
+            if (messageIds.Count() < 2 || messageIds.Count() > 100)
+                throw new ArgumentOutOfRangeException("messageIds",
+                    "You must provide no more than 100 and no less than 2 Messages or Message Ids");
 
             await Client.ClientAPI.Send(new BulkMessageDelete(Id, messageIds));
         }

--- a/src/Discord.Net/Models/Channel.cs
+++ b/src/Discord.Net/Models/Channel.cs
@@ -204,6 +204,8 @@ namespace Discord
 
         public async Task DeleteMessages(ulong[] messageIds)
         {
+            if (messageIds.Count() < 2) throw new ArgumentOutOfRangeException("messageIds", "You must provide at least 2 Messages or Message Ids");
+
             await Client.ClientAPI.Send(new BulkMessageDelete(Id, messageIds));
         }
 


### PR DESCRIPTION
Added OutOfBounds exception for DeleteMessages, for when Message Count is less than 2 or greater than 100