### PR TITLE
IAudioClient additions

### DIFF
--- a/src/Discord.Net.Core/Audio/IAudioClient.cs
+++ b/src/Discord.Net.Core/Audio/IAudioClient.cs
@@ -5,14 +5,16 @@ namespace Discord.Audio
 {
     public interface IAudioClient : IDisposable
     {
-        event Func<Task> Connected;
-        event Func<Exception, Task> Disconnected;
+        event Func<IAudioClient, Task> Connected;
+        event Func<IAudioClient, Exception, Task> Disconnected;
         event Func<int, int, Task> LatencyUpdated;
         
         /// <summary> Gets the current connection state of this client. </summary>
         ConnectionState ConnectionState { get; }
         /// <summary> Gets the estimated round-trip latency, in milliseconds, to the gateway server. </summary>
         int Latency { get; }
+        /// <summary> Gets the Guild this client is in. </summary>
+        IGuild Guild { get; }
 
         Task DisconnectAsync();
 

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -515,7 +515,7 @@ namespace Discord.WebSocket
                 {
                     var audioClient = new AudioClient(this, id);
                     var promise = _audioConnectPromise;
-                    audioClient.Disconnected += async ex =>
+                    audioClient.Disconnected += async (client, ex) =>
                     {
                         //If the initial connection hasn't been made yet, reconnecting will lead to deadlocks
                         if (!promise.Task.IsCompleted)


### PR DESCRIPTION
I started looking a little bit into audio just to have an idea of how it works so I can help others, and it occurred to me that I can't get the instance that fired an event in a subscriber, nor the Guild that the IAudioClient is connected to.

Basically, I'd like the following to work:
```cs
private Task Connected(IAudioClient client)
{
    return Log($"Connected to voice in {client.Guild.Name}");
}

private Task Disconnected(IAudioClient client, Exception ex)
{
    //need to unsubscribe events otherwise the instances won't get GC'd
    client.Connected -= Connected;
    client.Disconected -= Disconnected;

    return Log($"Disconnected from voice in {client.Guild.Name}");
}
```