### PR TITLE
Fix #320

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -117,12 +117,12 @@ namespace Discord.Rest
             return RestUserMessage.Create(client, guild, model);
         }
 
-        public static Task<RestUserMessage> SendFileAsync(IChannel channel, BaseDiscordClient client,
+        public static async Task<RestUserMessage> SendFileAsync(IChannel channel, BaseDiscordClient client,
             string filePath, string text, bool isTTS, IGuild guild, RequestOptions options)
         {
             string filename = Path.GetFileName(filePath);
             using (var file = File.OpenRead(filePath))
-                return SendFileAsync(channel, client, file, filename, text, isTTS, guild, options);
+                return await SendFileAsync(channel, client, file, filename, text, isTTS, guild, options).ConfigureAwait(false);
         }
         public static async Task<RestUserMessage> SendFileAsync(IChannel channel, BaseDiscordClient client,
             Stream stream, string filename, string text, bool isTTS, IGuild guild, RequestOptions options)


### PR DESCRIPTION
I'm not entirely sure this is the proper way to fix this. However, it seems like
SendFileAsync returns the Task<RestUserMessage>, which would exit the using
block, disposing of the FileStream potentially before the Task is finished.

Changed to await the result of the task before exiting the using block.

This has been tested in several cases, including the failing case mentioned in #320.