### PR TITLE
Add build prefix in CI rather than in project files

### DIFF
--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -1,7 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <VersionPrefix>1.0.2</VersionPrefix>
-        <VersionSuffix></VersionSuffix>
         <Authors>RogueException</Authors>
         <PackageTags>discord;discordapp</PackageTags>
         <PackageProjectUrl>https://github.com/RogueException/Discord.Net</PackageProjectUrl>
@@ -10,12 +9,10 @@
         <RepositoryUrl>git://github.com/RogueException/Discord.Net</RepositoryUrl>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
-        <VersionSuffix Condition=" '$(VersionSuffix)' != ''">$(VersionSuffix)-dev</VersionSuffix>
-        <VersionSuffix Condition=" '$(VersionSuffix)' == ''">dev</VersionSuffix>
+        <VersionSuffix>dev</VersionSuffix>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(BuildNumber)' != '' And '$(IsTagBuild)' != 'true' ">
-        <VersionSuffix Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
-        <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">build-$(BuildNumber)</VersionSuffix>
+    <PropertyGroup Condition=" '$(BuildNumber)' != '' ">
+        <VersionSuffix>$(BuildNumber)</VersionSuffix>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45' ">
         <DefineConstants>$(DefineConstants);FILESYSTEM;DEFAULTUDPCLIENT;DEFAULTWEBSOCKET</DefineConstants>

--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -8,7 +8,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>git://github.com/RogueException/Discord.Net</RepositoryUrl>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
+    <PropertyGroup Condition=" '$(BuildNumber)' == '' And '$(IsTaggedBuild)' != 'true' ">
         <VersionSuffix>dev</VersionSuffix>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(BuildNumber)' != '' ">

--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <VersionPrefix>1.0.1</VersionPrefix>
-        <VersionSuffix></VersionSuffix>
+        <VersionSuffix>build</VersionSuffix>
         <Authors>RogueException</Authors>
         <PackageTags>discord;discordapp</PackageTags>
         <PackageProjectUrl>https://github.com/RogueException/Discord.Net</PackageProjectUrl>

--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <VersionPrefix>1.0.1</VersionPrefix>
-        <VersionSuffix>build</VersionSuffix>
+        <VersionPrefix>1.0.2</VersionPrefix>
+        <VersionSuffix></VersionSuffix>
         <Authors>RogueException</Authors>
         <PackageTags>discord;discordapp</PackageTags>
         <PackageProjectUrl>https://github.com/RogueException/Discord.Net</PackageProjectUrl>
@@ -13,7 +13,7 @@
         <VersionSuffix Condition=" '$(VersionSuffix)' != ''">$(VersionSuffix)-dev</VersionSuffix>
         <VersionSuffix Condition=" '$(VersionSuffix)' == ''">dev</VersionSuffix>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(BuildNumber)' != '' And $(IsTagBuild) != 'true' ">
+    <PropertyGroup Condition=" '$(BuildNumber)' != '' And '$(IsTagBuild)' != 'true' ">
         <VersionSuffix Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">build-$(BuildNumber)</VersionSuffix>
     </PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ environment:
 init:
 - ps: $Env:BUILD = "$($Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))"
 
+
 build_script:
 - ps: appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
 - ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
@@ -34,7 +35,7 @@ after_build:
     if ($Env:APPVEYOR_REPO_TAG -eq "true") {
       nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts"
     } else {
-      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -suffix "$Env:BUILD"
+      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -suffix "$Env:BUILD" -properties suffix="build"
     }
 - ps: Get-ChildItem artifacts\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,9 @@ after_build:
 - ps: dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
 - ps: >-
     if ($Env:APPVEYOR_REPO_TAG -eq "true") {
-      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
+      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts"
     } else {
-      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-$Env:BUILD"
+      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -suffix "$Env:BUILD"
     }
 - ps: Get-ChildItem artifacts\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,17 +26,22 @@ init:
 
 
 build_script:
-- ps: appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD"
-- ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD"
+- ps: appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
 after_build:
-- ps: dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
-- ps: dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
-- ps: dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
-- ps: dotnet pack "src\Discord.Net.Rpc\Discord.Net.Rpc.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
-- ps: dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
-- ps: dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
-- ps: dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
-- ps: nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -suffix "$Env:BUILD"
+- ps: dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: dotnet pack "src\Discord.Net.Rpc\Discord.Net.Rpc.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTaggedBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: >-
+    if($Env:APPVEYOR_REPO_TAG -eq "true") {
+      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts"
+    } else {
+      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -suffix "$Env:BUILD"
+    }
 - ps: Get-ChildItem artifacts\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,32 +17,32 @@ environment:
     secure: l7h5e7UE7yRd70hAB97kjPiQpPOShwqoBbOzEAYQ+XBd/Pre5OA33IXa3uisdUeQJP/nPFhcOsI+yn7WpuFaoQ==
   DNET_TEST_GUILDID: 273160668180381696
 init:
-- ps: $Env:BUILD = "$($Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))"
+- ps: >-
+    if ($Env:APPVEYOR_REPO_TAG -eq "true") {
+      $Env:BUILD = "$($Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))"
+    } else {
+      $Env:BUILD = "build-$($Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))"
+    }
 
 
 build_script:
-- ps: appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD"
+- ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD"
 after_build:
