### PR TITLE
Add support for audit log reasons

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -66,10 +66,10 @@ namespace Discord
         Task<IReadOnlyCollection<IBan>> GetBansAsync(RequestOptions options = null);
         /// <summary> Bans the provided user from this guild and optionally prunes their recent messages. </summary>
         /// <param name="pruneDays">The number of days to remove messages from this user for - must be between [0, 7]</param>
-        Task AddBanAsync(IUser user, int pruneDays = 0, RequestOptions options = null);
+        Task AddBanAsync(IUser user, int pruneDays = 0, string reason = null, RequestOptions options = null);
         /// <summary> Bans the provided user id from this guild and optionally prunes their recent messages. </summary>
         /// <param name="pruneDays">The number of days to remove messages from this user for - must be between [0, 7]</param>
-        Task AddBanAsync(ulong userId, int pruneDays = 0, RequestOptions options = null);
+        Task AddBanAsync(ulong userId, int pruneDays = 0, string reason = null, RequestOptions options = null);
         /// <summary> Unbans the provided user if it is currently banned. </summary>
         Task RemoveBanAsync(IUser user, RequestOptions options = null);
         /// <summary> Unbans the provided user id if it is currently banned. </summary>

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -25,7 +25,7 @@ namespace Discord
         ChannelPermissions GetPermissions(IGuildChannel channel);
 
         /// <summary> Kicks this user from this guild. </summary>
-        Task KickAsync(RequestOptions options = null);
+        Task KickAsync(string reason = null, RequestOptions options = null);
         /// <summary> Modifies this user's properties in this guild. </summary>
         Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null);
 

--- a/src/Discord.Net.Core/Net/Rest/IRestClient.cs
+++ b/src/Discord.Net.Core/Net/Rest/IRestClient.cs
@@ -9,8 +9,8 @@ namespace Discord.Net.Rest
         void SetHeader(string key, string value);
         void SetCancelToken(CancellationToken cancelToken);
 
-        Task<RestResponse> SendAsync(string method, string endpoint, CancellationToken cancelToken, bool headerOnly = false);
-        Task<RestResponse> SendAsync(string method, string endpoint, string json, CancellationToken cancelToken, bool headerOnly = false);
-        Task<RestResponse> SendAsync(string method, string endpoint, IReadOnlyDictionary<string, object> multipartParams, CancellationToken cancelToken, bool headerOnly = false);
+        Task<RestResponse> SendAsync(string method, string endpoint, CancellationToken cancelToken, bool headerOnly = false, string reason = null);
+        Task<RestResponse> SendAsync(string method, string endpoint, string json, CancellationToken cancelToken, bool headerOnly = false, string reason = null);
+        Task<RestResponse> SendAsync(string method, string endpoint, IReadOnlyDictionary<string, object> multipartParams, CancellationToken cancelToken, bool headerOnly = false, string reason = null);
     }
 }

