### PR TITLE
Added `Command.Synopsis`

### DIFF
--- a/src/Discord.Net.Commands/Attributes/DescriptionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/DescriptionAttribute.cs
@@ -11,4 +11,14 @@ namespace Discord.Commands
             Text = text;
         }
     }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class SynopsisAttribute : Attribute
+    {
+        public string Text { get; }
+        public SynopsisAttribute(string text)
+        {
+            Text = text;
+        }
+    }
 }

--- a/src/Discord.Net.Commands/Command.cs
+++ b/src/Discord.Net.Commands/Command.cs
@@ -15,6 +15,7 @@ namespace Discord.Commands
 
         public string Name { get; }
         public string Description { get; }
+        public string Synopsis { get; }
         public string Text { get; }
         public Module Module { get; }
         public IReadOnlyList<CommandParameter> Parameters { get; }
@@ -30,6 +31,10 @@ namespace Discord.Commands
             var description = methodInfo.GetCustomAttribute<DescriptionAttribute>();
             if (description != null)
                 Description = description.Text;
+
+            var synopsis = methodInfo.GetCustomAttribute<SynopsisAttribute>();
+            if (synopsis != null)
+                Synopsis = synopsis.Text;
 
             Parameters = BuildParameters(methodInfo);
             _action = BuildAction(methodInfo);


### PR DESCRIPTION
Added `Command.Synopsis` for separation of short and long descriptions, this being intended for long.