### PR TITLE
Fix ParameterInfo.Type sometimes being null

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -210,6 +210,8 @@ namespace Discord.Commands
                 }
             }
 
+            builder.ParameterType = paramType;
+
             if (builder.TypeReader == null)
             {
                 var readers = service.GetTypeReaders(paramType);
@@ -220,7 +222,6 @@ namespace Discord.Commands
                 else
                     reader = service.GetDefaultTypeReader(paramType);
 
-                builder.ParameterType = paramType;
                 builder.TypeReader = reader;
             }
         }


### PR DESCRIPTION
Fixes the case where when a parameter is marked with `[OverrideTypeReader]`, it results in the parameter's `.Type` being null.