### PR TITLE
Add IUser#SendMessageAsync extension

### DIFF
--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -10,7 +10,7 @@ namespace Discord
             Embed embed = null, 
             RequestOptions options = null)
         {
-            return await (await user.GetOrCreateDMChannelAsync()).SendMessageAsync(text, isTTS, embed, options);
+            return await (await user.GetOrCreateDMChannelAsync().ConfigureAwait(false)).SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace Discord
+{
+    public static class UserExtensions
+    {
+        public static async Task<IUserMessage> SendMessageAsync(this IUser user, 
+            string text, 
+            bool isTTS = false,
+            Embed embed = null, 
+            RequestOptions options = null)
+        {
+            return await (await user.GetOrCreateDMChannelAsync()).SendMessageAsync(text, isTTS, embed, options);
+        }
+    }
+}


### PR DESCRIPTION
Allows users to use `await user.SendMessageAsync()` instead of `await (await user.GetOrCreateDMChannelAsync()).SendMessageAsync()`