### PR TITLE
Add CommandServiceConfig, DefaultRunMode

### DIFF
--- a/src/Discord.Net.Commands/Attributes/CommandAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/CommandAttribute.cs
@@ -6,7 +6,7 @@ namespace Discord.Commands
     public class CommandAttribute : Attribute
     {
         public string Text { get; }
-        public RunMode RunMode { get; set; } = RunMode.Sync;
+        public RunMode RunMode { get; set; }
 
         public CommandAttribute()
         {

--- a/src/Discord.Net.Commands/Builders/CommandBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/CommandBuilder.cs
@@ -17,7 +17,7 @@ namespace Discord.Commands.Builders
         public string Name { get; set; }
         public string Summary { get; set; }
         public string Remarks { get; set; }
-        public RunMode RunMode { get; set; }
+        public RunMode? RunMode { get; set; }
         public int Priority { get; set; }
 
         public IReadOnlyList<PreconditionAttribute> Preconditions => _preconditions;

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -19,10 +19,13 @@ namespace Discord.Commands
         private readonly ConcurrentBag<ModuleInfo> _moduleDefs;
         private readonly CommandMap _map;
 
+        internal readonly RunMode _defaultRunMode;
+
         public IEnumerable<ModuleInfo> Modules => _typedModuleDefs.Select(x => x.Value);
         public IEnumerable<CommandInfo> Commands => _typedModuleDefs.SelectMany(x => x.Value.Commands);
 
-        public CommandService()
+        public CommandService() : this(new CommandServiceConfig()) { }
+        public CommandService(CommandServiceConfig config)
         {
             _moduleLock = new SemaphoreSlim(1, 1);
             _typedModuleDefs = new ConcurrentDictionary<Type, ModuleInfo>();
@@ -64,6 +67,7 @@ namespace Discord.Commands
                 [typeof(IGroupUser)] = new UserTypeReader<IGroupUser>(),
                 [typeof(IGuildUser)] = new UserTypeReader<IGuildUser>(),
             };
+            _defaultRunMode = config.DefaultRunMode;
         }
 
         //Modules

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace Discord.Commands
+{
+    public class CommandServiceConfig
+    {
+        /// <summary> The default RunMode commands should have, if one is not specified on the Command attribute or builder. </summary>
+        public RunMode DefaultRunMode { get; set; } = RunMode.Mixed;
+    }
+}

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -37,7 +37,7 @@ namespace Discord.Commands
             Summary = builder.Summary;
             Remarks = builder.Remarks;
 
-            RunMode = builder.RunMode;
+            RunMode = builder.RunMode ?? service._defaultRunMode;
             Priority = builder.Priority;
             
             if (module.Aliases.Count != 0)


### PR DESCRIPTION
This adds an (optional) CommandServiceConfig, as well as a DefaultRunMode for commands.

This resolves #368 (for commands where a RunMode is not explicitly specified, a custom default value should be used)