### PR TITLE
Resolves #390

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -214,8 +214,8 @@ namespace Discord.Commands
         public SearchResult Search(CommandContext context, int argPos) => Search(context, context.Message.Content.Substring(argPos));
         public SearchResult Search(CommandContext context, string input)
         {
-            input = _caseSensitive ? input : input.ToLowerInvariant();
-            var matches = _map.GetCommands(input).OrderByDescending(x => x.Priority).ToImmutableArray();
+            string inputsearch = _caseSensitive ? input : input.ToLowerInvariant();
+            var matches = _map.GetCommands(inputsearch).OrderByDescending(x => x.Priority).ToImmutableArray();
             
             if (matches.Length > 0)
                 return SearchResult.FromSuccess(input, matches);


### PR DESCRIPTION
Fix case insensitive commands forcing parameters to return lowercase in SearchResult as specified in #390 