### PR TITLE
Add Sanitize function to escape Markdown

### DIFF
--- a/src/Discord.Net/Format.cs
+++ b/src/Discord.Net/Format.cs
@@ -2,6 +2,9 @@
 {
     public static class Format
     {
+        // Characters which need escaping
+        private static string[] SensitiveCharacters = { "*", "_", "~", "`", "\\" };
+
         /// <summary> Returns a markdown-formatted string with bold formatting. </summary>
         public static string Bold(string text) => $"**{text}**";
         /// <summary> Returns a markdown-formatted string with italics formatting. </summary>
@@ -18,6 +21,16 @@
                 return $"```{language ?? ""}\n{text}\n```";
             else
                 return $"`{text}`";
+        }
+
+        /// <summary> Sanitizes the string, safely escaping any Markdown sequences. </summary>
+        public static string Sanitize(string text)
+        {
+            foreach (string unsafeChar in SensitiveCharacters)
+            {
+                text = text.Replace(unsafeChar, $"\\{unsafeChar}");
+            }
+            return text;
         }
     }
 }


### PR DESCRIPTION
Resolves #249 

Automatically escaping in the individual formatting methods would be a bad idea because it would prevent chaining, e.g:

```cs
var message = $"Tried to ban user {Format.Bold(Format.Italics(user.Name))}";
```

Instead, the developer should be escaping manually, like so:

```cs
var message = $"Tried to ban user {Format.Bold(Format.Italics(Format.Sanitize(user.Name)))}";
```