### PR TITLE
Fix #311

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -116,7 +116,7 @@ namespace Discord.Commands
         private ModuleInfo AddModuleInternal(TypeInfo typeInfo, IDependencyMap dependencyMap)
         {
             var moduleDef = new ModuleInfo(typeInfo, this, dependencyMap);
-            _moduleDefs[typeInfo.BaseType] = moduleDef;
+            _moduleDefs[typeInfo.AsType()] = moduleDef;
 
             foreach (var cmd in moduleDef.Commands)
                 _map.AddCommand(cmd);


### PR DESCRIPTION
TypeInfo.BaseType will likely return the same Type if all modules derive from
ModuleBase or some common subclass of it. Making it appear as if only one module
is registered.

Changed to TypeInfo.AsType for expected behavior.