### PR TITLE
Implemented emoji endpoints

### DIFF
--- a/src/Discord.Net.Core/Entities/Emotes/EmoteProperties.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/EmoteProperties.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Discord
+{
+    public class EmoteProperties
+    {
+        public Optional<string> Name { get; set; }
+        public Optional<IEnumerable<IRole>> Roles { get; set; }
+    }
+}

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -117,5 +117,16 @@ namespace Discord
         Task DownloadUsersAsync();
         /// <summary> Removes all users from this guild if they have not logged on in a provided number of days or, if simulate is true, returns the number of users that would be removed. </summary>
         Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null);
+
+        /// <summary> Gets a collection of all emotes in this guild. </summary>
+        Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(RequestOptions options = null);
+        /// <summary> Gets a specific emote from this guild. </summary>
+        Task<GuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null);
+        /// <summary> Creates a new emote in this guild. </summary>
+        Task<GuildEmote> CreateEmoteAsync(string name, Image image, Optional<IEnumerable<IRole>> roles = default(Optional<IEnumerable<IRole>>), RequestOptions options = null);
+        /// <summary> Modifies an existing emote in this guild. </summary>
+        Task<GuildEmote> ModifyEmoteAsync(GuildEmote emote, Action<EmoteProperties> func, RequestOptions options = null);
+        /// <summary> Deletes an existing emote from this guild. </summary>
+        Task DeleteEmoteAsync(GuildEmote emote, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -118,8 +118,6 @@ namespace Discord
         /// <summary> Removes all users from this guild if they have not logged on in a provided number of days or, if simulate is true, returns the number of users that would be removed. </summary>
         Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null);
 
