### PR TITLE
Return CommandInfo at ExecuteResult

### DIFF
--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -99,13 +99,13 @@ namespace Discord.Commands
         public Task<ExecuteResult> ExecuteAsync(ICommandContext context, ParseResult parseResult, IDependencyMap map)
         {
             if (!parseResult.IsSuccess)
-                return Task.FromResult(ExecuteResult.FromError(parseResult));
+                return Task.FromResult(ExecuteResult.FromError(this, parseResult));
 
             var argList = new object[parseResult.ArgValues.Count];
             for (int i = 0; i < parseResult.ArgValues.Count; i++)
             {
                 if (!parseResult.ArgValues[i].IsSuccess)
-                    return Task.FromResult(ExecuteResult.FromError(parseResult.ArgValues[i]));
+                    return Task.FromResult(ExecuteResult.FromError(this, parseResult.ArgValues[i]));
                 argList[i] = parseResult.ArgValues[i].Values.First().Value;
             }
             
@@ -113,7 +113,7 @@ namespace Discord.Commands
             for (int i = 0; i < parseResult.ParamValues.Count; i++)
             {
                 if (!parseResult.ParamValues[i].IsSuccess)
-                    return Task.FromResult(ExecuteResult.FromError(parseResult.ParamValues[i]));
+                    return Task.FromResult(ExecuteResult.FromError(this, parseResult.ParamValues[i]));
                 paramList[i] = parseResult.ParamValues[i].Values.First().Value;
             }
 
@@ -132,7 +132,7 @@ namespace Discord.Commands
                 {
                     var result = await parameter.CheckPreconditionsAsync(context, args, map).ConfigureAwait(false);
                     if (!result.IsSuccess)
-                        return ExecuteResult.FromError(result);
+                        return ExecuteResult.FromError(this, result);
                 }
 
                 switch (RunMode)
@@ -147,11 +147,11 @@ namespace Discord.Commands
                         var t2 = Task.Run(() => _action(context, args, map));
                         break;
                 }
-                return ExecuteResult.FromSuccess();
+                return ExecuteResult.FromSuccess(this);
             }
             catch (Exception ex)
             {
-                return ExecuteResult.FromError(ex);
+                return ExecuteResult.FromError(this, ex);
             }
         }
 

--- a/src/Discord.Net.Commands/Results/ExecuteResult.cs
+++ b/src/Discord.Net.Commands/Results/ExecuteResult.cs
@@ -11,24 +11,35 @@ namespace Discord.Commands
         public CommandError? Error { get; }
         public string ErrorReason { get; }
 
+        public CommandInfo Command { get; }
+
         public bool IsSuccess => !Error.HasValue;
 
-        private ExecuteResult(Exception exception, CommandError? error, string errorReason)
+        private ExecuteResult(CommandInfo command, Exception exception, CommandError? error, string errorReason)
         {
+            Command = command;
             Exception = exception;
             Error = error;
             ErrorReason = errorReason;
         }
 
         public static ExecuteResult FromSuccess()
-            => new ExecuteResult(null, null, null);
+            => new ExecuteResult(null, null, null, null);
         public static ExecuteResult FromError(CommandError error, string reason)
-            => new ExecuteResult(null, error, reason);
+            => new ExecuteResult(null, null, error, reason);
         public static ExecuteResult FromError(Exception ex)
-            => new ExecuteResult(ex, CommandError.Exception, ex.Message);
+            => new ExecuteResult(null, ex, CommandError.Exception, ex.Message);
         public static ExecuteResult FromError(IResult result)
-            => new ExecuteResult(null, result.Error, result.ErrorReason);
-        
+            => new ExecuteResult(null, null, result.Error, result.ErrorReason);
+        public static ExecuteResult FromSuccess(CommandInfo command)
+            => new ExecuteResult(command, null, null, null);
+        public static ExecuteResult FromError(CommandInfo command, CommandError error, string reason)
+            => new ExecuteResult(command, null, error, reason);
+        public static ExecuteResult FromError(CommandInfo command, Exception ex)
+            => new ExecuteResult(command, ex, CommandError.Exception, ex.Message);
+        public static ExecuteResult FromError(CommandInfo command, IResult result)
+            => new ExecuteResult(command, null, result.Error, result.ErrorReason);
+
         public override string ToString() => IsSuccess ? "Success" : $"{Error}: {ErrorReason}";
         private string DebuggerDisplay => IsSuccess ? "Success" : $"{Error}: {ErrorReason}";
     }


### PR DESCRIPTION
It would help a lot if the ExecuteResult had the Command it was trying to execute, not just the reason why it failed or if it was successful.

One of the possibilites would be creating a custom error handler at your own CommandHandler without needing to redo what's already inside CommandService.ExecuterAsync or CommandInfo.ExecuteAsync.

So you at least know what command the ExecuteAsync was trying to execute (so you can get the parameters, summary, alias, etc of it).