### PR TITLE
Improve upon Property Summaries in CommandServiceConfig

### DIFF
--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -2,7 +2,7 @@
 {
     public class CommandServiceConfig
     {
-        /// <summary> The default RunMode commands should have, if one is not specified on the Command attribute or builder. </summary>
+        /// <summary> Gets or sets the default RunMode commands should have, if one is not specified on the Command attribute or builder. </summary>
         public RunMode DefaultRunMode { get; set; } = RunMode.Sync;
 
         public char SeparatorChar { get; set; } = ' ';

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -6,13 +6,14 @@
         public RunMode DefaultRunMode { get; set; } = RunMode.Sync;
 
         public char SeparatorChar { get; set; } = ' ';
-        /// <summary> Should commands be case-sensitive? </summary>
+        
+        /// <summary> Determines whether commands should be case-sensitive. </summary>
         public bool CaseSensitiveCommands { get; set; } = false;
 
         /// <summary> Gets or sets the minimum log level severity that will be sent to the Log event. </summary>
         public LogSeverity LogLevel { get; set; } = LogSeverity.Info;
 
-        /// <summary> Gets or sets whether RunMode.Sync commands should push exceptions up to the caller. </summary>
+        /// <summary> Determines whether RunMode.Sync commands should push exceptions up to the caller. </summary>
         public bool ThrowOnError { get; set; } = true;
     }
 }


### PR DESCRIPTION
Having the `CaseSensitiveCommands` property summary asking a question whenever Intellisense is invoked seems a bit nonessential instead of properly explaining what exactly it does. It would be better if instead, it stated it's use to be more comprehensible to the reader.

### Changes
- Edits the summaries of CaseSensitiveCommands and ThrowOnError to follow a more methodical convention for boolean property summaries 
(Determines whether X ... rather than Should X be ... ?).
- Changes the summary for `DefaultRunMode` to accurately reflect the default standard and be more consistent,

This is just a small change to improve upon the current documentation, so it shouldn't conflict with anything.