--- a/src/Discord.Net.Core/RequestOptions.cs
+++ b/src/Discord.Net.Core/RequestOptions.cs
@@ -5,7 +5,6 @@ namespace Discord
     public class RequestOptions
     {
         public static RequestOptions Default => new RequestOptions();
-        public static RequestOptions WithReason(string reason) => new RequestOptions { AuditLogReason = reason };
 
         /// <summary> 
         /// The max time, in milliseconds, to wait for this request to complete. If null, a request will not time out. 

--- a/src/Discord.Net.Core/RequestOptions.cs
+++ b/src/Discord.Net.Core/RequestOptions.cs
@@ -5,6 +5,7 @@ namespace Discord
     public class RequestOptions
     {
         public static RequestOptions Default => new RequestOptions();
+        public static RequestOptions WithReason(string reason) => new RequestOptions { AuditLogReason = reason };
 
         /// <summary> 
         /// The max time, in milliseconds, to wait for this request to complete. If null, a request will not time out. 
@@ -14,6 +15,10 @@ namespace Discord
         public CancellationToken CancelToken { get; set; } = CancellationToken.None;
         public RetryMode? RetryMode { get; set; }
         public bool HeaderOnly { get; internal set; }
+        /// <summary>
+        /// The reason for this action in the guild's audit log
+        /// </summary>
+        public string AuditLogReason { get; set; }
 
         internal bool IgnoreState { get; set; }
         internal string BucketId { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildBanParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildBanParams.cs
@@ -4,5 +4,6 @@ namespace Discord.API.Rest
     internal class CreateGuildBanParams
     {
         public Optional<int> DeleteMessageDays { get; set; }
+        public string Reason { get; set; } 
     }
 }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -803,7 +803,8 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            await SendAsync("PUT", () => $"guilds/{guildId}/bans/{userId}?delete-message-days={args.DeleteMessageDays}&reason={args.Reason}", ids, options: options).ConfigureAwait(false);
+            string reason = string.IsNullOrWhiteSpace(args.Reason) ? "" : $"&reason={args.Reason}";
+            await SendAsync("PUT", () => $"guilds/{guildId}/bans/{userId}?delete-message-days={args.DeleteMessageDays}{reason}", ids, options: options).ConfigureAwait(false);
         }
         public async Task RemoveGuildBanAsync(ulong guildId, ulong userId, RequestOptions options = null)
         {
@@ -987,7 +988,8 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            await SendAsync("DELETE", () => $"guilds/{guildId}/members/{userId}?reason={reason}", ids, options: options).ConfigureAwait(false);
+            reason = string.IsNullOrWhiteSpace(reason) ? "" : $"?reason={reason}";
+            await SendAsync("DELETE", () => $"guilds/{guildId}/members/{userId}{reason}", ids, options: options).ConfigureAwait(false);
         }
         public async Task ModifyGuildMemberAsync(ulong guildId, ulong userId, Rest.ModifyGuildMemberParams args, RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -803,7 +803,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            await SendAsync("PUT", () => $"guilds/{guildId}/bans/{userId}?delete-message-days={args.DeleteMessageDays}", ids, options: options).ConfigureAwait(false);
+            await SendAsync("PUT", () => $"guilds/{guildId}/bans/{userId}?delete-message-days={args.DeleteMessageDays}&reason={args.Reason}", ids, options: options).ConfigureAwait(false);
         }
         public async Task RemoveGuildBanAsync(ulong guildId, ulong userId, RequestOptions options = null)
         {
@@ -980,14 +980,14 @@ namespace Discord.API
             Expression<Func<string>> endpoint = () => $"guilds/{guildId}/members?limit={limit}&after={afterUserId}";
             return await SendAsync<IReadOnlyCollection<GuildMember>>("GET", endpoint, ids, options: options).ConfigureAwait(false);
         }
-        public async Task RemoveGuildMemberAsync(ulong guildId, ulong userId, RequestOptions options = null)
+        public async Task RemoveGuildMemberAsync(ulong guildId, ulong userId, string reason, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             Preconditions.NotEqual(userId, 0, nameof(userId));
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            await SendAsync("DELETE", () => $"guilds/{guildId}/members/{userId}", ids, options: options).ConfigureAwait(false);
+            await SendAsync("DELETE", () => $"guilds/{guildId}/members/{userId}?reason={reason}", ids, options: options).ConfigureAwait(false);
         }
         public async Task ModifyGuildMemberAsync(ulong guildId, ulong userId, Rest.ModifyGuildMemberParams args, RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -107,9 +107,9 @@ namespace Discord.Rest
         }
 
         public static async Task AddBanAsync(IGuild guild, BaseDiscordClient client,
-            ulong userId, int pruneDays, RequestOptions options)
+            ulong userId, int pruneDays, string reason, RequestOptions options)
         {
-            var args = new CreateGuildBanParams { DeleteMessageDays = pruneDays };
+            var args = new CreateGuildBanParams { DeleteMessageDays = pruneDays, Reason = reason };
             await client.ApiClient.CreateGuildBanAsync(guild.Id, userId, args, options).ConfigureAwait(false);
         }
         public static async Task RemoveBanAsync(IGuild guild, BaseDiscordClient client,

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -137,9 +137,9 @@ namespace Discord.Rest
         public Task<IReadOnlyCollection<RestBan>> GetBansAsync(RequestOptions options = null)
             => GuildHelper.GetBansAsync(this, Discord, options);
 
-        public Task AddBanAsync(IUser user, int pruneDays = 0, RequestOptions options = null)
+        public Task AddBanAsync(IUser user, int pruneDays = 0, string reason = null, RequestOptions options = null)
             => GuildHelper.AddBanAsync(this, Discord, user.Id, pruneDays, options);
-        public Task AddBanAsync(ulong userId, int pruneDays = 0, RequestOptions options = null)
+        public Task AddBanAsync(ulong userId, int pruneDays = 0, string reason = null, RequestOptions options = null)
             => GuildHelper.AddBanAsync(this, Discord, userId, pruneDays, options);
 
         public Task RemoveBanAsync(IUser user, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -138,9 +138,9 @@ namespace Discord.Rest
             => GuildHelper.GetBansAsync(this, Discord, options);
 
         public Task AddBanAsync(IUser user, int pruneDays = 0, string reason = null, RequestOptions options = null)
-            => GuildHelper.AddBanAsync(this, Discord, user.Id, pruneDays, options);
+            => GuildHelper.AddBanAsync(this, Discord, user.Id, pruneDays, reason, options);
         public Task AddBanAsync(ulong userId, int pruneDays = 0, string reason = null, RequestOptions options = null)
-            => GuildHelper.AddBanAsync(this, Discord, userId, pruneDays, options);
+            => GuildHelper.AddBanAsync(this, Discord, userId, pruneDays, reason, options);
 
         public Task RemoveBanAsync(IUser user, RequestOptions options = null)
             => GuildHelper.RemoveBanAsync(this, Discord, user.Id, options);

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -85,8 +85,8 @@ namespace Discord.Rest
             else if (args.RoleIds.IsSpecified)
                 UpdateRoles(args.RoleIds.Value.ToArray());
         }
-        public Task KickAsync(RequestOptions options = null)
-            => UserHelper.KickAsync(this, Discord, options);
+        public Task KickAsync(string reason = null, RequestOptions options = null)
+            => UserHelper.KickAsync(this, Discord, reason, options);
         /// <inheritdoc />
         public Task AddRoleAsync(IRole role, RequestOptions options = null)
             => AddRolesAsync(new[] { role }, options);

--- a/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
@@ -45,7 +45,7 @@ namespace Discord.Rest
         GuildPermissions IGuildUser.GuildPermissions => GuildPermissions.Webhook;
 
         ChannelPermissions IGuildUser.GetPermissions(IGuildChannel channel) => Permissions.ToChannelPerms(channel, GuildPermissions.Webhook.RawValue);
-        Task IGuildUser.KickAsync(RequestOptions options)
+        Task IGuildUser.KickAsync(string reason, RequestOptions options)
         {
             throw new NotSupportedException("Webhook users cannot be kicked.");
         }

--- a/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
@@ -53,9 +53,9 @@ namespace Discord.Rest
         }
 
         public static async Task KickAsync(IGuildUser user, BaseDiscordClient client,
-            RequestOptions options)
+            string reason, RequestOptions options)
         {
-            await client.ApiClient.RemoveGuildMemberAsync(user.GuildId, user.Id, options).ConfigureAwait(false);
+            await client.ApiClient.RemoveGuildMemberAsync(user.GuildId, user.Id, reason, options).ConfigureAwait(false);
         }
 
         public static async Task<RestDMChannel> CreateDMChannelAsync(IUser user, BaseDiscordClient client,

--- a/src/Discord.Net.Rest/Net/DefaultRestClient.cs
+++ b/src/Discord.Net.Rest/Net/DefaultRestClient.cs
@@ -67,7 +67,7 @@ namespace Discord.Net.Rest
             string uri = Path.Combine(_baseUrl, endpoint);
             using (var restRequest = new HttpRequestMessage(GetMethod(method), uri))
             {
-                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", reason);
+                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", Uri.EscapeDataString(reason));
                 return await SendInternalAsync(restRequest, cancelToken, headerOnly).ConfigureAwait(false);
             }
         }
@@ -76,7 +76,7 @@ namespace Discord.Net.Rest
             string uri = Path.Combine(_baseUrl, endpoint);
             using (var restRequest = new HttpRequestMessage(GetMethod(method), uri))
             {
-                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", reason);
+                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", Uri.EscapeDataString(reason));
                 restRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
                 return await SendInternalAsync(restRequest, cancelToken, headerOnly).ConfigureAwait(false);
             }
@@ -86,7 +86,7 @@ namespace Discord.Net.Rest
             string uri = Path.Combine(_baseUrl, endpoint);
             using (var restRequest = new HttpRequestMessage(GetMethod(method), uri))
             {
-                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", reason);
+                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", Uri.EscapeDataString(reason));
                 var content = new MultipartFormDataContent("Upload----" + DateTime.Now.ToString(CultureInfo.InvariantCulture));
                 if (multipartParams != null)
                 {

--- a/src/Discord.Net.Rest/Net/DefaultRestClient.cs
+++ b/src/Discord.Net.Rest/Net/DefaultRestClient.cs
@@ -62,26 +62,31 @@ namespace Discord.Net.Rest
             _cancelToken = cancelToken;
         }
 
-        public async Task<RestResponse> SendAsync(string method, string endpoint, CancellationToken cancelToken, bool headerOnly)
-        {
-            string uri = Path.Combine(_baseUrl, endpoint);
-            using (var restRequest = new HttpRequestMessage(GetMethod(method), uri))
-                return await SendInternalAsync(restRequest, cancelToken, headerOnly).ConfigureAwait(false);
-        }
-        public async Task<RestResponse> SendAsync(string method, string endpoint, string json, CancellationToken cancelToken, bool headerOnly)
+        public async Task<RestResponse> SendAsync(string method, string endpoint, CancellationToken cancelToken, bool headerOnly, string reason = null)
         {
             string uri = Path.Combine(_baseUrl, endpoint);
             using (var restRequest = new HttpRequestMessage(GetMethod(method), uri))
             {
+                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", reason);
+                return await SendInternalAsync(restRequest, cancelToken, headerOnly).ConfigureAwait(false);
+            }
+        }
+        public async Task<RestResponse> SendAsync(string method, string endpoint, string json, CancellationToken cancelToken, bool headerOnly, string reason = null)
+        {
+            string uri = Path.Combine(_baseUrl, endpoint);
+            using (var restRequest = new HttpRequestMessage(GetMethod(method), uri))
+            {
+                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", reason);
                 restRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
                 return await SendInternalAsync(restRequest, cancelToken, headerOnly).ConfigureAwait(false);
             }
         }
-        public async Task<RestResponse> SendAsync(string method, string endpoint, IReadOnlyDictionary<string, object> multipartParams, CancellationToken cancelToken, bool headerOnly)
+        public async Task<RestResponse> SendAsync(string method, string endpoint, IReadOnlyDictionary<string, object> multipartParams, CancellationToken cancelToken, bool headerOnly, string reason = null)
         {
             string uri = Path.Combine(_baseUrl, endpoint);
             using (var restRequest = new HttpRequestMessage(GetMethod(method), uri))
             {
+                if (reason != null) restRequest.Headers.Add("X-Audit-Log-Reason", reason);
                 var content = new MultipartFormDataContent("Upload----" + DateTime.Now.ToString(CultureInfo.InvariantCulture));
                 if (multipartParams != null)
                 {

--- a/src/Discord.Net.Rest/Net/Queue/Requests/JsonRestRequest.cs
+++ b/src/Discord.Net.Rest/Net/Queue/Requests/JsonRestRequest.cs
@@ -15,7 +15,7 @@ namespace Discord.Net.Queue
 
         public override async Task<RestResponse> SendAsync()
         {
-            return await Client.SendAsync(Method, Endpoint, Json, Options.CancelToken, Options.HeaderOnly).ConfigureAwait(false);
+            return await Client.SendAsync(Method, Endpoint, Json, Options.CancelToken, Options.HeaderOnly, Options.AuditLogReason).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Rest/Net/Queue/Requests/MultipartRestRequest.cs
+++ b/src/Discord.Net.Rest/Net/Queue/Requests/MultipartRestRequest.cs
@@ -16,7 +16,7 @@ namespace Discord.Net.Queue
 
         public override async Task<RestResponse> SendAsync()
         {
-            return await Client.SendAsync(Method, Endpoint, MultipartParams, Options.CancelToken, Options.HeaderOnly).ConfigureAwait(false);
+            return await Client.SendAsync(Method, Endpoint, MultipartParams, Options.CancelToken, Options.HeaderOnly, Options.AuditLogReason).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Rest/Net/Queue/Requests/RestRequest.cs
+++ b/src/Discord.Net.Rest/Net/Queue/Requests/RestRequest.cs
@@ -28,7 +28,7 @@ namespace Discord.Net.Queue
 
         public virtual async Task<RestResponse> SendAsync()
         {
-            return await Client.SendAsync(Method, Endpoint, Options.CancelToken, Options.HeaderOnly).ConfigureAwait(false);
+            return await Client.SendAsync(Method, Endpoint, Options.CancelToken, Options.HeaderOnly, Options.AuditLogReason).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -281,9 +281,9 @@ namespace Discord.WebSocket
         public Task<IReadOnlyCollection<RestBan>> GetBansAsync(RequestOptions options = null)
             => GuildHelper.GetBansAsync(this, Discord, options);
 
-        public Task AddBanAsync(IUser user, int pruneDays = 0, RequestOptions options = null)
+        public Task AddBanAsync(IUser user, int pruneDays = 0, string reason = null, RequestOptions options = null)
             => GuildHelper.AddBanAsync(this, Discord, user.Id, pruneDays, options);
-        public Task AddBanAsync(ulong userId, int pruneDays = 0, RequestOptions options = null)
+        public Task AddBanAsync(ulong userId, int pruneDays = 0, string reason = null, RequestOptions options = null)
             => GuildHelper.AddBanAsync(this, Discord, userId, pruneDays, options);
 
         public Task RemoveBanAsync(IUser user, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -282,9 +282,9 @@ namespace Discord.WebSocket
             => GuildHelper.GetBansAsync(this, Discord, options);
 
         public Task AddBanAsync(IUser user, int pruneDays = 0, string reason = null, RequestOptions options = null)
-            => GuildHelper.AddBanAsync(this, Discord, user.Id, pruneDays, options);
+            => GuildHelper.AddBanAsync(this, Discord, user.Id, pruneDays, reason, options);
         public Task AddBanAsync(ulong userId, int pruneDays = 0, string reason = null, RequestOptions options = null)
-            => GuildHelper.AddBanAsync(this, Discord, userId, pruneDays, options);
+            => GuildHelper.AddBanAsync(this, Discord, userId, pruneDays, reason, options);
 
         public Task RemoveBanAsync(IUser user, RequestOptions options = null)
             => GuildHelper.RemoveBanAsync(this, Discord, user.Id, options);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -122,8 +122,8 @@ namespace Discord.WebSocket
         
         public Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null)
             => UserHelper.ModifyAsync(this, Discord, func, options);
-        public Task KickAsync(RequestOptions options = null)
-            => UserHelper.KickAsync(this, Discord, options);
+        public Task KickAsync(string reason = null, RequestOptions options = null)
+            => UserHelper.KickAsync(this, Discord, reason, options);
         /// <inheritdoc />
         public Task AddRoleAsync(IRole role, RequestOptions options = null)
             => AddRolesAsync(new[] { role }, options);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -47,7 +47,7 @@ namespace Discord.WebSocket
         GuildPermissions IGuildUser.GuildPermissions => GuildPermissions.Webhook;
 
         ChannelPermissions IGuildUser.GetPermissions(IGuildChannel channel) => Permissions.ToChannelPerms(channel, GuildPermissions.Webhook.RawValue);
-        Task IGuildUser.KickAsync(RequestOptions options)
+        Task IGuildUser.KickAsync(string reason, RequestOptions options)
         {
             throw new NotSupportedException("Webhook users cannot be kicked.");
         }

--- a/test/Discord.Net.Tests/Net/CachedRestClient.cs
+++ b/test/Discord.Net.Tests/Net/CachedRestClient.cs
@@ -66,7 +66,7 @@ namespace Discord.Net
             _cancelToken = CancellationTokenSource.CreateLinkedTokenSource(_parentToken, _cancelTokenSource.Token).Token;
         }
 
-        public async Task<RestResponse> SendAsync(string method, string endpoint, CancellationToken cancelToken, bool headerOnly)
+        public async Task<RestResponse> SendAsync(string method, string endpoint, CancellationToken cancelToken, bool headerOnly, string reason = null)
         {
             if (method != "GET")
                 throw new InvalidOperationException("This RestClient only supports GET requests.");
@@ -75,11 +75,11 @@ namespace Discord.Net
             var bytes = await _blobCache.DownloadUrl(uri, _headers);
             return new RestResponse(HttpStatusCode.OK, _headers, new MemoryStream(bytes));
         }
-        public Task<RestResponse> SendAsync(string method, string endpoint, string json, CancellationToken cancelToken, bool headerOnly)
+        public Task<RestResponse> SendAsync(string method, string endpoint, string json, CancellationToken cancelToken, bool headerOnly, string reason = null)
         {
             throw new InvalidOperationException("This RestClient does not support payloads.");
         }
-        public Task<RestResponse> SendAsync(string method, string endpoint, IReadOnlyDictionary<string, object> multipartParams, CancellationToken cancelToken, bool headerOnly)
+        public Task<RestResponse> SendAsync(string method, string endpoint, IReadOnlyDictionary<string, object> multipartParams, CancellationToken cancelToken, bool headerOnly, string reason = null)
         {
             throw new InvalidOperationException("This RestClient does not support multipart requests.");
         }


### PR DESCRIPTION
**This is a breaking change!**
(But only if anyone actually uses RequestOptions)

A reason can now be set on kicks/bans, using the `reason` field that has been prepended to the RequestOptions parameter in their respective methods (making this essentially a non-breaking change).

A reason can also be added to the audit log for these actions via the `AuditLogReason` field in RequestOptions.

Examples:

```cs
[Command("ban")]
public async Task Ban(SocketUser target, [Remainder] string reason = null)
{
    await Context.Guild.AddBanAsync(target, 0, reason);
}
```
```cs
[Command("nick")]
public async Task Nick([Remainder] string nick)
{
    await Context.CurrentUser.ModifyAsync(x => x.Nickname = nick, RequestOptions.WithReason($"'nick' command as requested by {Context.User}"));
}
```