### PR TITLE
Allow module builders to have empty aliases

### DIFF
--- a/src/Discord.Net.Commands/Builders/CommandBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/CommandBuilder.cs
@@ -41,7 +41,9 @@ namespace Discord.Commands.Builders
             Discord.Preconditions.NotNull(callback, nameof(callback));
 
             Callback = callback;
-            _aliases.Add(primaryAlias);
+
+            if (!string.IsNullOrWhiteSpace(primaryAlias))
+                _aliases.Add(primaryAlias);
         }
 
         public CommandBuilder WithName(string name)

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -39,7 +39,8 @@ namespace Discord.Commands.Builders
         {
             Discord.Preconditions.NotNull(primaryAlias, nameof(primaryAlias));
 
-            _aliases = new List<string> { primaryAlias };
+            if (!string.IsNullOrWhiteSpace(primaryAlias))
+                _aliases.Add(primaryAlias);
         }
 
         public ModuleBuilder WithName(string name)

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -44,13 +44,13 @@ namespace Discord.Commands
 
             // both command and module provide aliases
             if (module.Aliases.Count > 0 && builder.Aliases.Count > 0)
-                Aliases = module.Aliases.Permutate(builder.Aliases, (first, second) => second != null ? first + " " + second : first).Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
+                Aliases = module.Aliases.Permutate(builder.Aliases, (first, second) => !string.IsNullOrWhiteSpace(second) ? first + " " + second : first).Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).Distinct().ToImmutableArray();
             // only module provides aliases
             else if (module.Aliases.Count > 0)
-                Aliases = module.Aliases.Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
+                Aliases = module.Aliases.Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).Distinct().ToImmutableArray();
             // only command provides aliases
             else if (builder.Aliases.Count > 0)
-                Aliases = builder.Aliases.Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).ToImmutableArray();
+                Aliases = builder.Aliases.Select(x => service._caseSensitive ? x : x.ToLowerInvariant()).Distinct().ToImmutableArray();
             // neither provide aliases
             else
                 throw new InvalidOperationException("Cannot build a command without any aliases");

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -15,7 +15,7 @@ namespace Discord.Commands
         public string Remarks { get; }
 
         public IReadOnlyList<string> Aliases { get; }
-        public IEnumerable<CommandInfo> Commands { get; }
+        public IReadOnlyList<CommandInfo> Commands { get; }
         public IReadOnlyList<PreconditionAttribute> Preconditions { get; }
         public IReadOnlyList<ModuleInfo> Submodules { get; }
         public ModuleInfo Parent { get; }
@@ -31,7 +31,7 @@ namespace Discord.Commands
             Parent = parent;
 
             Aliases = BuildAliases(builder).ToImmutableArray();
-            Commands = builder.Commands.Select(x => x.Build(this, service));
+            Commands = builder.Commands.Select(x => x.Build(this, service)).ToImmutableArray();
             Preconditions = BuildPreconditions(builder).ToImmutableArray();
 
             Submodules = BuildSubmodules(builder, service).ToImmutableArray();
@@ -68,7 +68,7 @@ namespace Discord.Commands
             if (result == null) //there were no aliases; default to an empty list
                 result = new List<string>();
 
-            return result;
+            return result.Distinct();
         }
 
         private List<ModuleInfo> BuildSubmodules(ModuleBuilder parent, CommandService service)


### PR DESCRIPTION
Fixes an issue foxbot found on discord

An empty alias is an empty string or whitespace: previously it didn't pick these things up which would cause commands to build incorrectly.

This commit should also fix an issue where commands would not get removed correctly from the command map when unloading modules.