### PR TITLE
Add Async suffix to command-related Tasks

### DIFF
--- a/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/ParameterPreconditionAttribute.cs
@@ -7,6 +7,6 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = true)]
     public abstract class ParameterPreconditionAttribute : Attribute
     {
-        public abstract Task<PreconditionResult> CheckPermissions(ICommandContext context, ParameterInfo parameter, object value, IServiceProvider services);
+        public abstract Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, ParameterInfo parameter, object value, IServiceProvider services);
     }
 }

--- a/src/Discord.Net.Commands/Attributes/PreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/PreconditionAttribute.cs
@@ -8,7 +8,7 @@ namespace Discord.Commands
     {
         /// <summary>
         /// Specify a group that this precondition belongs to. Preconditions of the same group require only one
-        /// of the preconditions to pass in order to be successful (A || B). Specifying <see cref="Group"/> = <see cref="null"/>
+        /// of the preconditions to pass in order to be successful (A || B). Specifying <see cref="Group"/> = <see langword="null"/>
         /// or not at all will require *all* preconditions to pass, just like normal (A &amp;&amp; B).
         /// </summary>
         public string Group { get; set; } = null;

--- a/src/Discord.Net.Commands/Attributes/PreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/PreconditionAttribute.cs
@@ -13,6 +13,6 @@ namespace Discord.Commands
         /// </summary>
         public string Group { get; set; } = null;
 
-        public abstract Task<PreconditionResult> CheckPermissions(ICommandContext context, CommandInfo command, IServiceProvider services);
+        public abstract Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services);
     }
 }

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
@@ -41,7 +41,7 @@ namespace Discord.Commands
             GuildPermission = null;
         }
 
-        public override async Task<PreconditionResult> CheckPermissions(ICommandContext context, CommandInfo command, IServiceProvider services)
+        public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             IGuildUser guildUser = null;
             if (context.Guild != null)

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireContextAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireContextAttribute.cs
@@ -38,7 +38,7 @@ namespace Discord.Commands
             Contexts = contexts;
         }
 
