### PR TITLE
NullOrEmpty -> NullOrWhiteSpace

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
@@ -249,7 +249,7 @@ namespace Discord
             get => _field.Name;
             set
             {
-                if (string.IsNullOrEmpty(value)) throw new ArgumentException($"Field name must not be null or empty.", nameof(Name));
+                if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException($"Field name must not be null, empty or entirely whitespace.", nameof(Name));
                 if (value.Length > MaxFieldNameLength) throw new ArgumentException($"Field name length must be less than or equal to {MaxFieldNameLength}.", nameof(Name));
                 _field.Name = value;
             }


### PR DESCRIPTION
Recently, it seems that checks have been added to this EmbedBuilder file to better inform users what's wrong with an invalid embed they might be sending, ahead of a BadRequest error that Discord will return.

However, I believe that Discord will also throw if you try and add an embed field where the value (and probably the title as well, though this is only an assumption) is just whitespace. If anyone could repro this fact in a more controlled environment that'd be great.

To make these 'pre-exceptions' more consistent, I changed NullOrEmpty to NullOrWhiteSpace, and updated the exception message to reflect it.