### PR TITLE
Support rich Embeds

### DIFF
--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -6,9 +6,9 @@ namespace Discord.Commands
     {
         public CommandContext Context { get; internal set; }
 
-        protected virtual async Task<IUserMessage> ReplyAsync(string message, bool isTTS = false, RequestOptions options = null)
+        protected virtual async Task<IUserMessage> ReplyAsync(string message, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
         {
-            return await Context.Channel.SendMessageAsync(message, isTTS, options).ConfigureAwait(false);
+            return await Context.Channel.SendMessageAsync(message, isTTS, embed, options).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Core/API/Common/Embed.cs
+++ b/src/Discord.Net.Core/API/Common/Embed.cs
@@ -14,7 +14,7 @@ namespace Discord.API
         [JsonProperty("url")]
         public string Url { get; set; }
         [JsonProperty("color")]
-        public uint Color { get; set; }
+        public uint? Color { get; set; }
         [JsonProperty("author")]
         public Optional<EmbedAuthor> Author { get; set; }
         [JsonProperty("footer")]

--- a/src/Discord.Net.Core/API/Common/Embed.cs
+++ b/src/Discord.Net.Core/API/Common/Embed.cs
@@ -13,9 +13,17 @@ namespace Discord.API
         public string Description { get; set; }
         [JsonProperty("url")]
         public string Url { get; set; }
+        [JsonProperty("color")]
+        public uint Color { get; set; }
+        [JsonProperty("author")]
+        public Optional<EmbedAuthor> Author { get; set; }
+        [JsonProperty("footer")]
+        public Optional<EmbedFooter> Footer { get; set; }
         [JsonProperty("thumbnail")]
         public Optional<EmbedThumbnail> Thumbnail { get; set; }
         [JsonProperty("provider")]
         public Optional<EmbedProvider> Provider { get; set; }
+        [JsonProperty("fields")]
+        public Optional<EmbedField[]> Fields { get; set; }
     }
 }

--- a/src/Discord.Net.Core/API/Common/EmbedAuthor.cs
+++ b/src/Discord.Net.Core/API/Common/EmbedAuthor.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    public class EmbedAuthor
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        [JsonProperty("url")]
+        public string Url { get; set; }
+        [JsonProperty("icon_url")]
+        public string IconUrl { get; set; }
+        [JsonProperty("proxy_icon_url")]
+        public string ProxyIconUrl { get; set; }
+    }
+}

--- a/src/Discord.Net.Core/API/Common/EmbedField.cs
+++ b/src/Discord.Net.Core/API/Common/EmbedField.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    public class EmbedField
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        [JsonProperty("value")]
+        public string Value { get; set; }
+        [JsonProperty("inline")]
+        public bool Inline { get; set; }
+    }
+}

--- a/src/Discord.Net.Core/API/Common/EmbedFooter.cs
+++ b/src/Discord.Net.Core/API/Common/EmbedFooter.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    public class EmbedFooter
+    {
+        [JsonProperty("text")]
+        public string Text { get; set; }
+        [JsonProperty("icon_url")]
+        public string IconUrl { get; set; }
+        [JsonProperty("proxy_icon_url")]
+        public string ProxyIconUrl { get; set; }
+    }
+}

--- a/src/Discord.Net.Core/API/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Core/API/DiscordRestApiClient.cs
@@ -439,8 +439,7 @@ namespace Discord.API
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
-            Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
-            if (args.Content.Length > DiscordConfig.MaxMessageSize)
+            if (args.Content.GetValueOrDefault()?.Length > DiscordConfig.MaxMessageSize)
                 throw new ArgumentException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
             options = RequestOptions.CreateOrClone(options);
 

--- a/src/Discord.Net.Core/API/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Core/API/DiscordRestApiClient.cs
@@ -439,7 +439,10 @@ namespace Discord.API
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));
             Preconditions.NotNull(args, nameof(args));
-            if (args.Content.GetValueOrDefault()?.Length > DiscordConfig.MaxMessageSize)
+            if (!args.Embed.IsSpecified || args.Embed.Value == null)
+                Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
+
+            if (args.Content.Length > DiscordConfig.MaxMessageSize)
                 throw new ArgumentException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
             options = RequestOptions.CreateOrClone(options);
 

