### PR TITLE
Fix CreateGuildAsync not sending icon stream.

### DIFF
--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -120,6 +120,9 @@ namespace Discord.Rest
             string name, IVoiceRegion region, Stream jpegIcon, RequestOptions options)
         {
             var args = new CreateGuildParams(name, region.Id);
+            if (jpegIcon != null)
+                args.Icon = new API.Image(jpegIcon);
+
             var model = await client.ApiClient.CreateGuildAsync(args, options).ConfigureAwait(false);
             return RestGuild.Create(client, model);
         }

--- a/src/Discord.Net.Rest/Net/Converters/ImageConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/ImageConverter.cs
@@ -35,7 +35,7 @@ namespace Discord.Net.Converters
                 {
                     var cloneStream = new MemoryStream();
                     image.Stream.CopyTo(cloneStream);
-                    byte[] bytes = new byte[cloneStream.Length];
+                    bytes = new byte[cloneStream.Length];
                     cloneStream.Position = 0;
                     cloneStream.Read(bytes, 0, bytes.Length);
                     length = (int)cloneStream.Length;

--- a/src/Discord.Net.Rest/Net/Converters/ImageConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/ImageConverter.cs
@@ -24,14 +24,24 @@ namespace Discord.Net.Converters
 
             if (image.Stream != null)
             {
-                Stream cloneStream = new MemoryStream();
-                image.Stream.CopyTo(cloneStream);
+                byte[] bytes;
+                int length;
+                if (image.Stream.CanSeek)
+                {
+                    bytes = new byte[image.Stream.Length - image.Stream.Position];
+                    length = image.Stream.Read(bytes, 0, bytes.Length);
+                }
+                else
+                {
+                    var cloneStream = new MemoryStream();
+                    image.Stream.CopyTo(cloneStream);
+                    byte[] bytes = new byte[cloneStream.Length];
+                    cloneStream.Position = 0;
+                    cloneStream.Read(bytes, 0, bytes.Length);
+                    length = (int)cloneStream.Length;
+                }
 
-                byte[] bytes = new byte[cloneStream.Length];
-                cloneStream.Seek(0, SeekOrigin.Begin);
-                cloneStream.Read(bytes, 0, bytes.Length);
-
-                string base64 = Convert.ToBase64String(bytes);
+                string base64 = Convert.ToBase64String(bytes, 0, length);
                 writer.WriteValue($"data:image/jpeg;base64,{base64}");
             }
             else if (image.Hash != null)

--- a/src/Discord.Net.Rest/Net/Converters/ImageConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/ImageConverter.cs
@@ -1,5 +1,6 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using System.IO;
+using Newtonsoft.Json;
 using Model = Discord.API.Image;
 
 namespace Discord.Net.Converters
@@ -23,8 +24,12 @@ namespace Discord.Net.Converters
 
             if (image.Stream != null)
             {
-                byte[] bytes = new byte[image.Stream.Length - image.Stream.Position];
-                image.Stream.Read(bytes, 0, bytes.Length);
+                Stream cloneStream = new MemoryStream();
+                image.Stream.CopyTo(cloneStream);
+
+                byte[] bytes = new byte[cloneStream.Length];
+                cloneStream.Seek(0, SeekOrigin.Begin);
+                cloneStream.Read(bytes, 0, bytes.Length);
 
                 string base64 = Convert.ToBase64String(bytes);
                 writer.WriteValue($"data:image/jpeg;base64,{base64}");


### PR DESCRIPTION
Fix CreateGuildAsync not doing anything with the input stream for the guild icon.

Also fixes an issue with potential stream types that throw a `NotSupportedException` when checking its properties. [Apparently, they exist.](https://github.com/dotnet/corefx/blob/master/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs)