### PR TITLE
Added ViewAuditLog GuildPermission to GuildPermissions

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -9,6 +9,7 @@
         Administrator = 3,
         ManageChannels = 4,
         ManageGuild = 5,
+        ViewAuditLog = 7,
 
         //Text
         AddReactions = 6,

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -80,7 +80,7 @@ namespace Discord
         public GuildPermissions(ulong rawValue) { RawValue = rawValue; }
 
         private GuildPermissions(ulong initialValue, bool? createInstantInvite = null, bool? kickMembers = null,
-            bool? banMembers = null, bool? administrator = null, bool? manageChannel = null, bool? manageGuild = null,
+            bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
             bool? addReactions = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
@@ -94,7 +94,7 @@ namespace Discord
             Permissions.SetValue(ref value, banMembers, GuildPermission.BanMembers);
             Permissions.SetValue(ref value, kickMembers, GuildPermission.KickMembers);
             Permissions.SetValue(ref value, administrator, GuildPermission.Administrator);
-            Permissions.SetValue(ref value, manageChannel, GuildPermission.ManageChannels);
+            Permissions.SetValue(ref value, manageChannels, GuildPermission.ManageChannels);
             Permissions.SetValue(ref value, manageGuild, GuildPermission.ManageGuild);
             Permissions.SetValue(ref value, addReactions, GuildPermission.AddReactions);
             Permissions.SetValue(ref value, readMessages, GuildPermission.ReadMessages);
@@ -124,7 +124,7 @@ namespace Discord
 
         /// <summary> Creates a new GuildPermissions with the provided permissions. </summary>
         public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false,
-            bool banMembers = false, bool administrator = false, bool manageChannel = false, bool manageGuild = false,
+            bool banMembers = false, bool administrator = false, bool manageChannels = false, bool manageGuild = false,
             bool addReactions = false,
             bool readMessages = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
             bool embedLinks = false, bool attachFiles = false, bool readMessageHistory = false, bool mentionEveryone = false,
@@ -133,7 +133,7 @@ namespace Discord
             bool manageRoles = false, bool manageWebhooks = false, bool manageEmojis = false,
             bool viewAuditLog = false)
             : this( initialValue: 0, createInstantInvite: createInstantInvite, kickMembers: kickMembers, banMembers: banMembers,
-                  administrator: administrator, manageChannel: manageChannel, manageGuild: manageGuild, addReactions: addReactions,
+                  administrator: administrator, manageChannels: manageChannels, manageGuild: manageGuild, addReactions: addReactions,
                   readMessages: readMessages, sendMessages: sendMessages, sendTTSMessages: sendTTSMessages, manageMessages: manageMessages,
                   embedLinks: embedLinks, attachFiles: attachFiles, readMessageHistory: readMessageHistory, mentionEveryone: mentionEveryone,
                   useExternalEmojis: useExternalEmojis, connect: connect, speak: speak, muteMembers: muteMembers, deafenMembers: deafenMembers,
@@ -144,7 +144,7 @@ namespace Discord
 
         /// <summary> Creates a new GuildPermissions from this one, changing the provided non-null permissions. </summary>
         public GuildPermissions Modify(bool? createInstantInvite = null, bool? kickMembers = null,
-            bool? banMembers = null, bool? administrator = null, bool? manageChannel = null, bool? manageGuild = null,
+            bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
             bool? addReactions = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
@@ -152,7 +152,7 @@ namespace Discord
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null, bool? viewAuditLog = null)
             => new GuildPermissions(RawValue, createInstantInvite: createInstantInvite, kickMembers: kickMembers, banMembers: banMembers,
-                  administrator: administrator, manageChannel: manageChannel, manageGuild: manageGuild, addReactions: addReactions,
+                  administrator: administrator, manageChannels: manageChannels, manageGuild: manageGuild, addReactions: addReactions,
                   readMessages: readMessages, sendMessages: sendMessages, sendTTSMessages: sendTTSMessages, manageMessages: manageMessages,
                   embedLinks: embedLinks, attachFiles: attachFiles, readMessageHistory: readMessageHistory, mentionEveryone: mentionEveryone,
                   useExternalEmojis: useExternalEmojis, connect: connect, speak: speak, muteMembers: muteMembers, deafenMembers: deafenMembers,

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -28,6 +28,8 @@ namespace Discord
         public bool ManageChannels => Permissions.GetValue(RawValue, GuildPermission.ManageChannels);
         /// <summary> If True, a user may adjust guild properties. </summary>
         public bool ManageGuild => Permissions.GetValue(RawValue, GuildPermission.ManageGuild);
+        /// <summary> If True, a user may view guild audit logs. </summary>
+        public bool ViewAuditLog => Permissions.GetValue(RawValue, GuildPermission.ViewAuditLog);
         
         /// <summary> If true, a user may add reactions. </summary>
         public bool AddReactions => Permissions.GetValue(RawValue, GuildPermission.AddReactions);
@@ -79,7 +81,7 @@ namespace Discord
 
         private GuildPermissions(ulong initialValue, bool? createInstantInvite = null, bool? kickMembers = null, 
             bool? banMembers = null, bool? administrator = null, bool? manageChannel = null,  bool? manageGuild = null,
-            bool? addReactions = null,
+            bool? viewAuditLog = null, bool? addReactions = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null,  bool? manageMessages = null, 
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null,  bool? mentionEveryone = null, 
             bool? userExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null,  bool? deafenMembers = null, 
@@ -94,6 +96,7 @@ namespace Discord
             Permissions.SetValue(ref value, administrator, GuildPermission.Administrator);
             Permissions.SetValue(ref value, manageChannel, GuildPermission.ManageChannels);
             Permissions.SetValue(ref value, manageGuild, GuildPermission.ManageGuild);
+            Permissions.SetValue(ref value, viewAuditLog, GuildPermission.ViewAuditLog);
             Permissions.SetValue(ref value, addReactions, GuildPermission.AddReactions);
             Permissions.SetValue(ref value, readMessages, GuildPermission.ReadMessages);
             Permissions.SetValue(ref value, sendMessages, GuildPermission.SendMessages);
@@ -122,29 +125,29 @@ namespace Discord
         /// <summary> Creates a new GuildPermissions with the provided permissions. </summary>
         public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false, 
             bool banMembers = false, bool administrator = false, bool manageChannels = false, bool manageGuild = false,
-            bool addReactions = false,
+            bool viewAuditLog = false, bool addReactions = false,
             bool readMessages = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
             bool embedLinks = false, bool attachFiles = false, bool readMessageHistory = false, bool mentionEveryone = false,
             bool useExternalEmojis = false, bool connect = false, bool speak = false, bool muteMembers = false, bool deafenMembers = false,
             bool moveMembers = false, bool useVoiceActivation = false, bool? changeNickname = false, bool? manageNicknames = false, 
             bool manageRoles = false, bool manageWebhooks = false, bool manageEmojis = false)
-            : this(0, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, addReactions, 
+            : this(0, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, viewAuditLog, addReactions, 
                 readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, useExternalEmojis, connect, 
                 manageWebhooks, manageEmojis) { }
 
         /// <summary> Creates a new GuildPermissions from this one, changing the provided non-null permissions. </summary>
         public GuildPermissions Modify(bool? createInstantInvite = null,  bool? kickMembers = null, 
             bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
-            bool? addReactions = null,
+            bool? viewAuditLog = null, bool? addReactions = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null, 
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null)
-            => new GuildPermissions(RawValue, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, addReactions,  
-                readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, useExternalEmojis, connect, 
-                speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, changeNickname, manageNicknames, manageRoles,
-                manageWebhooks, manageEmojis);
+            => new GuildPermissions(RawValue, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, viewAuditLog,
+                addReactions, readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, 
+                useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, changeNickname, 
+                manageNicknames, manageRoles, manageWebhooks, manageEmojis);
 
         public bool Has(GuildPermission permission) => Permissions.GetValue(RawValue, permission);
 

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -30,7 +30,7 @@ namespace Discord
         public bool ManageGuild => Permissions.GetValue(RawValue, GuildPermission.ManageGuild);
         /// <summary> If True, a user may view guild audit logs. </summary>
         public bool ViewAuditLog => Permissions.GetValue(RawValue, GuildPermission.ViewAuditLog);
-        
+
         /// <summary> If true, a user may add reactions. </summary>
         public bool AddReactions => Permissions.GetValue(RawValue, GuildPermission.AddReactions);
         /// <summary> If True, a user may join channels. </summary>
@@ -79,14 +79,14 @@ namespace Discord
         /// <summary> Creates a new GuildPermissions with the provided packed value. </summary>
         public GuildPermissions(ulong rawValue) { RawValue = rawValue; }
 
-        private GuildPermissions(ulong initialValue, bool? createInstantInvite = null, bool? kickMembers = null, 
-            bool? banMembers = null, bool? administrator = null, bool? manageChannel = null,  bool? manageGuild = null,
-            bool? viewAuditLog = null, bool? addReactions = null,
-            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null,  bool? manageMessages = null, 
-            bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null,  bool? mentionEveryone = null, 
-            bool? userExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null,  bool? deafenMembers = null, 
-            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null,  bool? manageNicknames = null, 
-            bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null)
+        private GuildPermissions(ulong initialValue, bool? createInstantInvite = null, bool? kickMembers = null,
+            bool? banMembers = null, bool? administrator = null, bool? manageChannel = null, bool? manageGuild = null,
+            bool? addReactions = null,
+            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
+            bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
+            bool? userExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
+            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
+            bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null, bool? viewAuditLog = null)
         {
             ulong value = initialValue;
 
@@ -96,7 +96,6 @@ namespace Discord
             Permissions.SetValue(ref value, administrator, GuildPermission.Administrator);
             Permissions.SetValue(ref value, manageChannel, GuildPermission.ManageChannels);
             Permissions.SetValue(ref value, manageGuild, GuildPermission.ManageGuild);
-            Permissions.SetValue(ref value, viewAuditLog, GuildPermission.ViewAuditLog);
             Permissions.SetValue(ref value, addReactions, GuildPermission.AddReactions);
             Permissions.SetValue(ref value, readMessages, GuildPermission.ReadMessages);
             Permissions.SetValue(ref value, sendMessages, GuildPermission.SendMessages);
@@ -118,36 +117,39 @@ namespace Discord
             Permissions.SetValue(ref value, manageRoles, GuildPermission.ManageRoles);
             Permissions.SetValue(ref value, manageWebhooks, GuildPermission.ManageWebhooks);
             Permissions.SetValue(ref value, manageEmojis, GuildPermission.ManageEmojis);
+            Permissions.SetValue(ref value, viewAuditLog, GuildPermission.ViewAuditLog);
 
             RawValue = value;
         }
 
         /// <summary> Creates a new GuildPermissions with the provided permissions. </summary>
-        public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false, 
+        public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false,
             bool banMembers = false, bool administrator = false, bool manageChannels = false, bool manageGuild = false,
-            bool viewAuditLog = false, bool addReactions = false,
+            bool addReactions = false,
             bool readMessages = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
             bool embedLinks = false, bool attachFiles = false, bool readMessageHistory = false, bool mentionEveryone = false,
             bool useExternalEmojis = false, bool connect = false, bool speak = false, bool muteMembers = false, bool deafenMembers = false,
-            bool moveMembers = false, bool useVoiceActivation = false, bool? changeNickname = false, bool? manageNicknames = false, 
-            bool manageRoles = false, bool manageWebhooks = false, bool manageEmojis = false)
-            : this(0, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, viewAuditLog, addReactions, 
-                readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, useExternalEmojis, connect, 
-                manageWebhooks, manageEmojis) { }
+            bool moveMembers = false, bool useVoiceActivation = false, bool? changeNickname = false, bool? manageNicknames = false,
+            bool manageRoles = false, bool manageWebhooks = false, bool manageEmojis = false,
+            bool viewAuditLog = false)
+            : this(0, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, addReactions,
+                readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, useExternalEmojis,
+                connect, manageWebhooks, manageEmojis, viewAuditLog)
+        { }
 
         /// <summary> Creates a new GuildPermissions from this one, changing the provided non-null permissions. </summary>
-        public GuildPermissions Modify(bool? createInstantInvite = null,  bool? kickMembers = null, 
+        public GuildPermissions Modify(bool? createInstantInvite = null, bool? kickMembers = null,
             bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
-            bool? viewAuditLog = null, bool? addReactions = null,
+            bool? addReactions = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
-            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null, 
-            bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null)
-            => new GuildPermissions(RawValue, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, viewAuditLog,
-                addReactions, readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, 
-                useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, changeNickname, 
-                manageNicknames, manageRoles, manageWebhooks, manageEmojis);
+            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
+            bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null, bool? viewAuditLog = null)
+            => new GuildPermissions(RawValue, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild,
+                addReactions, readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone,
+                useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, changeNickname,
+                manageNicknames, manageRoles, manageWebhooks, manageEmojis, viewAuditLog);
 
         public bool Has(GuildPermission permission) => Permissions.GetValue(RawValue, permission);
 

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -84,7 +84,7 @@ namespace Discord
             bool? addReactions = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
-            bool? userExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
+            bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null, bool? viewAuditLog = null)
         {
@@ -105,7 +105,7 @@ namespace Discord
             Permissions.SetValue(ref value, attachFiles, GuildPermission.AttachFiles);
             Permissions.SetValue(ref value, readMessageHistory, GuildPermission.ReadMessageHistory);
             Permissions.SetValue(ref value, mentionEveryone, GuildPermission.MentionEveryone);
-            Permissions.SetValue(ref value, userExternalEmojis, GuildPermission.UseExternalEmojis);
+            Permissions.SetValue(ref value, useExternalEmojis, GuildPermission.UseExternalEmojis);
             Permissions.SetValue(ref value, connect, GuildPermission.Connect);
             Permissions.SetValue(ref value, speak, GuildPermission.Speak);
             Permissions.SetValue(ref value, muteMembers, GuildPermission.MuteMembers);
@@ -124,7 +124,7 @@ namespace Discord
 
         /// <summary> Creates a new GuildPermissions with the provided permissions. </summary>
         public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false,
-            bool banMembers = false, bool administrator = false, bool manageChannels = false, bool manageGuild = false,
+            bool banMembers = false, bool administrator = false, bool manageChannel = false, bool manageGuild = false,
             bool addReactions = false,
             bool readMessages = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
             bool embedLinks = false, bool attachFiles = false, bool readMessageHistory = false, bool mentionEveryone = false,
@@ -132,24 +132,32 @@ namespace Discord
             bool moveMembers = false, bool useVoiceActivation = false, bool? changeNickname = false, bool? manageNicknames = false,
             bool manageRoles = false, bool manageWebhooks = false, bool manageEmojis = false,
             bool viewAuditLog = false)
