### PR TITLE
Add IEmbed#ToEmbedBuilder extension method

### DIFF
--- a/src/Discord.Net.Rest/Extensions/EmbedBuilderExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EmbedBuilderExtensions.cs
@@ -29,16 +29,25 @@ namespace Discord
 
             var builder = new EmbedBuilder
             {
-                Title = embed.Title,
+                Author = new EmbedAuthorBuilder
+                {
+                    Name = embed.Author?.Name,
+                    IconUrl = embed.Author?.IconUrl,
+                    Url = embed.Author?.Url
+                },
+                Color = embed.Color ?? Color.Default,
                 Description = embed.Description,
-                Url = embed.Url,
+                Footer = new EmbedFooterBuilder
+                {
+                    Text = embed.Footer?.Text,
+                    IconUrl = embed.Footer?.IconUrl
+                },
                 ImageUrl = embed.Image?.Url,
                 ThumbnailUrl = embed.Thumbnail?.Url,
                 Timestamp = embed.Timestamp,
-                Color = embed.Color ?? Color.Default
-            }
-            .WithAuthor(embed.Author?.Name, embed.Author?.IconUrl, embed.Author?.Url)
-            .WithFooter(embed.Footer?.Text, embed.Footer?.IconUrl);
+                Title = embed.Title,
+                Url = embed.Url
+            };
 
             foreach (var field in embed.Fields)
                 builder.AddField(field.Name, field.Value, field.Inline);

--- a/src/Discord.Net.Rest/Extensions/EmbedBuilderExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EmbedBuilderExtensions.cs
@@ -27,25 +27,23 @@ namespace Discord
             if (embed.Type != EmbedType.Rich)
                 throw new InvalidOperationException($"Only {nameof(EmbedType.Rich)} embeds may be built.");
 
-            var eb = new EmbedBuilder
+            var builder = new EmbedBuilder
             {
                 Title = embed.Title,
                 Description = embed.Description,
                 Url = embed.Url,
                 ImageUrl = embed.Image?.Url,
                 ThumbnailUrl = embed.Thumbnail?.Url,
-                Timestamp = embed.Timestamp
+                Timestamp = embed.Timestamp,
+                Color = embed.Color ?? Color.Default
             }
             .WithAuthor(embed.Author?.Name, embed.Author?.IconUrl, embed.Author?.Url)
             .WithFooter(embed.Footer?.Text, embed.Footer?.IconUrl);
 
-            if (embed.Color.HasValue)
-                eb.WithColor(embed.Color.Value);
-
             foreach (var field in embed.Fields)
-                eb.AddField(field.Name, field.Value, field.Inline);
+                builder.AddField(field.Name, field.Value, field.Inline);
 
-            return eb;
+            return builder;
         }
     }
 }

--- a/src/Discord.Net.Rest/Extensions/EmbedBuilderExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EmbedBuilderExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Discord
 {
     public static class EmbedBuilderExtensions
@@ -19,5 +21,31 @@ namespace Discord
 
         public static EmbedBuilder WithAuthor(this EmbedBuilder builder, IGuildUser user) =>
             builder.WithAuthor($"{user.Nickname ?? user.Username}#{user.Discriminator}", user.GetAvatarUrl());
+
+        public static EmbedBuilder ToEmbedBuilder(this IEmbed embed)
+        {
+            if (embed.Type != EmbedType.Rich)
+                throw new InvalidOperationException($"Only {nameof(EmbedType.Rich)} embeds may be built.");
+
+            var eb = new EmbedBuilder
+            {
+                Title = embed.Title,
+                Description = embed.Description,
+                Url = embed.Url,
+                ImageUrl = embed.Image?.Url,
+                ThumbnailUrl = embed.Thumbnail?.Url,
+                Timestamp = embed.Timestamp
+            }
+            .WithAuthor(embed.Author?.Name, embed.Author?.IconUrl, embed.Author?.Url)
+            .WithFooter(embed.Footer?.Text, embed.Footer?.IconUrl);
+
+            if (embed.Color.HasValue)
+                eb.WithColor(embed.Color.Value);
+
+            foreach (var field in embed.Fields)
+                eb.AddField(field.Name, field.Value, field.Inline);
+
+            return eb;
+        }
     }
 }


### PR DESCRIPTION
## Overview
This extension method should receive the most use out of users attempting to modify currently existing embeds, removing the need for them to copy the entire embed themselves into a new builder. 

### Caveats
Throws an `InvalidOperationException` for all embed types that are not [`EmbedType.Rich`](https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Messages/EmbedType.cs#L5) since those are the only kind that can be created anyway. Just something to keep in mind if Discord ever allows us to create new embed types at some point. 