--- a/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
+++ b/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
@@ -8,7 +8,7 @@ namespace Discord.API.Rest
     public class CreateMessageParams
     {
         [JsonProperty("content")]
-        public string Content { get; }
+        public Optional<string> Content { get; }
 
         [JsonProperty("nonce")]
         public Optional<string> Nonce { get; set; }
@@ -19,7 +19,10 @@ namespace Discord.API.Rest
 
         public CreateMessageParams(string content)
         {
-            Content = content;
+            if (string.IsNullOrEmpty(content))
+                Content = null;
+            else
+                Content = content;
         }
     }
 }

--- a/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
+++ b/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable CS1591
+using System;
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest
@@ -13,6 +14,8 @@ namespace Discord.API.Rest
         public Optional<string> Nonce { get; set; }
         [JsonProperty("tts")]
         public Optional<bool> IsTTS { get; set; }
+        [JsonProperty("embed")]
+        public Optional<Embed> Embed { get; set; }
 
         public CreateMessageParams(string content)
         {

--- a/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
+++ b/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
@@ -9,7 +9,6 @@ namespace Discord.API.Rest
     {
         [JsonProperty("content")]
         public Optional<string> Content { get; }
-
         [JsonProperty("nonce")]
         public Optional<string> Nonce { get; set; }
         [JsonProperty("tts")]
@@ -20,7 +19,7 @@ namespace Discord.API.Rest
         public CreateMessageParams(string content)
         {
             if (string.IsNullOrEmpty(content))
-                Content = null;
+                Content = Optional.Create<string>();
             else
                 Content = content;
         }

--- a/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
+++ b/src/Discord.Net.Core/API/Rest/CreateMessageParams.cs
@@ -8,7 +8,8 @@ namespace Discord.API.Rest
     public class CreateMessageParams
     {
         [JsonProperty("content")]
-        public Optional<string> Content { get; }
+        public string Content { get; }
+
         [JsonProperty("nonce")]
         public Optional<string> Nonce { get; set; }
         [JsonProperty("tts")]
@@ -18,10 +19,7 @@ namespace Discord.API.Rest
 
         public CreateMessageParams(string content)
         {
-            if (string.IsNullOrEmpty(content))
-                Content = Optional.Create<string>();
-            else
-                Content = content;
+            Content = content;
         }
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -8,7 +8,7 @@ namespace Discord
     public interface IMessageChannel : IChannel
     {
         /// <summary> Sends a message to this message channel. </summary>
-        Task<IUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null);
+        Task<IUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null);
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         Task<IUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, RequestOptions options = null);
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>

--- a/src/Discord.Net.Core/Entities/Messages/EmbedAuthor.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedAuthor.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics;
+using Model = Discord.API.EmbedAuthor;
+
+namespace Discord
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public struct EmbedAuthor
+    {
+        public string Name { get; set; }
+        public string Url { get; set; }
+        public string IconUrl { get; set; }
+        public string ProxyIconUrl { get; set; }
+
+        private EmbedAuthor(string name, string url, string iconUrl, string proxyIconUrl)
+        {
+            Name = name;
+            Url = url;
+            IconUrl = iconUrl;
+            ProxyIconUrl = proxyIconUrl;
+        }
+        internal static EmbedAuthor Create(Model model)
+        {
+            return new EmbedAuthor(model.Name, model.Url, model.IconUrl, model.ProxyIconUrl);
+        }
+
+        private string DebuggerDisplay => $"{Name} ({Url})";
+        public override string ToString() => Name;
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/EmbedField.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedField.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+using Model = Discord.API.EmbedField;
+
+namespace Discord
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public struct EmbedField
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+        public bool Inline { get; set; }
+
+        private EmbedField(string name, string value, bool inline)
+        {
+            Name = name;
+            Value = value;
+            Inline = inline;
+        }
+        internal static EmbedField Create(Model model)
+        {
+            return new EmbedField(model.Name, model.Value, model.Inline);
+        }
+
+        private string DebuggerDisplay => $"{Name} ({Value}";
+        public override string ToString() => Name;
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/EmbedFooter.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedFooter.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+using Model = Discord.API.EmbedFooter;
+
+namespace Discord
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public struct EmbedFooter
+    {
+        public string Text { get; set; }
+        public string IconUrl { get; set; }
+        public string ProxyUrl { get; set; }
+
+        private EmbedFooter(string text, string iconUrl, string proxyUrl)
+        {
+            Text = text;
+            IconUrl = iconUrl;
+            ProxyUrl = proxyUrl;
+        }
+        internal static EmbedFooter Create(Model model)
+        {
+            return new EmbedFooter(model.Text, model.IconUrl, model.ProxyIconUrl);
+        }
+
+        private string DebuggerDisplay => $"{Text} ({IconUrl})";
+        public override string ToString() => Text;
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
@@ -8,7 +8,7 @@ namespace Discord
         string Type { get; }
         string Title { get; }
         string Description { get; }
-        uint? Color { get; }
+        Color? Color { get; }
         EmbedAuthor? Author { get; }
         EmbedFooter? Footer { get; }
         EmbedProvider? Provider { get; }

--- a/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
@@ -1,4 +1,6 @@
-﻿namespace Discord
+﻿using System.Collections.Immutable;
+
+namespace Discord
 {
     public interface IEmbed
     {
@@ -6,7 +8,11 @@
         string Type { get; }
         string Title { get; }
         string Description { get; }
+        uint? Color { get; }
+        EmbedAuthor? Author { get; }
+        EmbedFooter? Footer { get; }
         EmbedProvider? Provider { get; }
         EmbedThumbnail? Thumbnail { get; }
+        ImmutableArray<EmbedField> Fields { get; }
     }
 }

--- a/src/Discord.Net.Core/Utils/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Utils/EmbedBuilder.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using Embed = Discord.API.Embed;
+using Field = Discord.API.EmbedField;
+using Author = Discord.API.EmbedAuthor;
+using Footer = Discord.API.EmbedFooter;
+
+namespace Discord
+{
+    public class EmbedBuilder
+    {
+        private Embed embed = new Embed();
+        List<Field> fields = new List<Field>();
+
+        public EmbedBuilder()
+        {
+            embed.Type = "rich";
+        }
+
+        public EmbedBuilder Title(string title)
+        {
+            embed.Title = title;
+            return this;
+        }
+        public EmbedBuilder Description(string description)
+        {
+            embed.Description = description;
+            return this;
+        }
+        public EmbedBuilder Url(string url)
+        {
+            embed.Url = url;
+            return this;
+        }
+        public EmbedBuilder Color(Color color)
+        {
+            embed.Color = color.RawValue;
+            return this;
+        }
+        public EmbedBuilder Field(Func<EmbedFieldBuilder, EmbedFieldBuilder> builder)
+        {
+            fields.Add(builder(new EmbedFieldBuilder()).Build());
+            return this;
+        }
+        public EmbedBuilder Author(Func<EmbedAuthorBuilder, EmbedAuthorBuilder> builder)
+        {
+            embed.Author = builder(new EmbedAuthorBuilder()).Build();
+            return this;
+        }
+        public EmbedBuilder Footer(Func<EmbedFooterBuilder, EmbedFooterBuilder> builder)
+        {
+            embed.Footer = builder(new EmbedFooterBuilder()).Build();
+            return this;
+        }
+        public Embed Build()
+        {
+            embed.Fields = fields.ToArray();
+            return embed;
+        }
+
+    }
+
+    public class EmbedFieldBuilder
+    {
+        private Field embedField = new Field();
+
+        public EmbedFieldBuilder Name(string name)
+        {
+            embedField.Name = name;
+            return this;
+        }
+        public EmbedFieldBuilder Value(string value)
+        {
+            embedField.Value = value;
+            return this;
+        }
+        public EmbedFieldBuilder Inline(bool inline)
+        {
+            embedField.Inline = inline;
+            return this;
+        }
+        public Field Build()
+        {
+            return embedField;
+        }
+    }
+
+    public class EmbedAuthorBuilder
+    {
+        private Author author = new Author();
+        
+        public EmbedAuthorBuilder Name(string name)
+        {
+            author.Name = name;
+            return this;
+        }
+        public EmbedAuthorBuilder Url(string url)
+        {
+            author.Url = url;
+            return this;
+        }
+        public EmbedAuthorBuilder IconUrl(string iconUrl)
+        {
+            author.IconUrl = iconUrl;
+            return this;
+        }
+        public Author Build()
+        {
+            return author;
+        }
+    }
+
+    public class EmbedFooterBuilder
+    {
+        private Footer footer = new Footer();
+
+        public EmbedFooterBuilder Text(string text)
+        {
+            footer.Text = text;
+            return this;
+        }
+        public EmbedFooterBuilder IconUrl(string iconUrl)
+        {
+            footer.IconUrl = iconUrl;
+            return this;
+        }
+        public Footer Build()
+        {
+            return footer;
+        }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -116,6 +116,13 @@ namespace Discord.Rest
             var model = await client.ApiClient.CreateMessageAsync(channel.Id, args, options).ConfigureAwait(false);
             return RestUserMessage.Create(client, guild, model);
         }
+        public static async Task<RestUserMessage> SendRichMessageAsync(IChannel channel, BaseDiscordClient client,
+            string text, bool isTTS, API.Embed embed, IGuild guild, RequestOptions options)
+        {
+            var args = new CreateMessageParams(text) { IsTTS = isTTS, Embed = embed };
+            var model = await client.ApiClient.CreateMessageAsync(channel.Id, args, options).ConfigureAwait(false);
+            return RestUserMessage.Create(client, guild, model);
+        }
 
         public static async Task<RestUserMessage> SendFileAsync(IChannel channel, BaseDiscordClient client,
             string filePath, string text, bool isTTS, IGuild guild, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -110,13 +110,6 @@ namespace Discord.Rest
         }
 
         public static async Task<RestUserMessage> SendMessageAsync(IChannel channel, BaseDiscordClient client,
-            string text, bool isTTS, IGuild guild, RequestOptions options)
-        {
-            var args = new CreateMessageParams(text) { IsTTS = isTTS };
-            var model = await client.ApiClient.CreateMessageAsync(channel.Id, args, options).ConfigureAwait(false);
-            return RestUserMessage.Create(client, guild, model);
-        }
-        public static async Task<RestUserMessage> SendRichMessageAsync(IChannel channel, BaseDiscordClient client,
             string text, bool isTTS, API.Embed embed, IGuild guild, RequestOptions options)
         {
             var args = new CreateMessageParams(text) { IsTTS = isTTS, Embed = embed };

--- a/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
@@ -7,7 +7,7 @@ namespace Discord.Rest
     public interface IRestMessageChannel : IMessageChannel
     {
         /// <summary> Sends a message to this message channel. </summary>
-        new Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null);
+        new Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null);
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         new Task<RestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, RequestOptions options = null);
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -63,8 +63,8 @@ namespace Discord.Rest
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -126,8 +126,8 @@ namespace Discord.Rest
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -76,8 +76,8 @@ namespace Discord.Rest
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -136,8 +136,8 @@ namespace Discord.Rest
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -55,8 +55,8 @@ namespace Discord.Rest
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -108,8 +108,8 @@ namespace Discord.Rest
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options) 
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options) 
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options) 
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options) 
             => EnterTypingState(options);
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestVirtualMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVirtualMessageChannel.cs
@@ -33,8 +33,8 @@ namespace Discord.Rest
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options = null)
@@ -86,8 +86,8 @@ namespace Discord.Rest
             => await SendFileAsync(filePath, text, isTTS, options);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
 

