### PR TITLE
Add exception parameter to AfterExecute method

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -201,7 +201,9 @@ namespace Discord.Commands
             {
                 var instance = createInstance(services);
                 instance.SetContext(context);
-
+                
+                Exception exc = null;
+                
                 try
                 {
                     instance.BeforeExecute(cmd);
@@ -217,9 +219,14 @@ namespace Discord.Commands
                         return ExecuteResult.FromSuccess();
                     }
                 }
+                catch (Exception exception)
+                {
+                    exc = exception;
+                    throw;
+                }
                 finally
                 {
-                    instance.AfterExecute(cmd);
+                    instance.AfterExecute(cmd, exc);
                     (instance as IDisposable)?.Dispose();
                 }
             }

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -1,4 +1,6 @@
-﻿namespace Discord.Commands
+using System;
+
+namespace Discord.Commands
 {
     internal interface IModuleBase
     {

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -6,6 +6,6 @@
 
         void BeforeExecute(CommandInfo command);
         
-        void AfterExecute(CommandInfo command);
+        void AfterExecute(CommandInfo command, Exception exception);
     }
 }

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -19,7 +19,7 @@ namespace Discord.Commands
         {
         }
 
-        protected virtual void AfterExecute(CommandInfo command)
+        protected virtual void AfterExecute(CommandInfo command, Exception exception)
         {
         }
 
@@ -32,6 +32,6 @@ namespace Discord.Commands
 
         void IModuleBase.BeforeExecute(CommandInfo command) => BeforeExecute(command);
 
-        void IModuleBase.AfterExecute(CommandInfo command) => AfterExecute(command);
+        void IModuleBase.AfterExecute(CommandInfo command, Exception exception) => AfterExecute(command, exception);
     }
 }


### PR DESCRIPTION
Adds ability to observe eventual exception in AfterExecute method.

This is handy since commands with _RunMode.Async_ doesn't report error status and the eventual exception might be lost.