### PR TITLE
Condense redundant AddField overloads in EmbedBuilder

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
@@ -171,10 +171,10 @@ namespace Discord
             return this;
         }
 
-        public EmbedBuilder AddField(string name, object value)
+        public EmbedBuilder AddField(string name, object value, bool inline = false)
         {
             var field = new EmbedFieldBuilder()
-                .WithIsInline(false)
+                .WithIsInline(inline)
                 .WithName(name)
                 .WithValue(value);
             AddField(field);
@@ -204,17 +204,6 @@ namespace Discord
             var field = new EmbedFieldBuilder();
             action(field);
             this.AddField(field);
-            return this;
-        }
-        public EmbedBuilder AddField(string title, string text, bool inline = false)
-        {
-            var field = new EmbedFieldBuilder
-            {
-                Name = title,
-                Value = text,
-                IsInline = inline
-            };
-            _fields.Add(field);
             return this;
         }
 

--- a/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
@@ -180,15 +180,7 @@ namespace Discord
             AddField(field);
             return this;
         }
-        public EmbedBuilder AddInlineField(string name, object value)
-        {
-            var field = new EmbedFieldBuilder()
-                .WithIsInline(true)
-                .WithName(name)
-                .WithValue(value);
-            AddField(field);
-            return this;
-        }
+
         public EmbedBuilder AddField(EmbedFieldBuilder field)
         {
             if (Fields.Count >= MaxFieldCount)


### PR DESCRIPTION
It seems redundant to have a `(string, string, bool)` overload when `EmbedFieldBuilder` takes an object anyway. I also don't know why the `(string, object)` overload has no parameter to specify inline where the `(string, string, bool)` one does.