-- ps: dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Rpc\Discord.Net.Rpc.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: >-
-    if ($Env:APPVEYOR_REPO_TAG -eq "true") {
-      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts"
-    } else {
-      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -suffix "$Env:BUILD" -properties suffix="build"
-    }
+- ps: dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
+- ps: dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
+- ps: dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
+- ps: dotnet pack "src\Discord.Net.Rpc\Discord.Net.Rpc.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
+- ps: dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
+- ps: dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
+- ps: dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD"
+- ps: nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -suffix "$Env:BUILD"
 - ps: Get-ChildItem artifacts\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
 test_script:
 - ps: >-
     if ($APPVEYOR_PULL_REQUEST_NUMBER -eq "") {
-      dotnet test test/Discord.Net.Tests/Discord.Net.Tests.csproj -c "Release" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+      dotnet test test/Discord.Net.Tests/Discord.Net.Tests.csproj -c "Release" --no-build /p:BuildNumber="$Env:BUILD"
     }
 
 deploy:

--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Discord.Net</id>
-    <version>1.0.1-build$suffix$</version>
+    <version>1.0.2$suffix$</version>
     <title>Discord.Net</title>
     <authors>RogueException</authors>
     <owners>RogueException</owners>
@@ -13,28 +13,28 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
         <group targetFramework="net45">
-            <dependency id="Discord.Net.Core" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.1-build$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Rest" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Commands" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2$suffix$" />
         </group>
         <group targetFramework="netstandard1.1">
-            <dependency id="Discord.Net.Core" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.1-build$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Rest" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Commands" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2$suffix$" />
         </group>
         <group targetFramework="netstandard1.3">
-            <dependency id="Discord.Net.Core" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.1-build$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.1-build$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Rest" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Commands" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2$suffix$" />
         </group>
     </dependencies>
   </metadata>

--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Discord.Net</id>
-    <version>1.0.2-$suffix$</version>
+    <version>1.0.2</version>
     <title>Discord.Net</title>
     <authors>RogueException</authors>
     <owners>RogueException</owners>
@@ -13,28 +13,28 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
         <group targetFramework="net45">
-            <dependency id="Discord.Net.Core" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2" />
+            <dependency id="Discord.Net.Rest" version="1.0.2" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2" />
+            <dependency id="Discord.Net.Commands" version="1.0.2" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2" />
         </group>
         <group targetFramework="netstandard1.1">
-            <dependency id="Discord.Net.Core" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2" />
+            <dependency id="Discord.Net.Rest" version="1.0.2" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2" />
+            <dependency id="Discord.Net.Commands" version="1.0.2" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2" />
         </group>
         <group targetFramework="netstandard1.3">
-            <dependency id="Discord.Net.Core" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.2-$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2" />
+            <dependency id="Discord.Net.Rest" version="1.0.2" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2" />
+            <dependency id="Discord.Net.Commands" version="1.0.2" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2" />
         </group>
     </dependencies>
   </metadata>

--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Discord.Net</id>
-    <version>1.0.2$suffix$</version>
+    <version>1.0.2</version>
     <title>Discord.Net</title>
     <authors>RogueException</authors>
     <owners>RogueException</owners>
@@ -13,28 +13,28 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
         <group targetFramework="net45">
-            <dependency id="Discord.Net.Core" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2" />
+            <dependency id="Discord.Net.Rest" version="1.0.2" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2" />
+            <dependency id="Discord.Net.Commands" version="1.0.2" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2" />
         </group>
         <group targetFramework="netstandard1.1">
-            <dependency id="Discord.Net.Core" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2" />
+            <dependency id="Discord.Net.Rest" version="1.0.2" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2" />
+            <dependency id="Discord.Net.Commands" version="1.0.2" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2" />
         </group>
         <group targetFramework="netstandard1.3">
-            <dependency id="Discord.Net.Core" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Rest" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Commands" version="1.0.2$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2$suffix$" />
+            <dependency id="Discord.Net.Core" version="1.0.2" />
+            <dependency id="Discord.Net.Rest" version="1.0.2" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2" />
+            <dependency id="Discord.Net.Commands" version="1.0.2" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2" />
         </group>
     </dependencies>
   </metadata>

--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Discord.Net</id>
-    <version>1.0.2</version>
+    <version>1.0.2-$suffix$</version>
     <title>Discord.Net</title>
     <authors>RogueException</authors>
     <owners>RogueException</owners>
@@ -13,28 +13,28 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
         <group targetFramework="net45">
-            <dependency id="Discord.Net.Core" version="1.0.2" />
-            <dependency id="Discord.Net.Rest" version="1.0.2" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2" />
-            <dependency id="Discord.Net.Commands" version="1.0.2" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2" />
+            <dependency id="Discord.Net.Core" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Rest" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Commands" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2-$suffix$" />
         </group>
         <group targetFramework="netstandard1.1">
-            <dependency id="Discord.Net.Core" version="1.0.2" />
-            <dependency id="Discord.Net.Rest" version="1.0.2" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2" />
-            <dependency id="Discord.Net.Commands" version="1.0.2" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2" />
+            <dependency id="Discord.Net.Core" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Rest" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Commands" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2-$suffix$" />
         </group>
         <group targetFramework="netstandard1.3">
-            <dependency id="Discord.Net.Core" version="1.0.2" />
-            <dependency id="Discord.Net.Rest" version="1.0.2" />
-            <dependency id="Discord.Net.WebSocket" version="1.0.2" />
-            <dependency id="Discord.Net.Rpc" version="1.0.2" />
-            <dependency id="Discord.Net.Commands" version="1.0.2" />
-            <dependency id="Discord.Net.Webhook" version="1.0.2" />
+            <dependency id="Discord.Net.Core" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Rest" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Rpc" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Commands" version="1.0.2-$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="1.0.2-$suffix$" />
         </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Fixes #728 by altering the build script so that it adds the build prefix rather than in the project config.

This likely means more flexibility as it is easier to define build prefixes in CI than it is in the targets and nuspec file.