### PR TITLE
Revert change of all Url types on IEmbed to string

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/Embed.cs
+++ b/src/Discord.Net.Core/Entities/Messages/Embed.cs
@@ -11,7 +11,7 @@ namespace Discord
         public EmbedType Type { get; }
 
         public string Description { get; internal set; }
-        public Uri Url { get; internal set; }
+        public string Url { get; internal set; }
         public string Title { get; internal set; }
         public DateTimeOffset? Timestamp { get; internal set; }
         public Color? Color { get; internal set; }
@@ -31,7 +31,7 @@ namespace Discord
         internal Embed(EmbedType type, 
             string title,
             string description,
-            Uri url,
+            string url,
             DateTimeOffset? timestamp,
             Color? color,
             EmbedImage? image,

--- a/src/Discord.Net.Core/Entities/Messages/EmbedAuthor.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedAuthor.cs
@@ -7,11 +7,11 @@ namespace Discord
     public struct EmbedAuthor
     {
         public string Name { get; internal set; }
-        public Uri Url { get; internal set; }
-        public Uri IconUrl { get; internal set; }
-        public Uri ProxyIconUrl { get; internal set; }
+        public string Url { get; internal set; }
+        public string IconUrl { get; internal set; }
+        public string ProxyIconUrl { get; internal set; }
 
-        internal EmbedAuthor(string name, Uri url, Uri iconUrl, Uri proxyIconUrl)
+        internal EmbedAuthor(string name, string url, string iconUrl, string proxyIconUrl)
         {
             Name = name;
             Url = url;

--- a/src/Discord.Net.Core/Entities/Messages/EmbedFooter.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedFooter.cs
@@ -7,10 +7,10 @@ namespace Discord
     public struct EmbedFooter
     {
         public string Text { get; internal set; }
-        public Uri IconUrl { get; internal set; }
-        public Uri ProxyUrl { get; internal set; }
+        public string IconUrl { get; internal set; }
+        public string ProxyUrl { get; internal set; }
 
-        internal EmbedFooter(string text, Uri iconUrl, Uri proxyUrl)
+        internal EmbedFooter(string text, string iconUrl, string proxyUrl)
         {
             Text = text;
             IconUrl = iconUrl;

--- a/src/Discord.Net.Core/Entities/Messages/EmbedImage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedImage.cs
@@ -6,12 +6,12 @@ namespace Discord
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public struct EmbedImage
     {
-        public Uri Url { get; }
-        public Uri ProxyUrl { get; }
+        public string Url { get; }
+        public string ProxyUrl { get; }
         public int? Height { get; }
         public int? Width { get; }
 
-        internal EmbedImage(Uri url, Uri proxyUrl, int? height, int? width)
+        internal EmbedImage(string url, string proxyUrl, int? height, int? width)
         {
             Url = url;
             ProxyUrl = proxyUrl;

--- a/src/Discord.Net.Core/Entities/Messages/EmbedProvider.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedProvider.cs
@@ -7,9 +7,9 @@ namespace Discord
     public struct EmbedProvider
     {
         public string Name { get; }
-        public Uri Url { get; }
+        public string Url { get; }
 
-        internal EmbedProvider(string name, Uri url)
+        internal EmbedProvider(string name, string url)
         {
             Name = name;
             Url = url;

--- a/src/Discord.Net.Core/Entities/Messages/EmbedThumbnail.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedThumbnail.cs
@@ -6,12 +6,12 @@ namespace Discord
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public struct EmbedThumbnail
     {
-        public Uri Url { get; }
-        public Uri ProxyUrl { get; }
+        public string Url { get; }
+        public string ProxyUrl { get; }
         public int? Height { get; }
         public int? Width { get; }
 
-        internal EmbedThumbnail(Uri url, Uri proxyUrl, int? height, int? width)
+        internal EmbedThumbnail(string url, string proxyUrl, int? height, int? width)
         {
             Url = url;
             ProxyUrl = proxyUrl;

--- a/src/Discord.Net.Core/Entities/Messages/EmbedVideo.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedVideo.cs
@@ -6,11 +6,11 @@ namespace Discord
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public struct EmbedVideo
     {
-        public Uri Url { get; }
+        public string Url { get; }
         public int? Height { get; }
         public int? Width { get; }
 
-        internal EmbedVideo(Uri url, int? height, int? width)
+        internal EmbedVideo(string url, int? height, int? width)
         {
             Url = url;
             Height = height;

--- a/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
@@ -5,7 +5,7 @@ namespace Discord
 {
     public interface IEmbed
     {
-        Uri Url { get; }
+        string Url { get; }
         string Title { get; }
         string Description { get; }
         EmbedType Type { get; }

--- a/src/Discord.Net.Rest/API/Common/Embed.cs
+++ b/src/Discord.Net.Rest/API/Common/Embed.cs
@@ -12,7 +12,7 @@ namespace Discord.API
         [JsonProperty("description")]
         public string Description { get; set; }
         [JsonProperty("url")]
-        public Uri Url { get; set; }
+        public string Url { get; set; }
         [JsonProperty("color")]
         public uint? Color { get; set; }
         [JsonProperty("type"), JsonConverter(typeof(StringEnumConverter))]

--- a/src/Discord.Net.Rest/API/Common/EmbedAuthor.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedAuthor.cs
@@ -8,10 +8,10 @@ namespace Discord.API
         [JsonProperty("name")]
         public string Name { get; set; }
         [JsonProperty("url")]
-        public Uri Url { get; set; }
+        public string Url { get; set; }
         [JsonProperty("icon_url")]
-        public Uri IconUrl { get; set; }
+        public string IconUrl { get; set; }
         [JsonProperty("proxy_icon_url")]
-        public Uri ProxyIconUrl { get; set; }
+        public string ProxyIconUrl { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedFooter.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedFooter.cs
@@ -8,8 +8,8 @@ namespace Discord.API
         [JsonProperty("text")]
         public string Text { get; set; }
         [JsonProperty("icon_url")]
-        public Uri IconUrl { get; set; }
+        public string IconUrl { get; set; }
         [JsonProperty("proxy_icon_url")]
-        public Uri ProxyIconUrl { get; set; }
+        public string ProxyIconUrl { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedImage.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedImage.cs
@@ -7,9 +7,9 @@ namespace Discord.API
     internal class EmbedImage
     {
         [JsonProperty("url")]
-        public Uri Url { get; set; }
+        public string Url { get; set; }
         [JsonProperty("proxy_url")]
-        public Uri ProxyUrl { get; set; }
+        public string ProxyUrl { get; set; }
         [JsonProperty("height")]
         public Optional<int> Height { get; set; }
         [JsonProperty("width")]

--- a/src/Discord.Net.Rest/API/Common/EmbedProvider.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedProvider.cs
@@ -9,6 +9,6 @@ namespace Discord.API
         [JsonProperty("name")]
         public string Name { get; set; }
         [JsonProperty("url")]
-        public Uri Url { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedThumbnail.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedThumbnail.cs
@@ -7,9 +7,9 @@ namespace Discord.API
     internal class EmbedThumbnail
     {
         [JsonProperty("url")]
-        public Uri Url { get; set; }
+        public string Url { get; set; }
         [JsonProperty("proxy_url")]
-        public Uri ProxyUrl { get; set; }
+        public string ProxyUrl { get; set; }
         [JsonProperty("height")]
         public Optional<int> Height { get; set; }
         [JsonProperty("width")]

--- a/src/Discord.Net.Rest/API/Common/EmbedVideo.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedVideo.cs
@@ -7,7 +7,7 @@ namespace Discord.API
     internal class EmbedVideo
     {
         [JsonProperty("url")]
-        public Uri Url { get; set; }
+        public string Url { get; set; }
         [JsonProperty("height")]
         public Optional<int> Height { get; set; }
         [JsonProperty("width")]

--- a/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
@@ -39,9 +39,33 @@ namespace Discord
             }
         }
 
-        public Uri Url { get => _embed.Url; set { _embed.Url = value; } }
-        public Uri ThumbnailUrl { get => _embed.Thumbnail?.Url; set { _embed.Thumbnail = new EmbedThumbnail(value, null, null, null); } }
-        public Uri ImageUrl { get => _embed.Image?.Url; set { _embed.Image = new EmbedImage(value, null, null, null); } }
+        public string Url
+        {
+            get => _embed.Url;
+            set
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.Absolute)) throw new ArgumentException("Url must be a well-formed URI", nameof(Url));
+                _embed.Url = value;
+            }
+        }
+        public string ThumbnailUrl
+        {
+            get => _embed.Thumbnail?.Url;
+            set
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.Absolute)) throw new ArgumentException("Url must be a well-formed URI", nameof(ThumbnailUrl));
+                _embed.Thumbnail = new EmbedThumbnail(value, null, null, null);
+            }
+        }
+        public string ImageUrl
+        {
+            get => _embed.Image?.Url;
+            set
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.Absolute)) throw new ArgumentException("Url must be a well-formed URI", nameof(ImageUrl));
+                _embed.Image = new EmbedImage(value, null, null, null);
+            }
+        }
         public DateTimeOffset? Timestamp { get => _embed.Timestamp; set { _embed.Timestamp = value; } }
         public Color? Color { get => _embed.Color; set { _embed.Color = value; } }
 
@@ -70,17 +94,17 @@ namespace Discord
             Description = description;
             return this;
         }
-        public EmbedBuilder WithUrl(Uri url)
+        public EmbedBuilder WithUrl(string url)
         {
             Url = url;
             return this;
         }
-        public EmbedBuilder WithThumbnailUrl(Uri thumbnailUrl)
+        public EmbedBuilder WithThumbnailUrl(string thumbnailUrl)
         {
             ThumbnailUrl = thumbnailUrl;
             return this;
         }
-        public EmbedBuilder WithImageUrl(Uri imageUrl)
+        public EmbedBuilder WithImageUrl(string imageUrl)
         {
             ImageUrl = imageUrl;
             return this;
@@ -252,8 +276,24 @@ namespace Discord
                 _author.Name = value;
             }
         }
-        public Uri Url { get => _author.Url; set { _author.Url = value; } }
-        public Uri IconUrl { get => _author.IconUrl; set { _author.IconUrl = value; } }
+        public string Url
+        {
+            get => _author.Url;
+            set
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.Absolute)) throw new ArgumentException("Url must be a well-formed URI", nameof(Url));
+                _author.Url = value;
+            }
+        }
+        public string IconUrl
+        {
+            get => _author.IconUrl;
+            set
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.Absolute)) throw new ArgumentException("Url must be a well-formed URI", nameof(IconUrl));
+                _author.IconUrl = value;
+            }
+        }
 
         public EmbedAuthorBuilder()
         {
@@ -265,12 +305,12 @@ namespace Discord
             Name = name;
             return this;
         }
-        public EmbedAuthorBuilder WithUrl(Uri url)
+        public EmbedAuthorBuilder WithUrl(string url)
         {
             Url = url;
             return this;
         }
-        public EmbedAuthorBuilder WithIconUrl(Uri iconUrl)
+        public EmbedAuthorBuilder WithIconUrl(string iconUrl)
         {
             IconUrl = iconUrl;
             return this;
@@ -295,7 +335,15 @@ namespace Discord
                 _footer.Text = value;
             }
         }
-        public Uri IconUrl { get => _footer.IconUrl; set { _footer.IconUrl = value; } }
+        public string IconUrl
+        {
+            get => _footer.IconUrl;
+            set
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.Absolute)) throw new ArgumentException("Url must be a well-formed URI", nameof(IconUrl));
+                _footer.IconUrl = value;
+            }
+        }
 
         public EmbedFooterBuilder()
         {
@@ -307,7 +355,7 @@ namespace Discord
             Text = text;
             return this;
         }
-        public EmbedFooterBuilder WithIconUrl(Uri iconUrl)
+        public EmbedFooterBuilder WithIconUrl(string iconUrl)
         {
             IconUrl = iconUrl;
             return this;


### PR DESCRIPTION
This change reverts the impact on usability in #711 where types of URL on an IEmbed were changed to `System.Uri`. 

The functionality of validating URLs is still left intact, by manually validating URLs on `EmbedBuilder`