### PR TITLE
Update commands with C#7 features

### DIFF
--- a/src/Discord.Net.Commands/Builders/CommandBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/CommandBuilder.cs
@@ -13,7 +13,7 @@ namespace Discord.Commands.Builders
         private readonly List<string> _aliases;
 
         public ModuleBuilder Module { get; }
-        internal Func<ICommandContext, object[], IServiceProvider, Task> Callback { get; set; }
+        internal Func<ICommandContext, object[], IServiceProvider, CommandInfo, Task> Callback { get; set; }
 
         public string Name { get; set; }
         public string Summary { get; set; }
@@ -36,7 +36,7 @@ namespace Discord.Commands.Builders
             _aliases = new List<string>();
         }
         //User-defined
-        internal CommandBuilder(ModuleBuilder module, string primaryAlias, Func<ICommandContext, object[], IServiceProvider, Task> callback)
+        internal CommandBuilder(ModuleBuilder module, string primaryAlias, Func<ICommandContext, object[], IServiceProvider, CommandInfo, Task> callback)
             : this(module)
         {
             Discord.Preconditions.NotNull(primaryAlias, nameof(primaryAlias));

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -74,7 +74,7 @@ namespace Discord.Commands.Builders
             _preconditions.Add(precondition);
             return this;
         }
