### PR TITLE
Implement IComparable<T> on IRole, add extension IRole#CompareTo

### DIFF
--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface IRole : ISnowflakeEntity, IDeletable, IMentionable
+    public interface IRole : ISnowflakeEntity, IDeletable, IMentionable, IComparable<IRole>
     {
         /// <summary> Gets the guild owning this role.</summary>
         IGuild Guild { get; }

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Discord
 {
     /// <summary> A Guild-User pairing. </summary>
-    public interface IGuildUser : IUser, IVoiceState
+    public interface IGuildUser : IUser, IVoiceState, IComparable<IGuildUser>
     {
         /// <summary> Gets when this user joined this guild. </summary>
         DateTimeOffset? JoinedAt { get; }

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Discord
 {
     /// <summary> A Guild-User pairing. </summary>
-    public interface IGuildUser : IUser, IVoiceState, IComparable<IGuildUser>
+    public interface IGuildUser : IUser, IVoiceState, IComparable<IGuildUser>, IComparable<IRole>
     {
         /// <summary> Gets when this user joined this guild. </summary>
         DateTimeOffset? JoinedAt { get; }

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Discord
 {
     /// <summary> A Guild-User pairing. </summary>
-    public interface IGuildUser : IUser, IVoiceState, IComparable<IGuildUser>, IComparable<IRole>
+    public interface IGuildUser : IUser, IVoiceState, IComparable<IRole>
     {
         /// <summary> Gets when this user joined this guild. </summary>
         DateTimeOffset? JoinedAt { get; }

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -28,5 +28,10 @@ namespace Discord
         Task KickAsync(RequestOptions options = null);
         /// <summary> Modifies this user's properties in this guild. </summary>
         Task ModifyAsync(Action<ModifyGuildMemberParams> func, RequestOptions options = null);
+
+        /// <summary> The position of the user within the role hirearchy. </summary>
+        /// <remarks> The returned value equal to the position of the highest role the user has, 
+        /// or int.MaxValue if user is the server owner. </remarks>
+        int Hirearchy { get; }
     }
 }

--- a/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
@@ -15,5 +15,17 @@ namespace Discord
             => RemoveRolesAsync(user, (IEnumerable<IRole>)roles);
         public static Task RemoveRolesAsync(this IGuildUser user, IEnumerable<IRole> roles)
             => user.ModifyAsync(x => x.RoleIds = user.RoleIds.Except(roles.Select(y => y.Id)).ToArray());
+
+        public static IEnumerable<IRole> GetRoles(this IGuildUser user) {
+            var guild = user.Guild;
+            return user.RoleIds.Select(r => guild.GetRole(r));
+        }
+
+        internal static int Compare(this IGuildUser u1, IGuildUser u2) {
+            var r1 = u1.GetRoles().Max();
+            var r2 = u2.GetRoles().Max();
+            var result = r1.CompareTo(r2);
+            return result != 0 ? result : u1.Id.CompareTo(u2.Id);
+        }
     }
 }

--- a/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
@@ -22,10 +22,15 @@ namespace Discord
         }
 
         internal static int Compare(this IGuildUser u1, IGuildUser u2) {
+            // These should never be empty since the everyone role is always present
             var r1 = u1.GetRoles().Max();
             var r2 = u2.GetRoles().Max();
             var result = r1.CompareTo(r2);
             return result != 0 ? result : u1.Id.CompareTo(u2.Id);
+        }
+
+        internal static int Compare(this IGuildUser user, IRole role) {
+            return user.GetRoles().Max().CompareTo(role);
         }
     }
 }

--- a/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
@@ -21,7 +21,7 @@ namespace Discord
             return user.RoleIds.Select(r => guild.GetRole(r));
         }
 
