### PR TITLE
Revert "Implement configurable command node separators"

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -22,7 +22,6 @@ namespace Discord.Commands
 
         internal readonly bool _caseSensitive;
         internal readonly RunMode _defaultRunMode;
-        internal readonly char _splitCharacter;
 
         public IEnumerable<ModuleInfo> Modules => _moduleDefs.Select(x => x);
         public IEnumerable<CommandInfo> Commands => _moduleDefs.SelectMany(x => x.Commands);
@@ -61,7 +60,6 @@ namespace Discord.Commands
 
             _caseSensitive = config.CaseSensitiveCommands;
             _defaultRunMode = config.DefaultRunMode;
-            _splitCharacter = config.CommandSplitCharacter;
         }
 
         //Modules
@@ -131,7 +129,7 @@ namespace Discord.Commands
             _moduleDefs.Add(module);
 
             foreach (var command in module.Commands)
-                _map.AddCommand(command, this);
+                _map.AddCommand(command);
 
             foreach (var submodule in module.Submodules)
                 LoadModuleInternal(submodule);
@@ -175,7 +173,7 @@ namespace Discord.Commands
                 return false;
 
             foreach (var cmd in module.Commands)
-                _map.RemoveCommand(cmd, this);
+                _map.RemoveCommand(cmd);
 
             foreach (var submodule in module.Submodules)
             {
@@ -216,7 +214,7 @@ namespace Discord.Commands
         public SearchResult Search(CommandContext context, string input)
         {
             string searchInput = _caseSensitive ? input : input.ToLowerInvariant();
-            var matches = _map.GetCommands(searchInput, this).OrderByDescending(x => x.Priority).ToImmutableArray();
+            var matches = _map.GetCommands(searchInput).OrderByDescending(x => x.Priority).ToImmutableArray();
             
             if (matches.Length > 0)
                 return SearchResult.FromSuccess(input, matches);

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -6,7 +6,5 @@
         public RunMode DefaultRunMode { get; set; } = RunMode.Sync;
         /// <summary> Should commands be case-sensitive? </summary>
         public bool CaseSensitiveCommands { get; set; } = false;
-        /// <summary> The character which splits commands </summary>
-        public char CommandSplitCharacter { get; set; } = ' ';
     }
 }

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -44,7 +44,7 @@ namespace Discord.Commands
 
             // both command and module provide aliases
             if (module.Aliases.Count > 0 && builder.Aliases.Count > 0)
-                Aliases = module.Aliases.Permutate(builder.Aliases, (first, second) => second != null ? first + service._splitCharacter + second : first).Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
+                Aliases = module.Aliases.Permutate(builder.Aliases, (first, second) => second != null ? first + " " + second : first).Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
             // only module provides aliases
             else if (module.Aliases.Count > 0)
                 Aliases = module.Aliases.Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -30,14 +30,14 @@ namespace Discord.Commands
             Remarks = builder.Remarks;
             Parent = parent;
 
-            Aliases = BuildAliases(builder, service).ToImmutableArray();
+            Aliases = BuildAliases(builder).ToImmutableArray();
             Commands = builder.Commands.Select(x => x.Build(this, service));
             Preconditions = BuildPreconditions(builder).ToImmutableArray();
 
             Submodules = BuildSubmodules(builder, service).ToImmutableArray();
         }
 
-        private static IEnumerable<string> BuildAliases(ModuleBuilder builder, CommandService service)
+        private static IEnumerable<string> BuildAliases(ModuleBuilder builder)
         {
             IEnumerable<string> result = null;
 
@@ -60,9 +60,9 @@ namespace Discord.Commands
                         result = level.Aliases.ToList(); //create a shallow copy so we don't overwrite the builder unexpectedly
                 }
                 else if (result.Count() > level.Aliases.Count)
-                    result = result.Permutate(level.Aliases, (first, second) => first + service._splitCharacter + second);
+                    result = result.Permutate(level.Aliases, (first, second) => first + " " + second);
                 else
-                    result = level.Aliases.Permutate(result, (second, first) => first + service._splitCharacter + second);
+                    result = level.Aliases.Permutate(result, (second, first) => first + " " + second);
             }
 
             if (result == null) //there were no aliases; default to an empty list

--- a/src/Discord.Net.Commands/Map/CommandMap.cs
+++ b/src/Discord.Net.Commands/Map/CommandMap.cs
@@ -12,20 +12,20 @@ namespace Discord.Commands
             _root = new CommandMapNode("");
         }
 
-        public void AddCommand(CommandInfo command, CommandService service)
+        public void AddCommand(CommandInfo command)
         {
             foreach (string text in GetAliases(command))
-                _root.AddCommand(service, text, 0, command);
+                _root.AddCommand(text, 0, command);
         }
-        public void RemoveCommand(CommandInfo command, CommandService service)
+        public void RemoveCommand(CommandInfo command)
         {
             foreach (string text in GetAliases(command))
-                _root.RemoveCommand(service, text, 0, command);
+                _root.RemoveCommand(text, 0, command);
         }
 
-        public IEnumerable<CommandInfo> GetCommands(string text, CommandService service)
+        public IEnumerable<CommandInfo> GetCommands(string text)
         {
-            return _root.GetCommands(service, text, 0);
+            return _root.GetCommands(text, 0);
         }
 
         private IReadOnlyList<string> GetAliases(CommandInfo command)


### PR DESCRIPTION
Reverts RogueException/Discord.Net#412

```
FiniteReality - Today at 4:33 PM
basically the discussion ended out as "touching the command map breaks a lot of things and it's hard to figure out what it breaks" - so I decided it would be best to revert and come up with a better solution
```

(wow revert commits suck)