-        /// <summary> Gets a collection of all emotes in this guild. </summary>
-        Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(RequestOptions options = null);
         /// <summary> Gets a specific emote from this guild. </summary>
         Task<GuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null);
         /// <summary> Creates a new emote in this guild. </summary>

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildEmoteParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildEmoteParams.cs
@@ -1,0 +1,16 @@
+﻿#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Discord.API.Rest
+{
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    internal class CreateGuildEmoteParams
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        [JsonProperty("image")]
+        public Image Image { get; set; }
+        [JsonProperty("roles")]
+        public Optional<ulong[]> RoleIds { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildEmoteParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildEmoteParams.cs
@@ -1,0 +1,14 @@
+﻿#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Discord.API.Rest
+{
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    internal class ModifyGuildEmoteParams
+    {
+        [JsonProperty("name")]
+        public Optional<string> Name { get; set; }
+        [JsonProperty("roles")]
+        public Optional<ulong[]> RoleIds { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1067,15 +1067,6 @@ namespace Discord.API
         }
 
         //Guild emoji
-        public async Task<IReadOnlyCollection<Emoji>> ListGuildEmotesAsync(ulong guildId, RequestOptions options = null)
-        {
-            Preconditions.NotEqual(guildId, 0, nameof(guildId));
-            options = RequestOptions.CreateOrClone(options);
-
-            var ids = new BucketIds(guildId: guildId);
-            return await SendAsync<IReadOnlyCollection<Emoji>>("GET", () => $"guilds/{guildId}/emojis", ids, options: options);
-        }
-
         public async Task<Emoji> GetGuildEmoteAsync(ulong guildId, ulong emoteId, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1067,26 +1067,26 @@ namespace Discord.API
         }
 
         //Guild emoji
-        public async Task<IReadOnlyCollection<GuildEmote>> ListGuildEmotesAsync(ulong guildId, RequestOptions options = null)
+        public async Task<IReadOnlyCollection<Emoji>> ListGuildEmotesAsync(ulong guildId, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            return await SendAsync<IReadOnlyCollection<GuildEmote>>("GET", () => $"guilds/{guildId}/emojis", ids, options: options);
+            return await SendAsync<IReadOnlyCollection<Emoji>>("GET", () => $"guilds/{guildId}/emojis", ids, options: options);
         }
 
-        public async Task<GuildEmote> GetGuildEmoteAsync(ulong guildId, ulong emoteId, RequestOptions options = null)
+        public async Task<Emoji> GetGuildEmoteAsync(ulong guildId, ulong emoteId, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             Preconditions.NotEqual(emoteId, 0, nameof(emoteId));
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            return await SendAsync<GuildEmote>("GET", () => $"guilds/{guildId}/emojis/{emoteId}", ids, options: options);
+            return await SendAsync<Emoji>("GET", () => $"guilds/{guildId}/emojis/{emoteId}", ids, options: options);
         }
 
-        public async Task<GuildEmote> CreateGuildEmoteAsync(ulong guildId, Rest.CreateGuildEmoteParams args, RequestOptions options = null)
+        public async Task<Emoji> CreateGuildEmoteAsync(ulong guildId, Rest.CreateGuildEmoteParams args, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             Preconditions.NotNull(args, nameof(args));
@@ -1095,10 +1095,10 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            return await SendJsonAsync<GuildEmote>("POST", () => $"guilds/{guildId}/emojis", args, ids, options: options);
+            return await SendJsonAsync<Emoji>("POST", () => $"guilds/{guildId}/emojis", args, ids, options: options);
         }
 
-        public async Task<GuildEmote> ModifyGuildEmoteAsync(ulong guildId, ulong emoteId, ModifyGuildEmoteParams args, RequestOptions options = null)
+        public async Task<Emoji> ModifyGuildEmoteAsync(ulong guildId, ulong emoteId, ModifyGuildEmoteParams args, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             Preconditions.NotEqual(emoteId, 0, nameof(emoteId));
@@ -1106,7 +1106,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            return await SendJsonAsync<GuildEmote>("PATCH", () => $"guilds/{guildId}/emojis/{emoteId}", args, ids, options: options);
+            return await SendJsonAsync<Emoji>("PATCH", () => $"guilds/{guildId}/emojis/{emoteId}", args, ids, options: options);
         }
 
         public async Task DeleteGuildEmoteAsync(ulong guildId, ulong emoteId, RequestOptions options = null)

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1066,6 +1066,59 @@ namespace Discord.API
             return await SendJsonAsync<IReadOnlyCollection<Role>>("PATCH", () => $"guilds/{guildId}/roles", args, ids, options: options).ConfigureAwait(false);
         }
 
+        //Guild emoji
+        public async Task<IReadOnlyCollection<GuildEmote>> ListGuildEmotesAsync(ulong guildId, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(guildId: guildId);
+            return await SendAsync<IReadOnlyCollection<GuildEmote>>("GET", () => $"guilds/{guildId}/emojis", ids, options: options);
+        }
+
+        public async Task<GuildEmote> GetGuildEmoteAsync(ulong guildId, ulong emoteId, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            Preconditions.NotEqual(emoteId, 0, nameof(emoteId));
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(guildId: guildId);
+            return await SendAsync<GuildEmote>("GET", () => $"guilds/{guildId}/emojis/{emoteId}", ids, options: options);
+        }
+
+        public async Task<GuildEmote> CreateGuildEmoteAsync(ulong guildId, Rest.CreateGuildEmoteParams args, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            Preconditions.NotNull(args, nameof(args));
+            Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
+            Preconditions.NotNull(args.Image.Stream, nameof(args.Image));
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(guildId: guildId);
+            return await SendJsonAsync<GuildEmote>("POST", () => $"guilds/{guildId}/emojis", args, ids, options: options);
+        }
+
+        public async Task<GuildEmote> ModifyGuildEmoteAsync(ulong guildId, ulong emoteId, ModifyGuildEmoteParams args, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            Preconditions.NotEqual(emoteId, 0, nameof(emoteId));
+            Preconditions.NotNull(args, nameof(args));
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(guildId: guildId);
+            return await SendJsonAsync<GuildEmote>("PATCH", () => $"guilds/{guildId}/emojis/{emoteId}", args, ids, options: options);
+        }
+
+        public async Task DeleteGuildEmoteAsync(ulong guildId, ulong emoteId, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            Preconditions.NotEqual(emoteId, 0, nameof(emoteId));
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(guildId: guildId);
+            await SendAsync("DELETE", () => $"guilds/{guildId}/emojis/{emoteId}", ids, options: options);
+        }
+
         //Users
         public async Task<User> GetUserAsync(ulong userId, RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -255,14 +255,6 @@ namespace Discord.Rest
         }
 
         //Emotes
-        public static async Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(IGuild guild, BaseDiscordClient client, RequestOptions options)
-        {
-            var model = await client.ApiClient.ListGuildEmotesAsync(guild.Id, options);
-            var emotes = ImmutableArray.CreateBuilder<GuildEmote>(model.Count);
-            foreach (var xm in model)
-                emotes.Add(xm.ToEntity());
-            return emotes;
-        }
         public static async Task<GuildEmote> GetEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options)
         {
             var emote = await client.ApiClient.GetGuildEmoteAsync(guild.Id, id, options);

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -255,11 +255,20 @@ namespace Discord.Rest
         }
 
         //Emotes
-        public static Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(IGuild guild, BaseDiscordClient client, RequestOptions options) 
-            => client.ApiClient.ListGuildEmotesAsync(guild.Id, options);
-        public static Task<GuildEmote> GetEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options) 
-            => client.ApiClient.GetGuildEmoteAsync(guild.Id, id, options);
-        public static Task<GuildEmote> CreateEmoteAsync(IGuild guild, BaseDiscordClient client, string name, Image image, Optional<IEnumerable<IRole>> roles, 
+        public static async Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(IGuild guild, BaseDiscordClient client, RequestOptions options)
+        {
+            var model = await client.ApiClient.ListGuildEmotesAsync(guild.Id, options);
+            var emotes = ImmutableArray.CreateBuilder<GuildEmote>(model.Count);
+            foreach (var xm in model)
+                emotes.Add(xm.ToEntity());
+            return emotes;
+        }
+        public static async Task<GuildEmote> GetEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options)
+        {
+            var emote = await client.ApiClient.GetGuildEmoteAsync(guild.Id, id, options);
+            return emote.ToEntity();
+        }
+        public static async Task<GuildEmote> CreateEmoteAsync(IGuild guild, BaseDiscordClient client, string name, Image image, Optional<IEnumerable<IRole>> roles, 
             RequestOptions options)
         {
             var apiargs = new CreateGuildEmoteParams
@@ -270,9 +279,10 @@ namespace Discord.Rest
             if (roles.IsSpecified)
                 apiargs.RoleIds = roles.Value?.Select(xr => xr.Id)?.ToArray();
 
-            return client.ApiClient.CreateGuildEmoteAsync(guild.Id, apiargs, options);
+            var emote = await client.ApiClient.CreateGuildEmoteAsync(guild.Id, apiargs, options);
+            return emote.ToEntity();
         }
-        public static Task<GuildEmote> ModifyEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, Action<EmoteProperties> func, 
+        public static async Task<GuildEmote> ModifyEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, Action<EmoteProperties> func, 
             RequestOptions options)
         {
             if (func == null) throw new ArgumentNullException(nameof(func));
@@ -287,7 +297,8 @@ namespace Discord.Rest
             if (props.Roles.IsSpecified)
                 apiargs.RoleIds = props.Roles.Value?.Select(xr => xr.Id)?.ToArray();
 
-            return client.ApiClient.ModifyGuildEmoteAsync(guild.Id, id, apiargs, options);
+            var emote = await client.ApiClient.ModifyGuildEmoteAsync(guild.Id, id, apiargs, options);
+            return emote.ToEntity();
         }
         public static Task DeleteEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options) 
             => client.ApiClient.DeleteGuildEmoteAsync(guild.Id, id, options);

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -253,5 +253,43 @@ namespace Discord.Rest
                 model = await client.ApiClient.BeginGuildPruneAsync(guild.Id, args, options).ConfigureAwait(false);
             return model.Pruned;
         }