-        public ModuleBuilder AddCommand(string primaryAlias, Func<ICommandContext, object[], IServiceProvider, Task> callback, Action<CommandBuilder> createFunc)
+        public ModuleBuilder AddCommand(string primaryAlias, Func<ICommandContext, object[], IServiceProvider, CommandInfo, Task> callback, Action<CommandBuilder> createFunc)
         {
             var builder = new CommandBuilder(this, primaryAlias, callback);
             createFunc(builder);

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -12,25 +12,42 @@ namespace Discord.Commands
     {
         private static readonly TypeInfo _moduleTypeInfo = typeof(IModuleBase).GetTypeInfo();
 
-        public static IEnumerable<TypeInfo> Search(Assembly assembly)
+        public static async Task<IReadOnlyList<TypeInfo>> SearchAsync(Assembly assembly, CommandService service)
         {
-            foreach (var type in assembly.ExportedTypes)
+            bool IsLoadableModule(TypeInfo info)
             {
-                var typeInfo = type.GetTypeInfo();
-                if (IsValidModuleDefinition(typeInfo) &&
-                    !typeInfo.IsDefined(typeof(DontAutoLoadAttribute)))
+                return info.DeclaredMethods.Any(x => x.GetCustomAttribute<CommandAttribute>() != null) &&
+                    info.GetCustomAttribute<DontAutoLoadAttribute>() == null;
+            }
+
+            List<TypeInfo> result = new List<TypeInfo>();
+
+            foreach (var typeInfo in assembly.DefinedTypes)
+            {
+                if (typeInfo.IsPublic)
                 {
-                    yield return typeInfo;
+                    if (IsValidModuleDefinition(typeInfo) &&
+                        !typeInfo.IsDefined(typeof(DontAutoLoadAttribute)))
+                    {
+                        result.Add(typeInfo);
+                    }
+                }
+                else if (IsLoadableModule(typeInfo))
+                {
+                    await service._cmdLogger.WarningAsync($"Class {typeInfo.FullName} is not public and cannot be loaded. To suppress this message, mark the class with {nameof(DontAutoLoadAttribute)}.");
                 }
             }
+
+            return result;
         }
 
-        public static Dictionary<Type, ModuleInfo> Build(CommandService service, params TypeInfo[] validTypes) => Build(validTypes, service);
-        public static Dictionary<Type, ModuleInfo> Build(IEnumerable<TypeInfo> validTypes, CommandService service)
+
+        public static Task<Dictionary<Type, ModuleInfo>> BuildAsync(CommandService service, params TypeInfo[] validTypes) => BuildAsync(validTypes, service);
+        public static async Task<Dictionary<Type, ModuleInfo>> BuildAsync(IEnumerable<TypeInfo> validTypes, CommandService service)
         {
             /*if (!validTypes.Any())
                 throw new InvalidOperationException("Could not find any valid modules from the given selection");*/
-            
+
             var topLevelGroups = validTypes.Where(x => x.DeclaringType == null);
             var subGroups = validTypes.Intersect(topLevelGroups);
 
@@ -48,9 +65,12 @@ namespace Discord.Commands
 
                 BuildModule(module, typeInfo, service);
                 BuildSubTypes(module, typeInfo.DeclaredNestedTypes, builtTypes, service);
+                builtTypes.Add(typeInfo);
 
                 result[typeInfo.AsType()] = module.Build(service);
             }
+
+            await service._cmdLogger.DebugAsync($"Successfully built and loaded {builtTypes.Count} modules.").ConfigureAwait(false);
 
             return result;
         }
@@ -128,26 +148,32 @@ namespace Discord.Commands
             
             foreach (var attribute in attributes)
             {
-                // TODO: C#7 type switch
-                if (attribute is CommandAttribute)
+                switch (attribute)
                 {
-                    var cmdAttr = attribute as CommandAttribute;
-                    builder.AddAliases(cmdAttr.Text);
-                    builder.RunMode = cmdAttr.RunMode;
-                    builder.Name = builder.Name ?? cmdAttr.Text;
+                    case CommandAttribute command:
+                        builder.AddAliases(command.Text);
+                        builder.RunMode = command.RunMode;
+                        builder.Name = builder.Name ?? command.Text;
+                        break;
+                    case NameAttribute name:
+                        builder.Name = name.Text;
+                        break;
+                    case PriorityAttribute priority:
+                        builder.Priority = priority.Priority;
+                        break;
+                    case SummaryAttribute summary:
+                        builder.Summary = summary.Text;
+                        break;
+                    case RemarksAttribute remarks:
+                        builder.Remarks = remarks.Text;
+                        break;
+                    case AliasAttribute alias:
+                        builder.AddAliases(alias.Aliases);
+                        break;
+                    case PreconditionAttribute precondition:
+                        builder.AddPrecondition(precondition);
+                        break;
                 }
-                else if (attribute is NameAttribute)
-                    builder.Name = (attribute as NameAttribute).Text;
-                else if (attribute is PriorityAttribute)
-                    builder.Priority = (attribute as PriorityAttribute).Priority;
-                else if (attribute is SummaryAttribute)
-                    builder.Summary = (attribute as SummaryAttribute).Text;
-                else if (attribute is RemarksAttribute)
-                    builder.Remarks = (attribute as RemarksAttribute).Text;
-                else if (attribute is AliasAttribute)
-                    builder.AddAliases((attribute as AliasAttribute).Aliases);
-                else if (attribute is PreconditionAttribute)
-                    builder.AddPrecondition(attribute as PreconditionAttribute);
             }
 
             if (builder.Name == null)
@@ -165,19 +191,19 @@ namespace Discord.Commands
 
             var createInstance = ReflectionUtils.CreateBuilder<IModuleBase>(typeInfo, service);
 
-            builder.Callback = async (ctx, args, map) => 
+            builder.Callback = async (ctx, args, map, cmd) => 
             {
                 var instance = createInstance(map);
                 instance.SetContext(ctx);
                 try
                 {
-                    instance.BeforeExecute();
+                    instance.BeforeExecute(cmd);
                     var task = method.Invoke(instance, args) as Task ?? Task.Delay(0);
                     await task.ConfigureAwait(false);
                 }
                 finally
                 {
-                    instance.AfterExecute();
+                    instance.AfterExecute(cmd);
                     (instance as IDisposable)?.Dispose();
                 }
             };
@@ -195,24 +221,24 @@ namespace Discord.Commands
 
             foreach (var attribute in attributes)
             {
-                // TODO: C#7 type switch
-                if (attribute is SummaryAttribute)
-                    builder.Summary = (attribute as SummaryAttribute).Text;
-                else if (attribute is OverrideTypeReaderAttribute)
-                    builder.TypeReader = GetTypeReader(service, paramType, (attribute as OverrideTypeReaderAttribute).TypeReader);
-                else if (attribute is ParameterPreconditionAttribute)
-                    builder.AddPrecondition(attribute as ParameterPreconditionAttribute);
-                else if (attribute is ParamArrayAttribute)
+                switch (attribute)
                 {
-                    builder.IsMultiple = true;
-                    paramType = paramType.GetElementType();
-                }
-                else if (attribute is RemainderAttribute)
-                {
-                    if (position != count-1)
-                        throw new InvalidOperationException($"Remainder parameters must be the last parameter in a command. Parameter: {paramInfo.Name} in {paramInfo.Member.DeclaringType.Name}.{paramInfo.Member.Name}");
-                    
-                    builder.IsRemainder = true;
+                    case SummaryAttribute summary:
+                        builder.Summary = summary.Text;
+                        break;
+                    case OverrideTypeReaderAttribute typeReader:
+                        builder.TypeReader = GetTypeReader(service, paramType, typeReader.TypeReader);
+                        break;
+                    case ParamArrayAttribute _:
+                        builder.IsMultiple = true;
+                        paramType = paramType.GetElementType();
+                        break;
+                    case RemainderAttribute _:
+                        if (position != count - 1)
+                            throw new InvalidOperationException($"Remainder parameters must be the last parameter in a command. Parameter: {paramInfo.Name} in {paramInfo.Member.DeclaringType.Name}.{paramInfo.Member.Name}");
+
+                        builder.IsRemainder = true;
+                        break;
                 }
             }
 

--- a/src/Discord.Net.Commands/CommandMatch.cs
+++ b/src/Discord.Net.Commands/CommandMatch.cs
@@ -18,8 +18,8 @@ namespace Discord.Commands
 
         public Task<PreconditionResult> CheckPreconditionsAsync(ICommandContext context, IServiceProvider services = null)
             => Command.CheckPreconditionsAsync(context, services);
-        public Task<ParseResult> ParseAsync(ICommandContext context, SearchResult searchResult, PreconditionResult preconditionResult = null)
-            => Command.ParseAsync(context, Alias.Length, searchResult, preconditionResult);
+        public Task<ParseResult> ParseAsync(ICommandContext context, SearchResult searchResult, PreconditionResult preconditionResult = null, IServiceProvider services = null)
+            => Command.ParseAsync(context, Alias.Length, searchResult, preconditionResult, services);
         public Task<ExecuteResult> ExecuteAsync(ICommandContext context, IEnumerable<object> argList, IEnumerable<object> paramList, IServiceProvider services)
             => Command.ExecuteAsync(context, argList, paramList, services);
         public Task<ExecuteResult> ExecuteAsync(ICommandContext context, ParseResult parseResult, IServiceProvider services)

--- a/src/Discord.Net.Commands/CommandParser.cs
+++ b/src/Discord.Net.Commands/CommandParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -13,7 +14,7 @@ namespace Discord.Commands
             QuotedParameter
         }
         
