### PR TITLE
System Channel Id ("Welcome new members channel") support, fix #815

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -60,6 +60,14 @@
         /// </summary>
         public Optional<ulong?> AfkChannelId { get; set; }
         /// <summary>
+        /// The ITextChannel where System messages should be sent.
+        /// </summary>
+        public Optional<ITextChannel> SystemChannel { get; set; }
+        /// <summary>
+        /// The ID of the ITextChannel where System messages should be sent.
+        /// </summary>
+        public Optional<ulong?> SystemChannelId { get; set; }
+        /// <summary>
         /// The owner of this guild.
         /// </summary>
         public Optional<IUser> Owner { get; set; }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -36,6 +36,8 @@ namespace Discord
         ulong DefaultChannelId { get; }
         /// <summary> Gets the id of the embed channel for this guild if set, or null if not. </summary>
         ulong? EmbedChannelId { get; }
+        /// <summary> Gets the id of the channel where randomized welcome messages are sent, or null if not. </summary>
+        ulong? SystemChannelId { get; }
         /// <summary> Gets the id of the user that created this guild. </summary>
         ulong OwnerId { get; }
         /// <summary> Gets the id of the region hosting this guild's voice channels. </summary>
@@ -84,6 +86,7 @@ namespace Discord
         Task<IReadOnlyCollection<IVoiceChannel>> GetVoiceChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         Task<IVoiceChannel> GetVoiceChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         Task<IVoiceChannel> GetAFKChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+        Task<ITextChannel> GetSystemChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         Task<ITextChannel> GetDefaultChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         Task<IGuildChannel> GetEmbedChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary> Creates a new text channel. </summary>

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -25,6 +25,8 @@ namespace Discord.API
         public bool EmbedEnabled { get; set; }
         [JsonProperty("embed_channel_id")]
         public ulong? EmbedChannelId { get; set; }
+        [JsonProperty("system_channel_id")]
+        public ulong? SystemChannelId { get; set; }
         [JsonProperty("verification_level")]
         public VerificationLevel VerificationLevel { get; set; }
         [JsonProperty("voice_states")]

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
@@ -18,6 +18,8 @@ namespace Discord.API.Rest
         public Optional<DefaultMessageNotifications> DefaultMessageNotifications { get; set; }
         [JsonProperty("afk_timeout")]
         public Optional<int> AfkTimeout { get; set; }
