### PR TITLE
Remove wrong parameter from FFMPEG audio example

### DIFF
--- a/docs/guides/voice/samples/audio_ffmpeg.cs
+++ b/docs/guides/voice/samples/audio_ffmpeg.cs
@@ -3,7 +3,7 @@ private async Task SendAsync(IAudioClient client, string path)
     // Create FFmpeg using the previous example
     var ffmpeg = CreateStream(path);
     var output = ffmpeg.StandardOutput.BaseStream;
-    var discord = client.CreatePCMStream(AudioApplication.Mixed, 1920);
+    var discord = client.CreatePCMStream(AudioApplication.Mixed);
     await output.CopyToAsync(discord);
     await discord.FlushAsync();
 }


### PR DESCRIPTION
This parameter was samples per frame but changed to bitrate. (1920 is a way to low bitrate :) )