### PR TITLE
Add support for 'params' in commands

### DIFF
--- a/src/Discord.Net.Commands/Command.cs
+++ b/src/Discord.Net.Commands/Command.cs
@@ -95,7 +95,7 @@ namespace Discord.Commands
 
                 if (reader == null && underlyingTypeInfo.IsEnum)
                 {
-                    reader = EnumTypeReader.GetReader(type);
+                    reader = EnumTypeReader.GetReader(underlyingType);
                     Module.Service.AddTypeReader(type, reader);
                 }
 

--- a/src/Discord.Net.Commands/Command.cs
+++ b/src/Discord.Net.Commands/Command.cs
@@ -76,20 +76,14 @@ namespace Discord.Commands
                         continue;
                 }
 
-                var reader = Module.Service.GetTypeReader(type);
-
                 // TODO: is there a better way of detecting 'params'?
                 bool isParams = type.IsArray && i == parameters.Length - 1;
                 if (isParams)
-                {
                     underlyingType = type.GetElementType();
-                    reader = Module.Service.GetTypeReader(underlyingType);
-                }
                 else
-                {
                     underlyingType = type;
-                }
 
+                var reader = Module.Service.GetTypeReader(underlyingType);
                 var underlyingTypeInfo = underlyingType.GetTypeInfo();
                 var typeInfo = type.GetTypeInfo();
 

--- a/src/Discord.Net.Commands/Command.cs
+++ b/src/Discord.Net.Commands/Command.cs
@@ -66,6 +66,7 @@ namespace Discord.Commands
             {
                 var parameter = parameters[i];
                 var type = parameter.ParameterType;
+                Type underlyingType = null;
 
                 if (i == 0)
                 {
@@ -75,10 +76,24 @@ namespace Discord.Commands
                         continue;
                 }
 
-                var typeInfo = type.GetTypeInfo();
                 var reader = Module.Service.GetTypeReader(type);
 
-                if (reader == null && typeInfo.IsEnum)
+                // TODO: is there a better way of detecting 'params'?
+                bool isParams = type.IsArray && i == parameters.Length - 1;
+                if (isParams)
+                {
+                    underlyingType = type.GetElementType();
+                    reader = Module.Service.GetTypeReader(underlyingType);
+                }
+                else
+                {
+                    underlyingType = type;
+                }
+
+                var underlyingTypeInfo = underlyingType.GetTypeInfo();
+                var typeInfo = type.GetTypeInfo();
+
+                if (reader == null && underlyingTypeInfo.IsEnum)
                 {
                     reader = EnumTypeReader.GetReader(type);
                     Module.Service.AddTypeReader(type, reader);
@@ -96,7 +111,7 @@ namespace Discord.Commands
                 bool isOptional = parameter.IsOptional;
                 object defaultValue = parameter.HasDefaultValue ? parameter.DefaultValue : null;
 
-                paramBuilder.Add(new CommandParameter(name, description, type, reader, isOptional, isRemainder, defaultValue));
+                paramBuilder.Add(new CommandParameter(name, description, type, underlyingType, reader, isOptional, isRemainder, isParams, defaultValue));
             }
             return paramBuilder.ToImmutable();
         }

--- a/src/Discord.Net.Commands/CommandParameter.cs
+++ b/src/Discord.Net.Commands/CommandParameter.cs
@@ -15,17 +15,21 @@ namespace Discord.Commands
         public string Description { get; }
         public bool IsOptional { get; }
         public bool IsRemainder { get; }
+        public bool IsParams { get; }
         public Type Type { get; }
+        public Type UnderlyingType { get; }
         internal object DefaultValue { get; }
 
-        public CommandParameter(string name, string description, Type type, TypeReader reader, bool isOptional, bool isRemainder, object defaultValue)
+        public CommandParameter(string name, string description, Type type, Type underlyingType, TypeReader reader, bool isOptional, bool isRemainder, bool isParams, object defaultValue)
         {
             Name = name;
             Description = description;
             Type = type;
+            UnderlyingType = underlyingType;
             _reader = reader;
             IsOptional = isOptional;
             IsRemainder = isRemainder;
+            IsParams = isParams;
             DefaultValue = defaultValue;
         }
 


### PR DESCRIPTION
This should work with any existing code and adds support for commands which have arrays as their last argument. Unfortunately it doesn't seem possible to require usage of 'params', hence the TODO comment in the Command class.

I also added a new property to CommandParameter which may not be needed (UnderlyingType) so that may be able to be cleaned up more.