### PR TITLE
Fixed Optional argument in Message Updated event

### DIFF
--- a/src/Discord.Net/WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net/WebSocket/DiscordSocketClient.cs
@@ -1262,7 +1262,10 @@ namespace Discord.WebSocket
                                                 after = channel.CreateMessage(author, data);
                                         }
                                         if (after != null)
-                                            await _messageUpdatedEvent.InvokeAsync(Optional.Create(before), after).ConfigureAwait(false);
+                                            if (before == null)
+                                                await _messageUpdatedEvent.InvokeAsync(Optional.Create<IMessage>(), after).ConfigureAwait(false);
+                                            else
+                                                await _messageUpdatedEvent.InvokeAsync(Optional.Create<IMessage>(before), after).ConfigureAwait(false);
                                     }
                                     else
                                     {


### PR DESCRIPTION
This is the way MessageDeleted works. Just making it consistent.

Right now, first argument is always returning true on IsSpecified with null as the value if message isn't in the cache. With this fix will return IsSpecified=false when it is null.