### PR TITLE
Made the default type readers publicly accessible 

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -193,7 +193,7 @@ namespace Discord.Commands
                 if (attribute is SummaryAttribute)
                     builder.Summary = (attribute as SummaryAttribute).Text;
                 else if (attribute is OverrideTypeReaderAttribute)
-                    builder.TypeReader = GetTypeReader(service, paramType, (attribute as OverrideTypeReaderAttribute).TypeReader);
+                    builder.TypeReader = GetCustomTypeReader(service, paramType, (attribute as OverrideTypeReaderAttribute).TypeReader);
                 else if (attribute is ParameterPreconditionAttribute)
                     builder.AddPrecondition(attribute as ParameterPreconditionAttribute);
                 else if (attribute is ParamArrayAttribute)
@@ -213,22 +213,14 @@ namespace Discord.Commands
             builder.ParameterType = paramType;
 
             if (builder.TypeReader == null)
-            {
-                var readers = service.GetTypeReaders(paramType);
-                TypeReader reader = null;
-
-                if (readers != null)
-                    reader = readers.FirstOrDefault().Value;
-                else
-                    reader = service.GetDefaultTypeReader(paramType);
-
-                builder.TypeReader = reader;
+            { 
+                builder.TypeReader = service.GetTypeReaders(paramType).FirstOrDefault().Value;
             }
         }
 
-        private static TypeReader GetTypeReader(CommandService service, Type paramType, Type typeReaderType)
+        private static TypeReader GetCustomTypeReader(CommandService service, Type paramType, Type typeReaderType)
         {
-            var readers = service.GetTypeReaders(paramType);
+            var readers = service.GetCustomTypeReaders(paramType);
             TypeReader reader = null;
             if (readers != null)
             {

--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -42,11 +42,7 @@ namespace Discord.Commands.Builders
 
         internal void SetType(Type type)
         {
-            var readers = Command.Module.Service.GetTypeReaders(type);
-            if (readers != null)
-                TypeReader = readers.FirstOrDefault().Value;
-            else
-                TypeReader = Command.Module.Service.GetDefaultTypeReader(type);
+            TypeReader = Command.Module.Service.GetTypeReaders(type).FirstOrDefault().Value;
 
             if (TypeReader == null)
                 throw new InvalidOperationException($"{type} does not have a TypeReader registered for it");            


### PR DESCRIPTION
Added method `public IDictionary<Type, TypeReader> CommandService.GetTypeReaders(Type type)` which gets all type readers for the given type, default readers included. This is intended to allow commands to use the built in type readers, rather than being restricted to the custom ones that can be added.

I also changed the naming of an existing method from `GetTypeReaders` to `GetCustomTypeReaders` and a private readonly variable from `_typeReaders` to `_customTypeReaders` to better fit what I understand their purpose to be with relation to the new function I added.