### PR TITLE
Add PriorityAttribute and sort commands by priority in CommandService

### DIFF
--- a/src/Discord.Net.Commands/Attributes/PriorityAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/PriorityAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Discord.Commands
+{
+    /// <summary> Sets priority of commands </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class PriorityAttribute : Attribute
+    {
+        /// <summary> The priority which has been set for the command </summary>
+        public int Priority { get; }
+
+        /// <summary> Creates a new <see cref="PriorityAttribute"/> with the given priority. </summary>
+        public PriorityAttribute(int priority)
+        {
+            Priority = priority;
+        }
+    }
+}

--- a/src/Discord.Net.Commands/Command.cs
+++ b/src/Discord.Net.Commands/Command.cs
@@ -24,6 +24,7 @@ namespace Discord.Commands
         public string Summary { get; }
         public string Remarks { get; }
         public string Text { get; }
+        public int Priority { get; }
         public bool HasVarArgs { get; }
         public IReadOnlyList<string> Aliases { get; }
         public IReadOnlyList<CommandParameter> Parameters { get; }
@@ -69,6 +70,9 @@ namespace Discord.Commands
                 var remarksAttr = source.GetCustomAttribute<RemarksAttribute>();
                 if (remarksAttr != null)
                     Remarks = remarksAttr.Text;
+
+                var priorityAttr = source.GetCustomAttribute<PriorityAttribute>();
+                Priority = priorityAttr?.Priority ?? 0;
 
                 Parameters = BuildParameters(source);
                 HasVarArgs = Parameters.Count > 0 ? Parameters[Parameters.Count - 1].IsMultiple : false;

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -180,7 +180,7 @@ namespace Discord.Commands
         public SearchResult Search(IUserMessage message, string input)
         {
             string lowerInput = input.ToLowerInvariant();
-            var matches = _map.GetCommands(input).ToImmutableArray();
+            var matches = _map.GetCommands(input).OrderByDescending(x => x.Priority).ToImmutableArray();
             
             if (matches.Length > 0)
                 return SearchResult.FromSuccess(input, matches);


### PR DESCRIPTION
Partially implements #264 - as I mentioned, prioritising typed overloads is harder and I'm not sure about the best way to implement it.
