### PR TITLE
Add null-conditional to MessageManager

### DIFF
--- a/src/Discord.Net/Entities/WebSocket/MessageManager.cs
+++ b/src/Discord.Net/Entities/WebSocket/MessageManager.cs
@@ -61,7 +61,7 @@ namespace Discord
                 };
                 var downloadedMessages = await _discord.ApiClient.GetChannelMessagesAsync(_channel.Id, args).ConfigureAwait(false);
 
-                var guild = (_channel as ICachedGuildChannel).Guild;
+                var guild = (_channel as ICachedGuildChannel)?.Guild;
                 return cachedMessages.Concat(downloadedMessages.Select(x =>
                 {
                     IUser user = _channel.GetUser(x.Author.Value.Id, true);


### PR DESCRIPTION
Downloading Messages from a DM Channel was causing a cast on Line 64 to throw a nullref.