### PR TITLE
Add NullableTypeReaders for ValueTypeReaders

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -43,8 +43,12 @@ namespace Discord.Commands
             _typeReaders = new ConcurrentDictionary<Type, ConcurrentDictionary<Type, TypeReader>>();
 
             _defaultTypeReaders = new ConcurrentDictionary<Type, TypeReader>();
-            foreach (var type in PrimitiveParsers.SupportedTypes)
+            foreach (Type type in PrimitiveParsers.SupportedTypes)
+            {
                 _defaultTypeReaders[type] = PrimitiveTypeReader.Create(type);
+                if (type.GetTypeInfo().IsValueType)
+                    _defaultTypeReaders[typeof(Nullable<>).MakeGenericType(type)] = NullableTypeReader.Create(type);
+            }
 
             var entityTypeReaders = ImmutableList.CreateBuilder<Tuple<Type, Type>>();
             entityTypeReaders.Add(new Tuple<Type, Type>(typeof(IMessage), typeof(MessageTypeReader<>)));

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -43,7 +43,7 @@ namespace Discord.Commands
             _typeReaders = new ConcurrentDictionary<Type, ConcurrentDictionary<Type, TypeReader>>();
 
             _defaultTypeReaders = new ConcurrentDictionary<Type, TypeReader>();
-            foreach (Type type in PrimitiveParsers.SupportedTypes)
+            foreach (var type in PrimitiveParsers.SupportedTypes)
             {
                 _defaultTypeReaders[type] = PrimitiveTypeReader.Create(type);
                 if (type.GetTypeInfo().IsValueType)

--- a/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Discord.Commands
+{
+    internal static class NullableTypeReader
+    {
+        public static TypeReader Create(Type type)
+        {
+            type = typeof(NullableTypeReader<>).MakeGenericType(type);
+            return Activator.CreateInstance(type) as TypeReader;
+        }
+    }
+
+    internal class NullableTypeReader<T> : TypeReader
+        where T : struct
+    {
+        private readonly TryParseDelegate<T> _tryParse;
+
+        public NullableTypeReader()
+        {
+            _tryParse = PrimitiveParsers.Get<T>();
+        }
+
+        public override Task<TypeReaderResult> Read(ICommandContext context, string input)
+        {
+            T value;
+            if (_tryParse(input, out value))
+                return Task.FromResult(TypeReaderResult.FromSuccess(new Nullable<T>(value)));
+            return Task.FromResult(TypeReaderResult.FromSuccess(new Nullable<T>()));
+        }
+    }
+}

--- a/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
@@ -24,10 +24,12 @@ namespace Discord.Commands
 
         public override Task<TypeReaderResult> Read(ICommandContext context, string input)
         {
+            if(input == null)
+                return Task.FromResult(TypeReaderResult.FromSuccess(new Nullable<T>()));
             T value;
             if (_tryParse(input, out value))
                 return Task.FromResult(TypeReaderResult.FromSuccess(new Nullable<T>(value)));
-            return Task.FromResult(TypeReaderResult.FromSuccess(new Nullable<T>()));
+            return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, $"Failed to parse {typeof(T).Name}"));
         }
     }
 }


### PR DESCRIPTION
From #480 

Someone can say that this "doesn't have any utility" but for me that's wrong. It probably doesn't have any utility for _you_ but it has for someone else (like me). And we should let people choose what they want to use.

And the library idea is to make everything easier to who's using it. The default CommandBuilder now does an awesome job, can't deny! But I think it could be better and this is a simple and small way of doing it.