### PR TITLE
Remove EmbedBuilder -> Embed implicit conversion

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
@@ -234,7 +234,6 @@ namespace Discord
 
             return _embed;
         }
-        public static implicit operator Embed(EmbedBuilder builder) => builder?.Build();
     }
 
     public class EmbedFieldBuilder


### PR DESCRIPTION
Literally every time someone in the support channel wants to know how to modify a message's embed, they ask why the compiler tells them `Cannot implicitly convert type 'Discord.EmbedBuilder' to 'Discord.Optional<Discord.Embed>'`. Reason being that the C# compiler doesn't do double implicit conversion.

Therefor I believe we should force users to always `.Build()` their embeds explicitly, so people can stop hitting this issue of seeming inconsistency.