### PR TITLE
UserTypeReader ArgumentNullException in DM

### DIFF
--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -60,12 +60,14 @@ namespace Discord.Commands
             {
                 foreach (var channelUser in channelUsers.Where(x => string.Equals(input, x.Username, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, channelUser as T, channelUser.Username == input ? 0.65f : 0.55f);
-
+                
+                if(context.Guild != null)
                 foreach (var guildUser in guildUsers.Where(x => string.Equals(input, x.Username, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, guildUser as T, guildUser.Username == input ? 0.60f : 0.50f);
             }
 
             //By Nickname (0.5-0.6)
+            if(context.Guild != null)
             {
                 foreach (var channelUser in channelUsers.Where(x => string.Equals(input, (x as IGuildUser).Nickname, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, channelUser as T, (channelUser as IGuildUser).Nickname == input ? 0.65f : 0.55f);

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -50,7 +50,7 @@ namespace Discord.Commands
                         string.Equals(username, x.Username, StringComparison.OrdinalIgnoreCase));
                     AddResult(results, channelUser as T, channelUser?.Username == username ? 0.85f : 0.75f);
 
-                    var guildUser = channelUsers.FirstOrDefault(x => x.DiscriminatorValue == discriminator &&
+                    var guildUser = guildUsers.FirstOrDefault(x => x.DiscriminatorValue == discriminator &&
                         string.Equals(username, x.Username, StringComparison.OrdinalIgnoreCase));
                     AddResult(results, guildUser as T, guildUser?.Username == username ? 0.80f : 0.70f);
                 }

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -61,13 +61,13 @@ namespace Discord.Commands
                 foreach (var channelUser in channelUsers.Where(x => string.Equals(input, x.Username, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, channelUser as T, channelUser.Username == input ? 0.65f : 0.55f);
                 
-                if(context.Guild != null)
+                if (context.Guild != null)
                 foreach (var guildUser in guildUsers.Where(x => string.Equals(input, x.Username, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, guildUser as T, guildUser.Username == input ? 0.60f : 0.50f);
             }
 
             //By Nickname (0.5-0.6)
-            if(context.Guild != null)
+            if (context.Guild != null)
             {
                 foreach (var channelUser in channelUsers.Where(x => string.Equals(input, (x as IGuildUser).Nickname, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, channelUser as T, (channelUser as IGuildUser).Nickname == input ? 0.65f : 0.55f);

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -14,7 +14,7 @@ namespace Discord.Commands
         {
             var results = new Dictionary<ulong, TypeReaderValue>();
             IReadOnlyCollection<IUser> channelUsers = (await context.Channel.GetUsersAsync(CacheMode.CacheOnly).Flatten().ConfigureAwait(false)).ToArray(); //TODO: must be a better way?
-            IReadOnlyCollection<IGuildUser> guildUsers = null;
+            IReadOnlyCollection<IGuildUser> guildUsers = ImmutableArray.Create<IGuildUser>();
             ulong id;
 
             if (context.Guild != null)
@@ -61,15 +61,13 @@ namespace Discord.Commands
                 foreach (var channelUser in channelUsers.Where(x => string.Equals(input, x.Username, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, channelUser as T, channelUser.Username == input ? 0.65f : 0.55f);
                 
-                if (context.Guild != null)
                 foreach (var guildUser in guildUsers.Where(x => string.Equals(input, x.Username, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, guildUser as T, guildUser.Username == input ? 0.60f : 0.50f);
             }
 
             //By Nickname (0.5-0.6)
-            if (context.Guild != null)
             {
-                foreach (var channelUser in channelUsers.Where(x => string.Equals(input, (x as IGuildUser).Nickname, StringComparison.OrdinalIgnoreCase)))
+                foreach (var channelUser in channelUsers.Where(x => string.Equals(input, (x as IGuildUser)?.Nickname, StringComparison.OrdinalIgnoreCase)))
                     AddResult(results, channelUser as T, (channelUser as IGuildUser).Nickname == input ? 0.65f : 0.55f);
 
                 foreach (var guildUser in guildUsers.Where(x => string.Equals(input, (x as IGuildUser).Nickname, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
Fixes #559

When you attempted to use the UserTypeReader in a DM channel, the TypeReader would attempt to use the Linq extension method Where on a null collection. The collection was null because it was a collection of Guild users, which in a DM would be null as it's checked before attempting to instantiate the collection.