-        public override Task<PreconditionResult> CheckPermissions(ICommandContext context, CommandInfo command, IServiceProvider services)
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             bool isValid = false;
 

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireNsfwAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireNsfwAttribute.cs
@@ -9,7 +9,7 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class RequireNsfwAttribute : PreconditionAttribute
     {
-        public override Task<PreconditionResult> CheckPermissions(ICommandContext context, CommandInfo command, IServiceProvider services)
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             if (context.Channel is ITextChannel text && text.IsNsfw)
                 return Task.FromResult(PreconditionResult.FromSuccess());

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
@@ -11,7 +11,7 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class RequireOwnerAttribute : PreconditionAttribute
     {
-        public override async Task<PreconditionResult> CheckPermissions(ICommandContext context, CommandInfo command, IServiceProvider services)
+        public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             switch (context.Client.TokenType)
             {

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
@@ -42,7 +42,7 @@ namespace Discord.Commands
             GuildPermission = null;
         }
         
-        public override Task<PreconditionResult> CheckPermissions(ICommandContext context, CommandInfo command, IServiceProvider services)
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             var guildUser = context.User as IGuildUser;
 

--- a/src/Discord.Net.Commands/CommandParser.cs
+++ b/src/Discord.Net.Commands/CommandParser.cs
@@ -14,7 +14,7 @@ namespace Discord.Commands
             QuotedParameter
         }
         
-        public static async Task<ParseResult> ParseArgs(CommandInfo command, ICommandContext context, IServiceProvider services, string input, int startPos)
+        public static async Task<ParseResult> ParseArgsAsync(CommandInfo command, ICommandContext context, IServiceProvider services, string input, int startPos)
         {
             ParameterInfo curParam = null;
             StringBuilder argBuilder = new StringBuilder(input.Length);
@@ -111,7 +111,7 @@ namespace Discord.Commands
                     if (curParam == null)
                         return ParseResult.FromError(CommandError.BadArgCount, "The input text has too many parameters.");
 
-                    var typeReaderResult = await curParam.Parse(context, argString, services).ConfigureAwait(false);
+                    var typeReaderResult = await curParam.ParseAsync(context, argString, services).ConfigureAwait(false);
                     if (!typeReaderResult.IsSuccess && typeReaderResult.Error != CommandError.MultipleMatches)
                         return ParseResult.FromError(typeReaderResult);
 
@@ -134,7 +134,7 @@ namespace Discord.Commands
 
             if (curParam != null && curParam.IsRemainder)
             {
-                var typeReaderResult = await curParam.Parse(context, argBuilder.ToString(), services).ConfigureAwait(false);
+                var typeReaderResult = await curParam.ParseAsync(context, argBuilder.ToString(), services).ConfigureAwait(false);
                 if (!typeReaderResult.IsSuccess)
                     return ParseResult.FromError(typeReaderResult);
                 argList.Add(typeReaderResult);

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -78,7 +78,7 @@ namespace Discord.Commands
                     {
                         foreach (PreconditionAttribute precondition in preconditionGroup)
                         {
-                            var result = await precondition.CheckPermissions(context, this, services).ConfigureAwait(false);
+                            var result = await precondition.CheckPermissionsAsync(context, this, services).ConfigureAwait(false);
                             if (!result.IsSuccess)
                                 return result;
                         }
@@ -87,7 +87,7 @@ namespace Discord.Commands
                     {
                         var results = new List<PreconditionResult>();
                         foreach (PreconditionAttribute precondition in preconditionGroup)
-                            results.Add(await precondition.CheckPermissions(context, this, services).ConfigureAwait(false));
+                            results.Add(await precondition.CheckPermissionsAsync(context, this, services).ConfigureAwait(false));
 
                         if (!results.Any(p => p.IsSuccess))
                             return PreconditionGroupResult.FromError($"{type} precondition group {preconditionGroup.Key} failed.", results);

--- a/src/Discord.Net.Commands/Info/CommandInfo.cs
+++ b/src/Discord.Net.Commands/Info/CommandInfo.cs
@@ -117,7 +117,7 @@ namespace Discord.Commands
                 return ParseResult.FromError(preconditionResult);
 
             string input = searchResult.Text.Substring(startIndex);
-            return await CommandParser.ParseArgs(this, context, services, input, 0).ConfigureAwait(false);
+            return await CommandParser.ParseArgsAsync(this, context, services, input, 0).ConfigureAwait(false);
         }
 
         public Task<IResult> ExecuteAsync(ICommandContext context, ParseResult parseResult, IServiceProvider services)
@@ -163,11 +163,11 @@ namespace Discord.Commands
                 switch (RunMode)
                 {
                     case RunMode.Sync: //Always sync
-                        return await ExecuteAsyncInternal(context, args, services).ConfigureAwait(false);
+                        return await ExecuteAsyncInternalAsync(context, args, services).ConfigureAwait(false);
                     case RunMode.Async: //Always async
                         var t2 = Task.Run(async () =>
                         {
-                            await ExecuteAsyncInternal(context, args, services).ConfigureAwait(false);
+                            await ExecuteAsyncInternalAsync(context, args, services).ConfigureAwait(false);
                         });
                         break;
                 }
@@ -179,7 +179,7 @@ namespace Discord.Commands
             }
         }
 
-        private async Task<IResult> ExecuteAsyncInternal(ICommandContext context, object[] args, IServiceProvider services)
+        private async Task<IResult> ExecuteAsyncInternalAsync(ICommandContext context, object[] args, IServiceProvider services)
         {
             await Module.Service._cmdLogger.DebugAsync($"Executing {GetLogText(context)}").ConfigureAwait(false);
             try

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -48,7 +48,7 @@ namespace Discord.Commands
 
             foreach (var precondition in Preconditions)
             {
-                var result = await precondition.CheckPermissions(context, this, arg, services).ConfigureAwait(false);
+                var result = await precondition.CheckPermissionsAsync(context, this, arg, services).ConfigureAwait(false);
                 if (!result.IsSuccess)
                     return result;
             }

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -56,7 +56,7 @@ namespace Discord.Commands
             return PreconditionResult.FromSuccess();
         }
 
-        public async Task<TypeReaderResult> Parse(ICommandContext context, string input, IServiceProvider services = null)
+        public async Task<TypeReaderResult> ParseAsync(ICommandContext context, string input, IServiceProvider services = null)
         {
             services = services ?? EmptyServiceProvider.Instance;
             return await _reader.ReadAsync(context, input, services).ConfigureAwait(false);

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -59,7 +59,7 @@ namespace Discord.Commands
         public async Task<TypeReaderResult> Parse(ICommandContext context, string input, IServiceProvider services = null)
         {
             services = services ?? EmptyServiceProvider.Instance;
-            return await _reader.Read(context, input, services).ConfigureAwait(false);
+            return await _reader.ReadAsync(context, input, services).ConfigureAwait(false);
         }
 
         public override string ToString() => Name;

--- a/src/Discord.Net.Commands/Readers/ChannelTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/ChannelTypeReader.cs
@@ -9,7 +9,7 @@ namespace Discord.Commands
     internal class ChannelTypeReader<T> : TypeReader
         where T : class, IChannel
     {
-        public override async Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
+        public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             if (context.Guild != null)
             {

--- a/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/EnumTypeReader.cs
@@ -44,7 +44,7 @@ namespace Discord.Commands
             _enumsByValue = byValueBuilder.ToImmutable();
         }
 
-        public override Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
+        public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             object enumValue;
 

--- a/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
@@ -7,7 +7,7 @@ namespace Discord.Commands
     internal class MessageTypeReader<T> : TypeReader
         where T : class, IMessage
     {
-        public override async Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
+        public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             ulong id;
 

--- a/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
@@ -28,7 +28,7 @@ namespace Discord.Commands
         {
             if (string.Equals(input, "null", StringComparison.OrdinalIgnoreCase) || string.Equals(input, "nothing", StringComparison.OrdinalIgnoreCase))
                 return TypeReaderResult.FromSuccess(new T?());
-            return await _baseTypeReader.ReadAsync(context, input, services); ;
+            return await _baseTypeReader.ReadAsync(context, input, services);
         }
     }
 }

--- a/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/NullableTypeReader.cs
@@ -24,11 +24,11 @@ namespace Discord.Commands
             _baseTypeReader = baseTypeReader;
         }
 
-        public override async Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
+        public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             if (string.Equals(input, "null", StringComparison.OrdinalIgnoreCase) || string.Equals(input, "nothing", StringComparison.OrdinalIgnoreCase))
                 return TypeReaderResult.FromSuccess(new T?());
-            return await _baseTypeReader.Read(context, input, services); ;
+            return await _baseTypeReader.ReadAsync(context, input, services); ;
         }
     }
 }