-        public static async Task<ParseResult> ParseArgs(CommandInfo command, ICommandContext context, string input, int startPos)
+        public static async Task<ParseResult> ParseArgs(CommandInfo command, ICommandContext context, IServiceProvider services, string input, int startPos)
         {
             ParameterInfo curParam = null;
             StringBuilder argBuilder = new StringBuilder(input.Length);
@@ -110,7 +111,7 @@ namespace Discord.Commands
                     if (curParam == null)
                         return ParseResult.FromError(CommandError.BadArgCount, "The input text has too many parameters.");
 
-                    var typeReaderResult = await curParam.Parse(context, argString).ConfigureAwait(false);
+                    var typeReaderResult = await curParam.Parse(context, argString, services).ConfigureAwait(false);
                     if (!typeReaderResult.IsSuccess && typeReaderResult.Error != CommandError.MultipleMatches)
                         return ParseResult.FromError(typeReaderResult);
 
@@ -133,7 +134,7 @@ namespace Discord.Commands
 
             if (curParam != null && curParam.IsRemainder)
             {
-                var typeReaderResult = await curParam.Parse(context, argBuilder.ToString()).ConfigureAwait(false);
+                var typeReaderResult = await curParam.Parse(context, argBuilder.ToString(), services).ConfigureAwait(false);
                 if (!typeReaderResult.IsSuccess)
                     return ParseResult.FromError(typeReaderResult);
                 argList.Add(typeReaderResult);

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -309,7 +309,8 @@ namespace Discord.Commands
                 var argValuesScore = parseResult.ArgValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
                 var paramValuesScore = parseResult.ParamValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
 
-                return match.Command.Priority + argValuesScore + paramValuesScore;
+                var totalArgsScore = (argValuesScore + paramValuesScore) / 2;
+                return match.Command.Priority + totalArgsScore * 0.99f;
             }
 
             //Order the parse results by their score so that we choose the most likely result to execute

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -281,7 +281,7 @@ namespace Discord.Commands
 
             //If we get this far, at least one precondition was successful.
 
-            var parseResults = new Dictionary<CommandMatch, ParseResult>();
+            var parseResultsDict = new Dictionary<CommandMatch, ParseResult>();
             foreach (var pair in successfulPreconditions)
             {
                 var parseResult = await pair.Key.ParseAsync(context, searchResult, pair.Value, services).ConfigureAwait(false);
@@ -299,7 +299,7 @@ namespace Discord.Commands
                     }
                 }
 
-                parseResults[pair.Key] = parseResult;
+                parseResultsDict[pair.Key] = parseResult;
             }
 
             // Calculates the 'score' of a command given a parse result
