### PR TITLE
Add BaseSocketClient object.

### DIFF
--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -85,7 +85,8 @@ namespace Discord.Rest
 
             await _loggedInEvent.InvokeAsync().ConfigureAwait(false);
         }
-        internal virtual Task OnLoginAsync(TokenType tokenType, string token) { return Task.Delay(0); }
+        internal virtual Task OnLoginAsync(TokenType tokenType, string token) 
+            => Task.Delay(0);
 
         /// <inheritdoc />
         public async Task LogoutAsync()
@@ -110,7 +111,8 @@ namespace Discord.Rest
 
             await _loggedOutEvent.InvokeAsync().ConfigureAwait(false);
         }
-        internal virtual Task OnLogoutAsync() { return Task.Delay(0); }
+        internal virtual Task OnLogoutAsync() 
+            => Task.Delay(0);
 
         internal virtual void Dispose(bool disposing)
         {
@@ -127,7 +129,8 @@ namespace Discord.Rest
         ConnectionState IDiscordClient.ConnectionState => ConnectionState.Disconnected;
         ISelfUser IDiscordClient.CurrentUser => CurrentUser;
 
-        Task<IApplication> IDiscordClient.GetApplicationInfoAsync(RequestOptions options) { throw new NotSupportedException(); }
+        Task<IApplication> IDiscordClient.GetApplicationInfoAsync(RequestOptions options) 
+            => throw new NotSupportedException();
 
         Task<IChannel> IDiscordClient.GetChannelAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IChannel>(null);
@@ -148,7 +151,8 @@ namespace Discord.Rest
             => Task.FromResult<IGuild>(null);
         Task<IReadOnlyCollection<IGuild>> IDiscordClient.GetGuildsAsync(CacheMode mode, RequestOptions options)
             => Task.FromResult<IReadOnlyCollection<IGuild>>(ImmutableArray.Create<IGuild>());
-        Task<IGuild> IDiscordClient.CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon, RequestOptions options) { throw new NotSupportedException(); }
+        Task<IGuild> IDiscordClient.CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon, RequestOptions options)
+            => throw new NotSupportedException();
 
         Task<IUser> IDiscordClient.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IUser>(null);

--- a/src/Discord.Net.Rpc/DiscordRpcClient.cs
+++ b/src/Discord.Net.Rpc/DiscordRpcClient.cs
@@ -67,6 +67,7 @@ namespace Discord.Rpc
 
         public Task StartAsync() => _connection.StartAsync();
         public Task StopAsync() => _connection.StopAsync();
+                        
 
         private async Task OnConnectingAsync()
         {

--- a/src/Discord.Net.Rpc/DiscordRpcClient.cs
+++ b/src/Discord.Net.Rpc/DiscordRpcClient.cs
@@ -22,7 +22,7 @@ namespace Discord.Rpc
 
         public ConnectionState ConnectionState { get; private set; }
         public IReadOnlyCollection<string> Scopes { get; private set; }
-        public DateTimeOffset TokenExpiresAt { get; private set; }                                                                                  
+        public DateTimeOffset TokenExpiresAt { get; private set; }
 
         internal new API.DiscordRpcApiClient ApiClient => base.ApiClient as API.DiscordRpcApiClient;
         public new RestSelfUser CurrentUser { get { return base.CurrentUser as RestSelfUser; } private set { base.CurrentUser = value; } }
@@ -66,7 +66,7 @@ namespace Discord.Rpc
         }
 
         public Task StartAsync() => _connection.StartAsync();
-        public Task StopAsync() => _connection.StopAsync();                                                                                                                             
+        public Task StopAsync() => _connection.StopAsync();
 
         private async Task OnConnectingAsync()
         {

--- a/src/Discord.Net.Rpc/DiscordRpcClient.cs
+++ b/src/Discord.Net.Rpc/DiscordRpcClient.cs
@@ -67,8 +67,7 @@ namespace Discord.Rpc
 
         public Task StartAsync() => _connection.StartAsync();
         public Task StopAsync() => _connection.StopAsync();
-                        
-
+                                                                                                                                                                                       
         private async Task OnConnectingAsync()
         {
             await _rpcLogger.DebugAsync("Connecting ApiClient").ConfigureAwait(false);
@@ -450,7 +449,7 @@ namespace Discord.Rpc
                             //Others
                             default:
                                 await _rpcLogger.WarningAsync($"Unknown Dispatch ({evnt})").ConfigureAwait(false);
-                                return;
+                                return;                                                                                                                                                 
                         }
                         break;
 

--- a/src/Discord.Net.Rpc/DiscordRpcClient.cs
+++ b/src/Discord.Net.Rpc/DiscordRpcClient.cs
@@ -22,7 +22,7 @@ namespace Discord.Rpc
 
         public ConnectionState ConnectionState { get; private set; }
         public IReadOnlyCollection<string> Scopes { get; private set; }
-        public DateTimeOffset TokenExpiresAt { get; private set; }
+        public DateTimeOffset TokenExpiresAt { get; private set; }                                                                                  
 
         internal new API.DiscordRpcApiClient ApiClient => base.ApiClient as API.DiscordRpcApiClient;
         public new RestSelfUser CurrentUser { get { return base.CurrentUser as RestSelfUser; } private set { base.CurrentUser = value; } }
@@ -66,8 +66,8 @@ namespace Discord.Rpc
         }
 
         public Task StartAsync() => _connection.StartAsync();
