### PR TITLE
Fix CommandMapNode.GetCommands and RemoveCommand

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -157,8 +157,8 @@ namespace Discord.Commands
             try
             {
                 ModuleInfo module;
-                _typedModuleDefs.TryGetValue(typeof(T), out module);
-                if (module == default(ModuleInfo))
+
+                if (!_typedModuleDefs.TryRemove(typeof(T), out module))
                     return false;
 
                 return RemoveModuleInternal(module);

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -15,7 +15,7 @@ namespace Discord.Commands
         public string Remarks { get; }
 
         public IReadOnlyList<string> Aliases { get; }
-        public IEnumerable<CommandInfo> Commands { get; }
+        public IReadOnlyList<CommandInfo> Commands { get; }
         public IReadOnlyList<PreconditionAttribute> Preconditions { get; }
         public IReadOnlyList<ModuleInfo> Submodules { get; }
         public ModuleInfo Parent { get; }
@@ -31,7 +31,7 @@ namespace Discord.Commands
             Parent = parent;
 
             Aliases = BuildAliases(builder, service).ToImmutableArray();
-            Commands = builder.Commands.Select(x => x.Build(this, service));
+            Commands = builder.Commands.Select(x => x.Build(this, service)).ToImmutableArray();
             Preconditions = BuildPreconditions(builder).ToImmutableArray();
 
             Submodules = BuildSubmodules(builder, service).ToImmutableArray();


### PR DESCRIPTION
I'm absolutely sure I tested this. In fact, I even have my test code for this which somehow broke. It works now, though.

Fixes #420