### PR TITLE
Prefix tokens being sent to Gateway

### DIFF
--- a/src/Discord.Net/API/DiscordSocketApiClient.cs
+++ b/src/Discord.Net/API/DiscordSocketApiClient.cs
@@ -191,7 +191,7 @@ namespace Discord.API
             };
             var msg = new IdentifyParams()
             {
-                Token = _authToken,
+                Token = GetPrefixedToken(AuthTokenType, _authToken),
                 Properties = props,
                 LargeThreshold = largeThreshold,
                 UseCompression = useCompression,


### PR DESCRIPTION
As of 2016/09/08, Discord started enforcing the requirement for tokens to be prefixed with the account type. While REST requests were already prefixed tokens, Gateway connections did not use a prefixed token. This fixes a fatal bug where no bot clients can create connections to Discord.

**Note:** As of the writing of this PR, Jake has started rolling out a "fix" to Gateway servers that do not enforce the requirement for prefixed tokens. **GW6 will still accept prefixed/nonprefixed tokens,** so this is still a working commit.