### PR TITLE
Fixed connecting with user tokens and updated gateway OP codes

### DIFF
--- a/src/Discord.Net/API/Client/GatewaySocket/Commands/Identify.cs
+++ b/src/Discord.Net/API/Client/GatewaySocket/Commands/Identify.cs
@@ -18,7 +18,7 @@ namespace Discord.API.Client.GatewaySocket
         public int LargeThreshold { get; set; }
         [JsonProperty("compress")]
         public bool UseCompression { get; set; }
-        [JsonProperty("shard")]
+        [JsonProperty("shard", NullValueHandling = NullValueHandling.Ignore)]
         public int[] ShardingParams { get; set; }
     }
 }

--- a/src/Discord.Net/API/Client/GatewaySocket/OpCodes.cs
+++ b/src/Discord.Net/API/Client/GatewaySocket/OpCodes.cs
@@ -18,7 +18,13 @@
         Resume = 6,
         /// <summary> C←S - Used to notify a client that they must reconnect to another gateway. </summary>
         Reconnect = 7,
-        /// <summary> C→S - Used to request all members that were withheld by large_threshold </summary>
-        RequestGuildMembers = 8
+        /// <summary> C→S - Used to request all members that were withheld by large_threshold. </summary>
+        RequestGuildMembers = 8,
+        /// <summary> C←S - Used to notify the client of an invalid session id. </summary>
+        InvalidSession = 9,
+        /// <summary> C←S - Used to receive heartbeat_interval information and initiate the websocket connection. </summary>
+        Hello = 10,
+        /// <summary> C←S - Used to acknowledge a heartbeat by the client. </summary>
+        HeartbeatACK = 11
     }
 }

--- a/src/Discord.Net/Net/WebSockets/GatewaySocket.cs
+++ b/src/Discord.Net/Net/WebSockets/GatewaySocket.cs
@@ -157,10 +157,10 @@ namespace Discord.Net.WebSockets
             var msg = new IdentifyCommand()
             {
                 Token = token,
-                Properties = props, 
+                Properties = props,
                 LargeThreshold = _config.LargeThreshold,
                 UseCompression = true,
-                ShardingParams = new int[] { shardId, totalShards },
+                ShardingParams = token.StartsWith("Bot ") ? new int[] { shardId, totalShards } : null
             };
 
             QueueMessage(msg);


### PR DESCRIPTION
The problem seemed to be that adding the `shards` field in your IDENTIFY payload with a user token would cause the api to return an OP code 9.

Should fix #349 too.