### PR TITLE
Add Channel to MessageDeleted event

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -59,12 +59,12 @@ namespace Discord.WebSocket
             remove { _messageReceivedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<SocketMessage, Task>> _messageReceivedEvent = new AsyncEvent<Func<SocketMessage, Task>>();
-        public event Func<ulong, Optional<SocketMessage>, Task> MessageDeleted
+        public event Func<ulong, SocketChannel, Optional<SocketMessage>, Task> MessageDeleted
         {
             add { _messageDeletedEvent.Add(value); }
             remove { _messageDeletedEvent.Remove(value); }
         }
-        private readonly AsyncEvent<Func<ulong, Optional<SocketMessage>, Task>> _messageDeletedEvent = new AsyncEvent<Func<ulong, Optional<SocketMessage>, Task>>();
+        private readonly AsyncEvent<Func<ulong, SocketChannel, Optional<SocketMessage>, Task>> _messageDeletedEvent = new AsyncEvent<Func<ulong, SocketChannel, Optional<SocketMessage>, Task>>();
         public event Func<Optional<SocketMessage>, SocketMessage, Task> MessageUpdated
         {
             add { _messageUpdatedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -59,12 +59,12 @@ namespace Discord.WebSocket
             remove { _messageReceivedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<SocketMessage, Task>> _messageReceivedEvent = new AsyncEvent<Func<SocketMessage, Task>>();
-        public event Func<ulong, SocketChannel, Optional<SocketMessage>, Task> MessageDeleted
+        public event Func<ulong, ISocketMessageChannel, Optional<SocketMessage>, Task> MessageDeleted
         {
             add { _messageDeletedEvent.Add(value); }
             remove { _messageDeletedEvent.Remove(value); }
         }
-        private readonly AsyncEvent<Func<ulong, SocketChannel, Optional<SocketMessage>, Task>> _messageDeletedEvent = new AsyncEvent<Func<ulong, SocketChannel, Optional<SocketMessage>, Task>>();
+        private readonly AsyncEvent<Func<ulong, ISocketMessageChannel, Optional<SocketMessage>, Task>> _messageDeletedEvent = new AsyncEvent<Func<ulong, ISocketMessageChannel, Optional<SocketMessage>, Task>>();
         public event Func<Optional<SocketMessage>, SocketMessage, Task> MessageUpdated
         {
             add { _messageUpdatedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1280,22 +1280,22 @@ namespace Discord.WebSocket
                             case "MESSAGE_DELETE":
                                 {
                                     await _gatewayLogger.DebugAsync("Received Dispatch (MESSAGE_DELETE)").ConfigureAwait(false);
-                                    
+
                                     var data = (payload as JToken).ToObject<API.Message>(_serializer);
                                     var channel = State.GetChannel(data.ChannelId) as ISocketMessageChannel;
                                     if (channel != null)
                                     {
                                         if (!((channel as SocketGuildChannel)?.Guild.IsSynced ?? true))
-                                        { 
+                                        {
                                             await _gatewayLogger.DebugAsync("Ignored MESSAGE_DELETE, guild is not synced yet.").ConfigureAwait(false);
                                             return;
                                         }
 
                                         var msg = SocketChannelHelper.RemoveMessage(channel, this, data.Id);
                                         if (msg != null)
-                                            await _messageDeletedEvent.InvokeAsync(data.Id, msg).ConfigureAwait(false);
+                                            await _messageDeletedEvent.InvokeAsync(data.Id, channel as SocketChannel, msg).ConfigureAwait(false);
                                         else
-                                            await _messageDeletedEvent.InvokeAsync(data.Id, Optional.Create<SocketMessage>()).ConfigureAwait(false);
+                                            await _messageDeletedEvent.InvokeAsync(data.Id, channel as SocketChannel, Optional.Create<SocketMessage>()).ConfigureAwait(false);
                                     }
                                     else
                                     {
@@ -1322,9 +1322,9 @@ namespace Discord.WebSocket
                                         {
                                             var msg = SocketChannelHelper.RemoveMessage(channel, this, id);
                                             if (msg != null)
-                                                await _messageDeletedEvent.InvokeAsync(id, msg).ConfigureAwait(false);
+                                                await _messageDeletedEvent.InvokeAsync(id, channel as SocketChannel, msg).ConfigureAwait(false);
                                             else
-                                                await _messageDeletedEvent.InvokeAsync(id, Optional.Create<SocketMessage>()).ConfigureAwait(false);
+                                                await _messageDeletedEvent.InvokeAsync(id, channel as SocketChannel, Optional.Create<SocketMessage>()).ConfigureAwait(false);
                                         }
                                     }
                                     else

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1293,9 +1293,9 @@ namespace Discord.WebSocket
 
                                         var msg = SocketChannelHelper.RemoveMessage(channel, this, data.Id);
                                         if (msg != null)
-                                            await _messageDeletedEvent.InvokeAsync(data.Id, channel as SocketChannel, msg).ConfigureAwait(false);
+                                            await _messageDeletedEvent.InvokeAsync(data.Id, channel, msg).ConfigureAwait(false);
                                         else
-                                            await _messageDeletedEvent.InvokeAsync(data.Id, channel as SocketChannel, Optional.Create<SocketMessage>()).ConfigureAwait(false);
+                                            await _messageDeletedEvent.InvokeAsync(data.Id, channel, Optional.Create<SocketMessage>()).ConfigureAwait(false);
                                     }
                                     else
                                     {


### PR DESCRIPTION
Adds channel to the MessageDeleted event. Getting the channel before required the message to be in cache, which it not always is.