### PR TITLE
Fixed Format.Sanitize

### DIFF
--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -3,7 +3,7 @@
     public static class Format
     {
         // Characters which need escaping
-        private static string[] SensitiveCharacters = { "\\", "*", "_", "~", "`",  };
+        private static string[] SensitiveCharacters = { "\\", "*", "_", "~", "`" };
 
         /// <summary> Returns a markdown-formatted string with bold formatting. </summary>
         public static string Bold(string text) => $"**{text}**";

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -3,7 +3,7 @@
     public static class Format
     {
         // Characters which need escaping
-        private static string[] SensitiveCharacters = { "*", "_", "~", "`", "\\" };
+        private static string[] SensitiveCharacters = { "\\", "*", "_", "~", "`",  };
 
         /// <summary> Returns a markdown-formatted string with bold formatting. </summary>
         public static string Bold(string text) => $"**{text}**";


### PR DESCRIPTION
Because `\` is also a sensitive character and needs to be escaped, any other sensitive character will be escaped twice, e.g. `Format.Sanitize("test*test")` returns `test\\*test` instead `test\*test`. So escaping `\` first and then the other sensitive characters will fix this.