### PR TITLE
Add Dependency Injection and Autoloading to the Commands service

### DIFF
--- a/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
@@ -6,13 +6,16 @@ namespace Discord.Commands
     public class ModuleAttribute : Attribute
     {
         public string Prefix { get; }
-        public ModuleAttribute()
+        public bool Autoload { get; }
+        public ModuleAttribute(bool autoload = true)
         {
             Prefix = null;
+            Autoload = autoload;
         }
-        public ModuleAttribute(string prefix)
+        public ModuleAttribute(string prefix, bool autoload = true)
         {
             Prefix = prefix;
+            Autoload = autoload;
         }
     }
 }

--- a/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
@@ -6,16 +6,16 @@ namespace Discord.Commands
     public class ModuleAttribute : Attribute
     {
         public string Prefix { get; }
-        public bool Autoload { get; }
-        public ModuleAttribute(bool autoload = true)
+        public bool AutoLoad { get; set; }
+        public ModuleAttribute()
         {
             Prefix = null;
-            Autoload = autoload;
+            AutoLoad = true;
         }
-        public ModuleAttribute(string prefix, bool autoload = true)
+        public ModuleAttribute(string prefix)
         {
             Prefix = prefix;
-            Autoload = autoload;
+            AutoLoad = true;
         }
     }
 }

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -174,7 +174,7 @@ namespace Discord.Commands
                 {
                     var typeInfo = type.GetTypeInfo();
                     var moduleAttr = typeInfo.GetCustomAttribute<ModuleAttribute>();
-                    if (moduleAttr != null)
+                    if (moduleAttr != null && moduleAttr.Autoload)
                     {
                         var moduleInstance = ReflectionUtils.CreateObject(typeInfo);
                         modules.Add(LoadInternal(moduleInstance, moduleAttr, typeInfo));

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -174,7 +174,7 @@ namespace Discord.Commands
                 {
                     var typeInfo = type.GetTypeInfo();
                     var moduleAttr = typeInfo.GetCustomAttribute<ModuleAttribute>();
-                    if (moduleAttr != null && moduleAttr.Autoload)
+                    if (moduleAttr != null && moduleAttr.AutoLoad)
                     {
                         var moduleInstance = ReflectionUtils.CreateObject(typeInfo, this, dependencyMap);
                         modules.Add(LoadInternal(moduleInstance, moduleAttr, typeInfo));

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -164,7 +164,7 @@ namespace Discord.Commands
 
             return loadedModule;
         }
-        public async Task<IEnumerable<Module>> LoadAssembly(Assembly assembly)
+        public async Task<IEnumerable<Module>> LoadAssembly(Assembly assembly, IDependencyMap dependencyMap = null)
         {
             var modules = ImmutableArray.CreateBuilder<Module>();
             await _moduleLock.WaitAsync().ConfigureAwait(false);
@@ -176,7 +176,7 @@ namespace Discord.Commands
                     var moduleAttr = typeInfo.GetCustomAttribute<ModuleAttribute>();
                     if (moduleAttr != null && moduleAttr.Autoload)
                     {
-                        var moduleInstance = ReflectionUtils.CreateObject(typeInfo);
+                        var moduleInstance = ReflectionUtils.CreateObject(typeInfo, this, dependencyMap);
                         modules.Add(LoadInternal(moduleInstance, moduleAttr, typeInfo));
                     }
                 }

--- a/src/Discord.Net.Commands/Dependencies/DependencyMap.cs
+++ b/src/Discord.Net.Commands/Dependencies/DependencyMap.cs
@@ -13,12 +13,16 @@ namespace Discord.Commands
             map = new Dictionary<Type, object>();
         }
 
-        public T Get<T>() where T : class
+        public object Get(Type t)
         {
-            var t = typeof(T);
             if (!map.ContainsKey(t))
                 throw new KeyNotFoundException($"The dependency map does not contain \"{t.FullName}\"");
-            return map[t] as T;
+            return map[t];
+        }
+
+        public T Get<T>() where T : class
+        {
+            return Get(typeof(T)) as T;
         }
 
         public void Add<T>(T obj)

--- a/src/Discord.Net.Commands/Dependencies/DependencyMap.cs
+++ b/src/Discord.Net.Commands/Dependencies/DependencyMap.cs
@@ -8,6 +8,11 @@ namespace Discord.Commands
     {
         private Dictionary<Type, object> map;
 
+        public DependencyMap()
+        {
+            map = new Dictionary<Type, object>();
+        }
+
         public T Get<T>() where T : class
         {
             var t = typeof(T);

--- a/src/Discord.Net.Commands/Dependencies/DependencyMap.cs
+++ b/src/Discord.Net.Commands/Dependencies/DependencyMap.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Discord.Commands
+{
+    public class DependencyMap : IDependencyMap
+    {
+        private Dictionary<Type, object> map;
+
+        public T Get<T>() where T : class
+        {
+            var t = typeof(T);
+            if (!map.ContainsKey(t))
+                throw new KeyNotFoundException($"The dependency map does not contain \"{t.FullName}\"");
+            return map[t] as T;
+        }
+
+        public void Add<T>(T obj)
+        {
+            var t = typeof(T);
+            if (map.ContainsKey(t))
+                throw new InvalidOperationException($"The dependency map already contains \"{t.FullName}\"");
+            map.Add(t, obj);
+        }
+    }
+}

--- a/src/Discord.Net.Commands/Dependencies/IDependencyMap.cs
+++ b/src/Discord.Net.Commands/Dependencies/IDependencyMap.cs
@@ -7,6 +7,7 @@ namespace Discord.Commands
 {
     public interface IDependencyMap
     {
+        object Get(Type t);
         T Get<T>() where T : class;
         void Add<T>(T obj);
     }

--- a/src/Discord.Net.Commands/Dependencies/IDependencyMap.cs
+++ b/src/Discord.Net.Commands/Dependencies/IDependencyMap.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Discord.Commands
+{
+    public interface IDependencyMap
+    {
+        T Get<T>() where T : class;
+        void Add<T>(T obj);
+    }
+}

--- a/src/Discord.Net.Commands/Module.cs
+++ b/src/Discord.Net.Commands/Module.cs
@@ -43,7 +43,7 @@ namespace Discord.Commands
                         nextGroupPrefix = groupPrefix + groupAttrib.Prefix ?? type.Name;
                     else
                         nextGroupPrefix = groupPrefix;
-                    SearchClass(ReflectionUtils.CreateObject(type), commands, type, nextGroupPrefix);
+                    SearchClass(ReflectionUtils.CreateObject(type, Service), commands, type, nextGroupPrefix);
                 }
             }
         }

--- a/src/Discord.Net.Commands/ReflectionUtils.cs
+++ b/src/Discord.Net.Commands/ReflectionUtils.cs
@@ -64,7 +64,7 @@ namespace Discord.Commands
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Error invoking constructor)", ex);
+                throw new InvalidOperationException($"Could not create \"{typeInfo.FullName}\"", ex);
             }
         }
     }

