### PR TITLE
Resolve #446

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -118,6 +118,8 @@ namespace Discord.Rest
                 else
                     _reactions = ImmutableArray.Create<RestReaction>();
             }
+            else
+                _reactions = ImmutableArray.Create<RestReaction>();
 
             if (model.Content.IsSpecified)
             {


### PR DESCRIPTION
Fixes issue #446. 
Fixed RestUserMessage so that if there are no reactions it still initializes the array so _reactions.ToDictionary() on get Reactions does not create an exception.