### PR TITLE
Cache outgoing presence data if disconnected

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -360,7 +360,7 @@ namespace Discord.WebSocket
         private async Task SendStatusAsync()
         {
             if (CurrentUser == null)
-                throw new InvalidOperationException("Presence data cannot be sent before the client has logged in.");
+                return;
             var game = Game;
             var status = Status;
             var statusSince = _statusSince;


### PR DESCRIPTION
Rather than throwing an exception here, we can just return early, since we're going to send presence data when the client connects.

This resolves #702 