### PR TITLE
Fix Audio Nullref

### DIFF
--- a/src/Discord.Net/WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net/WebSocket/Entities/Guilds/SocketGuild.cs
@@ -60,7 +60,7 @@ namespace Discord
             _audioLock = new SemaphoreSlim(1, 1);
             _syncPromise = new TaskCompletionSource<bool>();
             _downloaderPromise = new TaskCompletionSource<bool>();
-			_audioConnectPromise = new TaskCompletionSource<bool>();
+            _audioConnectPromise = new TaskCompletionSource<bool>();
             Update(model, UpdateSource.Creation, dataStore);
         }
 

--- a/src/Discord.Net/WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net/WebSocket/Entities/Guilds/SocketGuild.cs
@@ -60,6 +60,7 @@ namespace Discord
             _audioLock = new SemaphoreSlim(1, 1);
             _syncPromise = new TaskCompletionSource<bool>();
             _downloaderPromise = new TaskCompletionSource<bool>();
+			_audioConnectPromise = new TaskCompletionSource<bool>();
             Update(model, UpdateSource.Creation, dataStore);
         }
 


### PR DESCRIPTION
Seems I missed this out while completing SocketGuild.ConnectAudio which would have made a nullref possible (somehow it didn't happen? no idea why) and it wasn't picked up on. Should be a quick patch which doesn't change anything.