### PR TITLE
Improve parameter precondition type safety

### DIFF
--- a/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
@@ -6,6 +6,6 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = true)]
     public abstract class ParameterPreconditionAttribute : Attribute
     {
-        public abstract Task<PreconditionResult> CheckPermissions<T>(ICommandContext context, ParameterInfo parameter, T value, IDependencyMap map);
+        public abstract Task<PreconditionResult> CheckPermissions(ICommandContext context, ParameterInfo parameter, object value, IDependencyMap map);
     }
 }

--- a/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
@@ -6,6 +6,6 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = true)]
     public abstract class ParameterPreconditionAttribute : Attribute
     {
-        public abstract Task<PreconditionResult> CheckPermissions(ICommandContext context, ParameterInfo parameter, object value, IDependencyMap map);
+        public abstract Task<PreconditionResult> CheckPermissions<T>(ICommandContext context, ParameterInfo parameter, T value, IDependencyMap map);
     }
 }

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -128,9 +128,11 @@ namespace Discord.Commands
             {
                 object[] args = GenerateArgs(argList, paramList);
 
-                foreach (var parameter in Parameters)
+                for (int position = 0; position < Parameters.Count; position++)
                 {
-                    var result = await parameter.CheckPreconditionsAsync(context, args, map).ConfigureAwait(false);
+                    var parameter = Parameters[position];
+                    var argument = args[position];
+                    var result = await parameter.CheckPreconditionsAsync(context, argument, map).ConfigureAwait(false);
                     if (!result.IsSuccess)
                         return ExecuteResult.FromError(result);
                 }

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -10,12 +10,7 @@ namespace Discord.Commands
 {
     public class ParameterInfo
     {
-
-        private static MethodInfo _checkPermissionsMethod = typeof(ParameterPreconditionAttribute)
-            .GetTypeInfo().GetDeclaredMethod("CheckPermissions");
-
         private readonly TypeReader _reader;
-        private readonly MethodInfo _specializedCheckPermissionsMethod;
 
         public CommandInfo Command { get; }
         public string Name { get; }
@@ -44,8 +39,6 @@ namespace Discord.Commands
             Preconditions = builder.Preconditions.ToImmutableArray();
 
             _reader = builder.TypeReader;
-
-            _specializedCheckPermissionsMethod = _checkPermissionsMethod.MakeGenericMethod(Type);
         }
 
         public async Task<PreconditionResult> CheckPreconditionsAsync(ICommandContext context, object arg, IDependencyMap map = null)
@@ -55,9 +48,7 @@ namespace Discord.Commands
 
             foreach (var precondition in Preconditions)
             {
-                object[] parameters = new []{ context, this, arg, map };
-                var resultTask = (_specializedCheckPermissionsMethod.Invoke(precondition, parameters) as Task<PreconditionResult>);
-                var result = await resultTask.ConfigureAwait(false);
+                var result = await precondition.CheckPermissions(context, this, arg, map).ConfigureAwait(false);
                 if (!result.IsSuccess)
                     return result;
             }


### PR DESCRIPTION
Also removes some terrible code which was left over when I first implemented parameter preconditions. I don't know why that was there.

With this commit, parameter preconditions should be much safer as they use generic methods instead of janky casting of objects.