### PR TITLE
Fix nullref during CreateRoleAsync

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -142,7 +142,7 @@ namespace Discord.Rest
             if (name == null) throw new ArgumentNullException(nameof(name));
 
             var model = await client.ApiClient.CreateGuildRoleAsync(guild.Id, options).ConfigureAwait(false);
-            var role = RestRole.Create(client, model);
+            var role = RestRole.Create(guild, client, model);
 
             await role.ModifyAsync(x =>
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -87,7 +87,7 @@ namespace Discord.Rest
             if (model.Roles != null)
             {
                 for (int i = 0; i < model.Roles.Length; i++)
-                    roles[model.Roles[i].Id] = RestRole.Create(Discord, model.Roles[i]);
+                    roles[model.Roles[i].Id] = RestRole.Create(this, Discord, model.Roles[i]);
             }
             _roles = roles.ToImmutable();
 

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -9,7 +9,7 @@ namespace Discord.Rest
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class RestRole : RestEntity<ulong>, IRole
     {
-        public RestGuild Guild { get; }
+        public IGuild Guild { get; }
         public Color Color { get; private set; }
         public bool IsHoisted { get; private set; }
         public bool IsManaged { get; private set; }
@@ -22,13 +22,14 @@ namespace Discord.Rest
         public bool IsEveryone => Id == Guild.Id;
         public string Mention => MentionUtils.MentionRole(Id);
 
-        internal RestRole(BaseDiscordClient discord, ulong id)
+        internal RestRole(IGuild guild, BaseDiscordClient discord, ulong id)
             : base(discord, id)
         {
+            Guild = guild;
         }
-        internal static RestRole Create(BaseDiscordClient discord, Model model)
+        internal static RestRole Create(IGuild guild, BaseDiscordClient discord, Model model)
         {
-            var entity = new RestRole(discord, model.Id);
+            var entity = new RestRole(guild, discord, model.Id);
             entity.Update(model);
             return entity;
         }


### PR DESCRIPTION
Solves Issue #342 , but there might be a cleaner way to do this that doesn't make you end up with a IGuild in the RestRole that might return a SocketGuild or a RestGuild depending on your DiscordClient.

The other option I can see is to DI the guild.Id into role.ModifyAsync, but then you still end up with an empty RestGuild field in the RestRole object.

Suggestions greatly appreciated.