### PR TITLE
Automatic animated avatar detection

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -8,11 +8,9 @@
         {
             if (avatarId == null)
                 return null;
-            var baseUrl = $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}";
             if (format == AvatarFormat.Auto)
-                return baseUrl + (avatarId.StartsWith("a_") ? "gif" : "png") + $"?size={size}";
-            else
-                return baseUrl + format.ToString().ToLower() + $"?size={size}";
+                format = avatarId.StartsWith("a_") ? AvatarFormat.Gif : AvatarFormat.Png;
+            return $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.{format.ToString().ToLower()}?size={size}";
         }
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -4,14 +4,15 @@
     {
         public static string GetApplicationIconUrl(ulong appId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}app-icons/{appId}/{iconId}.jpg" : null;
-        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size, AvatarFormat format) {
+        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size, AvatarFormat format)
+        {
             if (avatarId == null)
                 return null;
-            var base = $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}";
+            var baseUrl = $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}";
             if (format == AvatarFormat.Auto)
-                return base + (avatarId.StartsWith("a_") ? "gif" : "png") + $"?size={size}";
+                return baseUrl + (avatarId.StartsWith("a_") ? "gif" : "png") + $"?size={size}";
             else
-                return base + format.ToString().ToLower() + $"?size={size}";
+                return baseUrl + format.ToString().ToLower() + $"?size={size}";
         }
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -4,8 +4,15 @@
     {
         public static string GetApplicationIconUrl(ulong appId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}app-icons/{appId}/{iconId}.jpg" : null;
-        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size, AvatarFormat format)
-            => avatarId != null ? $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.{format.ToString().ToLower()}?size={size}" : null;
+        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size, AvatarFormat format) {
+            if (avatarId == null)
+                return null;
+            var base = $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}";
+            if (format == AvatarFormat.Auto)
+                return base + (avatarId.StartsWith("a_") ? "gif" : "png") + $"?size={size}";
+            else
+                return base + format.ToString().ToLower() + $"?size={size}";
+        }
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
         public static string GetGuildSplashUrl(ulong guildId, string splashId)

--- a/src/Discord.Net.Core/Entities/Users/AvatarFormat.cs
+++ b/src/Discord.Net.Core/Entities/Users/AvatarFormat.cs
@@ -2,6 +2,7 @@
 {
     public enum AvatarFormat
     {
+        Auto,
         WebP,
         Png,
         Jpeg,

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -7,7 +7,7 @@ namespace Discord
         /// <summary> Gets the id of this user's avatar. </summary>
         string AvatarId { get; }
         /// <summary> Gets the url to this user's avatar. </summary>
-        string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128);
+        string GetAvatarUrl(AvatarFormat format = AvatarFormat.Auto, ushort size = 128);
         /// <summary> Gets the per-username unique id for this user. </summary>
         string Discriminator { get; }
         /// <summary> Gets the per-username unique id for this user. </summary>

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -13,7 +13,7 @@ namespace Discord.Rest
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Auto, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);
@@ -41,7 +41,7 @@ namespace Discord.Rest
             if (model.Username.IsSpecified)
                 Username = model.Username.Value;
         }
-        
+
         public virtual async Task UpdateAsync(RequestOptions options = null)
         {
             var model = await Discord.ApiClient.GetUserAsync(Id, options).ConfigureAwait(false);

--- a/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
+++ b/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
@@ -14,7 +14,7 @@ namespace Discord.Rpc
         public ushort DiscriminatorValue { get; private set; }
         public string AvatarId { get; private set; }
 
-        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Auto, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -15,7 +15,7 @@ namespace Discord.WebSocket
         internal abstract SocketGlobalUser GlobalUser { get; }
         internal abstract SocketPresence Presence { get; set; }
 
-        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Png, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+        public string GetAvatarUrl(AvatarFormat format = AvatarFormat.Auto, ushort size = 128) => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
         public DateTimeOffset CreatedAt => DateTimeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);


### PR DESCRIPTION
Right now avatars are statically fetched depending on the parameter passed into GetAvatarUrl. This PR does the following:

* Adds a AvatarFormat.Auto option and makes it the default for all GetAvatarUrl implementations.
* When used, it determines the type of avatar using the "a_" prefix used to differentiate animated avatars to fetch gifs, otherwise it defaults to PNGs.

I have been getting complaints on how all avatars returned by this call have horrible artifacts due to the GIF format. This should resolve them.