-            : this(0, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, addReactions,
-                readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, useExternalEmojis,
-                connect, manageWebhooks, manageEmojis, viewAuditLog)
+            : this( initialValue: 0, createInstantInvite: createInstantInvite, kickMembers: kickMembers, banMembers: banMembers,
+                  administrator: administrator, manageChannel: manageChannel, manageGuild: manageGuild, addReactions: addReactions,
+                  readMessages: readMessages, sendMessages: sendMessages, sendTTSMessages: sendTTSMessages, manageMessages: manageMessages,
+                  embedLinks: embedLinks, attachFiles: attachFiles, readMessageHistory: readMessageHistory, mentionEveryone: mentionEveryone,
+                  useExternalEmojis: useExternalEmojis, connect: connect, speak: speak, muteMembers: muteMembers, deafenMembers: deafenMembers,
+                  moveMembers: moveMembers, useVoiceActivation: useVoiceActivation, changeNickname: changeNickname, manageNicknames: manageNicknames, 
+                  manageRoles: manageRoles, manageWebhooks: manageWebhooks, manageEmojis: manageEmojis, viewAuditLog: viewAuditLog)
+
         { }
 
         /// <summary> Creates a new GuildPermissions from this one, changing the provided non-null permissions. </summary>
         public GuildPermissions Modify(bool? createInstantInvite = null, bool? kickMembers = null,
-            bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
+            bool? banMembers = null, bool? administrator = null, bool? manageChannel = null, bool? manageGuild = null,
             bool? addReactions = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null, bool? viewAuditLog = null)
