### PR TITLE
Unify ShardedCommandContext with SocketCommandContext

### DIFF
--- a/src/Discord.Net.WebSocket/Commands/ShardedCommandContext.cs
+++ b/src/Discord.Net.WebSocket/Commands/ShardedCommandContext.cs
@@ -2,7 +2,7 @@
 
 namespace Discord.Commands
 {
-    public class ShardedCommandContext : SocketCommandContext
+    public class ShardedCommandContext : SocketCommandContext, ICommandContext
     {
         public new DiscordShardedClient Client { get; }
 
@@ -14,5 +14,8 @@ namespace Discord.Commands
 
         private static int GetShardId(DiscordShardedClient client, IGuild guild)
             => guild == null ? 0 : client.GetShardIdFor(guild);
+
+        //ICommandContext
+        IDiscordClient ICommandContext.Client => Client;
     }
 }

--- a/src/Discord.Net.WebSocket/Commands/ShardedCommandContext.cs
+++ b/src/Discord.Net.WebSocket/Commands/ShardedCommandContext.cs
@@ -2,30 +2,17 @@
 
 namespace Discord.Commands
 {
-    public class ShardedCommandContext : ICommandContext
+    public class ShardedCommandContext : SocketCommandContext
     {
-        public DiscordShardedClient Client { get; }
-        public SocketGuild Guild { get; }
-        public ISocketMessageChannel Channel { get; }
-        public SocketUser User { get; }
-        public SocketUserMessage Message { get; }
-
-        public bool IsPrivate => Channel is IPrivateChannel;
+        public new DiscordShardedClient Client { get; }
 
         public ShardedCommandContext(DiscordShardedClient client, SocketUserMessage msg)
+            : base(client.GetShard(GetShardId(client, (msg.Channel as SocketGuildChannel)?.Guild)), msg)
         {
             Client = client;
-            Guild = (msg.Channel as SocketGuildChannel)?.Guild;
-            Channel = msg.Channel;
-            User = msg.Author;
-            Message = msg;
         }
 
-        //ICommandContext
-        IDiscordClient ICommandContext.Client => Client;
-        IGuild ICommandContext.Guild => Guild;
-        IMessageChannel ICommandContext.Channel => Channel;
-        IUser ICommandContext.User => User;
-        IUserMessage ICommandContext.Message => Message;
+        private static int GetShardId(DiscordShardedClient client, IGuild guild)
+            => guild == null ? 0 : client.GetShardIdFor(guild);
     }
 }


### PR DESCRIPTION
One thing that becomes a bit of a nag for addon developers is that there's no good way to write an addon module compatible for both `DiscordSocketClient` and `DiscordShardedClient` without using only the base `ICommandContext` and lose out on access to the socket entities.

It seems like a neat solution to let Sharded clients use `SocketCommandContext` modules, even if it requires a bit of inheritance trickery.