### PR TITLE
Raise UserUpdated for Avatar/Username changes; GuildMemberUpdated for Nickname

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1451,7 +1451,7 @@ namespace Discord.WebSocket
                                         }
 
                                         await _userPresenceUpdatedEvent.InvokeAsync(guild, user, before, user.Presence).ConfigureAwait(false);
-                                        if (data.User.Username.IsSpecified || data.Roles.IsSpecified)
+                                        if (data.User.Username.IsSpecified || data.Roles.IsSpecified || data.Nick.IsSpecified)
                                         {
                                             var before2 = user.Clone();
                                             await _guildMemberUpdatedEvent.InvokeAsync(before2, user).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1440,13 +1440,13 @@ namespace Discord.WebSocket
 
                                         SocketPresence beforePresence;
                                         SocketGuildUser beforeGuild;
-                                        SocketGlobalUser before;
+                                        SocketGlobalUser beforeGlobal;
                                         var user = guild.GetUser(data.User.Id);
                                         if (user != null)
                                         {
 
                                             beforePresence = user.Presence.Clone();
-                                            before = user.GlobalUser.Clone();
+                                            beforeGlobal = user.GlobalUser.Clone();
                                             beforeGuild = user.Clone();
                                             user.Update(State, data);
                                         }
@@ -1454,7 +1454,7 @@ namespace Discord.WebSocket
                                         {
                                             beforePresence = new SocketPresence(UserStatus.Offline, null);
                                             user = guild.AddOrUpdateUser(data);
-                                            before = user.GlobalUser.Clone();
+                                            beforeGlobal = user.GlobalUser.Clone();
                                             beforeGuild = user.Clone();
                                         }
 
@@ -1466,7 +1466,7 @@ namespace Discord.WebSocket
 
                                         if (data.User.Username.IsSpecified || data.User.Avatar.IsSpecified)
                                         {
-                                            await _userUpdatedEvent.InvokeAsync(before, user).ConfigureAwait(false);
+                                            await _userUpdatedEvent.InvokeAsync(beforeGlobal, user).ConfigureAwait(false);
                                         }
                                     }
                                     else
@@ -1476,7 +1476,7 @@ namespace Discord.WebSocket
                                         {
                                             var user = channel.GetUser(data.User.Id);
                                             var beforePresence = user.Presence.Clone();
-                                            var before = user.Clone();
+                                            var before = user.GlobalUser.Clone();
                                             user.Update(State, data);
 
                                             await _userPresenceUpdatedEvent.InvokeAsync(Optional.Create<SocketGuild>(), user, beforePresence, user.Presence).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1439,15 +1439,12 @@ namespace Discord.WebSocket
                                         }
 
                                         SocketPresence beforePresence;
-                                        SocketGuildUser beforeGuild;
                                         SocketGlobalUser beforeGlobal;
                                         var user = guild.GetUser(data.User.Id);
                                         if (user != null)
                                         {
-
                                             beforePresence = user.Presence.Clone();
                                             beforeGlobal = user.GlobalUser.Clone();
-                                            beforeGuild = user.Clone();
                                             user.Update(State, data);
                                         }
                                         else
@@ -1455,19 +1452,14 @@ namespace Discord.WebSocket
                                             beforePresence = new SocketPresence(UserStatus.Offline, null);
                                             user = guild.AddOrUpdateUser(data);
                                             beforeGlobal = user.GlobalUser.Clone();
-                                            beforeGuild = user.Clone();
-                                        }
-
-                                        await _userPresenceUpdatedEvent.InvokeAsync(guild, user, beforePresence, user.Presence).ConfigureAwait(false);
-                                        if (data.Roles.IsSpecified || data.Nick.IsSpecified)
-                                        {
-                                            await _guildMemberUpdatedEvent.InvokeAsync(beforeGuild, user).ConfigureAwait(false);
                                         }
 
                                         if (data.User.Username.IsSpecified || data.User.Avatar.IsSpecified)
                                         {
                                             await _userUpdatedEvent.InvokeAsync(beforeGlobal, user).ConfigureAwait(false);
+                                            return;
                                         }
+                                        await _userPresenceUpdatedEvent.InvokeAsync(guild, user, beforePresence, user.Presence).ConfigureAwait(false);
                                     }
                                     else
                                     {

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -92,6 +92,10 @@ namespace Discord.WebSocket
                 UpdateRoles(model.Roles.Value);
             if (model.Nick.IsSpecified)
                 Nickname = model.Nick.Value;
+            if (model.User.Username.IsSpecified)
+                GlobalUser.Username = model.User.Username.Value;
+            if (model.User.Avatar.IsSpecified)
+                GlobalUser.AvatarId = model.User.Avatar.Value;
         }
         private void UpdateRoles(ulong[] roleIds)
         {

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -88,14 +88,11 @@ namespace Discord.WebSocket
         internal override void Update(ClientState state, PresenceModel model)
         {
             base.Update(state, model);
+            GlobalUser.Update(state, model.User);
             if (model.Roles.IsSpecified)
                 UpdateRoles(model.Roles.Value);
             if (model.Nick.IsSpecified)
                 Nickname = model.Nick.Value;
-            if (model.User.Username.IsSpecified)
-                GlobalUser.Username = model.User.Username.Value;
-            if (model.User.Avatar.IsSpecified)
-                GlobalUser.AvatarId = model.User.Avatar.Value;
         }
         private void UpdateRoles(ulong[] roleIds)
         {


### PR DESCRIPTION
This should resolve #274, although I opted to raise `GuildMemberUpdated` over `UserUpdated`.

Since nicknames are guild-specific, it would make more sense to raise them in the context of a guild, rather than a global context.

With this change, any previously attached `SocketGuildUser` objects have their `Nickname` field modified.

This also raises `UserUpdated` for Username or Avatar Changes; any previously attached `SocketUser` objects are updated.
