### PR TITLE
Added CommandService.CommandExecuted

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -17,6 +17,9 @@ namespace Discord.Commands
         public event Func<LogMessage, Task> Log { add { _logEvent.Add(value); } remove { _logEvent.Remove(value); } }
         internal readonly AsyncEvent<Func<LogMessage, Task>> _logEvent = new AsyncEvent<Func<LogMessage, Task>>();
 
+        public event Func<CommandInfo, ICommandContext, IResult, Task> CommandExecuted { add { _commandExecutedEvent.Add(value); } remove { _commandExecutedEvent.Remove(value); } }
+        internal readonly AsyncEvent<Func<CommandInfo, ICommandContext, IResult, Task>> _commandExecutedEvent = new AsyncEvent<Func<CommandInfo, ICommandContext, IResult, Task>>();
+
         private readonly SemaphoreSlim _moduleLock;
         private readonly ConcurrentDictionary<Type, ModuleInfo> _typedModuleDefs;
         private readonly ConcurrentDictionary<Type, ConcurrentDictionary<Type, TypeReader>> _typeReaders;

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -188,17 +188,22 @@ namespace Discord.Commands
                 if (task is Task<IResult> resultTask)
                 {
                     var result = await resultTask.ConfigureAwait(false);
+                    await Module.Service._commandExecutedEvent.InvokeAsync(this, context, result).ConfigureAwait(false);
                     if (result is RuntimeResult execResult)
                         return execResult;
                 }
                 else if (task is Task<ExecuteResult> execTask)
                 {
-                    return await execTask.ConfigureAwait(false);
+                    var result = await execTask.ConfigureAwait(false);
+                    await Module.Service._commandExecutedEvent.InvokeAsync(this, context, result).ConfigureAwait(false);
+                    return result;
                 }
                 else
                     await task.ConfigureAwait(false);
 
-                return ExecuteResult.FromSuccess();
+                var executeResult = ExecuteResult.FromSuccess();
+                await Module.Service._commandExecutedEvent.InvokeAsync(this, context, executeResult).ConfigureAwait(false);
+                return executeResult;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This change allows developers to more easily access command results, without needing to search the text attached to the CommandService's Log event.

Commands with an async RunMode can now return a RuntimeResult.