### PR TITLE
Add an upper limit to prune length when banning a user

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -65,8 +65,10 @@ namespace Discord
         /// <summary> Gets a collection of all users banned on this guild. </summary>
         Task<IReadOnlyCollection<IBan>> GetBansAsync(RequestOptions options = null);
         /// <summary> Bans the provided user from this guild and optionally prunes their recent messages. </summary>
+        /// <param name="pruneDays">The number of days to remove messages from this user for - must be between [0, 7]</param>
         Task AddBanAsync(IUser user, int pruneDays = 0, RequestOptions options = null);
         /// <summary> Bans the provided user id from this guild and optionally prunes their recent messages. </summary>
+        /// <param name="pruneDays">The number of days to remove messages from this user for - must be between [0, 7]</param>
         Task AddBanAsync(ulong userId, int pruneDays = 0, RequestOptions options = null);
         /// <summary> Unbans the provided user if it is currently banned. </summary>
         Task RemoveBanAsync(IUser user, RequestOptions options = null);

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -798,7 +798,8 @@ namespace Discord.API
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             Preconditions.NotEqual(userId, 0, nameof(userId));
             Preconditions.NotNull(args, nameof(args));
-            Preconditions.AtLeast(args.DeleteMessageDays, 0, nameof(args.DeleteMessageDays));
+            Preconditions.AtLeast(args.DeleteMessageDays, 0, nameof(args.DeleteMessageDays), "Prune length must be within [0, 7]");
+            Preconditions.AtMost(args.DeleteMessageDays, 7, nameof(args.DeleteMessageDays), "Prune length must be within [0, 7]");
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);


### PR DESCRIPTION
This is a non-breaking change.

Message pruning must be set to a value between zero and seven, otherwise Discord will throw a 400 back.