### PR TITLE
Include names in command builder exceptions

### DIFF
--- a/src/Discord.Net.Commands/Builders/CommandBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/CommandBuilder.cs
@@ -122,11 +122,11 @@ namespace Discord.Commands.Builders
 
                 var firstMultipleParam = _parameters.FirstOrDefault(x => x.IsMultiple);
                 if ((firstMultipleParam != null) && (firstMultipleParam != lastParam))
-                    throw new InvalidOperationException("Only the last parameter in a command may have the Multiple flag.");
+                    throw new InvalidOperationException($"Only the last parameter in a command may have the Multiple flag. Parameter: {firstMultipleParam.Name} in {PrimaryAlias}");
                 
                 var firstRemainderParam = _parameters.FirstOrDefault(x => x.IsRemainder);
                 if ((firstRemainderParam != null) && (firstRemainderParam != lastParam))
-                    throw new InvalidOperationException("Only the last parameter in a command may have the Remainder flag.");
+                    throw new InvalidOperationException($"Only the last parameter in a command may have the Remainder flag. Parameter: {firstRemainderParam.Name} in {PrimaryAlias}");
             }
 
             return new CommandInfo(this, info, service);

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -210,7 +210,7 @@ namespace Discord.Commands
                 else if (attribute is RemainderAttribute)
                 {
                     if (position != count-1)
-                        throw new InvalidOperationException("Remainder parameters must be the last parameter in a command.");
+                        throw new InvalidOperationException($"Remainder parameters must be the last parameter in a command. Parameter: {paramInfo.Name} in {paramInfo.Member.DeclaringType.Name}.{paramInfo.Member.Name}");
                     
                     builder.IsRemainder = true;
                 }

--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -49,7 +49,7 @@ namespace Discord.Commands.Builders
                 TypeReader = Command.Module.Service.GetDefaultTypeReader(type);
 
             if (TypeReader == null)
-                throw new InvalidOperationException($"{type} does not have a TypeReader registered for it");            
+                throw new InvalidOperationException($"{type} does not have a TypeReader registered for it. Parameter: {Name} in {Command.PrimaryAlias}");            
 
             if (type.GetTypeInfo().IsValueType)
                 DefaultValue = Activator.CreateInstance(type);


### PR DESCRIPTION
Another thing I forgot to PR after I committed: this adds the name of the failed command/parameter when an exception occurs during building commands.