--- a/src/Discord.Net.Commands/Readers/PrimitiveTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/PrimitiveTypeReader.cs
@@ -30,7 +30,7 @@ namespace Discord.Commands
             _score = score;
         }
 
-        public override Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
+        public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             if (_tryParse(input, out T value))
                 return Task.FromResult(TypeReaderResult.FromSuccess(new TypeReaderValue(value, _score)));

--- a/src/Discord.Net.Commands/Readers/RoleTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/RoleTypeReader.cs
@@ -9,7 +9,7 @@ namespace Discord.Commands
     internal class RoleTypeReader<T> : TypeReader
         where T : class, IRole
     {
-        public override Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
+        public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             ulong id;
 

--- a/src/Discord.Net.Commands/Readers/TypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TypeReader.cs
@@ -5,6 +5,6 @@ namespace Discord.Commands
 {
     public abstract class TypeReader
     {
-        public abstract Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services);
+        public abstract Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services);
     }
 }

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -10,7 +10,7 @@ namespace Discord.Commands
     internal class UserTypeReader<T> : TypeReader
         where T : class, IUser
     {
-        public override async Task<TypeReaderResult> Read(ICommandContext context, string input, IServiceProvider services)
+        public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             var results = new Dictionary<ulong, TypeReaderValue>();
             IReadOnlyCollection<IUser> channelUsers = (await context.Channel.GetUsersAsync(CacheMode.CacheOnly).Flatten().ConfigureAwait(false)).ToArray(); //TODO: must be a better way?


### PR DESCRIPTION
This is a breaking change.

This fixes the inconsistent naming in `TypeReader`, `PreconditionAttribute`, and `ParameterPreconditionAttribute` abstractions, as well as several other async naming violation within the `Discord.Net.Commands` project.