### PR TITLE
Fix BuildInEngine.SendFile() error and suggestion to possible issue.

### DIFF
--- a/src/Discord.Net/Net/Rest/BuiltInEngine.cs
+++ b/src/Discord.Net/Net/Rest/BuiltInEngine.cs
@@ -65,7 +65,7 @@ namespace Discord.Net.Rest
             using (var request = new HttpRequestMessage(GetMethod(method), _baseUrl + path))
             {
                 var content = new MultipartFormDataContent("Upload----" + DateTime.Now.ToString(CultureInfo.InvariantCulture));
-                content.Add(new StreamContent(File.OpenRead(path)), "file", filename);
+                content.Add(new StreamContent(stream), "file", filename);
                 request.Content = content;
                 return await Send(request, cancelToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
Fixed `BuiltInEngine.SendFile()` method. `StreamContent` was creating `FileStream` from path resulting in error. Path in this method is filename with extension, so just used already created stream for requested file.

As I'm porting old bot as `netcoreapp1.0` already tested on `win10` and `debian8`, works just fine.

Also, when I first tried to send file, there was another error in https://github.com/Grimitsu/Discord.Net/blob/master/src/Discord.Net/Net/WebSockets/BuiltInEngine.cs#L68
Maybe it just me, but fixed this upgrading .NETLibrary to 1.6.1.
Would be good if anyone could reproduce it, cause I don't get a word about `MemoryStream` at least if adding `Discord.Net` as nuget package.
Consider updating reference to `.NetLibrary`.