-        public Task StopAsync() => _connection.StopAsync();
-                                                                                                                                                                                       
+        public Task StopAsync() => _connection.StopAsync();                                                                                                                             
+
         private async Task OnConnectingAsync()
         {
             await _rpcLogger.DebugAsync("Connecting ApiClient").ConfigureAwait(false);
@@ -449,7 +449,7 @@ namespace Discord.Rpc
                             //Others
                             default:
                                 await _rpcLogger.WarningAsync($"Unknown Dispatch ({evnt})").ConfigureAwait(false);
-                                return;                                                                                                                                                 
+                                return;
                         }
                         break;
 

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Discord.WebSocket
+{
+    public partial class BaseSocketClient
+    {
+        /// <summary>
+        /// Fired when a channel is created.
+        /// </summary>
+        public event Func<SocketChannel, Task> ChannelCreated 
+        {
+            add { _channelCreatedEvent.Add(value); }
+            remove { _channelCreatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketChannel, Task>> _channelCreatedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
+        /// <summary>
+        /// Fired when a channel is destroyed.
+        /// </summary>
+        public event Func<SocketChannel, Task> ChannelDestroyed {
+            add { _channelDestroyedEvent.Add(value); }
+            remove { _channelDestroyedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketChannel, Task>> _channelDestroyedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
+        /// <summary>
+        /// Fired when a channel is updated.
+        /// </summary>
+        public event Func<SocketChannel, SocketChannel, Task> ChannelUpdated {
+            add { _channelUpdatedEvent.Add(value); }
+            remove { _channelUpdatedEvent.Remove(value); }
+        }    
+        internal readonly AsyncEvent<Func<SocketChannel, SocketChannel, Task>> _channelUpdatedEvent = new AsyncEvent<Func<SocketChannel, SocketChannel, Task>>();
+
+        //Messages
+        /// <summary>
+        /// Fired when a message is received.
+        /// </summary>
+        public event Func<SocketMessage, Task> MessageReceived {
+            add { _messageReceivedEvent.Add(value); }
+            remove { _messageReceivedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketMessage, Task>> _messageReceivedEvent = new AsyncEvent<Func<SocketMessage, Task>>();
+        /// <summary>
+        /// Fired when a message is deleted.
+        /// </summary>
+        public event Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task> MessageDeleted {
+            add { _messageDeletedEvent.Add(value); }
+            remove { _messageDeletedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>>();
+        /// <summary>
+        /// Fired when a message is updated.
+        /// </summary>
+        public event Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task> MessageUpdated {
+            add { _messageUpdatedEvent.Add(value); }
+            remove { _messageUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>>();
+        /// <summary>
+        /// Fired when a reaction is added to a message.
+        /// </summary>
+        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionAdded {
+            add { _reactionAddedEvent.Add(value); }
+            remove { _reactionAddedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
+        /// <summary>
+        /// Fired when a reaction is removed from a message.
+        /// </summary>
+        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionRemoved {
+            add { _reactionRemovedEvent.Add(value); }
+            remove { _reactionRemovedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
+        /// <summary>
+        /// Fired when all reactions to a message are cleared.
+        /// </summary>
+        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task> ReactionsCleared {
+            add { _reactionsClearedEvent.Add(value); }
+            remove { _reactionsClearedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
+
+        //Roles
+        /// <summary>
+        /// Fired when a role is created.
+        /// </summary>
+        public event Func<SocketRole, Task> RoleCreated {
+            add { _roleCreatedEvent.Add(value); }
+            remove { _roleCreatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketRole, Task>> _roleCreatedEvent = new AsyncEvent<Func<SocketRole, Task>>();
+        /// <summary>
+        /// Fired when a role is deleted.
+        /// </summary>
+        public event Func<SocketRole, Task> RoleDeleted {
+            add { _roleDeletedEvent.Add(value); }
+            remove { _roleDeletedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketRole, Task>> _roleDeletedEvent = new AsyncEvent<Func<SocketRole, Task>>();
+        /// <summary>
+        /// Fired when a role is updated.
+        /// </summary>
+        public event Func<SocketRole, SocketRole, Task> RoleUpdated {
+            add { _roleUpdatedEvent.Add(value); }
+            remove { _roleUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketRole, SocketRole, Task>> _roleUpdatedEvent = new AsyncEvent<Func<SocketRole, SocketRole, Task>>();
+
+        //Guilds
+        /// <summary>
+        /// Fired when the connected account joins a guild.
+        /// </summary>
+        public event Func<SocketGuild, Task> JoinedGuild {
+            add { _joinedGuildEvent.Add(value); }
+            remove { _joinedGuildEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuild, Task>> _joinedGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
+        /// <summary>
+        /// Fired when the connected account leaves a guild.
+        /// </summary>
+        public event Func<SocketGuild, Task> LeftGuild {
+            add { _leftGuildEvent.Add(value); }
+            remove { _leftGuildEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuild, Task>> _leftGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
+        /// <summary>
+        /// Fired when a guild becomes available.
+        /// </summary>
+        public event Func<SocketGuild, Task> GuildAvailable {
+            add { _guildAvailableEvent.Add(value); }
+            remove { _guildAvailableEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuild, Task>> _guildAvailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
+        /// <summary>
+        /// Fired when a guild becomes unavailable.
+        /// </summary>
+        public event Func<SocketGuild, Task> GuildUnavailable {
+            add { _guildUnavailableEvent.Add(value); }
+            remove { _guildUnavailableEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuild, Task>> _guildUnavailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
+        /// <summary>
+        /// Fired when offline guild members are downloaded.
+        /// </summary>
+        public event Func<SocketGuild, Task> GuildMembersDownloaded {
+            add { _guildMembersDownloadedEvent.Add(value); }
+            remove { _guildMembersDownloadedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuild, Task>> _guildMembersDownloadedEvent = new AsyncEvent<Func<SocketGuild, Task>>();
+        /// <summary>
+        /// Fired when a guild is updated.
+        /// </summary>
+        public event Func<SocketGuild, SocketGuild, Task> GuildUpdated {
+            add { _guildUpdatedEvent.Add(value); }
+            remove { _guildUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuild, SocketGuild, Task>> _guildUpdatedEvent = new AsyncEvent<Func<SocketGuild, SocketGuild, Task>>();
+
+        //Users
+        /// <summary>
+        /// Fired when a user joins a guild.
+        /// </summary>
+        public event Func<SocketGuildUser, Task> UserJoined {
+            add { _userJoinedEvent.Add(value); }
+            remove { _userJoinedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuildUser, Task>> _userJoinedEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
+        /// <summary>
+        /// Fired when a user leaves a guild.
+        /// </summary>
+        public event Func<SocketGuildUser, Task> UserLeft {
+            add { _userLeftEvent.Add(value); }
+            remove { _userLeftEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuildUser, Task>> _userLeftEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
+        /// <summary>
+        /// Fired when a user is banned from a guild.
+        /// </summary>
+        public event Func<SocketUser, SocketGuild, Task> UserBanned {
+            add { _userBannedEvent.Add(value); }
+            remove { _userBannedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userBannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
+        /// <summary>
+        /// Fired when a user is unbanned from a guild.
+        /// </summary>
+        public event Func<SocketUser, SocketGuild, Task> UserUnbanned {
+            add { _userUnbannedEvent.Add(value); }
+            remove { _userUnbannedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userUnbannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
+        /// <summary>
+        /// Fired when a user is updated.
+        /// </summary>
+        public event Func<SocketUser, SocketUser, Task> UserUpdated {
+            add { _userUpdatedEvent.Add(value); }
+            remove { _userUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketUser, SocketUser, Task>> _userUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketUser, Task>>();
+        /// <summary>
+        /// Fired when a guild member is updated, or a member presence is updated.
+        /// </summary>
+        public event Func<SocketGuildUser, SocketGuildUser, Task> GuildMemberUpdated {
+            add { _guildMemberUpdatedEvent.Add(value); }
+            remove { _guildMemberUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>> _guildMemberUpdatedEvent = new AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>>();     
+        /// <summary>
+        /// Fired when a user joins, leaves, or moves voice channels.
+        /// </summary>
+        public event Func<SocketUser, SocketVoiceState, SocketVoiceState, Task> UserVoiceStateUpdated {
+            add { _userVoiceStateUpdatedEvent.Add(value); }
+            remove { _userVoiceStateUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>> _userVoiceStateUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>>();
+        /// <summary>
+        /// Fired when the connected account is updated.
+        /// </summary>
+        public event Func<SocketSelfUser, SocketSelfUser, Task> CurrentUserUpdated {
+            add { _selfUpdatedEvent.Add(value); }
+            remove { _selfUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>> _selfUpdatedEvent = new AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>>();
+        /// <summary>
+        /// Fired when a user starts typing.
+        /// </summary>
+        public event Func<SocketUser, ISocketMessageChannel, Task> UserIsTyping {
+            add { _userIsTypingEvent.Add(value); }
+            remove { _userIsTypingEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>> _userIsTypingEvent = new AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>>();
+        /// <summary>
+        /// Fired when a user joins a group channel.
+        /// </summary>
+        public event Func<SocketGroupUser, Task> RecipientAdded {
+            add { _recipientAddedEvent.Add(value); }
+            remove { _recipientAddedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientAddedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
+        /// <summary>
+        /// Fired when a user is removed from a group channel.
+        /// </summary>
+        public event Func<SocketGroupUser, Task> RecipientRemoved {
+            add { _recipientRemovedEvent.Add(value); }
+            remove { _recipientRemovedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientRemovedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
+    }
+}

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -5,26 +5,21 @@ namespace Discord.WebSocket
 {
     public partial class BaseSocketClient
     {
-        /// <summary>
-        /// Fired when a channel is created.
-        /// </summary>
+        //Channels
+        /// <summary> Fired when a channel is created. </summary>
         public event Func<SocketChannel, Task> ChannelCreated 
         {
             add { _channelCreatedEvent.Add(value); }
             remove { _channelCreatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketChannel, Task>> _channelCreatedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
-        /// <summary>
-        /// Fired when a channel is destroyed.
-        /// </summary>
+        /// <summary> Fired when a channel is destroyed. </summary>
         public event Func<SocketChannel, Task> ChannelDestroyed {
             add { _channelDestroyedEvent.Add(value); }
             remove { _channelDestroyedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketChannel, Task>> _channelDestroyedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
-        /// <summary>
-        /// Fired when a channel is updated.
-        /// </summary>
+        /// <summary> Fired when a channel is updated. </summary>
         public event Func<SocketChannel, SocketChannel, Task> ChannelUpdated {
             add { _channelUpdatedEvent.Add(value); }
             remove { _channelUpdatedEvent.Remove(value); }
@@ -32,49 +27,37 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<SocketChannel, SocketChannel, Task>> _channelUpdatedEvent = new AsyncEvent<Func<SocketChannel, SocketChannel, Task>>();
 
         //Messages
-        /// <summary>
-        /// Fired when a message is received.
-        /// </summary>
+        /// <summary> Fired when a message is received. </summary>
         public event Func<SocketMessage, Task> MessageReceived {
             add { _messageReceivedEvent.Add(value); }
             remove { _messageReceivedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketMessage, Task>> _messageReceivedEvent = new AsyncEvent<Func<SocketMessage, Task>>();
-        /// <summary>
-        /// Fired when a message is deleted.
-        /// </summary>
+        /// <summary> Fired when a message is deleted. </summary>
         public event Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task> MessageDeleted {
             add { _messageDeletedEvent.Add(value); }
             remove { _messageDeletedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>>();
-        /// <summary>
-        /// Fired when a message is updated.
-        /// </summary>
+        /// <summary> Fired when a message is updated. </summary>
         public event Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task> MessageUpdated {
             add { _messageUpdatedEvent.Add(value); }
             remove { _messageUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>>();
-        /// <summary>
-        /// Fired when a reaction is added to a message.
-        /// </summary>
+        /// <summary> Fired when a reaction is added to a message. </summary>
         public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionAdded {
             add { _reactionAddedEvent.Add(value); }
             remove { _reactionAddedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
-        /// <summary>
-        /// Fired when a reaction is removed from a message.
-        /// </summary>
+        /// <summary> Fired when a reaction is removed from a message. </summary>
         public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionRemoved {
             add { _reactionRemovedEvent.Add(value); }
             remove { _reactionRemovedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
-        /// <summary>
-        /// Fired when all reactions to a message are cleared.
-        /// </summary>
+        /// <summary> Fired when all reactions to a message are cleared. </summary>
         public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task> ReactionsCleared {
             add { _reactionsClearedEvent.Add(value); }
             remove { _reactionsClearedEvent.Remove(value); }
@@ -82,25 +65,19 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
 
         //Roles
-        /// <summary>
-        /// Fired when a role is created.
-        /// </summary>
+        /// <summary> Fired when a role is created. </summary>
         public event Func<SocketRole, Task> RoleCreated {
             add { _roleCreatedEvent.Add(value); }
             remove { _roleCreatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketRole, Task>> _roleCreatedEvent = new AsyncEvent<Func<SocketRole, Task>>();
-        /// <summary>
-        /// Fired when a role is deleted.
-        /// </summary>
+        /// <summary> Fired when a role is deleted. </summary>
         public event Func<SocketRole, Task> RoleDeleted {
             add { _roleDeletedEvent.Add(value); }
             remove { _roleDeletedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketRole, Task>> _roleDeletedEvent = new AsyncEvent<Func<SocketRole, Task>>();
-        /// <summary>
-        /// Fired when a role is updated.
-        /// </summary>
+        /// <summary> Fired when a role is updated. </summary>
         public event Func<SocketRole, SocketRole, Task> RoleUpdated {
             add { _roleUpdatedEvent.Add(value); }
             remove { _roleUpdatedEvent.Remove(value); }
@@ -108,49 +85,37 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<SocketRole, SocketRole, Task>> _roleUpdatedEvent = new AsyncEvent<Func<SocketRole, SocketRole, Task>>();
 
         //Guilds
-        /// <summary>
-        /// Fired when the connected account joins a guild.
-        /// </summary>
+        /// <summary> Fired when the connected account joins a guild. </summary>
         public event Func<SocketGuild, Task> JoinedGuild {
             add { _joinedGuildEvent.Add(value); }
             remove { _joinedGuildEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuild, Task>> _joinedGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        /// <summary>
-        /// Fired when the connected account leaves a guild.
-        /// </summary>
+        /// <summary> Fired when the connected account leaves a guild. </summary>
         public event Func<SocketGuild, Task> LeftGuild {
             add { _leftGuildEvent.Add(value); }
             remove { _leftGuildEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuild, Task>> _leftGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        /// <summary>
-        /// Fired when a guild becomes available.
-        /// </summary>
+        /// <summary> Fired when a guild becomes available. </summary>
         public event Func<SocketGuild, Task> GuildAvailable {
             add { _guildAvailableEvent.Add(value); }
             remove { _guildAvailableEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuild, Task>> _guildAvailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        /// <summary>
-        /// Fired when a guild becomes unavailable.
-        /// </summary>
+        /// <summary> Fired when a guild becomes unavailable. </summary>
         public event Func<SocketGuild, Task> GuildUnavailable {
             add { _guildUnavailableEvent.Add(value); }
             remove { _guildUnavailableEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuild, Task>> _guildUnavailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        /// <summary>
-        /// Fired when offline guild members are downloaded.
-        /// </summary>
+        /// <summary> Fired when offline guild members are downloaded. </summary>
         public event Func<SocketGuild, Task> GuildMembersDownloaded {
             add { _guildMembersDownloadedEvent.Add(value); }
             remove { _guildMembersDownloadedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuild, Task>> _guildMembersDownloadedEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        /// <summary>
-        /// Fired when a guild is updated.
-        /// </summary>
+        /// <summary> Fired when a guild is updated. </summary>
         public event Func<SocketGuild, SocketGuild, Task> GuildUpdated {
             add { _guildUpdatedEvent.Add(value); }
             remove { _guildUpdatedEvent.Remove(value); }
@@ -158,89 +123,67 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<SocketGuild, SocketGuild, Task>> _guildUpdatedEvent = new AsyncEvent<Func<SocketGuild, SocketGuild, Task>>();
 
         //Users
-        /// <summary>
-        /// Fired when a user joins a guild.
-        /// </summary>
+        /// <summary> Fired when a user joins a guild. </summary>
         public event Func<SocketGuildUser, Task> UserJoined {
             add { _userJoinedEvent.Add(value); }
             remove { _userJoinedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuildUser, Task>> _userJoinedEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
-        /// <summary>
-        /// Fired when a user leaves a guild.
-        /// </summary>
+        /// <summary> Fired when a user leaves a guild. </summary>
         public event Func<SocketGuildUser, Task> UserLeft {
             add { _userLeftEvent.Add(value); }
             remove { _userLeftEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuildUser, Task>> _userLeftEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
-        /// <summary>
-        /// Fired when a user is banned from a guild.
-        /// </summary>
+        /// <summary> Fired when a user is banned from a guild. </summary>
         public event Func<SocketUser, SocketGuild, Task> UserBanned {
             add { _userBannedEvent.Add(value); }
             remove { _userBannedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userBannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
-        /// <summary>
-        /// Fired when a user is unbanned from a guild.
-        /// </summary>
+        /// <summary> Fired when a user is unbanned from a guild. </summary>
         public event Func<SocketUser, SocketGuild, Task> UserUnbanned {
             add { _userUnbannedEvent.Add(value); }
             remove { _userUnbannedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userUnbannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
-        /// <summary>
-        /// Fired when a user is updated.
-        /// </summary>
+        /// <summary> Fired when a user is updated. </summary>
         public event Func<SocketUser, SocketUser, Task> UserUpdated {
             add { _userUpdatedEvent.Add(value); }
             remove { _userUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketUser, SocketUser, Task>> _userUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketUser, Task>>();
-        /// <summary>
-        /// Fired when a guild member is updated, or a member presence is updated.
-        /// </summary>
+        /// <summary> Fired when a guild member is updated, or a member presence is updated. </summary>
         public event Func<SocketGuildUser, SocketGuildUser, Task> GuildMemberUpdated {
             add { _guildMemberUpdatedEvent.Add(value); }
             remove { _guildMemberUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>> _guildMemberUpdatedEvent = new AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>>();     
-        /// <summary>
-        /// Fired when a user joins, leaves, or moves voice channels.
-        /// </summary>
+        /// <summary> Fired when a user joins, leaves, or moves voice channels. </summary>
         public event Func<SocketUser, SocketVoiceState, SocketVoiceState, Task> UserVoiceStateUpdated {
             add { _userVoiceStateUpdatedEvent.Add(value); }
             remove { _userVoiceStateUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>> _userVoiceStateUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>>();
-        /// <summary>
-        /// Fired when the connected account is updated.
-        /// </summary>
+        /// <summary> Fired when the connected account is updated. </summary>
         public event Func<SocketSelfUser, SocketSelfUser, Task> CurrentUserUpdated {
             add { _selfUpdatedEvent.Add(value); }
             remove { _selfUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>> _selfUpdatedEvent = new AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>>();
-        /// <summary>
-        /// Fired when a user starts typing.
-        /// </summary>
+        /// <summary> Fired when a user starts typing. </summary>
         public event Func<SocketUser, ISocketMessageChannel, Task> UserIsTyping {
             add { _userIsTypingEvent.Add(value); }
             remove { _userIsTypingEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>> _userIsTypingEvent = new AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>>();
-        /// <summary>
-        /// Fired when a user joins a group channel.
-        /// </summary>
+        /// <summary> Fired when a user joins a group channel. </summary>
         public event Func<SocketGroupUser, Task> RecipientAdded {
             add { _recipientAddedEvent.Add(value); }
             remove { _recipientAddedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientAddedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
-        /// <summary>
-        /// Fired when a user is removed from a group channel.
-        /// </summary>
+        /// <summary> Fired when a user is removed from a group channel. </summary>
         public event Func<SocketGroupUser, Task> RecipientRemoved {
             add { _recipientRemovedEvent.Add(value); }
             remove { _recipientRemovedEvent.Remove(value); }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Discord.API;
+using Discord.Rest;
+
+namespace Discord.WebSocket
+{
+    public abstract partial class BaseSocketClient : BaseDiscordClient, IDiscordClient
+    {
+        protected readonly DiscordSocketConfig _baseconfig;
+
+        /// <summary> Gets the estimated round-trip latency, in milliseconds, to the gateway server. </summary>
+        public abstract int Latency { get; protected set; }
+        public abstract UserStatus Status { get; protected set; } 
+        public abstract Game? Game { get; protected set; }
+
+        internal new DiscordSocketApiClient ApiClient => base.ApiClient as DiscordSocketApiClient;
+
+        public new SocketSelfUser CurrentUser { get => base.CurrentUser as SocketSelfUser; protected set => base.CurrentUser = value; }
+        public abstract IReadOnlyCollection<SocketGuild> Guilds { get; }
+        public abstract IReadOnlyCollection<ISocketPrivateChannel> PrivateChannels { get; }
+        public abstract IReadOnlyCollection<RestVoiceRegion> VoiceRegions { get; }
+
+        internal BaseSocketClient(DiscordSocketConfig config, DiscordRestApiClient client)
+            : base(config, client) => _baseconfig = config;
+        private static DiscordSocketApiClient CreateApiClient(DiscordSocketConfig config)
+            => new DiscordSocketApiClient(config.RestClientProvider, config.WebSocketProvider, DiscordRestConfig.UserAgent);
+
+        /// <inheritdoc />
+        public abstract Task<RestApplication> GetApplicationInfoAsync(RequestOptions options = null);
+        /// <inheritdoc />
+        public abstract SocketUser GetUser(ulong id);
+        /// <inheritdoc />
+        public abstract SocketUser GetUser(string username, string discriminator);
+        /// <inheritdoc />
+        public abstract SocketChannel GetChannel(ulong id);
+        /// <inheritdoc />
+        public abstract SocketGuild GetGuild(ulong id);
+        /// <inheritdoc />
+        public abstract RestVoiceRegion GetVoiceRegion(string id);
+        /// <inheritdoc />
+        public abstract Task StartAsync();
+        /// <inheritdoc />
+        public abstract Task StopAsync();
+        public abstract Task SetStatusAsync(UserStatus status);
+        public abstract Task SetGameAsync(string name, string streamUrl = null, StreamType streamType = StreamType.NotStreaming);
+        // TODO: DownloadUsersAsync? 
+
+        /// <inheritdoc />
+        public Task<RestGuild> CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon = null, RequestOptions options = null)
+            => ClientHelper.CreateGuildAsync(this, name, region, jpegIcon, options ?? RequestOptions.Default);
+        /// <inheritdoc />
+        public Task<IReadOnlyCollection<RestConnection>> GetConnectionsAsync(RequestOptions options = null)
+            => ClientHelper.GetConnectionsAsync(this, options ?? RequestOptions.Default);
+        /// <inheritdoc />
+        public Task<RestInvite> GetInviteAsync(string inviteId, RequestOptions options = null)
+            => ClientHelper.GetInviteAsync(this, inviteId, options ?? RequestOptions.Default);
+        
+        // IDiscordClient
+        async Task<IApplication> IDiscordClient.GetApplicationInfoAsync(RequestOptions options)
+            => await GetApplicationInfoAsync(options).ConfigureAwait(false);
+
+        Task<IChannel> IDiscordClient.GetChannelAsync(ulong id, CacheMode mode, RequestOptions options)
+            => Task.FromResult<IChannel>(GetChannel(id));
+        Task<IReadOnlyCollection<IPrivateChannel>> IDiscordClient.GetPrivateChannelsAsync(CacheMode mode, RequestOptions options)
+            => Task.FromResult<IReadOnlyCollection<IPrivateChannel>>(PrivateChannels);
+
+        async Task<IReadOnlyCollection<IConnection>> IDiscordClient.GetConnectionsAsync(RequestOptions options)
+            => await GetConnectionsAsync(options).ConfigureAwait(false);
+
+        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, RequestOptions options)
+            => await GetInviteAsync(inviteId, options).ConfigureAwait(false);
+
+        Task<IGuild> IDiscordClient.GetGuildAsync(ulong id, CacheMode mode, RequestOptions options)
+            => Task.FromResult<IGuild>(GetGuild(id));
+        Task<IReadOnlyCollection<IGuild>> IDiscordClient.GetGuildsAsync(CacheMode mode, RequestOptions options)
+            => Task.FromResult<IReadOnlyCollection<IGuild>>(Guilds);
+
+        async Task<IGuild> IDiscordClient.CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon, RequestOptions options)
+            => await CreateGuildAsync(name, region, jpegIcon, options).ConfigureAwait(false);
+
+        Task<IUser> IDiscordClient.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
+            => Task.FromResult<IUser>(GetUser(id));
+        Task<IUser> IDiscordClient.GetUserAsync(string username, string discriminator, RequestOptions options)
+            => Task.FromResult<IUser>(GetUser(username, discriminator));
+
+        Task<IVoiceRegion> IDiscordClient.GetVoiceRegionAsync(string id, RequestOptions options)
+            => Task.FromResult<IVoiceRegion>(GetVoiceRegion(id));
+        Task<IReadOnlyCollection<IVoiceRegion>> IDiscordClient.GetVoiceRegionsAsync(RequestOptions options)
+            => Task.FromResult<IReadOnlyCollection<IVoiceRegion>>(VoiceRegions);
+    }
+}

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -45,7 +45,7 @@ namespace Discord.WebSocket
         public abstract Task StopAsync();
         public abstract Task SetStatusAsync(UserStatus status);
         public abstract Task SetGameAsync(string name, string streamUrl = null, StreamType streamType = StreamType.NotStreaming);
-        // TODO: DownloadUsersAsync? 
+        public abstract Task DownloadUsersAsync(IEnumerable<IGuild> guilds);  
 
         /// <inheritdoc />
         public Task<RestGuild> CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon = null, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
@@ -6,194 +6,21 @@ namespace Discord.WebSocket
     //TODO: Add event docstrings
     public partial class DiscordShardedClient
     {
-        //Channels
-        public event Func<SocketChannel, Task> ChannelCreated
-        {
-            add { _channelCreatedEvent.Add(value); }
-            remove { _channelCreatedEvent.Remove(value); }
+        /// <summary>
+        /// Fired when a shard is connected to the Discord gateway.
+        /// </summary>
+        public event Func<DiscordSocketClient, Task> ShardConnected {
+            add { _shardConnectedEvent.Add(value); }
+            remove { _shardConnectedEvent.Remove(value); }
         }
-        private readonly AsyncEvent<Func<SocketChannel, Task>> _channelCreatedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
-        public event Func<SocketChannel, Task> ChannelDestroyed
-        {
-            add { _channelDestroyedEvent.Add(value); }
-            remove { _channelDestroyedEvent.Remove(value); }
+        private readonly AsyncEvent<Func<DiscordSocketClient, Task>> _shardConnectedEvent = new AsyncEvent<Func<DiscordSocketClient, Task>>();
+        /// <summary>
+        /// Fired when a shard is disconnected from the Discord gateway.
+        /// </summary>
+        public event Func<DiscordSocketClient, Exception, Task> ShardDisconnected {
+            add { _shardDisconnectedEvent.Add(value); }
+            remove { _shardDisconnectedEvent.Remove(value); }
         }
-        private readonly AsyncEvent<Func<SocketChannel, Task>> _channelDestroyedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
-        public event Func<SocketChannel, SocketChannel, Task> ChannelUpdated
-        {
-            add { _channelUpdatedEvent.Add(value); }
-            remove { _channelUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketChannel, SocketChannel, Task>> _channelUpdatedEvent = new AsyncEvent<Func<SocketChannel, SocketChannel, Task>>();
-
-        //Messages
-        public event Func<SocketMessage, Task> MessageReceived
-        {
-            add { _messageReceivedEvent.Add(value); }
-            remove { _messageReceivedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketMessage, Task>> _messageReceivedEvent = new AsyncEvent<Func<SocketMessage, Task>>();
-        public event Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task> MessageDeleted
-        {
-            add { _messageDeletedEvent.Add(value); }
-            remove { _messageDeletedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>>();
-        public event Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task> MessageUpdated
-        {
-            add { _messageUpdatedEvent.Add(value); }
-            remove { _messageUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>>();
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionAdded
-        {
-            add { _reactionAddedEvent.Add(value); }
-            remove { _reactionAddedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionRemoved
-        {
-            add { _reactionRemovedEvent.Add(value); }
-            remove { _reactionRemovedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task> ReactionsCleared
-        {
-            add { _reactionsClearedEvent.Add(value); }
-            remove { _reactionsClearedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
-
-        //Roles
-        public event Func<SocketRole, Task> RoleCreated
-        {
-            add { _roleCreatedEvent.Add(value); }
-            remove { _roleCreatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketRole, Task>> _roleCreatedEvent = new AsyncEvent<Func<SocketRole, Task>>();
-        public event Func<SocketRole, Task> RoleDeleted
-        {
-            add { _roleDeletedEvent.Add(value); }
-            remove { _roleDeletedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketRole, Task>> _roleDeletedEvent = new AsyncEvent<Func<SocketRole, Task>>();
-        public event Func<SocketRole, SocketRole, Task> RoleUpdated
-        {
-            add { _roleUpdatedEvent.Add(value); }
-            remove { _roleUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketRole, SocketRole, Task>> _roleUpdatedEvent = new AsyncEvent<Func<SocketRole, SocketRole, Task>>();
-
-        //Guilds
-        public event Func<SocketGuild, Task> JoinedGuild
-        {
-            add { _joinedGuildEvent.Add(value); }
-            remove { _joinedGuildEvent.Remove(value); }
-        }
-        private AsyncEvent<Func<SocketGuild, Task>> _joinedGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> LeftGuild
-        {
-            add { _leftGuildEvent.Add(value); }
-            remove { _leftGuildEvent.Remove(value); }
-        }
-        private AsyncEvent<Func<SocketGuild, Task>> _leftGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> GuildAvailable
-        {
-            add { _guildAvailableEvent.Add(value); }
-            remove { _guildAvailableEvent.Remove(value); }
-        }
-        private AsyncEvent<Func<SocketGuild, Task>> _guildAvailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> GuildUnavailable
-        {
-            add { _guildUnavailableEvent.Add(value); }
-            remove { _guildUnavailableEvent.Remove(value); }
-        }
-        private AsyncEvent<Func<SocketGuild, Task>> _guildUnavailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> GuildMembersDownloaded
-        {
-            add { _guildMembersDownloadedEvent.Add(value); }
-            remove { _guildMembersDownloadedEvent.Remove(value); }
-        }
-        private AsyncEvent<Func<SocketGuild, Task>> _guildMembersDownloadedEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, SocketGuild, Task> GuildUpdated
-        {
-            add { _guildUpdatedEvent.Add(value); }
-            remove { _guildUpdatedEvent.Remove(value); }
-        }
-        private AsyncEvent<Func<SocketGuild, SocketGuild, Task>> _guildUpdatedEvent = new AsyncEvent<Func<SocketGuild, SocketGuild, Task>>();
-
-        //Users
-        public event Func<SocketGuildUser, Task> UserJoined
-        {
-            add { _userJoinedEvent.Add(value); }
-            remove { _userJoinedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuildUser, Task>> _userJoinedEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
-        public event Func<SocketGuildUser, Task> UserLeft
-        {
-            add { _userLeftEvent.Add(value); }
-            remove { _userLeftEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuildUser, Task>> _userLeftEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
-        public event Func<SocketUser, SocketGuild, Task> UserBanned
-        {
-            add { _userBannedEvent.Add(value); }
-            remove { _userBannedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userBannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
-        public event Func<SocketUser, SocketGuild, Task> UserUnbanned
-        {
-            add { _userUnbannedEvent.Add(value); }
-            remove { _userUnbannedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userUnbannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
-        public event Func<SocketUser, SocketUser, Task> UserUpdated
-        {
-            add { _userUpdatedEvent.Add(value); }
-            remove { _userUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketUser, Task>> _userUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketUser, Task>>();
-        public event Func<SocketGuildUser, SocketGuildUser, Task> GuildMemberUpdated
-        {
-            add { _guildMemberUpdatedEvent.Add(value); }
-            remove { _guildMemberUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>> _guildMemberUpdatedEvent = new AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>>();
-        public event Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task> UserPresenceUpdated
-        {
-            add { _userPresenceUpdatedEvent.Add(value); }
-            remove { _userPresenceUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task>> _userPresenceUpdatedEvent = new AsyncEvent<Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task>>();
-        public event Func<SocketUser, SocketVoiceState, SocketVoiceState, Task> UserVoiceStateUpdated
-        {
-            add { _userVoiceStateUpdatedEvent.Add(value); }
-            remove { _userVoiceStateUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>> _userVoiceStateUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>>();
-        public event Func<SocketSelfUser, SocketSelfUser, Task> CurrentUserUpdated
-        {
-            add { _selfUpdatedEvent.Add(value); }
-            remove { _selfUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>> _selfUpdatedEvent = new AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>>();
-        public event Func<SocketUser, ISocketMessageChannel, Task> UserIsTyping
-        {
-            add { _userIsTypingEvent.Add(value); }
-            remove { _userIsTypingEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>> _userIsTypingEvent = new AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>>();
-        public event Func<SocketGroupUser, Task> RecipientAdded
-        {
-            add { _recipientAddedEvent.Add(value); }
-            remove { _recipientAddedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientAddedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
-        public event Func<SocketGroupUser, Task> RecipientRemoved
-        {
-            add { _recipientRemovedEvent.Add(value); }
-            remove { _recipientRemovedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientRemovedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
+        private readonly AsyncEvent<Func<DiscordSocketClient, Exception, Task>> _shardDisconnectedEvent = new AsyncEvent<Func<DiscordSocketClient, Exception, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
@@ -2,8 +2,7 @@
 using System.Threading.Tasks;
 
 namespace Discord.WebSocket
-{
-    //TODO: Add event docstrings
+{                                
     public partial class DiscordShardedClient
     {
         /// <summary>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
@@ -5,29 +5,34 @@ namespace Discord.WebSocket
 {                                
     public partial class DiscordShardedClient
     {
-        /// <summary>
-        /// Fired when a shard is connected to the Discord gateway.
-        /// </summary>
-        public event Func<DiscordSocketClient, Task> ShardConnected {
+        //General
+        /// <summary> Fired when a shard is connected to the Discord gateway. </summary>
+        public event Func<DiscordSocketClient, Task> ShardConnected 
+        {
             add { _shardConnectedEvent.Add(value); }
             remove { _shardConnectedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<DiscordSocketClient, Task>> _shardConnectedEvent = new AsyncEvent<Func<DiscordSocketClient, Task>>();
-        /// <summary>
-        /// Fired when a shard is disconnected from the Discord gateway.
-        /// </summary>
-        public event Func<DiscordSocketClient, Exception, Task> ShardDisconnected {
+        /// <summary> Fired when a shard is disconnected from the Discord gateway. </summary>
+        public event Func<Exception, DiscordSocketClient, Task> ShardDisconnected 
+        {
             add { _shardDisconnectedEvent.Add(value); }
             remove { _shardDisconnectedEvent.Remove(value); }
         }
-        private readonly AsyncEvent<Func<DiscordSocketClient, Exception, Task>> _shardDisconnectedEvent = new AsyncEvent<Func<DiscordSocketClient, Exception, Task>>();
-        /// <summary>
-        /// Fired when a guild data for a shard has finished downloading.
-        /// </summary>
-        public event Func<DiscordSocketClient, Task> ShardReady {
+        private readonly AsyncEvent<Func<Exception, DiscordSocketClient, Task>> _shardDisconnectedEvent = new AsyncEvent<Func<Exception, DiscordSocketClient, Task>>();
+        /// <summary> Fired when a guild data for a shard has finished downloading. </summary>
+        public event Func<DiscordSocketClient, Task> ShardReady 
+        {
             add { _shardReadyEvent.Add(value); }
             remove { _shardReadyEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<DiscordSocketClient, Task>> _shardReadyEvent = new AsyncEvent<Func<DiscordSocketClient, Task>>();
+        /// <summary> Fired when a shard receives a heartbeat from the Discord gateway. </summary>
+        public event Func<int, int, DiscordSocketClient, Task> ShardLatencyUpdated 
+        {
+            add { _shardLatencyUpdatedEvent.Add(value); }
+            remove { _shardLatencyUpdatedEvent.Remove(value); }
+        }
+        private readonly AsyncEvent<Func<int, int, DiscordSocketClient, Task>> _shardLatencyUpdatedEvent = new AsyncEvent<Func<int, int, DiscordSocketClient, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
@@ -22,5 +22,13 @@ namespace Discord.WebSocket
             remove { _shardDisconnectedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<DiscordSocketClient, Exception, Task>> _shardDisconnectedEvent = new AsyncEvent<Func<DiscordSocketClient, Exception, Task>>();
+        /// <summary>
+        /// Fired when a guild data for a shard has finished downloading.
+        /// </summary>
+        public event Func<DiscordSocketClient, Task> ShardReady {
+            add { _shardReadyEvent.Add(value); }
+            remove { _shardReadyEvent.Remove(value); }
+        }
+        private readonly AsyncEvent<Func<DiscordSocketClient, Task>> _shardReadyEvent = new AsyncEvent<Func<DiscordSocketClient, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
@@ -35,6 +35,7 @@ namespace Discord.WebSocket
         }
         private readonly AsyncEvent<Func<int, int, DiscordSocketClient, Task>> _shardLatencyUpdatedEvent = new AsyncEvent<Func<int, int, DiscordSocketClient, Task>>();
 
+        [Obsolete("This event is non-functioning and will be removed in the next major release. Functionality has been merged into the GuildMemberUpdated event.")]
         public event Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task> UserPresenceUpdated
         {
             add { _userPresenceUpdatedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 
 namespace Discord.WebSocket
-{                                
+{
     public partial class DiscordShardedClient
     {
         //General
@@ -34,5 +34,12 @@ namespace Discord.WebSocket
             remove { _shardLatencyUpdatedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<int, int, DiscordSocketClient, Task>> _shardLatencyUpdatedEvent = new AsyncEvent<Func<int, int, DiscordSocketClient, Task>>();
+
+        public event Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task> UserPresenceUpdated
+        {
+            add { _userPresenceUpdatedEvent.Add(value); }
+            remove { _userPresenceUpdatedEvent.Remove(value); }
+        }
+        private readonly AsyncEvent<Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task>> _userPresenceUpdatedEvent = new AsyncEvent<Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.Events.cs
@@ -34,13 +34,5 @@ namespace Discord.WebSocket
             remove { _shardLatencyUpdatedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<int, int, DiscordSocketClient, Task>> _shardLatencyUpdatedEvent = new AsyncEvent<Func<int, int, DiscordSocketClient, Task>>();
-
-        [Obsolete("This event is non-functioning and will be removed in the next major release. Functionality has been merged into the GuildMemberUpdated event.")]
-        public event Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task> UserPresenceUpdated
-        {
-            add { _userPresenceUpdatedEvent.Add(value); }
-            remove { _userPresenceUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task>> _userPresenceUpdatedEvent = new AsyncEvent<Func<Optional<SocketGuild>, SocketUser, SocketPresence, SocketPresence, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -214,7 +214,7 @@ namespace Discord.WebSocket
             => _shards[0].GetVoiceRegion(id);
 
         /// <summary> Downloads the users list for the provided guilds, if they don't have a complete list. </summary>
-        public async Task DownloadUsersAsync(IEnumerable<SocketGuild> guilds)
+        public override async Task DownloadUsersAsync(IEnumerable<IGuild> guilds)
         {
             for (int i = 0; i < _shards.Length; i++)
             {

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -117,8 +117,8 @@ namespace Discord.WebSocket
         public override async Task StartAsync() 
             => await Task.WhenAll(_shards.Select(x => x.StartAsync())).ConfigureAwait(false);
         /// <inheritdoc />
-        public override async Task StopAsync() => 
-            await Task.WhenAll(_shards.Select(x => x.StopAsync())).ConfigureAwait(false);
+        public override async Task StopAsync() 
+            => await Task.WhenAll(_shards.Select(x => x.StopAsync())).ConfigureAwait(false);
 
         public DiscordSocketClient GetShard(int id)
         {
@@ -168,11 +168,7 @@ namespace Discord.WebSocket
             for (int i = 0; i < _shards.Length; i++)
                 result += _shards[i].PrivateChannels.Count;
             return result;
-        }
-
-        /// <inheritdoc />
-        public Task<IReadOnlyCollection<RestConnection>> GetConnectionsAsync()
-            => ClientHelper.GetConnectionsAsync(this, new RequestOptions());
+        }                                                                    
 
         private IEnumerable<SocketGuild> GetGuilds()
         {
@@ -188,11 +184,7 @@ namespace Discord.WebSocket
             for (int i = 0; i < _shards.Length; i++)
                 result += _shards[i].Guilds.Count;
             return result;
-        }
-
-        /// <inheritdoc />
-        public Task<RestInvite> GetInviteAsync(string inviteId)
-            => ClientHelper.GetInviteAsync(this, inviteId, new RequestOptions());
+        }                    
 
         /// <inheritdoc />
         public override SocketUser GetUser(ulong id)

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -9,7 +9,7 @@ using System.Threading;
 
 namespace Discord.WebSocket
 {
-    public partial class DiscordShardedClient : BaseDiscordClient, IDiscordClient
+    public partial class DiscordShardedClient : BaseSocketClient, IDiscordClient
     {
         private readonly DiscordSocketConfig _baseConfig;
         private readonly SemaphoreSlim _connectionGroupLock;
@@ -20,16 +20,15 @@ namespace Discord.WebSocket
         private bool _automaticShards;
         
         /// <summary> Gets the estimated round-trip latency, in milliseconds, to the gateway server. </summary>
-        public int Latency => GetLatency();
-        public UserStatus Status => _shards[0].Status;
-        public Game? Game => _shards[0].Game;
+        public override int Latency { get => GetLatency(); protected set { } }
+        public override UserStatus Status { get => _shards[0].Status; protected set { } }
+        public override Game? Game { get => _shards[0].Game; protected set { } }
 
         internal new DiscordSocketApiClient ApiClient => base.ApiClient as DiscordSocketApiClient;
-        public new SocketSelfUser CurrentUser { get { return base.CurrentUser as SocketSelfUser; } private set { base.CurrentUser = value; } }
-        public IReadOnlyCollection<SocketGuild> Guilds => GetGuilds().ToReadOnlyCollection(() => GetGuildCount());
-        public IReadOnlyCollection<ISocketPrivateChannel> PrivateChannels => GetPrivateChannels().ToReadOnlyCollection(() => GetPrivateChannelCount());
+        public override IReadOnlyCollection<SocketGuild> Guilds => GetGuilds().ToReadOnlyCollection(() => GetGuildCount());
+        public override IReadOnlyCollection<ISocketPrivateChannel> PrivateChannels => GetPrivateChannels().ToReadOnlyCollection(() => GetPrivateChannelCount());
         public IReadOnlyCollection<DiscordSocketClient> Shards => _shards;
-        public IReadOnlyCollection<RestVoiceRegion> VoiceRegions => _shards[0].VoiceRegions;
+        public override IReadOnlyCollection<RestVoiceRegion> VoiceRegions => _shards[0].VoiceRegions;
 
         /// <summary> Creates a new REST/WebSocket discord client. </summary>
         public DiscordShardedClient() : this(null, new DiscordSocketConfig()) { }
@@ -115,15 +114,11 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc />
-        public async Task StartAsync()
-        {
-            await Task.WhenAll(_shards.Select(x => x.StartAsync())).ConfigureAwait(false);
-        }
+        public override async Task StartAsync() 
+            => await Task.WhenAll(_shards.Select(x => x.StartAsync())).ConfigureAwait(false);
         /// <inheritdoc />
-        public async Task StopAsync()
-        {
+        public override async Task StopAsync() => 
             await Task.WhenAll(_shards.Select(x => x.StopAsync())).ConfigureAwait(false);
-        }
 
         public DiscordSocketClient GetShard(int id)
         {
@@ -141,17 +136,15 @@ namespace Discord.WebSocket
             => GetShardFor(guild.Id);
 
         /// <inheritdoc />
-        public async Task<RestApplication> GetApplicationInfoAsync()
-            => await _shards[0].GetApplicationInfoAsync().ConfigureAwait(false);
+        public override async Task<RestApplication> GetApplicationInfoAsync(RequestOptions options = null)
+            => await _shards[0].GetApplicationInfoAsync(options).ConfigureAwait(false);
 
         /// <inheritdoc />
-        public SocketGuild GetGuild(ulong id) => GetShardFor(id).GetGuild(id);
-        /// <inheritdoc />
-        public Task<RestGuild> CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon = null)
-            => ClientHelper.CreateGuildAsync(this, name, region, jpegIcon, new RequestOptions());
+        public override SocketGuild GetGuild(ulong id) 
+            => GetShardFor(id).GetGuild(id);
 
         /// <inheritdoc />
-        public SocketChannel GetChannel(ulong id)
+        public override SocketChannel GetChannel(ulong id)
         {
             for (int i = 0; i < _shards.Length; i++)
             {
@@ -202,7 +195,7 @@ namespace Discord.WebSocket
             => ClientHelper.GetInviteAsync(this, inviteId, new RequestOptions());
 
         /// <inheritdoc />
-        public SocketUser GetUser(ulong id)
+        public override SocketUser GetUser(ulong id)
         {
             for (int i = 0; i < _shards.Length; i++)
             {
@@ -213,7 +206,7 @@ namespace Discord.WebSocket
             return null;
         }
         /// <inheritdoc />
-        public SocketUser GetUser(string username, string discriminator)
+        public override SocketUser GetUser(string username, string discriminator)
         {
             for (int i = 0; i < _shards.Length; i++)
             {
@@ -225,7 +218,7 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc />
-        public RestVoiceRegion GetVoiceRegion(string id)
+        public override RestVoiceRegion GetVoiceRegion(string id)
             => _shards[0].GetVoiceRegion(id);
 
         /// <summary> Downloads the users list for the provided guilds, if they don't have a complete list. </summary>
@@ -248,12 +241,12 @@ namespace Discord.WebSocket
             return (int)Math.Round(total / (double)_shards.Length);
         }
 
-        public async Task SetStatusAsync(UserStatus status)
+        public override async Task SetStatusAsync(UserStatus status)
         {
             for (int i = 0; i < _shards.Length; i++)
                 await _shards[i].SetStatusAsync(status).ConfigureAwait(false);
         }
-        public async Task SetGameAsync(string name, string streamUrl = null, StreamType streamType = StreamType.NotStreaming)
+        public override async Task SetGameAsync(string name, string streamUrl = null, StreamType streamType = StreamType.NotStreaming)
         {
             for (int i = 0; i < _shards.Length; i++)
                 await _shards[i].SetGameAsync(name, streamUrl, streamType).ConfigureAwait(false);
@@ -280,6 +273,9 @@ namespace Discord.WebSocket
                     return Task.Delay(0);
                 };
             }
+
+            client.Connected += () => _shardConnectedEvent.InvokeAsync(client);
+            client.Disconnected += (exception) => _shardDisconnectedEvent.InvokeAsync(client, exception);
 
             client.ChannelCreated += (channel) => _channelCreatedEvent.InvokeAsync(channel);
             client.ChannelDestroyed += (channel) => _channelDestroyedEvent.InvokeAsync(channel);

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -276,6 +276,7 @@ namespace Discord.WebSocket
 
             client.Connected += () => _shardConnectedEvent.InvokeAsync(client);
             client.Disconnected += (exception) => _shardDisconnectedEvent.InvokeAsync(client, exception);
+            client.Ready += () => _shardReadyEvent.InvokeAsync(client);
 
             client.ChannelCreated += (channel) => _channelCreatedEvent.InvokeAsync(channel);
             client.ChannelDestroyed += (channel) => _channelDestroyedEvent.InvokeAsync(channel);

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -267,8 +267,9 @@ namespace Discord.WebSocket
             }
 
             client.Connected += () => _shardConnectedEvent.InvokeAsync(client);
-            client.Disconnected += (exception) => _shardDisconnectedEvent.InvokeAsync(client, exception);
+            client.Disconnected += (exception) => _shardDisconnectedEvent.InvokeAsync(exception, client);
             client.Ready += () => _shardReadyEvent.InvokeAsync(client);
+            client.LatencyUpdated += (oldLatency, newLatency) => _shardLatencyUpdatedEvent.InvokeAsync(oldLatency, newLatency, client);
 
             client.ChannelCreated += (channel) => _channelCreatedEvent.InvokeAsync(channel);
             client.ChannelDestroyed += (channel) => _channelDestroyedEvent.InvokeAsync(channel);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -6,36 +6,28 @@ namespace Discord.WebSocket
     public partial class DiscordSocketClient
     {
         //General
-        /// <summary>
-        /// Fired when connected to the Discord gateway.
-        /// </summary>
+        /// <summary> Fired when connected to the Discord gateway. </summary>
         public event Func<Task> Connected
         {
             add { _connectedEvent.Add(value); }
             remove { _connectedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<Task>> _connectedEvent = new AsyncEvent<Func<Task>>();
-        /// <summary>
-        /// Fired when disconnected to the Discord gateway.
-        /// </summary>
+        /// <summary> Fired when disconnected to the Discord gateway. </summary>
         public event Func<Exception, Task> Disconnected
         {
             add { _disconnectedEvent.Add(value); }
             remove { _disconnectedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<Exception, Task>> _disconnectedEvent = new AsyncEvent<Func<Exception, Task>>();
-        /// <summary>
-        /// Fired when guild data has finished downloading.
-        /// </summary>
+        /// <summary> Fired when guild data has finished downloading. </summary>
         public event Func<Task> Ready
         {
             add { _readyEvent.Add(value); }
             remove { _readyEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<Task>> _readyEvent = new AsyncEvent<Func<Task>>();
-        /// <summary>
-        /// Fired when a heartbeat is received from the Discord gateway.
-        /// </summary>
+        /// <summary> Fired when a heartbeat is received from the Discord gateway. </summary>
         public event Func<int, int, Task> LatencyUpdated
         {
             add { _latencyUpdatedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -7,213 +7,41 @@ namespace Discord.WebSocket
     public partial class DiscordSocketClient
     {
         //General
+        /// <summary>
+        /// Fired when connected to the Discord gateway.
+        /// </summary>
         public event Func<Task> Connected
         {
             add { _connectedEvent.Add(value); }
             remove { _connectedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<Task>> _connectedEvent = new AsyncEvent<Func<Task>>();
+        /// <summary>
+        /// Fired when disconnected to the Discord gateway.
+        /// </summary>
         public event Func<Exception, Task> Disconnected
         {
             add { _disconnectedEvent.Add(value); }
             remove { _disconnectedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<Exception, Task>> _disconnectedEvent = new AsyncEvent<Func<Exception, Task>>();
+        /// <summary>
+        /// Fired when guild data has finished downloading.
+        /// </summary>
         public event Func<Task> Ready
         {
             add { _readyEvent.Add(value); }
             remove { _readyEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<Task>> _readyEvent = new AsyncEvent<Func<Task>>();
+        /// <summary>
+        /// Fired when a heartbeat is received from the Discord gateway.
+        /// </summary>
         public event Func<int, int, Task> LatencyUpdated
         {
             add { _latencyUpdatedEvent.Add(value); }
             remove { _latencyUpdatedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<int, int, Task>> _latencyUpdatedEvent = new AsyncEvent<Func<int, int, Task>>();
-
-        //Channels
-        public event Func<SocketChannel, Task> ChannelCreated
-        {
-            add { _channelCreatedEvent.Add(value); }
-            remove { _channelCreatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketChannel, Task>> _channelCreatedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
-        public event Func<SocketChannel, Task> ChannelDestroyed
-        {
-            add { _channelDestroyedEvent.Add(value); }
-            remove { _channelDestroyedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketChannel, Task>> _channelDestroyedEvent = new AsyncEvent<Func<SocketChannel, Task>>();
-        public event Func<SocketChannel, SocketChannel, Task> ChannelUpdated
-        {
-            add { _channelUpdatedEvent.Add(value); }
-            remove { _channelUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketChannel, SocketChannel, Task>> _channelUpdatedEvent = new AsyncEvent<Func<SocketChannel, SocketChannel, Task>>();
-
-        //Messages
-        public event Func<SocketMessage, Task> MessageReceived
-        {
-            add { _messageReceivedEvent.Add(value); }
-            remove { _messageReceivedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketMessage, Task>> _messageReceivedEvent = new AsyncEvent<Func<SocketMessage, Task>>();
-        public event Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task> MessageDeleted
-        {
-            add { _messageDeletedEvent.Add(value); }
-            remove { _messageDeletedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>>();
-        public event Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task> MessageUpdated
-        {
-            add { _messageUpdatedEvent.Add(value); }
-            remove { _messageUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>>();
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionAdded
-        {
-            add { _reactionAddedEvent.Add(value); }
-            remove { _reactionAddedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionRemoved
-        {
-            add { _reactionRemovedEvent.Add(value); }
-            remove { _reactionRemovedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task> ReactionsCleared
-        {
-            add { _reactionsClearedEvent.Add(value); }
-            remove { _reactionsClearedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
-
-        //Roles
-        public event Func<SocketRole, Task> RoleCreated
-        {
-            add { _roleCreatedEvent.Add(value); }
-            remove { _roleCreatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketRole, Task>> _roleCreatedEvent = new AsyncEvent<Func<SocketRole, Task>>();
-        public event Func<SocketRole, Task> RoleDeleted
-        {
-            add { _roleDeletedEvent.Add(value); }
-            remove { _roleDeletedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketRole, Task>> _roleDeletedEvent = new AsyncEvent<Func<SocketRole, Task>>();
-        public event Func<SocketRole, SocketRole, Task> RoleUpdated
-        {
-            add { _roleUpdatedEvent.Add(value); }
-            remove { _roleUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketRole, SocketRole, Task>> _roleUpdatedEvent = new AsyncEvent<Func<SocketRole, SocketRole, Task>>();
-
-        //Guilds
-        public event Func<SocketGuild, Task> JoinedGuild
-        {
-            add { _joinedGuildEvent.Add(value); }
-            remove { _joinedGuildEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuild, Task>> _joinedGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> LeftGuild
-        {
-            add { _leftGuildEvent.Add(value); }
-            remove { _leftGuildEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuild, Task>> _leftGuildEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> GuildAvailable
-        {
-            add { _guildAvailableEvent.Add(value); }
-            remove { _guildAvailableEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuild, Task>> _guildAvailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> GuildUnavailable
-        {
-            add { _guildUnavailableEvent.Add(value); }
-            remove { _guildUnavailableEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuild, Task>> _guildUnavailableEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, Task> GuildMembersDownloaded
-        {
-            add { _guildMembersDownloadedEvent.Add(value); }
-            remove { _guildMembersDownloadedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuild, Task>> _guildMembersDownloadedEvent = new AsyncEvent<Func<SocketGuild, Task>>();
-        public event Func<SocketGuild, SocketGuild, Task> GuildUpdated
-        {
-            add { _guildUpdatedEvent.Add(value); }
-            remove { _guildUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuild, SocketGuild, Task>> _guildUpdatedEvent = new AsyncEvent<Func<SocketGuild, SocketGuild, Task>>();
-
-        //Users
-        public event Func<SocketGuildUser, Task> UserJoined
-        {
-            add { _userJoinedEvent.Add(value); }
-            remove { _userJoinedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuildUser, Task>> _userJoinedEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
-        public event Func<SocketGuildUser, Task> UserLeft
-        {
-            add { _userLeftEvent.Add(value); }
-            remove { _userLeftEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuildUser, Task>> _userLeftEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
-        public event Func<SocketUser, SocketGuild, Task> UserBanned
-        {
-            add { _userBannedEvent.Add(value); }
-            remove { _userBannedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userBannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
-        public event Func<SocketUser, SocketGuild, Task> UserUnbanned
-        {
-            add { _userUnbannedEvent.Add(value); }
-            remove { _userUnbannedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketGuild, Task>> _userUnbannedEvent = new AsyncEvent<Func<SocketUser, SocketGuild, Task>>();
-        public event Func<SocketUser, SocketUser, Task> UserUpdated
-        {
-            add { _userUpdatedEvent.Add(value); }
-            remove { _userUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketUser, Task>> _userUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketUser, Task>>();
-        public event Func<SocketGuildUser, SocketGuildUser, Task> GuildMemberUpdated
-        {
-            add { _guildMemberUpdatedEvent.Add(value); }
-            remove { _guildMemberUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>> _guildMemberUpdatedEvent = new AsyncEvent<Func<SocketGuildUser, SocketGuildUser, Task>>();
-        public event Func<SocketUser, SocketVoiceState, SocketVoiceState, Task> UserVoiceStateUpdated
-        {
-            add { _userVoiceStateUpdatedEvent.Add(value); }
-            remove { _userVoiceStateUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>> _userVoiceStateUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>>();
-        public event Func<SocketSelfUser, SocketSelfUser, Task> CurrentUserUpdated
-        {
-            add { _selfUpdatedEvent.Add(value); }
-            remove { _selfUpdatedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>> _selfUpdatedEvent = new AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>>();
-        public event Func<SocketUser, ISocketMessageChannel, Task> UserIsTyping
-        {
-            add { _userIsTypingEvent.Add(value); }
-            remove { _userIsTypingEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>> _userIsTypingEvent = new AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>>();
-        public event Func<SocketGroupUser, Task> RecipientAdded
-        {
-            add { _recipientAddedEvent.Add(value); }
-            remove { _recipientAddedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientAddedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
-        public event Func<SocketGroupUser, Task> RecipientRemoved
-        {
-            add { _recipientRemovedEvent.Add(value); }
-            remove { _recipientRemovedEvent.Remove(value); }
-        }
-        private readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientRemovedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -2,8 +2,7 @@
 using System.Threading.Tasks;
 
 namespace Discord.WebSocket
-{
-    //TODO: Add event docstrings
+{                                
     public partial class DiscordSocketClient
     {
         //General

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -240,15 +240,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override SocketChannel GetChannel(ulong id) 
             => State.GetChannel(id);
-
-        /// <inheritdoc />
-        public Task<IReadOnlyCollection<RestConnection>> GetConnectionsAsync()
-            => ClientHelper.GetConnectionsAsync(this, new RequestOptions());
-
-        /// <inheritdoc />
-        public Task<RestInvite> GetInviteAsync(string inviteId)
-            => ClientHelper.GetInviteAsync(this, inviteId, new RequestOptions());
-
+                                                                                
         /// <inheritdoc />
         public override SocketUser GetUser(ulong id) 
             => State.GetUser(id);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -231,7 +231,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public override async Task<RestApplication> GetApplicationInfoAsync(RequestOptions options = null) 
-            => _applicationInfo ?? (_applicationInfo = await ClientHelper.GetApplicationInfoAsync(this, options ?? RequestOptions.Default));
+            => _applicationInfo ?? (_applicationInfo = await ClientHelper.GetApplicationInfoAsync(this, options ?? RequestOptions.Default).ConfigureAwait(false));
 
         /// <inheritdoc />
         public override SocketGuild GetGuild(ulong id) 
@@ -278,7 +278,7 @@ namespace Discord.WebSocket
         }
 
         /// <summary> Downloads the users list for the provided guilds, if they don't have a complete list. </summary>
-        public async Task DownloadUsersAsync(IEnumerable<IGuild> guilds)
+        public override async Task DownloadUsersAsync(IEnumerable<IGuild> guilds)
         {
             if (ConnectionState == ConnectionState.Connected)
             {


### PR DESCRIPTION
**Breaking changes:**

~~- Removed leftover `DiscordShardedClient.UserPresenceUpdated` event.~~
(Will be done on next major release)

**Additions:**
- Add BaseSocketClient object.
- Add ShardConnected, ShardDisconnected, ShardReady, and ShardLatencyUpdated events to DiscordShardedClient.
***Minor:***
-- Added optional [RequestOptions](https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Core/RequestOptions.cs) argument that was missing from various methods.
-- Added docstrings for all events.

There is no currently existing bridge between [DiscordSocketClient](https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.WebSocket/DiscordSocketClient.cs) and [DiscordShardedClient](https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.WebSocket/DiscordShardedClient.cs), leaving users to duplicate all websocket client functionality between the two if they wish to abstract code that should be shared to a BCL, or for addon developers that wish to support both client types out of the box. 

While it makes logical sense that this wasn't implemented previously as DiscordShardedClient isn't technically a client itself, but a wrapper for multiple DiscordSocketClients, that comes at an unfortunate expense of usability for accessing events or methods only supported via websockets. 