### PR TITLE
Add Roles property to SocketGuildUser

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -33,8 +33,7 @@ namespace Discord.WebSocket
         public bool IsDeafened => VoiceState?.IsDeafened ?? false;
         public bool IsMuted => VoiceState?.IsMuted ?? false;
         public DateTimeOffset? JoinedAt => DateTimeUtils.FromTicks(_joinedAtTicks);
-        public IEnumerable<SocketRole> Roles => _roleIds.Select(id => Guild.GetRole(id));
-        public IReadOnlyCollection<ulong> RoleIds => _roleIds;
+        public IEnumerable<SocketRole> Roles => _roleIds.Select(id => Guild.GetRole(id)).ToReadOnlyCollection(() => _roleIds.Count());
         public SocketVoiceChannel VoiceChannel => VoiceState?.VoiceChannel;
         public string VoiceSessionId => VoiceState?.VoiceSessionId ?? "";
         public SocketVoiceState? VoiceState => Guild.GetVoiceState(Id);
@@ -117,7 +116,7 @@ namespace Discord.WebSocket
         //IGuildUser
         IGuild IGuildUser.Guild => Guild;
         ulong IGuildUser.GuildId => Guild.Id;
-        IReadOnlyCollection<ulong> IGuildUser.RoleIds => RoleIds;
+        IReadOnlyCollection<ulong> IGuildUser.RoleIds => _roleIds;
 
         //IUser
         Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options) 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Model = Discord.API.GuildMember;
 using PresenceModel = Discord.API.Presence;
@@ -32,6 +33,7 @@ namespace Discord.WebSocket
         public bool IsDeafened => VoiceState?.IsDeafened ?? false;
         public bool IsMuted => VoiceState?.IsMuted ?? false;
         public DateTimeOffset? JoinedAt => DateTimeUtils.FromTicks(_joinedAtTicks);
+        public IEnumerable<SocketRole> Roles => _roleIds.Select(id => Guild.GetRole(id));
         public IReadOnlyCollection<ulong> RoleIds => _roleIds;
         public SocketVoiceChannel VoiceChannel => VoiceState?.VoiceChannel;
         public string VoiceSessionId => VoiceState?.VoiceSessionId ?? "";


### PR DESCRIPTION
there's a few different ways to select a user's roles from their role IDs, and this one seems to be the most efficient.

doesn't seem like there's any reason this shouldn't be included.