@@ -313,9 +313,11 @@ namespace Discord.Commands
             }
 
             //Order the parse results by their score so that we choose the most likely result to execute
+            var parseResults = parseResultsDict
+                .OrderByDescending(x => CalculateScore(x.Key, x.Value));
+
             var successfulParses = parseResults
                 .Where(x => x.Value.IsSuccess)
-                .OrderByDescending(x => CalculateScore(x.Key, x.Value))
                 .ToArray();
 
             if (successfulParses.Length == 0)

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -267,7 +267,7 @@ namespace Discord.Commands
                         continue;
                 }
 
-                var parseResult = await commands[i].ParseAsync(context, searchResult, preconditionResult).ConfigureAwait(false);
+                var parseResult = await commands[i].ParseAsync(context, searchResult, preconditionResult, services).ConfigureAwait(false);
                 if (!parseResult.IsSuccess)
                 {
                     if (parseResult.Error == CommandError.MultipleMatches)

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -33,7 +33,7 @@ namespace Discord.Commands
 
         public IEnumerable<ModuleInfo> Modules => _moduleDefs.Select(x => x);
         public IEnumerable<CommandInfo> Commands => _moduleDefs.SelectMany(x => x.Commands);
-        public ILookup<Type, TypeReader> TypeReaders => _typeReaders.SelectMany(x => x.Value.Select(y => new {y.Key, y.Value})).ToLookup(x => x.Key, x => x.Value);
+        public ILookup<Type, TypeReader> TypeReaders => _typeReaders.SelectMany(x => x.Value.Select(y => new { y.Key, y.Value })).ToLookup(x => x.Key, x => x.Value);
 
         public CommandService() : this(new CommandServiceConfig()) { }
         public CommandService(CommandServiceConfig config)
@@ -58,6 +58,9 @@ namespace Discord.Commands
             _defaultTypeReaders = new ConcurrentDictionary<Type, TypeReader>();
             foreach (var type in PrimitiveParsers.SupportedTypes)
                 _defaultTypeReaders[type] = PrimitiveTypeReader.Create(type);
+
+            _defaultTypeReaders[typeof(string)] =
+                new PrimitiveTypeReader<string>((string x, out string y) => { y = x; return true; }, 0);
 
             var entityTypeReaders = ImmutableList.CreateBuilder<Tuple<Type, Type>>();
             entityTypeReaders.Add(new Tuple<Type, Type>(typeof(IMessage), typeof(MessageTypeReader<>)));
@@ -195,7 +198,7 @@ namespace Discord.Commands
         }
         public void AddTypeReader(Type type, TypeReader reader)
         {
-            var readers = _typeReaders.GetOrAdd(type, x=> new ConcurrentDictionary<Type, TypeReader>());
+            var readers = _typeReaders.GetOrAdd(type, x => new ConcurrentDictionary<Type, TypeReader>());
             readers[reader.GetType()] = reader;
         }
         internal IDictionary<Type, TypeReader> GetTypeReaders(Type type)
@@ -232,13 +235,13 @@ namespace Discord.Commands
         }
 
         //Execution
