### PR TITLE
Moved IDeletable interface up inheritance to IMessage

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Discord
 {
-    public interface IMessage : ISnowflakeEntity
+    public interface IMessage : ISnowflakeEntity, IDeletable
     {
         /// <summary> Gets the type of this system message. </summary>
         MessageType Type { get; }

--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface IUserMessage : IMessage, IDeletable
+    public interface IUserMessage : IMessage
     {
         /// <summary> Modifies this message. </summary>
         Task ModifyAsync(Action<ModifyMessageParams> func, RequestOptions options = null);


### PR DESCRIPTION
Was originally an issue due to a bug that prevented deletion of System Messages. Bug has since been resolved.