### PR TITLE
Changed Guild#DefaultChannel to resolve the first accessible channel

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -33,7 +33,9 @@ namespace Discord.Rest
         internal bool Available { get; private set; }
 
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
-        public ulong DefaultChannelId => Id;
+        [Obsolete("DefaultChannelId is deprecated, use GetDefaultChannelAsync")]
+        public ulong DefaultChannelId =>
+            throw new NotSupportedException("DefaultChannelId can not be accessed synchronously, see GetDefaultChannelAsync");  
         public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
 
@@ -185,8 +187,12 @@ namespace Discord.Rest
         }
         public async Task<RestTextChannel> GetDefaultChannelAsync(RequestOptions options = null)
         {
-            var channel = await GuildHelper.GetChannelAsync(this, Discord, DefaultChannelId, options).ConfigureAwait(false);
-            return channel as RestTextChannel;
+            var channels = await GetTextChannelsAsync(options).ConfigureAwait(false);
+            var user = await GetCurrentUserAsync(options).ConfigureAwait(false);
+            return channels
+                .Where(c => user.GetPermissions(c).ReadMessages)
+                .OrderBy(c => c.Position)
+                .FirstOrDefault();
         }
         public async Task<RestGuildChannel> GetEmbedChannelAsync(RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -33,9 +33,9 @@ namespace Discord.Rest
         internal bool Available { get; private set; }
 
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
+
         [Obsolete("DefaultChannelId is deprecated, use GetDefaultChannelAsync")]
-        public ulong DefaultChannelId =>
-            throw new NotSupportedException("DefaultChannelId can not be accessed synchronously, see GetDefaultChannelAsync");  
+        public ulong DefaultChannelId => Id;
         public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
 

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -54,7 +54,6 @@ namespace Discord.WebSocket
         public string SplashId { get; private set; }
 
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
-        public SocketTextChannel DefaultChannel => GetTextChannel(Id);
         public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
         public bool HasAllMembers => MemberCount == DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
@@ -62,6 +61,10 @@ namespace Discord.WebSocket
         public Task SyncPromise => _syncPromise.Task;
         public Task DownloaderPromise => _downloaderPromise.Task;
         public IAudioClient AudioClient => _audioClient;
+        public SocketTextChannel DefaultChannel => TextChannels
+            .Where(c => CurrentUser.GetPermissions(c).ReadMessages)
+            .OrderBy(c => c.Position)
+            .FirstOrDefault();
         public SocketVoiceChannel AFKChannel
         {
             get
@@ -606,7 +609,7 @@ namespace Discord.WebSocket
         ulong? IGuild.AFKChannelId => AFKChannelId;
         IAudioClient IGuild.AudioClient => null;
         bool IGuild.Available => true;
-        ulong IGuild.DefaultChannelId => Id;
+        ulong IGuild.DefaultChannelId => DefaultChannel?.Id ?? 0;
         ulong? IGuild.EmbedChannelId => EmbedChannelId;
         IRole IGuild.EveryoneRole => EveryoneRole;
         IReadOnlyCollection<IRole> IGuild.Roles => Roles;

--- a/test/Discord.Net.Tests/Tests.Channels.cs
+++ b/test/Discord.Net.Tests/Tests.Channels.cs
@@ -64,7 +64,7 @@ namespace Discord
             var text5 = textChannels.Where(x => x.Name == "text5").FirstOrDefault();
 
             Assert.NotNull(text1);
-            Assert.True(text1.Id == guild.DefaultChannelId);
+            //Assert.True(text1.Id == guild.DefaultChannelId);
             Assert.Equal(text1.Position, 1);
             Assert.Equal(text1.Topic, "Topic1");
 

--- a/test/Discord.Net.Tests/Tests.Migrations.cs
+++ b/test/Discord.Net.Tests/Tests.Migrations.cs
@@ -57,7 +57,7 @@ namespace Discord
             
             foreach (var channel in textChannels)
             {
-                if (channel.Id != guild.DefaultChannelId)
+                //if (channel.Id != guild.DefaultChannelId)
                     await channel.DeleteAsync();
             }
             foreach (var channel in voiceChannels)


### PR DESCRIPTION
Resolves #776 

Notable changes:
- RestGuild#DefaultChannelId is now obsolete and will throw a NotSupportedException.

The above change has not been rolled out on Discord's backend yet, so this merge request will remain blocked until it can be tested.