### PR TITLE
DefaultRetryMode never assigned in DiscordRestAPIClient

### DIFF
--- a/src/Discord.Net.Core/API/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Core/API/DiscordRestApiClient.cs
@@ -52,6 +52,7 @@ namespace Discord.API
         {
             _restClientProvider = restClientProvider;
             UserAgent = userAgent;
+            DefaultRetryMode = defaultRetryMode;
             _serializer = serializer ?? new JsonSerializer { DateFormatString = "yyyy-MM-ddTHH:mm:ssZ", ContractResolver = new DiscordContractResolver() };
             RequestQueue = requestQueue;
             _fetchCurrentUser = fetchCurrentUser;


### PR DESCRIPTION
As the title states, DefaultRetryMode is never being assigned, thus defaults to AlwaysFail. Causes exceptions such as RateLimited to always be thrown. This also doesn't occur if you pass your own RequestOptions.

Commit where the problem was introduced: 1efcd3daf699b99330862364006ec1269f534dc7