-            => new GuildPermissions(RawValue, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild,
-                addReactions, readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone,
-                useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, changeNickname,
-                manageNicknames, manageRoles, manageWebhooks, manageEmojis, viewAuditLog);
+            => new GuildPermissions(RawValue, createInstantInvite: createInstantInvite, kickMembers: kickMembers, banMembers: banMembers,
+                  administrator: administrator, manageChannel: manageChannel, manageGuild: manageGuild, addReactions: addReactions,
+                  readMessages: readMessages, sendMessages: sendMessages, sendTTSMessages: sendTTSMessages, manageMessages: manageMessages,
+                  embedLinks: embedLinks, attachFiles: attachFiles, readMessageHistory: readMessageHistory, mentionEveryone: mentionEveryone,
+                  useExternalEmojis: useExternalEmojis, connect: connect, speak: speak, muteMembers: muteMembers, deafenMembers: deafenMembers,
+                  moveMembers: moveMembers, useVoiceActivation: useVoiceActivation, changeNickname: changeNickname, manageNicknames: manageNicknames,
+                  manageRoles: manageRoles, manageWebhooks: manageWebhooks, manageEmojis: manageEmojis, viewAuditLog: viewAuditLog);
 
         public bool Has(GuildPermission permission) => Permissions.GetValue(RawValue, permission);
 

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -11,7 +11,7 @@ namespace Discord
         /// <summary> Gets a GuildPermissions that grants all guild permissions for webhook users. </summary>
         public static readonly GuildPermissions Webhook = new GuildPermissions(0b00000_0000000_0001101100000_000000);
         /// <summary> Gets a GuildPermissions that grants all guild permissions. </summary>
-        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111110_0111111110001_111111);
+        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111110_0111111110011_111111);
 
         /// <summary> Gets a packed value representing all the permissions in this GuildPermissions. </summary>
         public ulong RawValue { get; }


### PR DESCRIPTION
Added ViewAuditLog to GuildPermissions struct, as well as ViewAuditLog to GuildPermission enum. Numbering of ViewAuditLog was based off of [this discord api reference doc](https://discordapp.com/developers/docs/topics/permissions).

The GuildPermission enum numbering appears out of order, however I kept the logical grouping consistent. In addition, I added this new value to the constructors of GuildPermissions. ~~Should the new value be added to the end? (This will affect existing code.)~~ edit: 4328e8d27a89771988e96860c0de12ac1f65a02a I moved the ViewAuditLog parameter to the end as to not break existing code that may be using that constructor.

I have gotten this to work myself, however I'm not sure the best way to show that here. (Yay CI works!)