### PR TITLE
Implemented GetChannels for Discord.DiscordClient.

### DIFF
--- a/src/Discord.Net/DiscordClient.cs
+++ b/src/Discord.Net/DiscordClient.cs
@@ -380,6 +380,12 @@ namespace Discord
             }
             return channel;
         }
+
+        public ConcurrentDictionary<ulong, Channel> GetChannels()
+        {
+            return _channels;
+        }
+
         public Channel GetChannel(ulong id)
         {
             Channel channel;


### PR DESCRIPTION
I wasn't sure if there is any other option for this but this seemed logical to add.
Useful for looping through the channels like so:

```
foreach (KeyValuePair<ulong, Channel> c in botClient.GetChannels())
{
    Console.WriteLine(c.Value.Name);
}
```