### PR TITLE
Fix [Priority] behaving inverse to spec.

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -228,6 +228,8 @@ namespace Discord.Commands
         public SearchResult Search(ICommandContext context, string input)
         {
             string searchInput = _caseSensitive ? input : input.ToLowerInvariant();
+
+            // We sort by Ascending priority here because the collection is looped over backwards later.
             var matches = _map.GetCommands(searchInput).OrderBy(x => x.Command.Priority).ToImmutableArray();
 
             if (matches.Length > 0)

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -223,13 +223,13 @@ namespace Discord.Commands
         }
 
         //Execution
-        public SearchResult Search(ICommandContext context, int argPos) 
+        public SearchResult Search(ICommandContext context, int argPos)
             => Search(context, context.Message.Content.Substring(argPos));
         public SearchResult Search(ICommandContext context, string input)
         {
             string searchInput = _caseSensitive ? input : input.ToLowerInvariant();
-            var matches = _map.GetCommands(searchInput).OrderByDescending(x => x.Command.Priority).ToImmutableArray();
-            
+            var matches = _map.GetCommands(searchInput).OrderBy(x => x.Command.Priority).ToImmutableArray();
+
             if (matches.Length > 0)
                 return SearchResult.FromSuccess(input, matches);
             else


### PR DESCRIPTION
Because after command matches are sorted the `ExecuteAsync()` method goes through them backwards (for a tiny perf gain), command priorities behave inverse to what was originally spec'd for them. This fixes it without changing to a forwards `for` loop.