### PR TITLE
Fix #328 by excluding nested types in CommandService

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -95,6 +95,16 @@ namespace Discord.Commands
             {
                 foreach (var type in assembly.ExportedTypes)
                 {
+                    //Ensure that we weren't declared as a submodule
+                    if (type.DeclaringType != null)
+                    {
+                        if (_moduleDefs.ContainsKey(type.DeclaringType))
+                            continue;
+
+                        var declaringTypeInfo = type.DeclaringType.GetTypeInfo();
+                        if (_moduleTypeInfo.IsAssignableFrom(declaringTypeInfo))
+                            continue;
+                    }
                     if (!_moduleDefs.ContainsKey(type))
                     {
                         var typeInfo = type.GetTypeInfo();


### PR DESCRIPTION
Apparently a nested type counts as an exported type and it is returned by Assembly.ExportedTypes - so we do a check to ensure that the type isn't nested before adding it ourselves.