### PR TITLE
Add `IsPrivate` to `ICommandContext`

### DIFF
--- a/src/Discord.Net.Core/Commands/ICommandContext.cs
+++ b/src/Discord.Net.Core/Commands/ICommandContext.cs
@@ -7,5 +7,6 @@
         IMessageChannel Channel { get; }
         IUser User { get; }
         IUserMessage Message { get; }
+        bool IsPrivate { get; }
     }
 }


### PR DESCRIPTION
All implementations of `ICommandContext` already define this, and since preconditions now take in the interface, it makes sense to have this on there as well.