### PR TITLE
Try to pull DM channels from cache on CHANNEL_CREATE

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1631,7 +1631,10 @@ namespace Discord.WebSocket
 
         internal ISocketPrivateChannel AddPrivateChannel(API.Channel model, ClientState state)
         {
-            var channel = SocketChannel.CreatePrivate(this, state, model);
+            ISocketPrivateChannel channel;
+            if ((channel = state.GetChannel(model.Id) as ISocketPrivateChannel) != null)
+                return channel;
+            channel = SocketChannel.CreatePrivate(this, state, model);
             state.AddChannel(channel as SocketChannel);
             if (channel is SocketDMChannel dm)
                 dm.Recipient.GlobalUser.DMChannel = dm;

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1631,8 +1631,7 @@ namespace Discord.WebSocket
 
         internal ISocketPrivateChannel AddPrivateChannel(API.Channel model, ClientState state)
         {
-            ISocketPrivateChannel channel;
-            if ((channel = state.GetChannel(model.Id) as ISocketPrivateChannel) != null)
+            if (state.GetChannel(model.Id) is ISocketPrivateChannel channel)
                 return channel;
             channel = SocketChannel.CreatePrivate(this, state, model);
             state.AddChannel(channel as SocketChannel);


### PR DESCRIPTION
This resoles #741

Since Discord now dispatches a CHANNEL_CREATE for every message sent to
a bot, we check to see if a channel has already been added to the state
before creating a new one.