--- a/src/Discord.Net.Rest/Entities/Messages/Embed.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/Embed.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Model = Discord.API.Embed;
@@ -12,7 +13,7 @@ namespace Discord
         public string Url { get; }
         public string Title { get; }
         public string Type { get; }
-        public uint? Color { get; }
+        public Color? Color { get; }
         public EmbedAuthor? Author { get; }
         public EmbedFooter? Footer { get; }
         public EmbedProvider? Provider { get; }
@@ -23,7 +24,7 @@ namespace Discord
             string title, 
             string description, 
             string url, 
-            uint? color, 
+            Color? color, 
             EmbedAuthor? author, 
             EmbedFooter? footer, 
             EmbedProvider? provider, 
@@ -34,12 +35,17 @@ namespace Discord
             Title = title;
             Description = description;
             Url = url;
+            Color = color;
+            Author = author;
+            Footer = footer;
             Provider = provider;
             Thumbnail = thumbnail;
+            Fields = fields;
         }
         internal static Embed Create(Model model)
         {
-            return new Embed(model.Type, model.Title, model.Description, model.Url, model.Color,
+            return new Embed(model.Type, model.Title, model.Description, model.Url,
+                model.Color.HasValue ? new Color(model.Color.Value) : (Color?)null,
                 model.Author.IsSpecified ? EmbedAuthor.Create(model.Author.Value) : (EmbedAuthor?)null,
                 model.Footer.IsSpecified ? EmbedFooter.Create(model.Footer.Value) : (EmbedFooter?)null,
                 model.Provider.IsSpecified ? EmbedProvider.Create(model.Provider.Value) : (EmbedProvider?)null,

--- a/src/Discord.Net.Rest/Entities/Messages/Embed.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/Embed.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
 using Model = Discord.API.Embed;
 
 namespace Discord
@@ -10,10 +12,23 @@ namespace Discord
         public string Url { get; }
         public string Title { get; }
         public string Type { get; }
+        public uint? Color { get; }
+        public EmbedAuthor? Author { get; }
+        public EmbedFooter? Footer { get; }
         public EmbedProvider? Provider { get; }
         public EmbedThumbnail? Thumbnail { get; }
+        public ImmutableArray<EmbedField> Fields { get; }
 
-        internal Embed(string type, string title, string description, string url, EmbedProvider? provider, EmbedThumbnail? thumbnail)
+        internal Embed(string type, 
+            string title, 
+            string description, 
+            string url, 
+            uint? color, 
+            EmbedAuthor? author, 
+            EmbedFooter? footer, 
+            EmbedProvider? provider, 
+            EmbedThumbnail? thumbnail, 
+            ImmutableArray<EmbedField> fields)
         {
             Type = type;
             Title = title;
@@ -24,9 +39,12 @@ namespace Discord
         }
         internal static Embed Create(Model model)
         {
-            return new Embed(model.Type, model.Title, model.Description, model.Url,
+            return new Embed(model.Type, model.Title, model.Description, model.Url, model.Color,
+                model.Author.IsSpecified ? EmbedAuthor.Create(model.Author.Value) : (EmbedAuthor?)null,
+                model.Footer.IsSpecified ? EmbedFooter.Create(model.Footer.Value) : (EmbedFooter?)null,
                 model.Provider.IsSpecified ? EmbedProvider.Create(model.Provider.Value) : (EmbedProvider?)null,
-                model.Thumbnail.IsSpecified ? EmbedThumbnail.Create(model.Thumbnail.Value) : (EmbedThumbnail?)null);
+                model.Thumbnail.IsSpecified ? EmbedThumbnail.Create(model.Thumbnail.Value) : (EmbedThumbnail?)null,
+                model.Fields.IsSpecified ? model.Fields.Value.Select(x => EmbedField.Create(x)).ToImmutableArray() : ImmutableArray.Create<EmbedField>());
         }
 
         public override string ToString() => Title;

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcDMChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcDMChannel.cs
@@ -44,8 +44,8 @@ namespace Discord.Rpc
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -104,8 +104,8 @@ namespace Discord.Rpc
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
 

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcGroupChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcGroupChannel.cs
@@ -46,8 +46,8 @@ namespace Discord.Rpc
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -103,8 +103,8 @@ namespace Discord.Rpc
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
 

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcTextChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcTextChannel.cs
@@ -49,8 +49,8 @@ namespace Discord.Rpc
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -105,8 +105,8 @@ namespace Discord.Rpc
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
     }

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -11,7 +11,7 @@ namespace Discord.WebSocket
         IReadOnlyCollection<SocketMessage> CachedMessages { get; }
 
         /// <summary> Sends a message to this message channel. </summary>
-        new Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null);
+        new Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null);
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         new Task<RestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, RequestOptions options = null);
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -66,8 +66,8 @@ namespace Discord.WebSocket
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -134,8 +134,8 @@ namespace Discord.WebSocket
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -89,8 +89,8 @@ namespace Discord.WebSocket
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, null, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, null, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, null, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -197,8 +197,8 @@ namespace Discord.WebSocket
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -72,8 +72,8 @@ namespace Discord.WebSocket
         public Task<IReadOnlyCollection<RestMessage>> GetPinnedMessagesAsync(RequestOptions options = null)
             => ChannelHelper.GetPinnedMessagesAsync(this, Discord, Guild, options);
 
-        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, Guild, options);
+        public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, API.Embed embed = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, Guild, options);
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, Guild, options);
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
@@ -135,8 +135,8 @@ namespace Discord.WebSocket
             => await SendFileAsync(filePath, text, isTTS, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, options).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, API.Embed embed, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
     }


### PR DESCRIPTION
This PR adds support for Rich Embeds.

**This can be a breaking change!**

The `IMessageChannel.SendMessage` method has been modified to include an optional `API.Embed` parameter, which will be sent to Discord with the message. You can produce an `API.Embed` object through the `EmbedBuilder` utility, or by creating it yourself.

This feature has been tested.

Since, with this update, messages no longer need to have any content to be valid, I have removed any preconditions that ensure messages have content. However, **sending messages with no content will crash the ratelimiter.** Still looking into a cause.