### PR TITLE
EmbedBuilder.WithImageUrl() now uses the value passed

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -52,7 +52,7 @@ namespace Discord
         }
         public EmbedBuilder WithImageUrl(string imageUrl)
         {
-            ImageUrl = ImageUrl;
+            ImageUrl = imageUrl;
             return this;
         }
         public EmbedBuilder WithCurrentTimestamp()


### PR DESCRIPTION
This is arguably the silliest Pull Request. But better than just whining about it.