### PR TITLE
Expose last_message_id field in text channels

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -14,6 +14,7 @@ namespace Discord
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         Task<IUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, RequestOptions options = null);
 
+        ulong? LastMessageId { get; }
         /// <summary> Gets a message from this message channel with the given id, or null if not found. </summary>
         Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary> Gets the last N messages from this message channel. </summary>

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -14,6 +14,7 @@ namespace Discord.Rest
     {
         public RestUser CurrentUser { get; private set; }
         public RestUser Recipient { get; private set; }
+        public ulong? LastMessageId { get; private set; }
 
         public IReadOnlyCollection<RestUser> Users => ImmutableArray.Create(CurrentUser, Recipient);
 
@@ -32,6 +33,7 @@ namespace Discord.Rest
         internal override void Update(Model model)
         {
             Recipient.Update(model.Recipients.Value[0]);
+            LastMessageId = model.LastMessageId;
         }
 
         public override async Task UpdateAsync(RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -16,6 +16,7 @@ namespace Discord.Rest
         private ImmutableDictionary<ulong, RestGroupUser> _users;
 
         public string Name { get; private set; }
+        public ulong? LastMessageId { get; private set; }
 
         public IReadOnlyCollection<RestGroupUser> Users => _users.ToReadOnlyCollection();
         public IReadOnlyCollection<RestGroupUser> Recipients 
@@ -40,6 +41,8 @@ namespace Discord.Rest
 
             if (model.Recipients.IsSpecified)
                 UpdateUsers(model.Recipients.Value);
+
+            LastMessageId = model.LastMessageId;
         }
         internal void UpdateUsers(API.User[] models)
         {

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -13,6 +13,7 @@ namespace Discord.Rest
     public class RestTextChannel : RestGuildChannel, IRestMessageChannel, ITextChannel
     {
         public string Topic { get; private set; }
+        public ulong? LastMessageId { get; private set; }
 
         public string Mention => MentionUtils.MentionChannel(Id);
 
@@ -31,6 +32,7 @@ namespace Discord.Rest
             base.Update(model);
 
             Topic = model.Topic.Value;
+            LastMessageId = model.LastMessageId;
         }
 
         public async Task ModifyAsync(Action<ModifyTextChannelParams> func, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestVirtualMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVirtualMessageChannel.cs
@@ -12,6 +12,7 @@ namespace Discord.Rest
     {
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Mention => MentionUtils.MentionChannel(Id);
+        public ulong? LastMessageId { get; private set; }
 
         internal RestVirtualMessageChannel(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcDMChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcDMChannel.cs
@@ -12,6 +12,7 @@ namespace Discord.Rpc
     public class RpcDMChannel : RpcChannel, IRpcMessageChannel, IRpcPrivateChannel, IDMChannel
     {
         public IReadOnlyCollection<RpcMessage> CachedMessages { get; private set; }
+        public ulong? LastMessageId { get { throw new NotSupportedException(); } }
 
         internal RpcDMChannel(DiscordRpcClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcGroupChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcGroupChannel.cs
@@ -13,6 +13,7 @@ namespace Discord.Rpc
     {
         public IReadOnlyCollection<RpcMessage> CachedMessages { get; private set; }
         public IReadOnlyCollection<RpcVoiceState> VoiceStates { get; private set; }
+        public ulong? LastMessageId { get { throw new NotSupportedException(); } }
 
         internal RpcGroupChannel(DiscordRpcClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcTextChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcTextChannel.cs
@@ -15,6 +15,7 @@ namespace Discord.Rpc
     public class RpcTextChannel : RpcGuildChannel, IRpcMessageChannel, ITextChannel
     {
         public IReadOnlyCollection<RpcMessage> CachedMessages { get; private set; }
+        public ulong? LastMessageId { get { throw new NotSupportedException(); } }
 
         public string Mention => MentionUtils.MentionChannel(Id);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -16,6 +16,7 @@ namespace Discord.WebSocket
         private readonly MessageCache _messages;
 
         public SocketUser Recipient { get; private set; }
+        public ulong? LastMessageId { get; private set; }
 
         public IReadOnlyCollection<SocketMessage> CachedMessages => _messages?.Messages ?? ImmutableArray.Create<SocketMessage>();
         public new IReadOnlyCollection<SocketUser> Users => ImmutableArray.Create(Discord.CurrentUser, Recipient);
@@ -36,6 +37,7 @@ namespace Discord.WebSocket
         internal override void Update(ClientState state, Model model)
         {
             Recipient.Update(state, model.Recipients.Value[0]);
+            LastMessageId = model.LastMessageId;
         }
 
         public Task CloseAsync(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -23,6 +23,7 @@ namespace Discord.WebSocket
         private ConcurrentDictionary<ulong, SocketVoiceState> _voiceStates;
 
         public string Name { get; private set; }
+        public ulong? LastMessageId { get; private set; }
 
         public IReadOnlyCollection<SocketMessage> CachedMessages => _messages?.Messages ?? ImmutableArray.Create<SocketMessage>();
         public new IReadOnlyCollection<SocketGroupUser> Users => _users.ToReadOnlyCollection();
@@ -52,6 +53,8 @@ namespace Discord.WebSocket
 
             if (model.Recipients.IsSpecified)
                 UpdateUsers(state, model.Recipients.Value);
+
+            LastMessageId = model.LastMessageId;
         }
         private void UpdateUsers(ClientState state, UserModel[] models)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -17,6 +17,7 @@ namespace Discord.WebSocket
         private readonly MessageCache _messages;
 
         public string Topic { get; private set; }
+        public ulong? LastMessageId { get; private set; }
 
         public string Mention => MentionUtils.MentionChannel(Id);
         public IReadOnlyCollection<SocketMessage> CachedMessages => _messages?.Messages ?? ImmutableArray.Create<SocketMessage>();
@@ -42,6 +43,7 @@ namespace Discord.WebSocket
             base.Update(state, model);
 
             Topic = model.Topic.Value;
+            LastMessageId = model.LastMessageId;
         }
 
         public Task ModifyAsync(Action<ModifyTextChannelParams> func, RequestOptions options = null)


### PR DESCRIPTION
Another 1.1 milestone feature that closes #183 by exposing the last_message_id field in REST and socket text channels.