### PR TITLE
Changed NameAttribute to work for parameters

### DIFF
--- a/src/Discord.Net.Commands/Attributes/NameAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/NameAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Discord.Commands
 {
     // Override public name of command/module
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Parameter)]
     public class NameAttribute : Attribute
     {
         public string Text { get; }

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -254,6 +254,9 @@ namespace Discord.Commands
                     case ParameterPreconditionAttribute precon:
                         builder.AddPrecondition(precon);
                         break;
+                    case NameAttribute name:
+                        builder.Name = name.Text;
+                        break;
                     case RemainderAttribute _:
                         if (position != count - 1)
                             throw new InvalidOperationException($"Remainder parameters must be the last parameter in a command. Parameter: {paramInfo.Name} in {paramInfo.Member.DeclaringType.Name}.{paramInfo.Member.Name}");


### PR DESCRIPTION
This seemed like an arbitrary restriction and could be very useful, especially for help commands.
If this is by design, then you can just close it.