### PR TITLE
Adding missing WithVideoUrl method for EmbedBuilder

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/EmbedBuilder.cs
@@ -66,6 +66,15 @@ namespace Discord
                 _embed.Image = new EmbedImage(value, null, null, null);
             }
         }
+        public string VideoUrl
+        {
+            get => _embed.Video?.Url;
+            set
+            {
+                if (!value.IsNullOrUri()) throw new ArgumentException("Url must be a well-formed URI", nameof(VideoUrl));
+                _embed.Video = new EmbedVideo(value, null, null);
+            }
+        }
         public DateTimeOffset? Timestamp { get => _embed.Timestamp; set { _embed.Timestamp = value; } }
         public Color? Color { get => _embed.Color; set { _embed.Color = value; } }
 
@@ -107,6 +116,11 @@ namespace Discord
         public EmbedBuilder WithImageUrl(string imageUrl)
         {
             ImageUrl = imageUrl;
+            return this;
+        }
+        public EmbedBuilder WithVideoUrl(string videoUrl)
+        {
+            VideoUrl = videoUrl;
             return this;
         }
         public EmbedBuilder WithCurrentTimestamp()


### PR DESCRIPTION
So while working with Embeds in my bot I came across VideoEmbed being unable to build with EmbedBuilder, it seems that only get/set and "WithVideoUrl" parts are missing while everything else is already implemented. So here it is:)