### PR TITLE
Add mentionable property to ModifyGuildRoleParams

### DIFF
--- a/src/Discord.Net.Core/API/Rest/ModifyGuildRoleParams.cs
+++ b/src/Discord.Net.Core/API/Rest/ModifyGuildRoleParams.cs
@@ -16,5 +16,7 @@ namespace Discord.API.Rest
         public Optional<uint> Color { get; set; }
         [JsonProperty("hoist")]
         public Optional<bool> Hoist { get; set; }
+        [JsonProperty("mentionable")]
+        public Optional<bool> Mentionable { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Roles/ModifyGuildRoleParams.cs
+++ b/src/Discord.Net.Core/Entities/Roles/ModifyGuildRoleParams.cs
@@ -47,5 +47,12 @@
         /// If this role is the EveryoneRole, this value may not be set.
         /// </remarks>
         public Optional<bool> Hoist { get; set; }
+        /// <summary>
+        /// Whether or not this role can be mentioned.
+        /// </summary>
+        /// <remarks>
+        /// If this role is the EveryoneRole, this value may not be set.
+        /// </remarks>
+        public Optional<bool> Mentionable { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
@@ -22,6 +22,7 @@ namespace Discord.Rest
             {
                 Color = args.Color.IsSpecified ? args.Color.Value.RawValue : Optional.Create<uint>(),
                 Hoist = args.Hoist,
+                Mentionable = args.Mentionable,
                 Name = args.Name,
                 Permissions = args.Permissions.IsSpecified ? args.Permissions.Value.RawValue : Optional.Create<ulong>(),
                 Position = args.Position


### PR DESCRIPTION
Allows roles to be configured to be mentionable, fixes #424