### PR TITLE
Add owner/administrator check to RequirePermissionAttribute

### DIFF
--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequirePermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequirePermissionAttribute.cs
@@ -8,21 +8,33 @@ namespace Discord.Commands
     {
         public GuildPermission? GuildPermission { get; }
         public ChannelPermission? ChannelPermission { get; }
+        public bool Fuzzy { get; set; } // public for `RequirePermission(permission, Fuzzy = false)`
 
         public RequirePermissionAttribute(GuildPermission permission)
         {
             GuildPermission = permission;
             ChannelPermission = null;
+            Fuzzy = true;
         }
         public RequirePermissionAttribute(ChannelPermission permission)
         {
             ChannelPermission = permission;
             GuildPermission = null;
+            Fuzzy = true;
         }
         
         public override Task<PreconditionResult> CheckPermissions(IMessage context, Command executingCommand, object moduleInstance)
         {
             var guildUser = context.Author as IGuildUser;
+
+            if (Fuzzy)
+            {
+                if (guildUser.Id == guildUser.Guild.OwnerId)
+                    return Task.FromResult(PreconditionResult.FromSuccess());
+
+                if (guildUser.GuildPermissions.Administrator)
+                    return Task.FromResult(PreconditionResult.FromSuccess());
+            }
 
             if (GuildPermission.HasValue)
             {

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequirePermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequirePermissionAttribute.cs
@@ -27,13 +27,16 @@ namespace Discord.Commands
         {
             var guildUser = context.Author as IGuildUser;
 
-            if (Fuzzy)
+            if (guildUser != null)
             {
-                if (guildUser.Id == guildUser.Guild.OwnerId)
-                    return Task.FromResult(PreconditionResult.FromSuccess());
+                if (Fuzzy)
+                {
+                    if (guildUser.Id == guildUser.Guild.OwnerId)
+                        return Task.FromResult(PreconditionResult.FromSuccess());
 
-                if (guildUser.GuildPermissions.Administrator)
-                    return Task.FromResult(PreconditionResult.FromSuccess());
+                    if (guildUser.GuildPermissions.Administrator)
+                        return Task.FromResult(PreconditionResult.FromSuccess());
+                }
             }
 
             if (GuildPermission.HasValue)


### PR DESCRIPTION
Resolves #207.

A 'Fuzzy' property has been introduced for people who want the old behavior of ignoring owner/administrator checks, which can be used something like this:

``` cs
[RequirePermission(permission, Fuzzy = false)]
```
