### PR TITLE
Allow arbitrary attributes to be added to commands

### DIFF
--- a/src/Discord.Net.Commands/Builders/CommandBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/CommandBuilder.cs
@@ -9,6 +9,7 @@ namespace Discord.Commands.Builders
     {
         private readonly List<PreconditionAttribute> _preconditions;
         private readonly List<ParameterBuilder> _parameters;
+        private readonly List<Attribute> _attributes;
         private readonly List<string> _aliases;
 
         public ModuleBuilder Module { get; }
@@ -22,6 +23,7 @@ namespace Discord.Commands.Builders
 
         public IReadOnlyList<PreconditionAttribute> Preconditions => _preconditions;
         public IReadOnlyList<ParameterBuilder> Parameters => _parameters;
+        public IReadOnlyList<Attribute> Attributes => _attributes;
         public IReadOnlyList<string> Aliases => _aliases;
 
         //Automatic
@@ -31,6 +33,7 @@ namespace Discord.Commands.Builders
 
             _preconditions = new List<PreconditionAttribute>();
             _parameters = new List<ParameterBuilder>();
+            _attributes = new List<Attribute>();
             _aliases = new List<string>();
         }
         //User-defined
@@ -78,6 +81,11 @@ namespace Discord.Commands.Builders
                 if (!_aliases.Contains(alias))
                     _aliases.Add(alias);
             }
+            return this;
+        }
+        public CommandBuilder AddAttributes(params Attribute[] attributes)
+        {
+            _attributes.AddRange(attributes);
             return this;
         }
         public CommandBuilder AddPrecondition(PreconditionAttribute precondition)

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -9,6 +9,7 @@ namespace Discord.Commands.Builders
         private readonly List<CommandBuilder> _commands;
         private readonly List<ModuleBuilder> _submodules;
         private readonly List<PreconditionAttribute> _preconditions;
+        private readonly List<Attribute> _attributes;
         private readonly List<string> _aliases;
 
         public CommandService Service { get; }
@@ -20,6 +21,7 @@ namespace Discord.Commands.Builders
         public IReadOnlyList<CommandBuilder> Commands => _commands;
         public IReadOnlyList<ModuleBuilder> Modules => _submodules;
         public IReadOnlyList<PreconditionAttribute> Preconditions => _preconditions;
+        public IReadOnlyList<Attribute> Attributes => _attributes;
         public IReadOnlyList<string> Aliases => _aliases;
 
         //Automatic
@@ -31,6 +33,7 @@ namespace Discord.Commands.Builders
             _commands = new List<CommandBuilder>();
             _submodules = new List<ModuleBuilder>();
             _preconditions = new List<PreconditionAttribute>();
+            _attributes = new List<Attribute>();
             _aliases = new List<string>();
         }
         //User-defined
@@ -66,6 +69,11 @@ namespace Discord.Commands.Builders
                 if (!_aliases.Contains(alias))
                     _aliases.Add(alias);
             }
+            return this;
+        }
+        public ModuleBuilder AddAttributes(params Attribute[] attributes)
+        {
+            _attributes.AddRange(attributes);
             return this;
         }
         public ModuleBuilder AddPrecondition(PreconditionAttribute precondition)

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -98,6 +98,8 @@ namespace Discord.Commands
                 }
                 else if (attribute is PreconditionAttribute)
                     builder.AddPrecondition(attribute as PreconditionAttribute);
+                else
+                    builder.AddAttributes(attribute);
             }
 
             //Check for unspecified info
@@ -143,6 +145,8 @@ namespace Discord.Commands
                     builder.AddAliases((attribute as AliasAttribute).Aliases);
                 else if (attribute is PreconditionAttribute)
                     builder.AddPrecondition(attribute as PreconditionAttribute);
+                else
+                    builder.AddAttributes(attribute);
             }
 
             if (builder.Name == null)


### PR DESCRIPTION
I still don't approve adding type info back into commands, so I decided to use this solution for allowing arbitrary attributes to be added to commands.