### PR TITLE
Remove dead link

### DIFF
--- a/docs/guides/voice/sending-voice.md
+++ b/docs/guides/voice/sending-voice.md
@@ -16,9 +16,6 @@ bot. (When developing on .NET Framework, this would be `bin/debug`,
 when developing on .NET Core, this is where you execute `dotnet run` 
 from; typically the same directory as your csproj).
 
-For Windows Users, precompiled binaries are available for your 
-convienence [here](https://discord.foxbot.me/binaries/)
-
 For Linux Users, you will need to compile [Sodium] and [Opus] from 
 source, or install them from your package manager.
 


### PR DESCRIPTION
As per https://github.com/RogueException/Discord.Net/issues/737, this link is not going to be fixed, so it should be removed

Please ignore the last line. It's Git being stupid.