### PR TITLE
Fires Ready event after Resumed dispatch message is done

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -519,6 +519,7 @@ namespace Discord.WebSocket
                                             await GuildAvailableAsync(guild).ConfigureAwait(false);
                                     }
 
+                                    await _readyEvent.InvokeAsync().ConfigureAwait(false);
                                     await _gatewayLogger.InfoAsync("Resumed previous session").ConfigureAwait(false);
                                 }
                                 break;


### PR DESCRIPTION
The Ready event isn't fired when the client recovers from being disconnected from Discord, this solves the gap between Connected and Ready for this case.