### PR TITLE
ModifyAsync will accept an EmbedBuilder

### DIFF
--- a/src/Discord.Net.Core/API/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Core/API/DiscordRestApiClient.cs
@@ -498,7 +498,7 @@ namespace Discord.API
                     break;
             }
         }
-        public async Task<Message> ModifyMessageAsync(ulong channelId, ulong messageId, ModifyMessageParams args, RequestOptions options = null)
+        public async Task<Message> ModifyMessageAsync(ulong channelId, ulong messageId, Rest.ModifyMessageParams args, RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));
             Preconditions.NotEqual(messageId, 0, nameof(messageId));

--- a/src/Discord.Net.Core/API/Rest/ModifyMessageParams.cs
+++ b/src/Discord.Net.Core/API/Rest/ModifyMessageParams.cs
@@ -8,5 +8,7 @@ namespace Discord.API.Rest
     {
         [JsonProperty("content")]
         public Optional<string> Content { get; set; }
+        [JsonProperty("embed")]
+        public Optional<Embed> Embed { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -1,5 +1,4 @@
-﻿using Discord.API.Rest;
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace Discord

--- a/src/Discord.Net.Core/Entities/Messages/ModifyMessageParams.cs
+++ b/src/Discord.Net.Core/Entities/Messages/ModifyMessageParams.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Discord
+{
+    public class ModifyMessageParams
+    {
+        public Optional<string> Content { get; set; }
+        public Optional<EmbedBuilder> Embed { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -15,7 +15,12 @@ namespace Discord.Rest
         {
             var args = new ModifyMessageParams();
             func(args);
-            return await client.ApiClient.ModifyMessageAsync(msg.Channel.Id, msg.Id, args, options).ConfigureAwait(false);
+            var apiArgs = new API.Rest.ModifyMessageParams
+            {
+                Content = args.Content,
+                Embed = args.Embed.IsSpecified ? args.Embed.Value.Build() : Optional.Create<API.Embed>()
+            };
+            return await client.ApiClient.ModifyMessageAsync(msg.Channel.Id, msg.Id, apiArgs, options).ConfigureAwait(false);
         }
         public static async Task DeleteAsync(IMessage msg, BaseDiscordClient client,
             RequestOptions options)


### PR DESCRIPTION
**This is not a breaking change**.

This change begins to implement #379, where IUserMessage.ModifyAsync will now accept a `Discord.ModifyMessageParams` func over a `Discord.API.Rest.ModifyMessageParams` func.