### PR TITLE
Allow arbitrary attributes to be added to commands

### DIFF
--- a/src/Discord.Net.Commands/Builders/CommandBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/CommandBuilder.cs
@@ -10,6 +10,7 @@ namespace Discord.Commands.Builders
     {
         private readonly List<PreconditionAttribute> _preconditions;
         private readonly List<ParameterBuilder> _parameters;
+        private readonly List<Attribute> _attributes;
         private readonly List<string> _aliases;
 
         public ModuleBuilder Module { get; }
@@ -24,6 +25,7 @@ namespace Discord.Commands.Builders
 
         public IReadOnlyList<PreconditionAttribute> Preconditions => _preconditions;
         public IReadOnlyList<ParameterBuilder> Parameters => _parameters;
+        public IReadOnlyList<Attribute> Attributes => _attributes;
         public IReadOnlyList<string> Aliases => _aliases;
 
         //Automatic
@@ -33,6 +35,7 @@ namespace Discord.Commands.Builders
 
             _preconditions = new List<PreconditionAttribute>();
             _parameters = new List<ParameterBuilder>();
+            _attributes = new List<Attribute>();
             _aliases = new List<string>();
         }
         //User-defined
@@ -81,6 +84,11 @@ namespace Discord.Commands.Builders
                 if (!_aliases.Contains(alias))
                     _aliases.Add(alias);
             }
+            return this;
+        }
+        public CommandBuilder AddAttributes(params Attribute[] attributes)
+        {
+            _attributes.AddRange(attributes);
             return this;
         }
         public CommandBuilder AddPrecondition(PreconditionAttribute precondition)

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -10,6 +10,7 @@ namespace Discord.Commands.Builders
         private readonly List<CommandBuilder> _commands;
         private readonly List<ModuleBuilder> _submodules;
         private readonly List<PreconditionAttribute> _preconditions;
+        private readonly List<Attribute> _attributes;
         private readonly List<string> _aliases;
 
         public CommandService Service { get; }
@@ -21,6 +22,7 @@ namespace Discord.Commands.Builders
         public IReadOnlyList<CommandBuilder> Commands => _commands;
         public IReadOnlyList<ModuleBuilder> Modules => _submodules;
         public IReadOnlyList<PreconditionAttribute> Preconditions => _preconditions;
+        public IReadOnlyList<Attribute> Attributes => _attributes;
         public IReadOnlyList<string> Aliases => _aliases;
 
         //Automatic
@@ -32,6 +34,7 @@ namespace Discord.Commands.Builders
             _commands = new List<CommandBuilder>();
             _submodules = new List<ModuleBuilder>();
             _preconditions = new List<PreconditionAttribute>();
+            _attributes = new List<Attribute>();
             _aliases = new List<string>();
         }
         //User-defined
@@ -67,6 +70,11 @@ namespace Discord.Commands.Builders
                 if (!_aliases.Contains(alias))
                     _aliases.Add(alias);
             }
+            return this;
+        }
+        public ModuleBuilder AddAttributes(params Attribute[] attributes)
+        {
+            _attributes.AddRange(attributes);
             return this;
         }
         public ModuleBuilder AddPrecondition(PreconditionAttribute precondition)

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -122,6 +122,9 @@ namespace Discord.Commands
                     case PreconditionAttribute precondition:
                         builder.AddPrecondition(precondition);
                         break;
+                    default:
+                        builder.AddAttributes(attribute);
+                        break;
                 }
             }
 
@@ -172,6 +175,9 @@ namespace Discord.Commands
                         break;
                     case PreconditionAttribute precondition:
                         builder.AddPrecondition(precondition);
+                        break;
+                    default:
+                        builder.AddAttributes(attribute);
                         break;
                 }
             }
@@ -240,6 +246,8 @@ namespace Discord.Commands
                         builder.IsRemainder = true;
                         break;
                 }
+                else
+                    builder.AddAttributes(attribute);
             }
 
             builder.ParameterType = paramType;

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -245,9 +245,10 @@ namespace Discord.Commands
 
                         builder.IsRemainder = true;
                         break;
+                    default:
+                        builder.AddAttributes(attribute);
+                        break;
                 }
-                else
-                    builder.AddAttributes(attribute);
             }
 
             builder.ParameterType = paramType;