-        public SearchResult Search(ICommandContext context, int argPos) 
+        public SearchResult Search(ICommandContext context, int argPos)
             => Search(context, context.Message.Content.Substring(argPos));
         public SearchResult Search(ICommandContext context, string input)
         {
             string searchInput = _caseSensitive ? input : input.ToLowerInvariant();
             var matches = _map.GetCommands(searchInput).OrderByDescending(x => x.Command.Priority).ToImmutableArray();
-            
+
             if (matches.Length > 0)
                 return SearchResult.FromSuccess(input, matches);
             else
@@ -255,47 +258,85 @@ namespace Discord.Commands
             if (!searchResult.IsSuccess)
                 return searchResult;
 
+            //Group commands by their alias
             var commands = searchResult.Commands;
-            for (int i = 0; i < commands.Count; i++)
+            var preconditionResults = new Dictionary<CommandMatch, PreconditionResult>();
+
+            foreach (var match in commands)
             {
-                var preconditionResult = await commands[i].CheckPreconditionsAsync(context, services).ConfigureAwait(false);
-                if (!preconditionResult.IsSuccess)
-                {
-                    if (commands.Count == 1)
-                        return preconditionResult;
-                    else
-                        continue;
-                }
-
-                var parseResult = await commands[i].ParseAsync(context, searchResult, preconditionResult, services).ConfigureAwait(false);
-                if (!parseResult.IsSuccess)
-                {
-                    if (parseResult.Error == CommandError.MultipleMatches)
-                    {
-                        IReadOnlyList<TypeReaderValue> argList, paramList;
-                        switch (multiMatchHandling)
-                        {
-                            case MultiMatchHandling.Best:
-                                argList = parseResult.ArgValues.Select(x => x.Values.OrderByDescending(y => y.Score).First()).ToImmutableArray();
-                                paramList = parseResult.ParamValues.Select(x => x.Values.OrderByDescending(y => y.Score).First()).ToImmutableArray();
-                                parseResult = ParseResult.FromSuccess(argList, paramList);
-                                break;
-                        }
-                    }
-
-                    if (!parseResult.IsSuccess)
-                    {
-                        if (commands.Count == 1)
-                            return parseResult;
-                        else
-                            continue;
-                    }
-                }
-
-                return await commands[i].ExecuteAsync(context, parseResult, services).ConfigureAwait(false);
+                preconditionResults[match] = await match.Command.CheckPreconditionsAsync(context, services).ConfigureAwait(false);
             }
 
-            return SearchResult.FromError(CommandError.UnknownCommand, "This input does not match any overload.");
+            var successfulPreconditions = preconditionResults
+                .Where(x => x.Value.IsSuccess)
+                .ToArray();
+
+            if (successfulPreconditions.Length == 0)
+            {
+                //All preconditions failed, return the one from the highest priority command
+                var bestCandidate = preconditionResults
+                    .OrderByDescending(x => x.Key.Command.Priority)
+                    .FirstOrDefault(x => !x.Value.IsSuccess);
+                return bestCandidate.Value;
+            }
+
+            //If we get this far, at least one precondition was successful.
+
+            var parseResults = new Dictionary<CommandMatch, ParseResult>();
+            foreach (var pair in successfulPreconditions)
+            {
+                var parseResult = await pair.Key.ParseAsync(context, searchResult, pair.Value, services).ConfigureAwait(false);
+
+                if (parseResult.Error == CommandError.MultipleMatches)
+                {
+                    IReadOnlyList<TypeReaderValue> argList, paramList;
+                    switch (multiMatchHandling)
+                    {
+                        case MultiMatchHandling.Best:
+                            argList = parseResult.ArgValues.Select(x => x.Values.OrderByDescending(y => y.Score).First()).ToImmutableArray();
+                            paramList = parseResult.ParamValues.Select(x => x.Values.OrderByDescending(y => y.Score).First()).ToImmutableArray();
+                            parseResult = ParseResult.FromSuccess(argList, paramList);
+                            break;
+                    }
+                }
+
+                parseResults[pair.Key] = parseResult;
+            }
+
+            // Calculates the 'score' of a command given a parse result
+            float CalculateScore(CommandMatch match, ParseResult parseResult)
+            {
+                //TODO: is this calculation correct?
+                var argValuesScore = parseResult.ArgValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score);
+                var paramValuesScore = parseResult.ParamValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score);
+
+                /* Since argValuesScore and paramValuesScore are in the range [0, numOfParams]
+                 * we multiply the priority by the number of parameters plus one, so that it is
+                 * always the most important value.
+                 */
+                var priorityScore = match.Command.Priority * (match.Command.Parameters.Count + 1);
+
+                return priorityScore + argValuesScore + paramValuesScore;
+            }
+
+            //Order the parse results by their score so that we choose the most likely result to execute
+            var successfulParses = parseResults
+                .Where(x => x.Value.IsSuccess)
+                .OrderByDescending(x => CalculateScore(x.Key, x.Value))
+                .ToArray();
+
+            if (successfulParses.Length == 0)
+            {
+                //All parses failed, return the one from the highest priority command, using score as a tie breaker
+
+                var bestMatch = parseResults
+                    .FirstOrDefault(x => !x.Value.IsSuccess);
+                return bestMatch.Value;
+            }
+
+            //If we get this far, at least one parse was successful. Execute the most likely overload.
+            var chosenOverload = successfulParses[0];
+            return await chosenOverload.Key.ExecuteAsync(context, chosenOverload.Value, services).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -305,9 +305,13 @@ namespace Discord.Commands
             // Calculates the 'score' of a command given a parse result
             float CalculateScore(CommandMatch match, ParseResult parseResult)
             {
-                //TODO: is this calculation correct?
-                var argValuesScore = parseResult.ArgValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
-                var paramValuesScore = parseResult.ParamValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
+                float argValuesScore = 0, paramValuesScore = 0;
+                
+                if (match.Command.Parameters.Count > 0)
+                {
+                    argValuesScore = parseResult.ArgValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
+                    paramValuesScore = parseResult.ParamValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
+                }
 
                 var totalArgsScore = (argValuesScore + paramValuesScore) / 2;
                 return match.Command.Priority + totalArgsScore * 0.99f;

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -258,7 +258,6 @@ namespace Discord.Commands
             if (!searchResult.IsSuccess)
                 return searchResult;
 
-            //Group commands by their alias
             var commands = searchResult.Commands;
             var preconditionResults = new Dictionary<CommandMatch, PreconditionResult>();
 
@@ -307,16 +306,10 @@ namespace Discord.Commands
             float CalculateScore(CommandMatch match, ParseResult parseResult)
             {
                 //TODO: is this calculation correct?
-                var argValuesScore = parseResult.ArgValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score);
-                var paramValuesScore = parseResult.ParamValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score);
+                var argValuesScore = parseResult.ArgValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
+                var paramValuesScore = parseResult.ParamValues.Sum(x => x.Values.OrderByDescending(y => y.Score).FirstOrDefault().Score) / match.Command.Parameters.Count;
 
