### PR TITLE
Fix issue retrieving the most probable command from ExecuteAsync

### DIFF
--- a/src/Discord.Net.Commands/CommandMatch.cs
+++ b/src/Discord.Net.Commands/CommandMatch.cs
@@ -16,8 +16,8 @@ namespace Discord.Commands
 
         public Task<PreconditionResult> CheckPreconditionsAsync(ICommandContext context, IDependencyMap map = null)
             => Command.CheckPreconditionsAsync(context, map);
-        public Task<ParseResult> ParseAsync(ICommandContext context, SearchResult searchResult, PreconditionResult? preconditionResult = null)
-            => Command.ParseAsync(context, Alias.Length, searchResult, preconditionResult);
+        public Task<ParseResult> ParseAsync(ICommandContext context, SearchResult searchResult)
+            => Command.ParseAsync(context, Alias.Length, searchResult);
         public Task<ExecuteResult> ExecuteAsync(ICommandContext context, IEnumerable<object> argList, IEnumerable<object> paramList, IDependencyMap map)
             => Command.ExecuteAsync(context, argList, paramList, map);
         public Task<ExecuteResult> ExecuteAsync(ICommandContext context, ParseResult parseResult, IDependencyMap map)

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -254,7 +254,7 @@ namespace Discord.Commands
                 {
                     if (commands.Count == 1)
                         return preconditionResult;
-                    else if (secondOption != null) //we already got our last hope, so we can skip
+                    else if (secondOption != null) //we already got our second option, so we can skip
                         continue;
                 }
                 var parseResult = await commands[i].ParseAsync(context, searchResult).ConfigureAwait(false);
@@ -276,7 +276,7 @@ namespace Discord.Commands
                     {
                         if (commands.Count == 1)
                             return parseResult;
-                        else if (secondOption != null) //we already got our last hope, so we can skip
+                        else if (secondOption != null) //we already got our second option, so we can skip
                             continue;
                     }
                 }
@@ -288,7 +288,7 @@ namespace Discord.Commands
             }
 
             if (secondOption != null)
-                return secondOption;
+                return secondOption.Value;
             return SearchResult.FromError(CommandError.UnknownCommand, "This input does not match any overload.");
         }
     }

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -245,6 +245,7 @@ namespace Discord.Commands
             if (!searchResult.IsSuccess)
                 return searchResult;
 
+            PreconditionResult? secondOption = null;
             var commands = searchResult.Commands;
             for (int i = commands.Count - 1; i >= 0; i--)
             {
@@ -253,11 +254,10 @@ namespace Discord.Commands
                 {
                     if (commands.Count == 1)
                         return preconditionResult;
-                    else
+                    else if (secondOption != null) //we already got our last hope, so we can skip
                         continue;
                 }
-
-                var parseResult = await commands[i].ParseAsync(context, searchResult, preconditionResult).ConfigureAwait(false);
+                var parseResult = await commands[i].ParseAsync(context, searchResult).ConfigureAwait(false);
                 if (!parseResult.IsSuccess)
                 {
                     if (parseResult.Error == CommandError.MultipleMatches)
@@ -272,19 +272,23 @@ namespace Discord.Commands
                                 break;
                         }
                     }
-
                     if (!parseResult.IsSuccess)
                     {
                         if (commands.Count == 1)
                             return parseResult;
-                        else
+                        else if (secondOption != null) //we already got our last hope, so we can skip
                             continue;
                     }
                 }
 
-                return await commands[i].ExecuteAsync(context, parseResult, dependencyMap).ConfigureAwait(false);
+                if (parseResult.IsSuccess && preconditionResult.IsSuccess)
+                    return await commands[i].ExecuteAsync(context, parseResult, dependencyMap).ConfigureAwait(false); // Perfect match and highest priority
+                else if (secondOption == null && parseResult.IsSuccess)
+                    secondOption = preconditionResult; // It's a parse match, not perfect, but the highest priority
             }
 
+            if (secondOption != null)
+                return secondOption;
             return SearchResult.FromError(CommandError.UnknownCommand, "This input does not match any overload.");
         }
     }

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -85,13 +85,13 @@ namespace Discord.Commands
             return PreconditionResult.FromSuccess();
         }
         
-        public async Task<ParseResult> ParseAsync(ICommandContext context, int startIndex, SearchResult searchResult, PreconditionResult? preconditionResult = null)
+        public async Task<ParseResult> ParseAsync(ICommandContext context, int startIndex, SearchResult searchResult)
         {
-            if (!searchResult.IsSuccess)
+            if (!searchResult.IsSuccess)                                            // I think this should be removed too. Same reason as below.
                 return ParseResult.FromError(searchResult);
-            if (preconditionResult != null && !preconditionResult.Value.IsSuccess)
-                return ParseResult.FromError(preconditionResult.Value);
-            
+            //if (preconditionResult != null && !preconditionResult.Value.IsSuccess)    Why? It could be our last hope and some preconditions removed it?
+            //    return ParseResult.FromError(preconditionResult.Value);               Parse should parse, not check if the preconditions are okay, this is ExecuteAsync's job.
+
             string input = searchResult.Text.Substring(startIndex);
             return await CommandParser.ParseArgs(this, context, input, 0).ConfigureAwait(false);
         }


### PR DESCRIPTION
The main culprit is the `continue;` in the precondition check in the ExecuteAsync. It will ignore the parse, even with the possibility of it being the right command, just without the preconditions.
After changing the logic of the `else continue`, CommandInfo.ParseAsync will fail because the preconditions failed, even being the right command, so it was removed from the ParseAsync, so it'll at least try to parse it.

A second option was added, it'll will be the highest priority command with a successful parse.

The loop won't stop before reaching the end, so if it finds a perfect match that's not the second option, it'll return the perfect one, if not, the second option (that had the successful parse, highest priority, but missing preconditions).

Fixes #514 