--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -8,7 +8,8 @@ namespace Discord.Commands.Builders
 {
     public class ParameterBuilder
     {
-        private readonly List<ParameterPreconditionAttribute> _preconditions; 
+        private readonly List<ParameterPreconditionAttribute> _preconditions;
+        private readonly List<Attribute> _attributes;
 
         public CommandBuilder Command { get; }
         public string Name { get; internal set; }
@@ -22,11 +23,13 @@ namespace Discord.Commands.Builders
         public string Summary { get; set; }
 
         public IReadOnlyList<ParameterPreconditionAttribute> Preconditions => _preconditions;
+        public IReadOnlyList<Attribute> Attributes => _attributes;
 
         //Automatic
         internal ParameterBuilder(CommandBuilder command)
         {
             _preconditions = new List<ParameterPreconditionAttribute>();
+            _attributes = new List<Attribute>();
 
             Command = command;
         }
@@ -84,6 +87,11 @@ namespace Discord.Commands.Builders
             return this;
         }
 
+        public ParameterBuilder AddAttributes(params Attribute[] attributes)
+        {
+            _attributes.AddRange(attributes);
+            return this;
+        }
         public ParameterBuilder AddPrecondition(ParameterPreconditionAttribute precondition)
         {
             _preconditions.Add(precondition);

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -31,6 +31,7 @@ namespace Discord.Commands
         public IReadOnlyList<string> Aliases { get; }
         public IReadOnlyList<ParameterInfo> Parameters { get; }
         public IReadOnlyList<PreconditionAttribute> Preconditions { get; }
+        public IReadOnlyList<Attribute> Attributes { get; }
 
         internal CommandInfo(CommandBuilder builder, ModuleInfo module, CommandService service)
         {
@@ -57,6 +58,7 @@ namespace Discord.Commands
                 .ToImmutableArray();
 
             Preconditions = builder.Preconditions.ToImmutableArray();
+            Attributes = builder.Attributes.ToImmutableArray();
 
             Parameters = builder.Parameters.Select(x => x.Build(this)).ToImmutableArray();
             HasVarArgs = builder.Parameters.Count > 0 ? builder.Parameters[builder.Parameters.Count - 1].IsMultiple : false;

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -16,6 +16,7 @@ namespace Discord.Commands
         public IReadOnlyList<string> Aliases { get; }
         public IReadOnlyList<CommandInfo> Commands { get; }
         public IReadOnlyList<PreconditionAttribute> Preconditions { get; }
+        public IReadOnlyList<Attribute> Attributes { get; }
         public IReadOnlyList<ModuleInfo> Submodules { get; }
         public ModuleInfo Parent { get; }
         public bool IsSubmodule => Parent != null;
@@ -32,6 +33,7 @@ namespace Discord.Commands
             Aliases = BuildAliases(builder, service).ToImmutableArray();
             Commands = builder.Commands.Select(x => x.Build(this, service)).ToImmutableArray();
             Preconditions = BuildPreconditions(builder).ToImmutableArray();
+            Attributes = BuildAttributes(builder).ToImmutableArray();
 
             Submodules = BuildSubmodules(builder, service).ToImmutableArray();
         }
@@ -81,6 +83,20 @@ namespace Discord.Commands
             while (parent != null)
             {
                 result.AddRange(parent.Preconditions);
+                parent = parent.Parent;
+            }
+
+            return result;
+        }
+
+        private static List<Attribute> BuildAttributes(ModuleBuilder builder)
+        {
+            var result = new List<Attribute>();
+
+            ModuleBuilder parent = builder;
+            while (parent != null)
+            {
+                result.AddRange(parent.Attributes);
                 parent = parent.Parent;
             }
 

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -21,6 +21,7 @@ namespace Discord.Commands
         public object DefaultValue { get; }
 
         public IReadOnlyList<ParameterPreconditionAttribute> Preconditions { get; }
+        public IReadOnlyList<Attribute> Attributes { get; }
 
         internal ParameterInfo(ParameterBuilder builder, CommandInfo command, CommandService service)
         {
@@ -36,6 +37,7 @@ namespace Discord.Commands
             DefaultValue = builder.DefaultValue;
 
             Preconditions = builder.Preconditions.ToImmutableArray();
+            Attributes = builder.Attributes.ToImmutableArray();
 
             _reader = builder.TypeReader;
         }


### PR DESCRIPTION
I still don't approve adding type info back into commands, so I decided to use this solution for allowing arbitrary attributes to be added to commands.

This time I added all the files, and squashed into a single commit.