### PR TITLE
Disable ratelimits on reactions

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -577,7 +577,8 @@ namespace Discord.API
 
             options = RequestOptions.CreateOrClone(options);
 
-            var ids = new BucketIds(channelId: channelId);
+            var id = new Random().Next(0, int.MaxValue);
+            var ids = new BucketIds(channelId: (ulong)id);
 
             await SendAsync("PUT", () => $"channels/{channelId}/messages/{messageId}/reactions/{emoji}/@me", ids, options: options).ConfigureAwait(false);
         }
@@ -589,7 +590,8 @@ namespace Discord.API
 
             options = RequestOptions.CreateOrClone(options);
 
-            var ids = new BucketIds(channelId: channelId);
+            var id = new Random().Next(0, int.MaxValue);
+            var ids = new BucketIds(channelId: (ulong)id);
 
             await SendAsync("DELETE", () => $"channels/{channelId}/messages/{messageId}/reactions/{emoji}/{userId}", ids, options: options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1631,7 +1631,10 @@ namespace Discord.WebSocket
 
         internal ISocketPrivateChannel AddPrivateChannel(API.Channel model, ClientState state)
         {
-            var channel = SocketChannel.CreatePrivate(this, state, model);
+            ISocketPrivateChannel channel;
+            if ((channel = state.GetChannel(model.Id) as ISocketPrivateChannel) != null)
+                return channel;
+            channel = SocketChannel.CreatePrivate(this, state, model);
             state.AddChannel(channel as SocketChannel);
             if (channel is SocketDMChannel dm)
                 dm.Recipient.GlobalUser.DMChannel = dm;

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1631,8 +1631,7 @@ namespace Discord.WebSocket
 
         internal ISocketPrivateChannel AddPrivateChannel(API.Channel model, ClientState state)
         {
-            ISocketPrivateChannel channel;
-            if ((channel = state.GetChannel(model.Id) as ISocketPrivateChannel) != null)
+            if (state.GetChannel(model.Id) is ISocketPrivateChannel channel)
                 return channel;
             channel = SocketChannel.CreatePrivate(this, state, model);
             state.AddChannel(channel as SocketChannel);


### PR DESCRIPTION
This pull request generates a random channel ID to be passed into the ratelimit bucket when adding a reaction.

This should avoid any preemptive ratelimiting on the AddReactionAsync endpoint.

This change is necessary because right now it takes our library seven seconds to generate seven reactions, whereas competing libraries (Discord4J, DiscordNim) can do it in just under two seconds.