-        internal static int Compare(this IGuildUser u1, IGuildUser u2) {
+        public static int CompareRoles(this IGuildUser u1, IGuildUser u2) {
             // These should never be empty since the everyone role is always present
             var r1 = u1.GetRoles().Max();
             var r2 = u2.GetRoles().Max();
@@ -29,7 +29,7 @@ namespace Discord
             return result != 0 ? result : u1.Id.CompareTo(u2.Id);
         }
 
-        internal static int Compare(this IGuildUser user, IRole role) {
+        public static int Compare(this IGuildUser user, IRole role) {
             return user.GetRoles().Max().CompareTo(role);
         }
     }

--- a/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
@@ -21,12 +21,11 @@ namespace Discord
             return user.RoleIds.Select(r => guild.GetRole(r));
         }
 
-        public static int CompareRoles(this IGuildUser u1, IGuildUser u2) {
+        public static int CompareRoles(this IGuildUser left, IGuildUser right) {
             // These should never be empty since the everyone role is always present
-            var r1 = u1.GetRoles().Max();
-            var r2 = u2.GetRoles().Max();
-            var result = r1.CompareTo(r2);
-            return result != 0 ? result : u1.Id.CompareTo(u2.Id);
+            var roleLeft = left.GetRoles().Max();
+            var roleRight= right.GetRoles().Max();
+            return roleLeft.CompareTo(roleRight);
         }
 
         public static int Compare(this IGuildUser user, IRole role) {

--- a/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/GuildUserExtensions.cs
@@ -21,15 +21,20 @@ namespace Discord
             return user.RoleIds.Select(r => guild.GetRole(r));
         }
 
-        public static int CompareRoles(this IGuildUser left, IGuildUser right) {
-            // These should never be empty since the everyone role is always present
-            var roleLeft = left.GetRoles().Max();
-            var roleRight= right.GetRoles().Max();
-            return roleLeft.CompareTo(roleRight);
+        internal static int GetHirearchy(this IGuildUser user) {
+            if(user == null)
+                return -1;
+            if(user.Id == user.Guild.OwnerId)
+                return int.MaxValue;
+            return user.GetRoles().Max(r => r.Position);
         }
 
-        public static int Compare(this IGuildUser user, IRole role) {
-            return user.GetRoles().Max().CompareTo(role);
+        internal static int CompareRole(this IGuildUser user, IRole role) {
+            if(user == null)
+                return -1;
+            if(role == null)
+                return 1;
+            return -user.Hirearchy.CompareTo(role.Position);
         }
     }
 }

--- a/src/Discord.Net.Core/Extensions/RoleExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/RoleExtensions.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+  public static class RoleExtensions
+  {
+    internal static int Compare(this IRole r1, IRole r2) {
+      if(r2 == null)
+        return 1;
+      var result = r1.Position.CompareTo(r2.Position);
+      // As per Discord's documentation, a tie is broken by ID
+      if(result != 0)
+        return result;
+      return r1.Id.CompareTo(r2.Id);
+    }
+  }
+}

