### PR TITLE
Support GET /channels/{id}/pins

### DIFF
--- a/src/Discord.Net/API/DiscordRestApiClient.cs
+++ b/src/Discord.Net/API/DiscordRestApiClient.cs
@@ -357,6 +357,12 @@ namespace Discord.API
 
             await SendAsync("DELETE", $"channels/{channelId}/pins/{messageId}", options: options).ConfigureAwait(false);
         }
+        public async Task<IReadOnlyCollection<Message>> GetPinsAsync(ulong channelId, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(channelId, 0, nameof(channelId));
+
+            return await SendAsync<IReadOnlyCollection<Message>>("GET", $"channels/{channelId}/pins", options: options).ConfigureAwait(false);
+        }
 
         //Channel Recipients
         public async Task AddGroupRecipientAsync(ulong channelId, ulong userId, RequestOptions options = null)

--- a/src/Discord.Net/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net/Entities/Channels/IMessageChannel.cs
@@ -23,6 +23,8 @@ namespace Discord
         Task<IReadOnlyCollection<IMessage>> GetMessagesAsync(int limit = DiscordConfig.MaxMessagesPerBatch);
         /// <summary> Gets a collection of messages in this channel. </summary>
         Task<IReadOnlyCollection<IMessage>> GetMessagesAsync(ulong fromMessageId, Direction dir, int limit = DiscordConfig.MaxMessagesPerBatch);
+        /// <summary> Gets a collection of pinned messages in this channel. </summary>
+        Task<IReadOnlyCollection<IMessage>> GetPinnedMessagesAsync();
         /// <summary> Bulk deletes multiple messages. </summary>
         Task DeleteMessagesAsync(IEnumerable<IMessage> messages);        
 

--- a/src/Discord.Net/Rest/Entities/Channels/DMChannel.cs
+++ b/src/Discord.Net/Rest/Entities/Channels/DMChannel.cs
@@ -108,6 +108,11 @@ namespace Discord
         {
             await Discord.ApiClient.DeleteDMMessagesAsync(Id, new DeleteMessagesParams { MessageIds = messages.Select(x => x.Id) }).ConfigureAwait(false);
         }   
+        public async Task<IReadOnlyCollection<IMessage>> GetPinnedMessagesAsync()
+        {
+            var models = await Discord.ApiClient.GetPinsAsync(Id);
+            return models.Select(x => new Message(this, new User(x.Author.Value), x)).ToImmutableArray();
+        }
 
         public async Task TriggerTypingAsync()
         {

--- a/src/Discord.Net/Rest/Entities/Channels/GroupChannel.cs
+++ b/src/Discord.Net/Rest/Entities/Channels/GroupChannel.cs
@@ -133,6 +133,11 @@ namespace Discord
         {
             await Discord.ApiClient.DeleteDMMessagesAsync(Id, new DeleteMessagesParams { MessageIds = messages.Select(x => x.Id) }).ConfigureAwait(false);
         }
+        public async Task<IReadOnlyCollection<IMessage>> GetPinnedMessagesAsync()
+        {
+            var models = await Discord.ApiClient.GetPinsAsync(Id);
+            return models.Select(x => new Message(this, new User(x.Author.Value), x)).ToImmutableArray();
+        }
 
         public async Task TriggerTypingAsync()
         {

--- a/src/Discord.Net/Rest/Entities/Channels/TextChannel.cs
+++ b/src/Discord.Net/Rest/Entities/Channels/TextChannel.cs
@@ -102,7 +102,12 @@ namespace Discord
         {
             await Discord.ApiClient.DeleteMessagesAsync(Guild.Id, Id, new DeleteMessagesParams { MessageIds = messages.Select(x => x.Id) }).ConfigureAwait(false);
         }
-        
+        public async Task<IReadOnlyCollection<IMessage>> GetPinnedMessagesAsync()
+        {
+            var models = await Discord.ApiClient.GetPinsAsync(Id);
+            return models.Select(x => new Message(this, new User(x.Author.Value), x)).ToImmutableArray();
+        }
+
         public async Task TriggerTypingAsync()
         {
             await Discord.ApiClient.TriggerTypingIndicatorAsync(Id).ConfigureAwait(false);


### PR DESCRIPTION
Resolves #168.

This commit adds GET /channels/{id}/pins to the ApiClient, and adds GetPinnedMessagesAsync to IMessageChannel. This method is only implemented on the REST entities, and the WebSocket entities do not include an override to retrieve pinned messages from cache.