### PR TITLE
Fix issue with precondition checking

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -250,7 +250,7 @@ namespace Discord.Commands
                 var preconditionResult = await commands[i].CheckPreconditionsAsync(context, dependencyMap).ConfigureAwait(false);
                 if (!preconditionResult.IsSuccess)
                 {
-                    if (commands.Count == 1)
+                    if (i == 1)
                         return preconditionResult;
                     else
                         continue;


### PR DESCRIPTION
Previously `commands.Count` would never change, so by the current logic
it was never checking the last command.

Fixes: https://github.com/RogueException/Discord.Net/issues/514