### PR TITLE
Fix #323

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
@@ -36,7 +36,7 @@ namespace Discord.WebSocket
                     return result;
 
                 //Download remaining messages
-                ulong? minId = cachedMessages.Count > 0 ? cachedMessages.Min(x => x.Id) : (ulong?)null;
+                ulong? minId = cachedMessages.Count > 0 ? cachedMessages.Min(x => x.Id) : fromMessageId;
                 var downloadedMessages = ChannelHelper.GetMessagesAsync(channel, discord, minId, dir, limit, guild, options);
                 return result.Concat(downloadedMessages);
             }


### PR DESCRIPTION
Fixes the issue #323 where getMessagesAsync was always returning the most recent messages in the channel and not respecting the provided fromMessageId when either the cache was disabled or didn't contain the message.