### PR TITLE
Allow users to opt out of preemtive rate limiting

### DIFF
--- a/src/Discord.Net.Core/RequestOptions.cs
+++ b/src/Discord.Net.Core/RequestOptions.cs
@@ -15,6 +15,11 @@ namespace Discord
         public RetryMode? RetryMode { get; set; }
         public bool HeaderOnly { get; internal set; }
         /// <summary>
+        /// Should this request bypass the ratelimit buckets? This option should be used sparingly, and when used, should be coupled with your own
+        /// delays between requests, to avoid encountering 429 errors.
+        /// </summary>
+        public bool BypassBuckets { get; set; }
+        /// <summary>
         /// The reason for this action in the guild's audit log
         /// </summary>
         public string AuditLogReason { get; set; }

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -48,8 +48,11 @@ namespace Discord.Net.Queue
             LastAttemptAt = DateTimeOffset.UtcNow;
             while (true)
             {
-                await _queue.EnterGlobalAsync(id, request).ConfigureAwait(false);
-                await EnterAsync(id, request).ConfigureAwait(false);
+                if (!request.Options.BypassBuckets)
+                {
+                    await _queue.EnterGlobalAsync(id, request).ConfigureAwait(false);
+                    await EnterAsync(id, request).ConfigureAwait(false);
+                }
 
 #if DEBUG_LIMITS
                 Debug.WriteLine($"[{id}] Sending...");


### PR DESCRIPTION
This change adds a property, `BypassBuckets` to RequestOptions.

When this property is set to true, the global ratelimit, and route-specific ratelimit buckets will be bypassed entirely. Users can now send requests at their intended speed, instead of being crippled by the broken ratelimit headers.

![Example](https://i-was-scammed-by.dabbot.org/7e7de1.gif)