### PR TITLE
Fixed guild member's joinedat reseting after certain events

### DIFF
--- a/src/Discord.Net.Rest/API/Common/GuildMember.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildMember.cs
@@ -13,7 +13,7 @@ namespace Discord.API
         [JsonProperty("roles")]
         public ulong[] Roles { get; set; }
         [JsonProperty("joined_at")]
-        public DateTimeOffset JoinedAt { get; set; }
+        public Optional<DateTimeOffset> JoinedAt { get; set; }
         [JsonProperty("deaf")]
         public bool Deaf { get; set; }
         [JsonProperty("mute")]

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -47,7 +47,8 @@ namespace Discord.Rest
         }
         internal void Update(Model model)
         {
-            _joinedAtTicks = model.JoinedAt.UtcTicks;
+            if (model.JoinedAt.IsSpecified)
+                _joinedAtTicks = model.JoinedAt.Value.UtcTicks;
             if (model.Nick.IsSpecified)
                 Nickname = model.Nick.Value;
             IsDeafened = model.Deaf;

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -80,7 +80,8 @@ namespace Discord.WebSocket
         internal void Update(ClientState state, Model model)
         {
             base.Update(state, model.User);
-            _joinedAtTicks = model.JoinedAt.UtcTicks;
+            if (model.JoinedAt.IsSpecified)
+                _joinedAtTicks = model.JoinedAt.Value.UtcTicks;
             if (model.Nick.IsSpecified)
                 Nickname = model.Nick.Value;
             UpdateRoles(model.Roles);


### PR DESCRIPTION
Changed `JoinedAt` to an optional field, fixing a bug where a guild member's joinedat would reset after certain events (namely GUILD_MEMBER_UPDATE).