### PR TITLE
Don't load modules that are already loaded

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -117,6 +117,9 @@ namespace Discord.Commands
         }
         private Module LoadInternal(object moduleInstance, ModuleAttribute moduleAttr, TypeInfo typeInfo)
         {
+            if (_modules.Any(m => m.Key.GetType().GetTypeInfo() == typeInfo))
+                return _modules.FirstOrDefault(m => m.Key.GetType().GetTypeInfo() == typeInfo).Value;
+
             var loadedModule = new Module(this, moduleInstance, moduleAttr, typeInfo);
             _modules[moduleInstance] = loadedModule;
 


### PR DESCRIPTION
Resolves #160.

Previously, if a user autoloaded commands more than once, commands that were already in the command map would be readded. 

If the module list already contains a module with the same type as the module being loaded, it will not load the new instance of this module.