+
+        //Emotes
+        public static Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(IGuild guild, BaseDiscordClient client, RequestOptions options) 
+            => client.ApiClient.ListGuildEmotesAsync(guild.Id, options);
+        public static Task<GuildEmote> GetEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options) 
+            => client.ApiClient.GetGuildEmoteAsync(guild.Id, id, options);
+        public static Task<GuildEmote> CreateEmoteAsync(IGuild guild, BaseDiscordClient client, string name, Image image, Optional<IEnumerable<IRole>> roles, 
+            RequestOptions options)
+        {
+            var apiargs = new CreateGuildEmoteParams
+            {
+                Name = name,
+                Image = image.ToModel()
+            };
+            if (roles.IsSpecified)
+                apiargs.RoleIds = roles.Value?.Select(xr => xr.Id)?.ToArray();
+
+            return client.ApiClient.CreateGuildEmoteAsync(guild.Id, apiargs, options);
+        }
+        public static Task<GuildEmote> ModifyEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, Action<EmoteProperties> func, 
+            RequestOptions options)
+        {
+            if (func == null) throw new ArgumentNullException(nameof(func));
+
+            var props = new EmoteProperties();
+            func(props);
+
+            var apiargs = new ModifyGuildEmoteParams
+            {
+                Name = props.Name
+            };
+            if (props.Roles.IsSpecified)
+                apiargs.RoleIds = props.Roles.Value?.Select(xr => xr.Id)?.ToArray();
+
+            return client.ApiClient.ModifyGuildEmoteAsync(guild.Id, id, apiargs, options);
+        }
+        public static Task DeleteEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options) 
+            => client.ApiClient.DeleteGuildEmoteAsync(guild.Id, id, options);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -261,8 +261,6 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Name} ({Id})";
 
         //Emotes
