### PR TITLE
Replace IUser.AvatarUrl with IUser#GetAvatarUrl(size)

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -4,8 +4,8 @@
     {
         public static string GetApplicationIconUrl(ulong appId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}app-icons/{appId}/{iconId}.jpg" : null;
-        public static string GetUserAvatarUrl(ulong userId, string avatarId)
-            => avatarId != null ? $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.jpg" : null;
+        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size)
+            => avatarId != null ? $"{DiscordConfig.AvatarUrl}avatars/{userId}/{avatarId}.webp?size={size}" : null;
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
         public static string GetGuildSplashUrl(ulong guildId, string splashId)

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -5,7 +5,7 @@
         public static string GetApplicationIconUrl(ulong appId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}app-icons/{appId}/{iconId}.jpg" : null;
         public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size)
-            => avatarId != null ? $"{DiscordConfig.AvatarUrl}avatars/{userId}/{avatarId}.webp?size={size}" : null;
+            => avatarId != null ? $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.webp?size={size}" : null;
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
         public static string GetGuildSplashUrl(ulong guildId, string splashId)

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -4,8 +4,8 @@
     {
         public static string GetApplicationIconUrl(ulong appId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}app-icons/{appId}/{iconId}.jpg" : null;
-        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size)
-            => avatarId != null ? $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.webp?size={size}" : null;
+        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size, AvatarFormat format)
+            => avatarId != null ? $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.{format.ToString().ToLower()}?size={size}" : null;
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
         public static string GetGuildSplashUrl(ulong guildId, string splashId)

--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -12,6 +12,7 @@ namespace Discord
 
         public static readonly string ClientAPIUrl = $"https://discordapp.com/api/v{APIVersion}/";
         public const string CDNUrl = "https://cdn.discordapp.com/";
+        public const string AvatarUrl = "https://images.discordapp.net/";
         public const string InviteUrl = "https://discord.gg/";
 
         public const int DefaultRequestTimeout = 15000;

--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -12,7 +12,6 @@ namespace Discord
 
         public static readonly string ClientAPIUrl = $"https://discordapp.com/api/v{APIVersion}/";
         public const string CDNUrl = "https://cdn.discordapp.com/";
-        public const string AvatarUrl = "https://images.discordapp.net/";
         public const string InviteUrl = "https://discord.gg/";
 
         public const int DefaultRequestTimeout = 15000;

--- a/src/Discord.Net.Core/Entities/Users/AvatarFormat.cs
+++ b/src/Discord.Net.Core/Entities/Users/AvatarFormat.cs
@@ -1,0 +1,10 @@
+﻿namespace Discord
+{
+    public enum AvatarFormat
+    {
+        WebP,
+        Png,
+        Jpeg,
+        Gif,
+    }
+}

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -7,7 +7,7 @@ namespace Discord
         /// <summary> Gets the id of this user's avatar. </summary>
         string AvatarId { get; }
         /// <summary> Gets the url to this user's avatar. </summary>
-        string AvatarUrl { get; }
+        string GetAvatarUrl(ushort size = 1024);
         /// <summary> Gets the per-username unique id for this user. </summary>
         string Discriminator { get; }
         /// <summary> Gets the per-username unique id for this user. </summary>

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -7,7 +7,7 @@ namespace Discord
         /// <summary> Gets the id of this user's avatar. </summary>
         string AvatarId { get; }
         /// <summary> Gets the url to this user's avatar. </summary>
-        string GetAvatarUrl(ushort size = 1024);
+        string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128);
         /// <summary> Gets the per-username unique id for this user. </summary>
         string Discriminator { get; }
         /// <summary> Gets the per-username unique id for this user. </summary>

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -13,7 +13,7 @@ namespace Discord.Rest
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string AvatarUrl => CDN.GetUserAvatarUrl(Id, AvatarId);
+        public string GetAvatarUrl(ushort size) => API.CDN.GetUserAvatarUrl(Id, AvatarId, size);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -13,7 +13,7 @@ namespace Discord.Rest
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string GetAvatarUrl(ushort size) => API.CDN.GetUserAvatarUrl(Id, AvatarId, size);
+        public string GetAvatarUrl(ushort size) => CDN.GetUserAvatarUrl(Id, AvatarId, size);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -13,7 +13,7 @@ namespace Discord.Rest
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string GetAvatarUrl(ushort size) => CDN.GetUserAvatarUrl(Id, AvatarId, size);
+        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
+++ b/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
@@ -14,7 +14,7 @@ namespace Discord.Rpc
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string GetAvatarUrl(ushort size) => CDN.GetUserAvatarUrl(Id, AvatarId, size);
+        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
+++ b/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
@@ -14,7 +14,7 @@ namespace Discord.Rpc
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string GetAvatarUrl(ushort size) => API.CDN.GetUserAvatarUrl(Id, AvatarId, size);
+        public string GetAvatarUrl(ushort size) => CDN.GetUserAvatarUrl(Id, AvatarId, size);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
+++ b/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
@@ -14,7 +14,7 @@ namespace Discord.Rpc
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string AvatarUrl => CDN.GetUserAvatarUrl(Id, AvatarId);
+        public string GetAvatarUrl(ushort size) => API.CDN.GetUserAvatarUrl(Id, AvatarId, size);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -15,7 +15,7 @@ namespace Discord.WebSocket
         internal abstract SocketGlobalUser GlobalUser { get; }
         internal abstract SocketPresence Presence { get; set; }
 
-        public string GetAvatarUrl(ushort size) => CDN.GetUserAvatarUrl(Id, AvatarId, size);
+        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -15,7 +15,7 @@ namespace Discord.WebSocket
         internal abstract SocketGlobalUser GlobalUser { get; }
         internal abstract SocketPresence Presence { get; set; }
 
-        public string AvatarUrl => CDN.GetUserAvatarUrl(Id, AvatarId);
+        public string GetAvatarUrl(ushort size) => API.CDN.GetUserAvatarUrl(Id, AvatarId, size);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -15,7 +15,7 @@ namespace Discord.WebSocket
         internal abstract SocketGlobalUser GlobalUser { get; }
         internal abstract SocketPresence Presence { get; set; }
 
-        public string GetAvatarUrl(ushort size) => API.CDN.GetUserAvatarUrl(Id, AvatarId, size);
+        public string GetAvatarUrl(ushort size) => CDN.GetUserAvatarUrl(Id, AvatarId, size);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);


### PR DESCRIPTION
**This is a breaking change!**

This is to support the new user image endpoint, which provides a parameter for image resizing.

Placing this on hold until Discord releases upstream to stable.