### PR TITLE
Add configuration option for case insensitive commands

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -19,6 +19,7 @@ namespace Discord.Commands
         private readonly ConcurrentBag<ModuleInfo> _moduleDefs;
         private readonly CommandMap _map;
 
+        internal readonly bool _caseSensitive;
         internal readonly RunMode _defaultRunMode;
 
         public IEnumerable<ModuleInfo> Modules => _moduleDefs.Select(x => x);
@@ -67,6 +68,7 @@ namespace Discord.Commands
                 [typeof(IGroupUser)] = new UserTypeReader<IGroupUser>(),
                 [typeof(IGuildUser)] = new UserTypeReader<IGuildUser>(),
             };
+            _caseSensitive = config.CaseSensitiveCommands;
             _defaultRunMode = config.DefaultRunMode;
         }
 
@@ -212,7 +214,7 @@ namespace Discord.Commands
         public SearchResult Search(CommandContext context, int argPos) => Search(context, context.Message.Content.Substring(argPos));
         public SearchResult Search(CommandContext context, string input)
         {
-            string lowerInput = input.ToLowerInvariant();
+            input = _caseSensitive ? input : input.ToLowerInvariant();
             var matches = _map.GetCommands(input).OrderByDescending(x => x.Priority).ToImmutableArray();
             
             if (matches.Length > 0)

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -4,5 +4,7 @@
     {
         /// <summary> The default RunMode commands should have, if one is not specified on the Command attribute or builder. </summary>
         public RunMode DefaultRunMode { get; set; } = RunMode.Mixed;
+        /// <summary> Should commands be case-sensitive? </summary>
+        public bool CaseSensitiveCommands { get; set; } = false;
     }
 }

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -7,9 +7,11 @@ using System.Threading.Tasks;
 using System.Reflection;
 
 using Discord.Commands.Builders;
+using System.Diagnostics;
 
 namespace Discord.Commands
 {
+    [DebuggerDisplay("{Name,nq}")]
     public class CommandInfo
     {
         private static readonly System.Reflection.MethodInfo _convertParamsMethod = typeof(CommandInfo).GetTypeInfo().GetDeclaredMethod(nameof(ConvertParamsList));

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -44,13 +44,13 @@ namespace Discord.Commands
 
             // both command and module provide aliases
             if (module.Aliases.Count > 0 && builder.Aliases.Count > 0)
-                Aliases = module.Aliases.Permutate(builder.Aliases, (first, second) => second != null ? first + " " + second : first).ToImmutableArray();
+                Aliases = module.Aliases.Permutate(builder.Aliases, (first, second) => second != null ? first + " " + second : first).Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
             // only module provides aliases
             else if (module.Aliases.Count > 0)
-                Aliases = module.Aliases.ToImmutableArray();
+                Aliases = module.Aliases.Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
             // only command provides aliases
             else if (builder.Aliases.Count > 0)
-                Aliases = builder.Aliases.ToImmutableArray();
+                Aliases = builder.Aliases.Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
             // neither provide aliases
             else
                 throw new InvalidOperationException("Cannot build a command without any aliases");


### PR DESCRIPTION
Currently, commands are case-sensitive. This PR allows for commands to be case insensitive (which is now the default option).

Resolves #268 