### PR TITLE
Add BeforeExecute/AfterExecute methods to ModuleBase

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -166,10 +166,12 @@ namespace Discord.Commands
                 instance.SetContext(ctx);
                 try
                 {
+                    instance.BeforeExecute();
                     return method.Invoke(instance, args) as Task ?? Task.Delay(0);
                 }
                 finally
                 {
+                    instance.AfterExecute();
                     (instance as IDisposable)?.Dispose();
                 }
             };

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -3,5 +3,9 @@
     internal interface IModuleBase
     {
         void SetContext(ICommandContext context);
+
+        void BeforeExecute();
+        
+        void AfterExecute();
     }
 }

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -15,6 +15,14 @@ namespace Discord.Commands
             return await Context.Channel.SendMessageAsync(message, isTTS, embed, options).ConfigureAwait(false);
         }
 
+        protected void BeforeExecute()
+        {
+        }
+
+        protected void AfterExecute()
+        {
+        }
+
         //IModuleBase
         void IModuleBase.SetContext(ICommandContext context)
         {
@@ -23,5 +31,9 @@ namespace Discord.Commands
                 throw new InvalidOperationException($"Invalid context type. Expected {typeof(T).Name}, got {context.GetType().Name}");
             Context = newValue;
         }
+
+        void IModuleBase.BeforeExecute() => BeforeExecute();
+
+        void IModuleBase.AfterExecute() => AfterExecute();
     }
 }

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -15,11 +15,11 @@ namespace Discord.Commands
             return await Context.Channel.SendMessageAsync(message, isTTS, embed, options).ConfigureAwait(false);
         }
 
-        protected void BeforeExecute()
+        protected virtual void BeforeExecute()
         {
         }
 
-        protected void AfterExecute()
+        protected virtual void AfterExecute()
         {
         }
 


### PR DESCRIPTION
After the feedback of the previous attempt, I decided to try again. I know that Volt would like to expose some other useful things later, but not having a `BeforeExecute()` method at all is a blocker for MpGame.