-                /* Since argValuesScore and paramValuesScore are in the range [0, numOfParams]
-                 * we multiply the priority by the number of parameters plus one, so that it is
-                 * always the most important value.
-                 */
-                var priorityScore = match.Command.Priority * (match.Command.Parameters.Count + 1);
-
-                return priorityScore + argValuesScore + paramValuesScore;
+                return match.Command.Priority + argValuesScore + paramValuesScore;
             }
 
             //Order the parse results by their score so that we choose the most likely result to execute
@@ -328,7 +321,6 @@ namespace Discord.Commands
             if (successfulParses.Length == 0)
             {
                 //All parses failed, return the one from the highest priority command, using score as a tie breaker
-
                 var bestMatch = parseResults
                     .FirstOrDefault(x => !x.Value.IsSuccess);
                 return bestMatch.Value;

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -4,8 +4,8 @@
     {
         void SetContext(ICommandContext context);
 
-        void BeforeExecute();
+        void BeforeExecute(CommandInfo command);
         
-        void AfterExecute();
+        void AfterExecute(CommandInfo command);
     }
 }

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -105,15 +105,17 @@ namespace Discord.Commands
             return PreconditionResult.FromSuccess();
         }
         
-        public async Task<ParseResult> ParseAsync(ICommandContext context, int startIndex, SearchResult searchResult, PreconditionResult preconditionResult = null)
+        public async Task<ParseResult> ParseAsync(ICommandContext context, int startIndex, SearchResult searchResult, PreconditionResult preconditionResult = null, IServiceProvider services = null)
         {
+            services = services ?? EmptyServiceProvider.Instance;
+
             if (!searchResult.IsSuccess)
                 return ParseResult.FromError(searchResult);
             if (preconditionResult != null && !preconditionResult.IsSuccess)
                 return ParseResult.FromError(preconditionResult);
             
             string input = searchResult.Text.Substring(startIndex);
-            return await CommandParser.ParseArgs(this, context, input, 0).ConfigureAwait(false);
+            return await CommandParser.ParseArgs(this, context, services, input, 0).ConfigureAwait(false);
         }
 
         public Task<ExecuteResult> ExecuteAsync(ICommandContext context, ParseResult parseResult, IServiceProvider services)

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -18,7 +18,7 @@ namespace Discord.Commands
         private static readonly System.Reflection.MethodInfo _convertParamsMethod = typeof(CommandInfo).GetTypeInfo().GetDeclaredMethod(nameof(ConvertParamsList));
         private static readonly ConcurrentDictionary<Type, Func<IEnumerable<object>, object>> _arrayConverters = new ConcurrentDictionary<Type, Func<IEnumerable<object>, object>>();
 
-        private readonly Func<ICommandContext, object[], IServiceProvider, Task> _action;
+        private readonly Func<ICommandContext, object[], IServiceProvider, CommandInfo, Task> _action;
 
         public ModuleInfo Module { get; }
         public string Name { get; }
@@ -181,7 +181,7 @@ namespace Discord.Commands
             await Module.Service._cmdLogger.DebugAsync($"Executing {GetLogText(context)}").ConfigureAwait(false);
             try
             {
-                await _action(context, args, services).ConfigureAwait(false);
+                await _action(context, args, services, this).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -54,9 +54,10 @@ namespace Discord.Commands
             return PreconditionResult.FromSuccess();
         }
 
