### PR TITLE
Fixed users not being updated on PRESENCE_UPDATEs

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -40,6 +40,7 @@ namespace Discord.WebSocket
         internal virtual void Update(ClientState state, PresenceModel model)
         {
             Presence = SocketPresence.Create(model);
+            Update(state, model.User);
         }
 
         public Task<RestDMChannel> CreateDMChannelAsync(RequestOptions options = null)


### PR DESCRIPTION
Previously, the `user` object in the USER_PRESENCE events were not being used, leading to #407. Also fixes some of the problems in #272. 