--- a/src/Discord.Net.Core/Extensions/RoleExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/RoleExtensions.cs
@@ -6,14 +6,16 @@ namespace Discord
 {
   public static class RoleExtensions
   {
-    internal static int Compare(this IRole r1, IRole r2) {
-      if(r2 == null)
+    internal static int Compare(this IRole left, IRole right) {
+      if(left == null)
+        return -1;
+      if(right == null)
         return 1;
-      var result = r1.Position.CompareTo(r2.Position);
+      var result = left.Position.CompareTo(right.Position);
       // As per Discord's documentation, a tie is broken by ID
       if(result != 0)
         return result;
-      return r1.Id.CompareTo(r2.Id);
+      return left.Id.CompareTo(right.Id);
     }
   }
 }

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -55,6 +55,6 @@ namespace Discord.Rest { [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
 
         //IRole
         IGuild IRole.Guild => Guild;
-        public int CompareTo(IRole role) => Position.CompareTo(role.Position);
+        public int CompareTo(IRole role) => this.Compare(role);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -4,9 +4,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Model = Discord.API.Role;
 
-namespace Discord.Rest
-{
-    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+namespace Discord.Rest { [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class RestRole : RestEntity<ulong>, IRole
     {
         public RestGuild Guild { get; }
@@ -51,10 +49,12 @@ namespace Discord.Rest
         public Task DeleteAsync(RequestOptions options = null)
             => RoleHelper.DeleteAsync(this, Discord, options);
 
+
         public override string ToString() => Name;
         private string DebuggerDisplay => $"{Name} ({Id})";
 
         //IRole
         IGuild IRole.Guild => Guild;
+        public int CompareTo(IRole role) => Position.CompareTo(role.Position);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -96,6 +96,8 @@ namespace Discord.Rest
                 throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
             }
         }
+    
+        public int CompareTo(IGuildUser user) => this.Compare(user);
 
         //IVoiceState
         bool IVoiceState.IsSelfDeafened => false;
@@ -103,5 +105,6 @@ namespace Discord.Rest
         bool IVoiceState.IsSuppressed => false;
         IVoiceChannel IVoiceState.VoiceChannel => null;
         string IVoiceState.VoiceSessionId => null;
+
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -96,8 +96,8 @@ namespace Discord.Rest
                 throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
             }
         }
-    
-        public int CompareTo(IRole role) => this.Compare(role);
+        public int Hirearchy => this.GetHirearchy();
+        public int CompareTo(IRole role) => this.CompareRole(role);
 
         //IVoiceState
         bool IVoiceState.IsSelfDeafened => false;

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -98,6 +98,7 @@ namespace Discord.Rest
         }
     
         public int CompareTo(IGuildUser user) => this.Compare(user);
+        public int CompareTo(IRole role) => this.Compare(role);
 
         //IVoiceState
         bool IVoiceState.IsSelfDeafened => false;

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -97,7 +97,6 @@ namespace Discord.Rest
             }
         }
     
-        public int CompareTo(IGuildUser user) => this.Compare(user);
         public int CompareTo(IRole role) => this.Compare(role);
 
         //IVoiceState

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -57,5 +57,6 @@ namespace Discord.WebSocket
 
         //IRole
         IGuild IRole.Guild => Guild;
+        public int CompareTo(IRole role) => Position.CompareTo(role.Position);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -57,6 +57,6 @@ namespace Discord.WebSocket
 
         //IRole
         IGuild IRole.Guild => Guild;
-        public int CompareTo(IRole role) => Position.CompareTo(role.Position);
+        public int CompareTo(IRole role) => this.CompareTo(role);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -96,7 +96,6 @@ namespace Discord.WebSocket
         IGuild IGuildUser.Guild => Guild;
         ulong IGuildUser.GuildId => Guild.Id;
         IReadOnlyCollection<ulong> IGuildUser.RoleIds => RoleIds;
-        public int CompareTo(IGuildUser user) => this.Compare(user);
         public int CompareTo(IRole role) => this.Compare(role);
 
         //IUser

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -96,6 +96,7 @@ namespace Discord.WebSocket
         IGuild IGuildUser.Guild => Guild;
         ulong IGuildUser.GuildId => Guild.Id;
         IReadOnlyCollection<ulong> IGuildUser.RoleIds => RoleIds;
+        public int CompareTo(IGuildUser user) => this.Compare(user);
 
         //IUser
         Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options) 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -97,6 +97,7 @@ namespace Discord.WebSocket
         ulong IGuildUser.GuildId => Guild.Id;
         IReadOnlyCollection<ulong> IGuildUser.RoleIds => RoleIds;
         public int CompareTo(IGuildUser user) => this.Compare(user);
+        public int CompareTo(IRole role) => this.Compare(role);
 
         //IUser
         Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options) 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -96,7 +96,8 @@ namespace Discord.WebSocket
         IGuild IGuildUser.Guild => Guild;
         ulong IGuildUser.GuildId => Guild.Id;
         IReadOnlyCollection<ulong> IGuildUser.RoleIds => RoleIds;
-        public int CompareTo(IRole role) => this.Compare(role);
+        public int CompareTo(IRole role) => this.CompareRole(role);
+        public int Hirearchy => this.GetHirearchy();
 
         //IUser
         Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options) 


### PR DESCRIPTION
Allows GuildUsers and Roles to be compared with each other in a reasonable manner. Addresses the issue mentioned in #248.
