### PR TITLE
Fix EnumTypeReader missing equivalent Enum values by name.

### DIFF
--- a/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
@@ -32,10 +32,12 @@ namespace Discord.Commands
             var byNameBuilder = ImmutableDictionary.CreateBuilder<string, object>();
             var byValueBuilder = ImmutableDictionary.CreateBuilder<T, object>();
             
-            foreach (var v in Enum.GetValues(_enumType))
+            foreach (var v in Enum.GetNames(_enumType))
             {
-                byNameBuilder.Add(v.ToString().ToLower(), v);
-                byValueBuilder.Add((T)v, v);
+                byNameBuilder.Add(v.ToLower(), v);
+                var parsedValue = (T)Enum.Parse(_enumType, v);
+                if (!byValueBuilder.ContainsKey(parsedValue))
+                    byValueBuilder.Add(parsedValue, v);
             }
 
             _enumsByName = byNameBuilder.ToImmutable();
@@ -59,7 +61,7 @@ namespace Discord.Commands
                 if (_enumsByName.TryGetValue(input.ToLower(), out enumValue))
                     return Task.FromResult(TypeReaderResult.FromSuccess(enumValue));
                 else
-                    return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, $"Value is not a {_enumType.Name}"));
+                    return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, $"Name is not a {_enumType.Name}"));
             }
         }
     }

--- a/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
@@ -61,7 +61,7 @@ namespace Discord.Commands
                 if (_enumsByName.TryGetValue(input.ToLower(), out enumValue))
                     return Task.FromResult(TypeReaderResult.FromSuccess(enumValue));
                 else
-                    return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, $"Name is not a {_enumType.Name}"));
+                    return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, $"Value is not a {_enumType.Name}"));
             }
         }
     }


### PR DESCRIPTION
Enumerating over the Enum values would prevent declarations such as this: `enum Foo {A, B, AliasForA = A}` from being parsed properly as AliasForA would not be contained within _enumsByName. By all means, if there's a cleaner implementation rather than having to check if _enumsByValue already contains the key, spruce up my changes.

Also opted to have the error message say exactly which parse failed.