### PR TITLE
Changed CommandServiceConfig constructor to public

### DIFF
--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -41,7 +41,7 @@ namespace Discord.Commands
         /// <summary> Gets or sets whether a help function should be automatically generated. </summary>
 		public HelpMode HelpMode { get; set; } = HelpMode.Disabled;
 
-        internal CommandServiceConfig(CommandServiceConfigBuilder builder)
+        public CommandServiceConfig(CommandServiceConfigBuilder builder)
         {
             PrefixChar = builder.PrefixChar;
             AllowMentionPrefix = builder.AllowMentionPrefix;


### PR DESCRIPTION
Changed CommandServiceConfig constructor to public, so that it can be instantiated by projects implementing the library... so that commands can be registered.