-        public async Task<TypeReaderResult> Parse(ICommandContext context, string input)
+        public async Task<TypeReaderResult> Parse(ICommandContext context, string input, IServiceProvider services = null)
         {
-            return await _reader.Read(context, input).ConfigureAwait(false);
+            services = services ?? EmptyServiceProvider.Instance;
+            return await _reader.Read(context, input, services).ConfigureAwait(false);
         }
 
         public override string ToString() => Name;

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -15,11 +15,11 @@ namespace Discord.Commands
             return await Context.Channel.SendMessageAsync(message, isTTS, embed, options).ConfigureAwait(false);
         }
 
-        protected virtual void BeforeExecute()
+        protected virtual void BeforeExecute(CommandInfo command)
         {
         }
 
-        protected virtual void AfterExecute()
+        protected virtual void AfterExecute(CommandInfo command)
         {
         }
 
@@ -27,13 +27,11 @@ namespace Discord.Commands
         void IModuleBase.SetContext(ICommandContext context)
         {
             var newValue = context as T;
-            if (newValue == null)
-                throw new InvalidOperationException($"Invalid context type. Expected {typeof(T).Name}, got {context.GetType().Name}");
-            Context = newValue;
+            Context = newValue ?? throw new InvalidOperationException($"Invalid context type. Expected {typeof(T).Name}, got {context.GetType().Name}");
         }
 
-        void IModuleBase.BeforeExecute() => BeforeExecute();
+        void IModuleBase.BeforeExecute(CommandInfo command) => BeforeExecute(command);
 
-        void IModuleBase.AfterExecute() => AfterExecute();
+        void IModuleBase.AfterExecute(CommandInfo command) => AfterExecute(command);
     }
 }

--- a/src/Discord.Net.Commands/PrimitiveParsers.cs
+++ b/src/Discord.Net.Commands/PrimitiveParsers.cs
@@ -31,11 +31,6 @@ namespace Discord.Commands
             parserBuilder[typeof(DateTimeOffset)] = (TryParseDelegate<DateTimeOffset>)DateTimeOffset.TryParse;
             parserBuilder[typeof(TimeSpan)] = (TryParseDelegate<TimeSpan>)TimeSpan.TryParse;
             parserBuilder[typeof(char)] = (TryParseDelegate<char>)char.TryParse;
-            parserBuilder[typeof(string)] = (TryParseDelegate<string>)delegate (string str, out string value)
-            {
-                value = str;
-                return true;
-            };
             return parserBuilder.ToImmutable();
         }
 

--- a/src/Discord.Net.Commands/Readers/ChannelTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/ChannelTypeReader.cs
@@ -9,7 +9,7 @@ namespace Discord.Commands
     internal class ChannelTypeReader<T> : TypeReader
         where T : class, IChannel
     {
-        public override async Task<TypeReaderResult> Read(ICommandContext context, string input)
+        public override async Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
         {
             if (context.Guild != null)
             {

--- a/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
@@ -44,12 +44,11 @@ namespace Discord.Commands
             _enumsByValue = byValueBuilder.ToImmutable();
         }
 
-        public override Task<TypeReaderResult> Read(ICommandContext context, string input)
+        public override Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
         {
-            T baseValue;
             object enumValue;
 
-            if (_tryParse(input, out baseValue))
+            if (_tryParse(input, out T baseValue))
             {
                 if (_enumsByValue.TryGetValue(baseValue, out enumValue))
                     return Task.FromResult(TypeReaderResult.FromSuccess(enumValue));

--- a/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Discord.Commands
@@ -6,15 +7,14 @@ namespace Discord.Commands
     internal class MessageTypeReader<T> : TypeReader
         where T : class, IMessage
     {
-        public override async Task<TypeReaderResult> Read(ICommandContext context, string input)
+        public override async Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
         {
             ulong id;
 
             //By Id (1.0)
             if (ulong.TryParse(input, NumberStyles.None, CultureInfo.InvariantCulture, out id))
             {
-                var msg = await context.Channel.GetMessageAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) as T;
-                if (msg != null)
+                if (await context.Channel.GetMessageAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) is T msg)
                     return TypeReaderResult.FromSuccess(msg);
             }
 

--- a/src/Discord.Net.Commands/Readers/PrimitiveTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/PrimitiveTypeReader.cs
@@ -15,16 +15,25 @@ namespace Discord.Commands
     internal class PrimitiveTypeReader<T> : TypeReader
     {
         private readonly TryParseDelegate<T> _tryParse;
+        private readonly float _score;
 
         public PrimitiveTypeReader()
+            : this(PrimitiveParsers.Get<T>(), 1)
+        { }
+
+        public PrimitiveTypeReader(TryParseDelegate<T> tryParse, float score)
         {
-            _tryParse = PrimitiveParsers.Get<T>();
+            if (score < 0 || score > 1)
+                throw new ArgumentOutOfRangeException(nameof(score), score, "Scores must be within the range [0, 1]");
+
+            _tryParse = tryParse;
+            _score = score;
         }
 
         public override Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
         {
             if (_tryParse(input, out T value))
-                return Task.FromResult(TypeReaderResult.FromSuccess(value));
+                return Task.FromResult(TypeReaderResult.FromSuccess(new TypeReaderValue(value, _score)));
             return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, $"Failed to parse {typeof(T).Name}"));
         }
     }

--- a/src/Discord.Net.Commands/Readers/PrimitiveTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/PrimitiveTypeReader.cs
@@ -21,10 +21,9 @@ namespace Discord.Commands
             _tryParse = PrimitiveParsers.Get<T>();
         }
 
-        public override Task<TypeReaderResult> Read(ICommandContext context, string input)
+        public override Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
         {
-            T value;
-            if (_tryParse(input, out value))
+            if (_tryParse(input, out T value))
                 return Task.FromResult(TypeReaderResult.FromSuccess(value));
             return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, $"Failed to parse {typeof(T).Name}"));
         }

