### PR TITLE
SocketSelfUser inherits ISelfUser

### DIFF
--- a/src/Discord.Net/WebSocket/Entities/Users/SocketSelfUser.cs
+++ b/src/Discord.Net/WebSocket/Entities/Users/SocketSelfUser.cs
@@ -6,7 +6,7 @@ using Model = Discord.API.User;
 
 namespace Discord
 {
-    internal class SocketSelfUser : SelfUser, ISocketUser
+    internal class SocketSelfUser : SelfUser, ISocketUser, ISelfUser
     {
         internal override bool IsAttached => true;
 


### PR DESCRIPTION
Resolves #159.

The previous bug was that SocketSelfUser did not inherit from ISelfUser, so DiscordSocketClient.GetCurrentUserAsync was not returning a SocketSelfUser, despite the underlying type being that. This caused ModifyStatusAsync to throw the NotSupportedException that existed on the REST SelfUser.