### PR TITLE
Fix parsing of quoted parameters in params arguments (Fix #262)

### DIFF
--- a/src/Discord.Net.Commands/CommandParser.cs
+++ b/src/Discord.Net.Commands/CommandParser.cs
@@ -65,7 +65,9 @@ namespace Discord.Commands
                         return ParseResult.FromError(CommandError.ParseFailed, "There must be at least one character of whitespace between arguments.");
                     else
                     {
-                        curParam = command.Parameters.Count > argList.Count ? command.Parameters[argList.Count] : null;
+                        if (curParam == null)
+                            curParam = command.Parameters.Count > argList.Count ? command.Parameters[argList.Count] : null;
+
                         if (curParam != null && curParam.IsRemainder)
                         {
                             argBuilder.Append(c);
@@ -116,11 +118,7 @@ namespace Discord.Commands
                     {
                         paramList.Add(typeReaderResult);
 
-                        if (curPos == endPos)
-                        {
-                            curParam = null;
-                            curPart = ParserPart.None;
-                        }
+                        curPart = ParserPart.None;
                     }
                     else
                     {


### PR DESCRIPTION
A simple fix for #262. The problem was that `curPart` was never reset to `ParserPart.None` when reading a parameter with IsMultiple, so the parser would throw an error when it found `ParserPart.QuotedParameter` at the end of the parsing.

The solution is to always reset `curPart` to `ParserPart.None` and not reset `curParam` to `null` when reading a IsMultiple parameter. That way we can check if `curParam` is `null` before beginning a new parameter.

I've tested this solution with multiple parameter and input combinations and haven't found any problems.