### PR TITLE
Make the WS4Net provider target NETStandard

### DIFF
--- a/src/Discord.Net.Providers.WS4Net/Discord.Net.Providers.WS4Net.csproj
+++ b/src/Discord.Net.Providers.WS4Net/Discord.Net.Providers.WS4Net.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>An optional WebSocket client provider for Discord.Net using WebSocket4Net</Description>
     <VersionPrefix>1.0.0-rc</VersionPrefix>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Discord.Net.Providers.WS4Net</AssemblyName>
     <PackageTags>discord;discordapp</PackageTags>
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WebSocket4Net" Version="0.14.1" />
+    <PackageReference Include="WebSocket4Net" Version="0.15.0-beta6" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <NoWarn>$(NoWarn);CS1573;CS1591</NoWarn>

--- a/src/Discord.Net.Providers.WS4Net/project.json
+++ b/src/Discord.Net.Providers.WS4Net/project.json
@@ -29,10 +29,10 @@
     "Discord.Net.Core": {
       "target": "project"
     },
-    "WebSocket4Net": "0.14.1"
+    "WebSocket4Net": "0.15.0-beta6"
   },
 
   "frameworks": {
-    "net45": {}
+    "netstandard1.3": {}
   }
 }

--- a/src/Discord.Net.Providers.WS4Net/project.json
+++ b/src/Discord.Net.Providers.WS4Net/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-*",
+  "version": "1.1.0-*",
   "description": "An optional WebSocket client provider for Discord.Net using WebSocket4Net.",
   "authors": [ "RogueException", "foxbot" ],
 


### PR DESCRIPTION
I found out there's a beta version of WS4Net that works against NETStandard 1.3 now. This (*finally*) allows me to use WS4Net as a provider on Win7 and also target .NET Core which solves all the ref-def issues that come with trying to use Discord.Net *and* target full framework (because this lib demanded as such).