--- a/src/Discord.Net.Commands/Readers/RoleTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/RoleTypeReader.cs
@@ -9,7 +9,7 @@ namespace Discord.Commands
     internal class RoleTypeReader<T> : TypeReader
         where T : class, IRole
     {
-        public override Task<TypeReaderResult> Read(ICommandContext context, string input)
+        public override Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
         {
             ulong id;
 

--- a/src/Discord.Net.Commands/Readers/TypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TypeReader.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Discord.Commands
 {
     public abstract class TypeReader
     {
-        public abstract Task<TypeReaderResult> Read(ICommandContext context, string input);
+        public abstract Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services);
     }
 }

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -10,7 +10,7 @@ namespace Discord.Commands
     internal class UserTypeReader<T> : TypeReader
         where T : class, IUser
     {
-        public override async Task<TypeReaderResult> Read(ICommandContext context, string input)
+        public override async Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
         {
             var results = new Dictionary<ulong, TypeReaderValue>();
             IReadOnlyCollection<IUser> channelUsers = (await context.Channel.GetUsersAsync(CacheMode.CacheOnly).Flatten().ConfigureAwait(false)).ToArray(); //TODO: must be a better way?
@@ -43,8 +43,7 @@ namespace Discord.Commands
             if (index >= 0)
             {
                 string username = input.Substring(0, index);
-                ushort discriminator;
-                if (ushort.TryParse(input.Substring(index + 1), out discriminator))
+                if (ushort.TryParse(input.Substring(index + 1), out ushort discriminator))
                 {
                     var channelUser = channelUsers.FirstOrDefault(x => x.DiscriminatorValue == discriminator &&
                         string.Equals(username, x.Username, StringComparison.OrdinalIgnoreCase));

--- a/src/Discord.Net.Commands/Utilities/ReflectionUtils.cs
+++ b/src/Discord.Net.Commands/Utilities/ReflectionUtils.cs
@@ -58,7 +58,7 @@ namespace Discord.Commands
             {
                 foreach (var prop in ownerType.DeclaredProperties)
                 {
-                    if (prop.GetMethod?.IsStatic == false && prop.SetMethod?.IsPublic == true && prop.GetCustomAttribute<DontInjectAttribute>() == null)
+                    if (prop.SetMethod?.IsStatic == false && prop.SetMethod?.IsPublic == true && prop.GetCustomAttribute<DontInjectAttribute>() == null)
                         result.Add(prop);
                 }
                 ownerType = ownerType.BaseType.GetTypeInfo();


### PR DESCRIPTION
This PR contains most of the contents of #678, but without the overload builders themselves.

I'm not sure about argument order, especially in places like [here](https://github.com/FiniteReality/Discord.Net/blob/ed51d3e84677469420ddc85c3b2e2d2fc3f89c6d/src/Discord.Net.Commands/Info/CommandInfo.cs#L88) and [here](https://github.com/FiniteReality/Discord.Net/blob/ed51d3e84677469420ddc85c3b2e2d2fc3f89c6d/src/Discord.Net.Commands/CommandParser.cs#L17), (CommandInfo line 88 and CommandParser line 17 respectively) but I have tested and all of these changes work successfully.

This is a breaking change for users who create custom TypeReaders or use builders, but should not affect anybody who does not use these custom features.

EDIT: Fixes #675, Fixes #264 and Fixes #514 