### PR TITLE
Remove IUser.CreateDMChannelAsync / Fix SocketGlobalUser.DMChannel

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -20,8 +20,6 @@ namespace Discord
         string Username { get; }
 
         /// <summary> Returns a private message channel to this user, creating one if it does not already exist. </summary>
-        Task<IDMChannel> GetDMChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
-        /// <summary> Returns a private message channel to this user, creating one if it does not already exist. </summary>
-        Task<IDMChannel> CreateDMChannelAsync(RequestOptions options = null);
+        Task<IDMChannel> GetDMChannelAsync(RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -20,6 +20,6 @@ namespace Discord
         string Username { get; }
 
         /// <summary> Returns a private message channel to this user, creating one if it does not already exist. </summary>
-        Task<IDMChannel> GetDMChannelAsync(RequestOptions options = null);
+        Task<IDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -54,7 +54,7 @@ namespace Discord.Rest
             Update(model);
         }
 
-        public Task<RestDMChannel> CreateDMChannelAsync(RequestOptions options = null)
+        public Task<RestDMChannel> GetDMChannelAsync(RequestOptions options = null)
             => UserHelper.CreateDMChannelAsync(this, Discord, options);
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
@@ -64,9 +64,7 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";
 
         //IUser
-        Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options)
-            => Task.FromResult<IDMChannel>(null);
-        async Task<IDMChannel> IUser.CreateDMChannelAsync(RequestOptions options)
-            => await CreateDMChannelAsync(options).ConfigureAwait(false);
+        async Task<IDMChannel> IUser.GetDMChannelAsync(RequestOptions options)
+            => await GetDMChannelAsync(options);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -54,7 +54,7 @@ namespace Discord.Rest
             Update(model);
         }
 
-        public Task<RestDMChannel> GetDMChannelAsync(RequestOptions options = null)
+        public Task<RestDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null)
             => UserHelper.CreateDMChannelAsync(this, Discord, options);
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
@@ -64,7 +64,7 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";
 
         //IUser
-        async Task<IDMChannel> IUser.GetDMChannelAsync(RequestOptions options)
-            => await GetDMChannelAsync(options);
+        async Task<IDMChannel> IUser.GetOrCreateDMChannelAsync(RequestOptions options)
+            => await GetOrCreateDMChannelAsync(options);
     }
 }

--- a/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
+++ b/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
@@ -49,7 +49,7 @@ namespace Discord.Rpc
                 Username = model.Username.Value;
         }
 
-        public Task<RestDMChannel> GetDMChannelAsync(RequestOptions options = null)
+        public Task<RestDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null)
             => UserHelper.CreateDMChannelAsync(this, Discord, options);
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
@@ -59,7 +59,7 @@ namespace Discord.Rpc
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";
 
         //IUser
-        async Task<IDMChannel> IUser.GetDMChannelAsync(RequestOptions options)
-            => await GetDMChannelAsync(options);
+        async Task<IDMChannel> IUser.GetOrCreateDMChannelAsync(RequestOptions options)
+            => await GetOrCreateDMChannelAsync(options);
     }
 }

--- a/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
+++ b/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
@@ -49,7 +49,7 @@ namespace Discord.Rpc
                 Username = model.Username.Value;
         }
 
-        public Task<RestDMChannel> CreateDMChannelAsync(RequestOptions options = null)
+        public Task<RestDMChannel> GetDMChannelAsync(RequestOptions options = null)
             => UserHelper.CreateDMChannelAsync(this, Discord, options);
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
@@ -59,9 +59,7 @@ namespace Discord.Rpc
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";
 
         //IUser
-        Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options)
-            => Task.FromResult<IDMChannel>(null);
-        async Task<IDMChannel> IUser.CreateDMChannelAsync(RequestOptions options)
-            => await CreateDMChannelAsync(options).ConfigureAwait(false);
+        async Task<IDMChannel> IUser.GetDMChannelAsync(RequestOptions options)
+            => await GetDMChannelAsync(options);
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1634,6 +1634,9 @@ namespace Discord.WebSocket
         {
             var channel = SocketChannel.CreatePrivate(this, state, model);
             state.AddChannel(channel as SocketChannel);
+            if (channel is SocketDMChannel dm)
+                dm.Recipient.GlobalUser.DMChannel = dm;
+
             return channel;
         }
         internal ISocketPrivateChannel RemovePrivateChannel(ulong id)
