### PR TITLE
Added a flag "ForceWhitespace" on module attribute

### DIFF
--- a/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
@@ -6,16 +6,14 @@ namespace Discord.Commands
     public class ModuleAttribute : Attribute
     {
         public string Prefix { get; }
-        public bool AutoLoad { get; set; }
-        public ModuleAttribute()
-        {
-            Prefix = null;
-            AutoLoad = true;
-        }
-        public ModuleAttribute(string prefix)
+        public bool AutoLoad { get; }
+        public bool ForceWhitespace { get; }
+
+        public ModuleAttribute(string prefix = null)
         {
             Prefix = prefix;
             AutoLoad = true;
+            ForceWhitespace = true;
         }
     }
 }

--- a/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
@@ -7,13 +7,15 @@ namespace Discord.Commands
     {
         public string Prefix { get; }
         public bool AutoLoad { get; set; }
-        public bool ForceWhitespace { get; set; }
+        public bool AppendSpace { get; set; }
+
+        public ModuleAttribute() : this(null) { }
 
         public ModuleAttribute(string prefix = null)
         {
             Prefix = prefix;
             AutoLoad = true;
-            ForceWhitespace = true;
+            AppendSpace = true;
         }
     }
 }

--- a/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ModuleAttribute.cs
@@ -6,8 +6,8 @@ namespace Discord.Commands
     public class ModuleAttribute : Attribute
     {
         public string Prefix { get; }
-        public bool AutoLoad { get; }
-        public bool ForceWhitespace { get; }
+        public bool AutoLoad { get; set; }
+        public bool ForceWhitespace { get; set; }
 
         public ModuleAttribute(string prefix = null)
         {

--- a/src/Discord.Net.Commands/Module.cs
+++ b/src/Discord.Net.Commands/Module.cs
@@ -34,15 +34,15 @@ namespace Discord.Commands
                 Description = descriptionAttr.Text;
 
             List<Command> commands = new List<Command>();
-            SearchClass(source, instance, commands, moduleAttr.Prefix ?? "");
+            SearchClass(source, instance, commands, moduleAttr.Prefix ?? "", moduleAttr.ForceWhitespace);
             Commands = commands;
 
             Preconditions = BuildPreconditions();
         }
 
-        private void SearchClass(TypeInfo parentType, object instance, List<Command> commands, string groupPrefix)
+        private void SearchClass(TypeInfo parentType, object instance, List<Command> commands, string groupPrefix, bool forceWhitespace)
         {
-            if (groupPrefix != "")
+            if (groupPrefix != "" && forceWhitespace)
                 groupPrefix += " ";
             foreach (var method in parentType.DeclaredMethods)
             {
@@ -60,7 +60,7 @@ namespace Discord.Commands
                         nextGroupPrefix = groupPrefix + groupAttrib.Prefix ?? type.Name;
                     else
                         nextGroupPrefix = groupPrefix;
-                    SearchClass(type, ReflectionUtils.CreateObject(type, Service), commands, nextGroupPrefix);
+                    SearchClass(type, ReflectionUtils.CreateObject(type, Service), commands, nextGroupPrefix, forceWhitespace);
                 }
             }
         }

--- a/src/Discord.Net.Commands/Module.cs
+++ b/src/Discord.Net.Commands/Module.cs
@@ -34,15 +34,15 @@ namespace Discord.Commands
                 Description = descriptionAttr.Text;
 
             List<Command> commands = new List<Command>();
-            SearchClass(source, instance, commands, moduleAttr.Prefix ?? "", moduleAttr.ForceWhitespace);
+            SearchClass(source, instance, commands, moduleAttr.Prefix ?? "", moduleAttr.AppendSpace);
             Commands = commands;
 
             Preconditions = BuildPreconditions();
         }
 
-        private void SearchClass(TypeInfo parentType, object instance, List<Command> commands, string groupPrefix, bool forceWhitespace)
+        private void SearchClass(TypeInfo parentType, object instance, List<Command> commands, string groupPrefix, bool appendWhitespace)
         {
-            if (groupPrefix != "" && forceWhitespace)
+            if (groupPrefix != "" && appendWhitespace)
                 groupPrefix += " ";
             foreach (var method in parentType.DeclaredMethods)
             {
@@ -60,7 +60,7 @@ namespace Discord.Commands
                         nextGroupPrefix = groupPrefix + groupAttrib.Prefix ?? type.Name;
                     else
                         nextGroupPrefix = groupPrefix;
-                    SearchClass(type, ReflectionUtils.CreateObject(type, Service), commands, nextGroupPrefix, forceWhitespace);
+                    SearchClass(type, ReflectionUtils.CreateObject(type, Service), commands, nextGroupPrefix, appendWhitespace);
                 }
             }
         }


### PR DESCRIPTION
In order to opt out of forced whitespaces after module prefix.

Its default is set to true, in order to not break older code. I think this should be default behavior though