+        [JsonProperty("system_channel_id")]
+        public Optional<ulong?> SystemChannelId { get; set; }
         [JsonProperty("icon")]
         public Optional<Image?> Icon { get; set; }
         [JsonProperty("splash")]

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -26,6 +26,7 @@ namespace Discord.Rest
             {
                 AfkChannelId = args.AfkChannelId,
                 AfkTimeout = args.AfkTimeout,
+                SystemChannelId = args.SystemChannelId,
                 DefaultMessageNotifications = args.DefaultMessageNotifications,
                 Icon = args.Icon.IsSpecified ? args.Icon.Value?.ToModel() : Optional.Create<ImageModel?>(),
                 Name = args.Name,
@@ -38,6 +39,11 @@ namespace Discord.Rest
                 apiArgs.AfkChannelId = args.AfkChannel.Value.Id;
             else if (args.AfkChannelId.IsSpecified)
                 apiArgs.AfkChannelId = args.AfkChannelId.Value;
+
+            if (args.SystemChannel.IsSpecified)
+                apiArgs.SystemChannelId = args.SystemChannel.Value.Id;
+            else if (args.SystemChannelId.IsSpecified)
+                apiArgs.SystemChannelId = args.SystemChannelId.Value;
 
             if (args.Owner.IsSpecified)
                 apiArgs.OwnerId = args.Owner.Value.Id;

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -26,6 +26,7 @@ namespace Discord.Rest
         
         public ulong? AFKChannelId { get; private set; }
         public ulong? EmbedChannelId { get; private set; }
+        public ulong? SystemChannelId { get; private set; }
         public ulong OwnerId { get; private set; }
         public string VoiceRegionId { get; private set; }
         public string IconId { get; private set; }
@@ -58,6 +59,7 @@ namespace Discord.Rest
         {
             AFKChannelId = model.AFKChannelId;
             EmbedChannelId = model.EmbedChannelId;
+            SystemChannelId = model.SystemChannelId;
             AFKTimeout = model.AFKTimeout;
             IsEmbeddable = model.EmbedEnabled;
             IconId = model.Icon;
@@ -201,6 +203,16 @@ namespace Discord.Rest
                 return await GuildHelper.GetChannelAsync(this, Discord, embedId.Value, options).ConfigureAwait(false);
             return null;
         }
+        public async Task<RestTextChannel> GetSystemChannelAsync(RequestOptions options = null)
+        {
+            var systemId = SystemChannelId;
+            if (systemId.HasValue)
+            {
+                var channel = await GuildHelper.GetChannelAsync(this, Discord, systemId.Value, options).ConfigureAwait(false);
+                return channel as RestTextChannel;
+            }
+            return null;
+        }
         public Task<RestTextChannel> CreateTextChannelAsync(string name, RequestOptions options = null)
             => GuildHelper.CreateTextChannelAsync(this, Discord, name, options);
         public Task<RestVoiceChannel> CreateVoiceChannelAsync(string name, RequestOptions options = null)
@@ -317,6 +329,13 @@ namespace Discord.Rest
         {
             if (mode == CacheMode.AllowDownload)
                 return await GetEmbedChannelAsync(options).ConfigureAwait(false);
+            else
+                return null;
+        }
+        async Task<ITextChannel> IGuild.GetSystemChannelAsync(CacheMode mode, RequestOptions options)
+        {
+            if (mode == CacheMode.AllowDownload)
+                return await GetSystemChannelAsync(options).ConfigureAwait(false);
             else
                 return null;
         }

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -47,6 +47,7 @@ namespace Discord.WebSocket
 
         internal ulong? AFKChannelId { get; private set; }
         internal ulong? EmbedChannelId { get; private set; }
+        internal ulong? SystemChannelId { get; private set; }
         public ulong OwnerId { get; private set; }
         public SocketGuildUser Owner => GetUser(OwnerId);
         public string VoiceRegionId { get; private set; }
@@ -79,6 +80,14 @@ namespace Discord.WebSocket
             {
                 var id = EmbedChannelId;
                 return id.HasValue ? GetChannel(id.Value) : null;
+            }
+        }
+        public SocketTextChannel SystemChannel
+        {
+            get
+            {
+                var id = SystemChannelId;
+                return id.HasValue ? GetTextChannel(id.Value) : null;
             }
         }
         public IReadOnlyCollection<SocketTextChannel> TextChannels
@@ -191,6 +200,7 @@ namespace Discord.WebSocket
         {
             AFKChannelId = model.AFKChannelId;
             EmbedChannelId = model.EmbedChannelId;
+            SystemChannelId = model.SystemChannelId;
             AFKTimeout = model.AFKTimeout;
             IsEmbeddable = model.EmbedEnabled;
             IconId = model.Icon;
@@ -607,6 +617,7 @@ namespace Discord.WebSocket
         bool IGuild.Available => true;
         ulong IGuild.DefaultChannelId => DefaultChannel?.Id ?? 0;
         ulong? IGuild.EmbedChannelId => EmbedChannelId;
+        ulong? IGuild.SystemChannelId => SystemChannelId;
         IRole IGuild.EveryoneRole => EveryoneRole;
         IReadOnlyCollection<IRole> IGuild.Roles => Roles;
 
@@ -631,6 +642,8 @@ namespace Discord.WebSocket
             => Task.FromResult<ITextChannel>(DefaultChannel);
         Task<IGuildChannel> IGuild.GetEmbedChannelAsync(CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuildChannel>(EmbedChannel);
+        Task<ITextChannel> IGuild.GetSystemChannelAsync(CacheMode mode, RequestOptions options)
+            => Task.FromResult<ITextChannel>(SystemChannel);
         async Task<ITextChannel> IGuild.CreateTextChannelAsync(string name, RequestOptions options)
             => await CreateTextChannelAsync(name, options).ConfigureAwait(false);
         async Task<IVoiceChannel> IGuild.CreateVoiceChannelAsync(string name, RequestOptions options)


### PR DESCRIPTION
Implementation of the "new member messages channel" guild option. Tried to closely follow the similar implementation of AFKChannel.

I was able to test the functionality of `SocketChannel#SystemChannel` property and `IGuild.ModifyAsync`, and both appear to be working as expected.

Per @khionu 's comment on #815, and some confirmation in the debugger, `system_channel_id` appears to be the correct name for this value in the API. I kept this name in the implementation to stay consistent with the API.

Feedback and review is appreciated. My discord handle is ChrisJ#8703.