### PR TITLE
Added GetPrecondition<TPrecondition>() to ModuleInfo and CommandInfo

### DIFF
--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -63,6 +63,9 @@ namespace Discord.Commands
             _action = builder.Callback;
         }
 
+        public TPrecondition GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
+            Preconditions.FirstOrDefault(x => x is TPrecondition) as TPrecondition;
+
         public async Task<PreconditionResult> CheckPreconditionsAsync(ICommandContext context, IDependencyMap map = null)
         {
             if (map == null)

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -63,8 +63,8 @@ namespace Discord.Commands
             _action = builder.Callback;
         }
 
-        public TPrecondition GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
-            Preconditions.FirstOrDefault(x => x.GetType() == typeof(TPrecondition)) as TPrecondition;
+        public IEnumerable<TPrecondition> GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
+            Preconditions.Where(x => x.GetType() == typeof(TPrecondition)).Select(x => x as TPrecondition);
 
         public async Task<PreconditionResult> CheckPreconditionsAsync(ICommandContext context, IDependencyMap map = null)
         {

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -64,7 +64,7 @@ namespace Discord.Commands
         }
 
         public TPrecondition GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
-            Preconditions.FirstOrDefault(x => x is TPrecondition) as TPrecondition;
+            Preconditions.FirstOrDefault(x => x.GetType() == typeof(TPrecondition)) as TPrecondition;
 
         public async Task<PreconditionResult> CheckPreconditionsAsync(ICommandContext context, IDependencyMap map = null)
         {

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -63,8 +63,8 @@ namespace Discord.Commands
             _action = builder.Callback;
         }
 
-        public IEnumerable<TPrecondition> GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
-            Preconditions.Where(x => x.GetType() == typeof(TPrecondition)).Select(x => x as TPrecondition);
+        public IEnumerable<TPrecondition> GetPreconditions<TPrecondition>() where TPrecondition : PreconditionAttribute =>
+            Preconditions.Where(x => x.GetType() == typeof(TPrecondition)).Cast<TPrecondition>();
 
         public async Task<PreconditionResult> CheckPreconditionsAsync(ICommandContext context, IDependencyMap map = null)
         {

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -21,7 +21,7 @@ namespace Discord.Commands
         public bool IsSubmodule => Parent != null;
 
         public TPrecondition GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
-            Preconditions.FirstOrDefault(x => x is TPrecondition) as TPrecondition;
+            Preconditions.FirstOrDefault(x => x.GetType() == typeof(TPrecondition)) as TPrecondition;
 
         internal ModuleInfo(ModuleBuilder builder, CommandService service, ModuleInfo parent = null)
         {

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -20,8 +20,8 @@ namespace Discord.Commands
         public ModuleInfo Parent { get; }
         public bool IsSubmodule => Parent != null;
 
-        public TPrecondition GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
-            Preconditions.FirstOrDefault(x => x.GetType() == typeof(TPrecondition)) as TPrecondition;
+        public IEnumerable<TPrecondition> GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
+            Preconditions.Where(x => x.GetType() == typeof(TPrecondition)).Select(x => x as TPrecondition);
 
         internal ModuleInfo(ModuleBuilder builder, CommandService service, ModuleInfo parent = null)
         {

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -20,8 +20,8 @@ namespace Discord.Commands
         public ModuleInfo Parent { get; }
         public bool IsSubmodule => Parent != null;
 
-        public IEnumerable<TPrecondition> GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
-            Preconditions.Where(x => x.GetType() == typeof(TPrecondition)).Select(x => x as TPrecondition);
+        public IEnumerable<TPrecondition> GetPreconditions<TPrecondition>() where TPrecondition : PreconditionAttribute =>
+            Preconditions.Where(x => x.GetType() == typeof(TPrecondition)).Cast<TPrecondition>();
 
         internal ModuleInfo(ModuleBuilder builder, CommandService service, ModuleInfo parent = null)
         {

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -20,6 +20,9 @@ namespace Discord.Commands
         public ModuleInfo Parent { get; }
         public bool IsSubmodule => Parent != null;
 
+        public TPrecondition GetPrecondition<TPrecondition>() where TPrecondition : PreconditionAttribute =>
+            Preconditions.FirstOrDefault(x => x is TPrecondition) as TPrecondition;
+
         internal ModuleInfo(ModuleBuilder builder, CommandService service, ModuleInfo parent = null)
         {
             Service = service;


### PR DESCRIPTION
An easier way of getting Preconditions for modules and commands without having to use LINQ on `x.Preconditions` yourself.