### PR TITLE
Add command suggestions for incorrect commands

### DIFF
--- a/src/Discord.Net.Commands/Map/CommandMap.cs
+++ b/src/Discord.Net.Commands/Map/CommandMap.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Discord.Commands
 {
@@ -28,6 +28,11 @@ namespace Discord.Commands
         public IEnumerable<CommandMatch> GetCommands(string text)
         {
             return _root.GetCommands(_service, text, 0, text != "");
+        }
+
+        public IEnumerable<CommandMatch> GetPartialMatches(string text, int maxDifferences)
+        {
+            return _root.GetPartialMatches(_service, text, maxDifferences, 0, text != "");
         }
     }
 }

--- a/src/Discord.Net.Commands/Map/CommandMapNode.cs
+++ b/src/Discord.Net.Commands/Map/CommandMapNode.cs
@@ -49,6 +49,7 @@ namespace Discord.Commands
                 }
             }
         }
+
         public void RemoveCommand(CommandService service, string text, int index, CommandInfo command)
         {
             int nextSegment = NextSegment(text, index, service._separatorChar);
@@ -113,6 +114,52 @@ namespace Discord.Commands
             }
         }
 
+        internal IEnumerable<CommandMatch> GetPartialMatches(CommandService service, string text, int maxDifference, int index, bool visitChildren = true)
+        {
+            var commands = _commands;
+            for (int i = 0; i < commands.Length; i++)
+                yield return new CommandMatch(_commands[i], _name);
+
+            if (visitChildren)
+            {
+                string name;
+                CommandMapNode nextNode;
+
+                //Search for next segment
+                int nextSegment = NextSegment(text, index, service._separatorChar);
+                if (nextSegment == -1)
+                    name = text.Substring(index);
+                else
+                    name = text.Substring(index, nextSegment - index);
+
+                foreach (var key in _nodes.Keys)
+                {
+                    if (LevenshteinDistance(name, key) < maxDifference)
+                    {
+                        if (_nodes.TryGetValue(key, out nextNode))
+                            foreach (var cmd in nextNode.GetPartialMatches(service, nextSegment == -1 ? "" : text, maxDifference, nextSegment + 1, true))
+                                yield return cmd;
+                    }
+                }
+
+                //Check if this is the last command segment before args
+                nextSegment = NextSegment(text, index, _whitespaceChars, service._separatorChar);
+                if (nextSegment != -1)
+                {
+                    name = text.Substring(index, nextSegment - index);
+                    foreach (var key in _nodes.Keys)
+                    {
+                        if (LevenshteinDistance(name, key) < maxDifference)
+                        {
+                            if (_nodes.TryGetValue(key, out nextNode))
+                                foreach (var cmd in nextNode.GetPartialMatches(service, nextSegment == -1 ? "" : text, maxDifference, nextSegment + 1, false))
+                                    yield return cmd;
+                        }
+                    }
+                }
+            }
+        }
+
         private static int NextSegment(string text, int startIndex, char separator)
         {
             return text.IndexOf(separator, startIndex);
@@ -130,6 +177,52 @@ namespace Discord.Commands
                 }
             }
             return (lowest != int.MaxValue) ? lowest : -1;
+        }
+
+        private static int LevenshteinDistance(string source, string target)
+        {
+            var sourceLength = source.Length;
+            var targetLength = target.Length;
+
+            if (sourceLength == 0)
+                return targetLength;
+            if (targetLength == 0)
+                return sourceLength;
+
+            var matrix = new int[sourceLength + 1, targetLength + 1];
+            for (int row = 0; row <= sourceLength; matrix[row, 0] = row++)
+            { }
+            for (int col = 0; col <= targetLength; matrix[0, col] = col++)
+            { }
+
+            for (int i = 1; i <= sourceLength; i++)
+            {
+                char sourceChr = source[i - 1];
+                for (int j = 1; j <= targetLength; j++)
+                {
+                    char targetChr = target[j - 1];
+
+                    int cost = sourceChr == targetChr ? 0 : 1;
+
+                    int above = matrix[i - 1, j] + 1;
+                    int left = matrix[i, j - 1] + 1;
+                    int diagonal = matrix[i - 1, j - 1] + cost;
+
+                    int minimum = int.MaxValue;
+
+                    if (above < left)
+                        minimum = above;
+                    else
+                        minimum = left;
+
+                    if (diagonal < minimum)
+                        minimum = diagonal;
+
+                    matrix[i, j] = minimum;
+                }
+            }
+
+            return matrix[sourceLength, targetLength];
         }
     }
 }

--- a/src/Discord.Net.Commands/Results/SearchResult.cs
+++ b/src/Discord.Net.Commands/Results/SearchResult.cs
@@ -24,8 +24,8 @@ namespace Discord.Commands
 
         public static SearchResult FromSuccess(string text, IReadOnlyList<CommandMatch> commands)
             => new SearchResult(text, commands, null, null);
-        public static SearchResult FromError(CommandError error, string reason)
-            => new SearchResult(null, null, error, reason);
+        public static SearchResult FromError(CommandError error, string reason, IReadOnlyList<CommandMatch> suggestions = null)
+            => new SearchResult(null, suggestions, error, reason);
         public static SearchResult FromError(IResult result)
             => new SearchResult(null, null, result.Error, result.ErrorReason);
 


### PR DESCRIPTION
Allows bot devs to get a list of similar commands from the command map when users try to execute an invalid command.

Example Usage:
```cs
var result = await service.ExecuteAsync(context, 0, maxDifferences: 3);
if (result is SearchResult)
{
    var sResult = (SearchResult)result;
    if (sResult.Commands != null)
    {
        var commands = sResult.Commands.Select(x => x.Alias);
        await message.Channel.SendMessageAsync($"Invalid command - Did you mean:\n{string.Join("\n", commands)}");
    }
}
```

I'm fairly sure the code in CommandMapNode.cs could be cleaned up more, but I'm not sure about the best way to do that without making changes that would probably break everything.