-        public Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(RequestOptions options = null)
-            => GuildHelper.ListEmotesAsync(this, Discord, options);
         public Task<GuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetEmoteAsync(this, Discord, id, options);
         public Task<GuildEmote> CreateEmoteAsync(string name, Image image, Optional<IEnumerable<IRole>> roles = default(Optional<IEnumerable<IRole>>), RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -260,6 +260,18 @@ namespace Discord.Rest
         public override string ToString() => Name;
         private string DebuggerDisplay => $"{Name} ({Id})";
 
+        //Emotes
+        public Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(RequestOptions options = null)
+            => GuildHelper.ListEmotesAsync(this, Discord, options);
+        public Task<GuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null)
+            => GuildHelper.GetEmoteAsync(this, Discord, id, options);
+        public Task<GuildEmote> CreateEmoteAsync(string name, Image image, Optional<IEnumerable<IRole>> roles = default(Optional<IEnumerable<IRole>>), RequestOptions options = null)
+            => GuildHelper.CreateEmoteAsync(this, Discord, name, image, roles, options);
+        public Task<GuildEmote> ModifyEmoteAsync(GuildEmote emote, Action<EmoteProperties> func, RequestOptions options = null)
+            => GuildHelper.ModifyEmoteAsync(this, Discord, emote.Id, func, options);
+        public Task DeleteEmoteAsync(GuildEmote emote, RequestOptions options = null)
+            => GuildHelper.DeleteEmoteAsync(this, Discord, emote.Id, options);
+
         //IGuild
         bool IGuild.Available => Available;
         IAudioClient IGuild.AudioClient => null;

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -434,8 +434,6 @@ namespace Discord.WebSocket
         }
 
         //Emotes
-        public Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(RequestOptions options = null)
-            => GuildHelper.ListEmotesAsync(this, Discord, options);
         public Task<GuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetEmoteAsync(this, Discord, id, options);
         public Task<GuildEmote> CreateEmoteAsync(string name, Image image, Optional<IEnumerable<IRole>> roles = default(Optional<IEnumerable<IRole>>), RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -433,6 +433,18 @@ namespace Discord.WebSocket
             _downloaderPromise.TrySetResultAsync(true);
         }
 
+        //Emotes
+        public Task<IReadOnlyCollection<GuildEmote>> ListEmotesAsync(RequestOptions options = null)
+            => GuildHelper.ListEmotesAsync(this, Discord, options);
+        public Task<GuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null)
+            => GuildHelper.GetEmoteAsync(this, Discord, id, options);
+        public Task<GuildEmote> CreateEmoteAsync(string name, Image image, Optional<IEnumerable<IRole>> roles = default(Optional<IEnumerable<IRole>>), RequestOptions options = null)
+            => GuildHelper.CreateEmoteAsync(this, Discord, name, image, roles, options);
+        public Task<GuildEmote> ModifyEmoteAsync(GuildEmote emote, Action<EmoteProperties> func, RequestOptions options = null)
+            => GuildHelper.ModifyEmoteAsync(this, Discord, emote.Id, func, options);
+        public Task DeleteEmoteAsync(GuildEmote emote, RequestOptions options = null)
+            => GuildHelper.DeleteEmoteAsync(this, Discord, emote.Id, options);
+
         //Voice States
         internal async Task<SocketVoiceState> AddOrUpdateVoiceStateAsync(ClientState state, VoiceStateModel model)
         {


### PR DESCRIPTION
This PR implements the emoji endpoints, as [documented here](https://discordapp.com/developers/docs/resources/emoji). This enables bots to manipulate guild emoji.

![in action](https://ping-b1nzy.today/e1ed71.gif)

There is one caveat, however. Bots are only able to get, modify, and delete emoji they've created. They can, however, list all emoji, but it requires manage emoji permission.

Everything is tested, and it works.