### PR TITLE
Parameter preconditions and typereader overriding

### DIFF
--- a/src/Discord.Net.Commands/Attributes/OverrideTypeReaderAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/OverrideTypeReaderAttribute.cs
@@ -11,12 +11,12 @@ namespace Discord.Commands
 
         public Type TypeReader { get; }
 
-        public OverrideTypeReaderAttribute(Type overridenType)
+        public OverrideTypeReaderAttribute(Type overridenTypeReader)
         {
-            if (!_typeReaderTypeInfo.IsAssignableFrom(overridenType.GetTypeInfo()))
-                throw new ArgumentException($"{nameof(overridenType)} must inherit from {nameof(TypeReader)}");
+            if (!_typeReaderTypeInfo.IsAssignableFrom(overridenTypeReader.GetTypeInfo()))
+                throw new ArgumentException($"{nameof(overridenTypeReader)} must inherit from {nameof(TypeReader)}");
             
-            TypeReader = overridenType;
+            TypeReader = overridenTypeReader;
         }
     } 
 }

--- a/src/Discord.Net.Commands/Attributes/OverrideTypeReaderAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/OverrideTypeReaderAttribute.cs
@@ -7,7 +7,7 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Parameter)]
     public class OverrideTypeReaderAttribute : Attribute
     {
-        private readonly TypeInfo _typeReaderTypeInfo = typeof(TypeReader).GetTypeInfo();
+        private static readonly TypeInfo _typeReaderTypeInfo = typeof(TypeReader).GetTypeInfo();
 
         public Type TypeReader { get; }
 

--- a/src/Discord.Net.Commands/Attributes/OverrideTypeReaderAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/OverrideTypeReaderAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+
+using System.Reflection;
+
+namespace Discord.Commands
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class OverrideTypeReaderAttribute : Attribute
+    {
+        private readonly TypeInfo _typeReaderTypeInfo = typeof(TypeReader).GetTypeInfo();
+
+        public Type TypeReader { get; }
+
+        public OverrideTypeReaderAttribute(Type overridenType)
+        {
+            if (!_typeReaderTypeInfo.IsAssignableFrom(overridenType.GetTypeInfo()))
+                throw new ArgumentException($"{nameof(overridenType)} must inherit from {nameof(TypeReader)}");
+            
+            TypeReader = overridenType;
+        }
+    } 
+}

--- a/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Discord.Commands
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = true)]
+    public abstract class ParameterPreconditionAttribute : Attribute
+    {
+        public abstract Task<PreconditionResult> CheckPermissions(CommandContext context, ParameterInfo parameter, object value);
+    }
+}

--- a/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
@@ -6,6 +6,6 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = true)]
     public abstract class ParameterPreconditionAttribute : Attribute
     {
-        public abstract Task<PreconditionResult> CheckPermissions(CommandContext context, ParameterInfo parameter, object value);
+        public abstract Task<PreconditionResult> CheckPermissions(CommandContext context, ParameterInfo parameter, object value, IDependencyMap map);
     }
 }

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -182,6 +182,10 @@ namespace Discord.Commands
                 // TODO: C#7 type switch
                 if (attribute is SummaryAttribute)
                     builder.Summary = (attribute as SummaryAttribute).Text;
