### PR TITLE
Move DeleteMessageAsync from IMessageChannel to ITextChannel

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -29,10 +29,6 @@ namespace Discord
             CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary> Gets a collection of pinned messages in this channel. </summary>
         Task<IReadOnlyCollection<IMessage>> GetPinnedMessagesAsync(RequestOptions options = null);
-        /// <summary> Bulk deletes multiple messages. </summary>
-        Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null);
-        /// <summary> Bulk deletes multiple messages. </summary>
-        Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null);
 
         /// <summary> Broadcasts the "user is typing" message to all users in this channel, lasting 10 seconds. </summary>
         Task TriggerTypingAsync(RequestOptions options = null);

--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -10,6 +11,11 @@ namespace Discord
 
         /// <summary> Gets the current topic for this text channel. </summary>
         string Topic { get; }
+
+        /// <summary> Bulk deletes multiple messages. </summary>
+        Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null);
+        /// <summary> Bulk deletes multiple messages. </summary>
+        Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null);
 
         /// <summary> Modifies this text channel. </summary>
         Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null);

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -181,7 +181,7 @@ namespace Discord.Rest
             return RestUserMessage.Create(client, channel, client.CurrentUser, model);
         }     
 
-        public static async Task DeleteMessagesAsync(IMessageChannel channel, BaseDiscordClient client,
+        public static async Task DeleteMessagesAsync(ITextChannel channel, BaseDiscordClient client,
             IEnumerable<ulong> messageIds, RequestOptions options)
         {
             var msgs = messageIds.ToArray();

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -72,11 +72,6 @@ namespace Discord.Rest
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, options);
 
-        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messages.Select(x => x.Id), options);
-        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messageIds, options);
-
         public Task TriggerTypingAsync(RequestOptions options = null)
             => ChannelHelper.TriggerTypingAsync(this, Discord, options);
         public IDisposable EnterTypingState(RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -85,11 +85,6 @@ namespace Discord.Rest
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, options);
 
-        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messages.Select(x => x.Id), options);
-        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messageIds, options);
-
         public Task TriggerTypingAsync(RequestOptions options = null)
             => ChannelHelper.TriggerTypingAsync(this, Discord, options);
         public IDisposable EnterTypingState(RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RpcVirtualMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RpcVirtualMessageChannel.cs
@@ -42,11 +42,6 @@ namespace Discord.Rest
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, options);
 
-        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messages.Select(x => x.Id), options);
-        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messageIds, options);
-
         public Task TriggerTypingAsync(RequestOptions options = null)
             => ChannelHelper.TriggerTypingAsync(this, Discord, options);
         public IDisposable EnterTypingState(RequestOptions options = null)

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcDMChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcDMChannel.cs
@@ -53,11 +53,6 @@ namespace Discord.Rpc
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, options);
 
-        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messages.Select(x => x.Id), options);
-        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messageIds, options);
-
         public Task TriggerTypingAsync(RequestOptions options = null)
             => ChannelHelper.TriggerTypingAsync(this, Discord, options);
         public IDisposable EnterTypingState(RequestOptions options = null)

--- a/src/Discord.Net.Rpc/Entities/Channels/RpcGroupChannel.cs
+++ b/src/Discord.Net.Rpc/Entities/Channels/RpcGroupChannel.cs
@@ -56,11 +56,6 @@ namespace Discord.Rpc
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, options);
 
-        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messages.Select(x => x.Id), options);
-        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messageIds, options);
-
         public Task TriggerTypingAsync(RequestOptions options = null)
             => ChannelHelper.TriggerTypingAsync(this, Discord, options);
         public IDisposable EnterTypingState(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -76,11 +76,6 @@ namespace Discord.WebSocket
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, options);
 
-        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messages.Select(x => x.Id), options);
-        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messageIds, options);
-
         public Task TriggerTypingAsync(RequestOptions options = null)
             => ChannelHelper.TriggerTypingAsync(this, Discord, options);
         public IDisposable EnterTypingState(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -104,11 +104,6 @@ namespace Discord.WebSocket
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, options);
 
-        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messages.Select(x => x.Id), options);
-        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null)
-            => ChannelHelper.DeleteMessagesAsync(this, Discord, messageIds, options);
-
         public Task TriggerTypingAsync(RequestOptions options = null)
             => ChannelHelper.TriggerTypingAsync(this, Discord, options);
         public IDisposable EnterTypingState(RequestOptions options = null)


### PR DESCRIPTION
 **Breaking Change:** `DeleteMessagesAsync()` has been removed from `IMessageChannel`.
___
Per [Discord's documentation](https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages), this endpoint is only valid for guild channels. Moving the method definition will prevent 403 errors on attempting this request on an invalid channel type. 

Resolves #778. 