@@ -1641,6 +1644,9 @@ namespace Discord.WebSocket
             var channel = State.RemoveChannel(id) as ISocketPrivateChannel;
             if (channel != null)
             {
+                if (channel is SocketDMChannel dmChannel)
+                    dmChannel.Recipient.GlobalUser.DMChannel = null;
+
                 foreach (var recipient in channel.Recipients)
                     recipient.GlobalUser.RemoveRef(this);
             }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Linq;
 using Model = Discord.API.User;
 using PresenceModel = Discord.API.Presence;
 
@@ -51,6 +52,7 @@ namespace Discord.WebSocket
         internal void Update(ClientState state, PresenceModel model)
         {
             Presence = SocketPresence.Create(model);
+            DMChannel = state.DMChannels.FirstOrDefault(x => x.Recipient.Id == Id);
         }
         
         internal new SocketGlobalUser Clone() => MemberwiseClone() as SocketGlobalUser;

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -146,11 +146,7 @@ namespace Discord.WebSocket
         IGuild IGuildUser.Guild => Guild;
         ulong IGuildUser.GuildId => Guild.Id;
         IReadOnlyCollection<ulong> IGuildUser.RoleIds => _roleIds;
-
-        //IUser
-        Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options) 
-            => Task.FromResult<IDMChannel>(GlobalUser.DMChannel);
-
+        
         //IVoiceState
         IVoiceChannel IVoiceState.VoiceChannel => VoiceChannel;
     }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -55,7 +55,7 @@ namespace Discord.WebSocket
             return hasChanges;
         } 
 
-        public async Task<IDMChannel> GetDMChannelAsync(RequestOptions options = null)
+        public async Task<IDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null)
             => GlobalUser.DMChannel ?? await UserHelper.CreateDMChannelAsync(this, Discord, options) as IDMChannel;
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
@@ -64,9 +64,5 @@ namespace Discord.WebSocket
         public override string ToString() => $"{Username}#{Discriminator}";
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";
         internal SocketUser Clone() => MemberwiseClone() as SocketUser;
-
-        //IUser
-        Task<IDMChannel> IUser.GetDMChannelAsync(RequestOptions options)
-            => GetDMChannelAsync(options);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -53,10 +53,10 @@ namespace Discord.WebSocket
                 hasChanges = true;
             }
             return hasChanges;
-        }
+        } 
 
-        public Task<RestDMChannel> CreateDMChannelAsync(RequestOptions options = null)
-            => UserHelper.CreateDMChannelAsync(this, Discord, options);
+        public async Task<IDMChannel> GetDMChannelAsync(RequestOptions options = null)
+            => GlobalUser.DMChannel ?? await UserHelper.CreateDMChannelAsync(this, Discord, options) as IDMChannel;
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
@@ -66,9 +66,7 @@ namespace Discord.WebSocket
         internal SocketUser Clone() => MemberwiseClone() as SocketUser;
 
         //IUser
-        async Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options)
-            => await Task.FromResult<IDMChannel>(GlobalUser.DMChannel ?? await CreateDMChannelAsync(options) as IDMChannel);
-        async Task<IDMChannel> IUser.CreateDMChannelAsync(RequestOptions options)
-            => await CreateDMChannelAsync(options).ConfigureAwait(false);
+        Task<IDMChannel> IUser.GetDMChannelAsync(RequestOptions options)
+            => GetDMChannelAsync(options);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -66,8 +66,8 @@ namespace Discord.WebSocket
         internal SocketUser Clone() => MemberwiseClone() as SocketUser;
 
         //IUser
-        Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options)
-            => Task.FromResult<IDMChannel>(GlobalUser.DMChannel);
+        async Task<IDMChannel> IUser.GetDMChannelAsync(CacheMode mode, RequestOptions options)
+            => await Task.FromResult<IDMChannel>(GlobalUser.DMChannel ?? await CreateDMChannelAsync(options) as IDMChannel);
         async Task<IDMChannel> IUser.CreateDMChannelAsync(RequestOptions options)
             => await CreateDMChannelAsync(options).ConfigureAwait(false);
     }


### PR DESCRIPTION
**This is a breaking change.**
- `IUser.CreateDMChannelAsync()` has been removed per discussion on #657. 
- The method signature for `IUser.GetDMChannelAsync()` has been changed.