### PR TITLE
Reworked IChannel.IsNsfw to support the new API flag

### DIFF
--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -29,6 +29,8 @@ namespace Discord.API
         public Optional<string> Topic { get; set; }
         [JsonProperty("last_pin_timestamp")]
         public Optional<DateTimeOffset?> LastPinTimestamp { get; set; }
+        [JsonProperty("nsfw")]
+        public Optional<bool> Nsfw { get; set; }
 
         //VoiceChannel
         [JsonProperty("bitrate")]

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -290,8 +290,8 @@ namespace Discord.Rest
             return author;
         }
 
-        public static bool IsNsfw(IChannel channel) =>
-            IsNsfw(channel.Name);
+        public static bool IsNsfw(IChannel channel)
+            => IsNsfw(channel.Name);
         public static bool IsNsfw(string channelName) =>
             channelName == "nsfw" || channelName.StartsWith("nsfw-");
     }

--- a/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
@@ -46,7 +46,7 @@ namespace Discord.Rest
 
         //IChannel
         string IChannel.Name => null;
-        bool IChannel.IsNsfw => ChannelHelper.IsNsfw(this);
+        bool IChannel.IsNsfw => false;
 
         Task<IUser> IChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IUser>(null); //Overriden

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -15,6 +15,8 @@ namespace Discord.Rest
 
         public string Mention => MentionUtils.MentionChannel(Id);
 
+        internal bool Nsfw { get; private set; }
+
         internal RestTextChannel(BaseDiscordClient discord, IGuild guild, ulong id)
             : base(discord, guild, id)
         {
@@ -30,6 +32,7 @@ namespace Discord.Rest
             base.Update(model);
 
             Topic = model.Topic.Value;
+            Nsfw = model.Nsfw.GetValueOrDefault();
         }
 
         public async Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null)
@@ -149,5 +152,6 @@ namespace Discord.Rest
             else
                 return AsyncEnumerable.Empty<IReadOnlyCollection<IGuildUser>>();
         }
+        bool IChannel.IsNsfw => Nsfw || ChannelHelper.IsNsfw(this);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketChannel.cs
@@ -41,7 +41,7 @@ namespace Discord.WebSocket
 
         //IChannel
         string IChannel.Name => null;
-        bool IChannel.IsNsfw => ChannelHelper.IsNsfw(this);
+        bool IChannel.IsNsfw => false;
 
         Task<IUser> IChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IUser>(null); //Overridden

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -16,6 +16,7 @@ namespace Discord.WebSocket
         private readonly MessageCache _messages;
 
         public string Topic { get; private set; }
+        internal bool Nsfw { get; private set; }
 
         public string Mention => MentionUtils.MentionChannel(Id);
         public IReadOnlyCollection<SocketMessage> CachedMessages => _messages?.Messages ?? ImmutableArray.Create<SocketMessage>();
@@ -41,6 +42,7 @@ namespace Discord.WebSocket
             base.Update(state, model);
 
             Topic = model.Topic.Value;
+            Nsfw = model.Nsfw.GetValueOrDefault();
         }
 
         public Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null)
@@ -144,5 +146,8 @@ namespace Discord.WebSocket
             => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
+
+        // IChannel
+        bool IChannel.IsNsfw => Nsfw || ChannelHelper.IsNsfw(this);
     }
 }


### PR DESCRIPTION
IChannel.IsNsfw will now return false when being used on any channel
that is not an ITextChannel. When being used on an ITextChannel, this
will now account for the API flag, and fall back to the channel name.

(this is gross design, thanks discord)