### PR TITLE
Add 'tweet' embed type

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedType.cs
@@ -7,6 +7,7 @@
         Video,
         Image,
         Gifv,
-        Article
+        Article,
+        Tweet
     }
 }


### PR DESCRIPTION
Paulo in Discord:
```
Error converting value "tweet" to type 'Discord.EmbedType'. Path '[47].embeds[0].type', line 1, position 37232. System.ArgumentException: Requested value 'tweet' was not found.
```