+                else if (attribute is OverrideTypeReaderAttribute)
+                    builder.TypeReader = service.GetTypeReader((attribute as OverrideTypeReaderAttribute).TypeReader);
+                else if (attribute is ParameterPreconditionAttribute)
+                    builder.AddPrecondition(attribute as ParameterPreconditionAttribute);
                 else if (attribute is ParamArrayAttribute)
                 {
                     builder.IsMultiple = true;

--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 
 using System.Collections.Generic;
@@ -41,7 +42,11 @@ namespace Discord.Commands.Builders
 
         internal void SetType(Type type)
         {
-            TypeReader = Command.Module.Service.GetTypeReader(type);
+            var readers = Command.Module.Service.GetTypeReaders(type);
+            if (readers == null)
+                throw new InvalidOperationException($"{type} does not have a TypeReader registered for it");
+            
+            TypeReader = readers.FirstOrDefault();
 
             if (type.GetTypeInfo().IsValueType)
                 DefaultValue = Activator.CreateInstance(type);

--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -46,7 +46,7 @@ namespace Discord.Commands.Builders
             if (readers == null)
                 throw new InvalidOperationException($"{type} does not have a TypeReader registered for it");
             
-            TypeReader = readers.FirstOrDefault();
+            TypeReader = readers.FirstOrDefault().Value;
 
             if (type.GetTypeInfo().IsValueType)
                 DefaultValue = Activator.CreateInstance(type);

--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Reflection;
 
+using System.Collections.Generic;
+
 namespace Discord.Commands.Builders
 {
     public class ParameterBuilder
     {
+        private readonly List<ParameterPreconditionAttribute> _preconditions; 
+
         public CommandBuilder Command { get; }
         public string Name { get; internal set; }
         public Type ParameterType { get; internal set; }
@@ -16,16 +20,20 @@ namespace Discord.Commands.Builders
         public object DefaultValue { get; set; }
         public string Summary { get; set; }
 
+        public IReadOnlyList<ParameterPreconditionAttribute> Preconditions => _preconditions;
+
         //Automatic
         internal ParameterBuilder(CommandBuilder command)
         {
+            _preconditions = new List<ParameterPreconditionAttribute>();
+
             Command = command;
         }
         //User-defined
         internal ParameterBuilder(CommandBuilder command, string name, Type type)
             : this(command)
         {
-            Preconditions.NotNull(name, nameof(name));
+            Discord.Preconditions.NotNull(name, nameof(name));
 
             Name = name;
             SetType(type);
@@ -49,7 +57,7 @@ namespace Discord.Commands.Builders
         }
         public ParameterBuilder WithDefault(object defaultValue)
         {
-            DefaultValue = defaultValue;            
+            DefaultValue = defaultValue;
             return this;
         }
         public ParameterBuilder WithIsOptional(bool isOptional)
@@ -65,6 +73,12 @@ namespace Discord.Commands.Builders
         public ParameterBuilder WithIsMultiple(bool isMultiple)
         {
             IsMultiple = isMultiple;
+            return this;
+        }
+
+        public ParameterBuilder AddPrecondition(ParameterPreconditionAttribute precondition)
+        {
+            _preconditions.Add(precondition);
             return this;
         }
 

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -14,8 +14,9 @@ namespace Discord.Commands
     public class CommandService
     {
         private readonly SemaphoreSlim _moduleLock;
-        private readonly ConcurrentDictionary<Type, ModuleInfo> _typedModuleDefs; 
-        private readonly ConcurrentDictionary<Type, ConcurrentBag<TypeReader>> _typeReaders;
+        private readonly ConcurrentDictionary<Type, ModuleInfo> _typedModuleDefs;
+        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<Type, TypeReader>> _typeReaders;
+        private readonly ConcurrentDictionary<Type, TypeReader> _defaultTypeReaders;
         private readonly ConcurrentBag<ModuleInfo> _moduleDefs;
         private readonly CommandMap _map;
 
@@ -24,7 +25,7 @@ namespace Discord.Commands
 
         public IEnumerable<ModuleInfo> Modules => _moduleDefs.Select(x => x);
         public IEnumerable<CommandInfo> Commands => _moduleDefs.SelectMany(x => x.Commands);
-        public ILookup<Type, TypeReader> TypeReaders => _typeReaders.SelectMany(x => x.Value, (a, value) => new {a.Key, value}).ToLookup(x => x.Key, x => x.value);
+        public ILookup<Type, TypeReader> TypeReaders => _typeReaders.SelectMany(x => x.Value.Select(y => new {y.Key, y.Value})).ToLookup(x => x.Key, x => x.Value);
 
         public CommandService() : this(new CommandServiceConfig()) { }
         public CommandService(CommandServiceConfig config)
@@ -33,41 +34,43 @@ namespace Discord.Commands
             _typedModuleDefs = new ConcurrentDictionary<Type, ModuleInfo>();
             _moduleDefs = new ConcurrentBag<ModuleInfo>();
             _map = new CommandMap();
-            _typeReaders = new ConcurrentDictionary<Type, ConcurrentBag<TypeReader>>
+            _typeReaders = new ConcurrentDictionary<Type, ConcurrentDictionary<Type, TypeReader>>();
+
+            _defaultTypeReaders = new ConcurrentDictionary<Type, TypeReader>
             {
-                [typeof(bool)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<bool>()},
-                [typeof(char)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<char>()},
-                [typeof(string)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<string>()},
-                [typeof(byte)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<byte>()},
-                [typeof(sbyte)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<sbyte>()},
-                [typeof(ushort)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<ushort>()},
-                [typeof(short)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<short>()},
-                [typeof(uint)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<uint>()},
-                [typeof(int)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<int>()},
-                [typeof(ulong)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<ulong>()},
-                [typeof(long)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<long>()},
-                [typeof(float)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<float>()},
-                [typeof(double)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<double>()},
-                [typeof(decimal)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<decimal>()},
-                [typeof(DateTime)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<DateTime>()},
-                [typeof(DateTimeOffset)] = new ConcurrentBag<TypeReader>{new SimpleTypeReader<DateTimeOffset>()},
+                [typeof(bool)] = new SimpleTypeReader<bool>(),
+                [typeof(char)] = new SimpleTypeReader<char>(),
+                [typeof(string)] = new SimpleTypeReader<string>(),
+                [typeof(byte)] = new SimpleTypeReader<byte>(),
+                [typeof(sbyte)] = new SimpleTypeReader<sbyte>(),
+                [typeof(ushort)] = new SimpleTypeReader<ushort>(),
+                [typeof(short)] = new SimpleTypeReader<short>(),
+                [typeof(uint)] = new SimpleTypeReader<uint>(),
+                [typeof(int)] = new SimpleTypeReader<int>(),
+                [typeof(ulong)] = new SimpleTypeReader<ulong>(),
+                [typeof(long)] = new SimpleTypeReader<long>(),
+                [typeof(float)] = new SimpleTypeReader<float>(),
+                [typeof(double)] = new SimpleTypeReader<double>(),
+                [typeof(decimal)] = new SimpleTypeReader<decimal>(),
+                [typeof(DateTime)] = new SimpleTypeReader<DateTime>(),
+                [typeof(DateTimeOffset)] = new SimpleTypeReader<DateTimeOffset>(),
                 
-                [typeof(IMessage)] = new ConcurrentBag<TypeReader>{new MessageTypeReader<IMessage>()},
-                [typeof(IUserMessage)] = new ConcurrentBag<TypeReader>{new MessageTypeReader<IUserMessage>()},
-                [typeof(IChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<IChannel>()},
-                [typeof(IDMChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<IDMChannel>()},
-                [typeof(IGroupChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<IGroupChannel>()},
-                [typeof(IGuildChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<IGuildChannel>()},
-                [typeof(IMessageChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<IMessageChannel>()},
-                [typeof(IPrivateChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<IPrivateChannel>()},
-                [typeof(ITextChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<ITextChannel>()},
-                [typeof(IVoiceChannel)] = new ConcurrentBag<TypeReader>{new ChannelTypeReader<IVoiceChannel>()},
+                [typeof(IMessage)] = new MessageTypeReader<IMessage>(),
+                [typeof(IUserMessage)] = new MessageTypeReader<IUserMessage>(),
+                [typeof(IChannel)] = new ChannelTypeReader<IChannel>(),
+                [typeof(IDMChannel)] = new ChannelTypeReader<IDMChannel>(),
+                [typeof(IGroupChannel)] = new ChannelTypeReader<IGroupChannel>(),
+                [typeof(IGuildChannel)] = new ChannelTypeReader<IGuildChannel>(),
+                [typeof(IMessageChannel)] = new ChannelTypeReader<IMessageChannel>(),
+                [typeof(IPrivateChannel)] = new ChannelTypeReader<IPrivateChannel>(),
+                [typeof(ITextChannel)] = new ChannelTypeReader<ITextChannel>(),
+                [typeof(IVoiceChannel)] = new ChannelTypeReader<IVoiceChannel>(),
 
-                [typeof(IRole)] = new ConcurrentBag<TypeReader>{new RoleTypeReader<IRole>()},
+                [typeof(IRole)] = new RoleTypeReader<IRole>(),
 
-                [typeof(IUser)] = new ConcurrentBag<TypeReader>{new UserTypeReader<IUser>()},
-                [typeof(IGroupUser)] = new ConcurrentBag<TypeReader>{new UserTypeReader<IGroupUser>()},
-                [typeof(IGuildUser)] = new ConcurrentBag<TypeReader>{new UserTypeReader<IGuildUser>()},
+                [typeof(IUser)] = new UserTypeReader<IUser>(),
+                [typeof(IGroupUser)] = new UserTypeReader<IGroupUser>(),
+                [typeof(IGuildUser)] = new UserTypeReader<IGuildUser>(),
             };
             _caseSensitive = config.CaseSensitiveCommands;
             _defaultRunMode = config.DefaultRunMode;
@@ -197,19 +200,26 @@ namespace Discord.Commands
         //Type Readers
         public void AddTypeReader<T>(TypeReader reader)
         {
-            var readers = _typeReaders.GetOrAdd(typeof(T), x => new ConcurrentBag<TypeReader>());
-            readers.Add(reader);
+            var readers = _typeReaders.GetOrAdd(typeof(T), x => new ConcurrentDictionary<Type, TypeReader>());
+            readers[reader.GetType()] = reader;
         }
         public void AddTypeReader(Type type, TypeReader reader)
         {
-            var readers = _typeReaders.GetOrAdd(type, x=> new ConcurrentBag<TypeReader>());
-            readers.Add(reader);
+            var readers = _typeReaders.GetOrAdd(type, x=> new ConcurrentDictionary<Type, TypeReader>());
+            readers[reader.GetType()] = reader;
         }
-        internal IEnumerable<TypeReader> GetTypeReaders(Type type)
+        internal IDictionary<Type, TypeReader> GetTypeReaders(Type type)
         {
-            ConcurrentBag<TypeReader> definedTypeReaders;
+            ConcurrentDictionary<Type, TypeReader> definedTypeReaders;
             if (_typeReaders.TryGetValue(type, out definedTypeReaders))
                 return definedTypeReaders;
+            return null;
+        }
+        internal TypeReader GetDefaultTypeReader(Type type)
+        {
+            TypeReader reader;
+            if (_defaultTypeReaders.TryGetValue(type, out reader))
+                return reader;
             return null;
         }
 

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -135,9 +135,26 @@ namespace Discord.Commands
             if (map == null)
                 map = DependencyMap.Empty;
 
+            object[] args = null;
+
             try
             {
-                var args = GenerateArgs(argList, paramList);
+                args = GenerateArgs(argList, paramList);
+            }
+            catch (Exception ex)
+            {
+                return ExecuteResult.FromError(ex);
+            }
+
+            foreach (var parameter in Parameters)
+            {
+                var result = await parameter.CheckPreconditionsAsync(context, args, map).ConfigureAwait(false);
+                if (!result.IsSuccess)
+                    return ExecuteResult.FromError(result);
+            }
+
+            try
+            {
                 switch (RunMode)
                 {
                     case RunMode.Sync: //Always sync

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -135,26 +135,17 @@ namespace Discord.Commands
             if (map == null)
                 map = DependencyMap.Empty;
 
-            object[] args = null;
-
             try
             {
-                args = GenerateArgs(argList, paramList);
-            }
-            catch (Exception ex)
-            {
-                return ExecuteResult.FromError(ex);
-            }
+                object[] args = GenerateArgs(argList, paramList);
 
-            foreach (var parameter in Parameters)
-            {
-                var result = await parameter.CheckPreconditionsAsync(context, args, map).ConfigureAwait(false);
-                if (!result.IsSuccess)
-                    return ExecuteResult.FromError(result);
-            }
+                foreach (var parameter in Parameters)
+                {
+                    var result = await parameter.CheckPreconditionsAsync(context, args, map).ConfigureAwait(false);
+                    if (!result.IsSuccess)
+                        return ExecuteResult.FromError(result);
+                }
 
-            try
-            {
                 switch (RunMode)
                 {
                     case RunMode.Sync: //Always sync

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -53,7 +53,7 @@ namespace Discord.Commands
 
             foreach (var precondition in Preconditions)
             {
-                var result = await precondition.CheckPermissions(context, this, args[position]).ConfigureAwait(false);
+                var result = await precondition.CheckPermissions(context, this, args[position], map).ConfigureAwait(false);
                 if (!result.IsSuccess)
                     return result;
             }


### PR DESCRIPTION
Using the new command builder system, since I'm not sure whether Joe4evr is going to update his system.

Parameter preconditions had to be done as part of the execute phase as they require the value passed to the command after parsing - I wasn't sure about the best way to include it as a separate phase as it would have meant changing how the parameter list was built and passed around heavily.