--- a/src/Discord.Net.Commands/ReflectionUtils.cs
+++ b/src/Discord.Net.Commands/ReflectionUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -6,33 +7,39 @@ namespace Discord.Commands
 {
     internal class ReflectionUtils
     {
-        internal static object CreateObject(TypeInfo typeInfo, CommandService commands, IDependencyMap map = null)
+        internal static object CreateObject(TypeInfo typeInfo, CommandService service, IDependencyMap map = null)
         {
             if (typeInfo.DeclaredConstructors.Count() > 1)
                 throw new InvalidOperationException($"Found too many constructors for \"{typeInfo.FullName}\"");
+
             var constructor = typeInfo.DeclaredConstructors.FirstOrDefault();
+
+            if (constructor == null)
+                throw new InvalidOperationException($"Found no constructor for \"{typeInfo.FullName}\"");
+
+            object[] parameters;
             try
             {
-                if (constructor.GetParameters().Length == 0)
-                    return constructor.Invoke(null);
-                else if (constructor.GetParameters().Length > 1)
-                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Found too many parameters)");
-                var parameter = constructor.GetParameters().FirstOrDefault();
-                if (parameter == null)
-                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (No valid parameters)");
-                if (parameter.ParameterType == typeof(CommandService))
-                    return constructor.Invoke(new object[1] { commands });
-                else if (parameter.ParameterType == typeof(IDependencyMap))
-                {
-                    if (map == null) throw new InvalidOperationException($"The constructor for \"{typeInfo.FullName}\" requires a Dependency Map.");
-                    return constructor.Invoke(new object[1] { map });
-                }
-                else
-                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Invalid Parameter Type: \"{parameter.ParameterType.FullName}\")");
+                // TODO: probably change this ternary into something sensible
+                parameters = constructor.GetParameters()
+                    .Select(x => x.ParameterType == typeof(CommandService) ? service : map.Get(x.ParameterType)).ToArray();
             }
-            catch (Exception e)
+            catch (KeyNotFoundException ex) // tried to inject an invalid dependency
             {
-                throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Error invoking constructor)");
+                throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (could not provide parameter)", ex);
+            }
+            catch (NullReferenceException ex) // tried to find a dependency
+            {
+                throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (type requires dependency injection)", ex);
+            }
+
+            try
+            {
+                return constructor.Invoke(parameters);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Error invoking constructor)", ex);
             }
         }
     }

--- a/src/Discord.Net.Commands/ReflectionUtils.cs
+++ b/src/Discord.Net.Commands/ReflectionUtils.cs
@@ -16,23 +16,23 @@ namespace Discord.Commands
                 if (constructor.GetParameters().Length == 0)
                     return constructor.Invoke(null);
                 else if (constructor.GetParameters().Length > 1)
-                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\"");
+                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Found too many parameters)");
                 var parameter = constructor.GetParameters().FirstOrDefault();
                 if (parameter == null)
-                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\"");
-                if (parameter.GetType() == typeof(CommandService))
+                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (No valid parameters)");
+                if (parameter.ParameterType == typeof(CommandService))
                     return constructor.Invoke(new object[1] { commands });
-                else if (parameter is IDependencyMap)
+                else if (parameter.ParameterType == typeof(IDependencyMap))
                 {
                     if (map == null) throw new InvalidOperationException($"The constructor for \"{typeInfo.FullName}\" requires a Dependency Map.");
                     return constructor.Invoke(new object[1] { map });
                 }
                 else
-                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\"");
+                    throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Invalid Parameter Type: \"{parameter.ParameterType.FullName}\")");
             }
-            catch
+            catch (Exception e)
             {
-                throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\"");
+                throw new InvalidOperationException($"Could not find a valid constructor for \"{typeInfo.FullName}\" (Error invoking constructor)");
             }
         }
     }


### PR DESCRIPTION
Resolves #128 and improves on foxbot's existing code.

Modules can now be constructed using something like this:
```cs
public Module(ClassA a, ClassB b, CommandService service) { }
```
If the code has any other parameters other than CommandService, a DependencyMap is required to be passed to LoadAssembly; otherwise the code will throw an exception stating that dependency injection is required.