### PR TITLE
Fix GuildPermission Modify, Add Missing Permission to AllowAll

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -10,7 +10,7 @@ namespace Discord
         /// <summary> Gets a blank ChannelPermissions that grants no permissions. </summary>
         public static readonly ChannelPermissions None = new ChannelPermissions();
         /// <summary> Gets a ChannelPermissions that grants all permissions for text channels. </summary>
-        public static readonly ChannelPermissions Text = new ChannelPermissions(0b00100_0000000_1111111110001_010001);
+        public static readonly ChannelPermissions Text = new ChannelPermissions(0b01100_0000000_1111111110001_010001);
         /// <summary> Gets a ChannelPermissions that grants all permissions for voice channels. </summary>
         public static readonly ChannelPermissions Voice = new ChannelPermissions(0b00100_1111110_0000000000000_010001);
         /// <summary> Gets a ChannelPermissions that grants all permissions for direct message channels. </summary>

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -150,7 +150,7 @@ namespace Discord
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null)
-            => new GuildPermissions(RawValue, kickMembers, banMembers, administrator, manageChannels, manageGuild, addReactions,
+            => new GuildPermissions(RawValue, createInstantInvite, kickMembers, banMembers, administrator, manageChannels, manageGuild, addReactions,
                 viewAuditLog, readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
                 readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers,
                 useVoiceActivation, changeNickname, manageNicknames, manageRoles, manageWebhooks, manageEmojis);

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -11,7 +11,7 @@ namespace Discord
         /// <summary> Gets a GuildPermissions that grants all guild permissions for webhook users. </summary>
         public static readonly GuildPermissions Webhook = new GuildPermissions(0b00000_0000000_0001101100000_000000);
         /// <summary> Gets a GuildPermissions that grants all guild permissions. </summary>
-        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111110_0111111110011_111111);
+        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111110_11111111110011_111111);
 
         /// <summary> Gets a packed value representing all the permissions in this GuildPermissions. </summary>
         public ulong RawValue { get; }

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -28,7 +28,7 @@ namespace Discord
         public bool ManageChannels => Permissions.GetValue(RawValue, GuildPermission.ManageChannels);
         /// <summary> If True, a user may adjust guild properties. </summary>
         public bool ManageGuild => Permissions.GetValue(RawValue, GuildPermission.ManageGuild);
-        
+
         /// <summary> If true, a user may add reactions. </summary>
         public bool AddReactions => Permissions.GetValue(RawValue, GuildPermission.AddReactions);
         /// <summary> If true, a user may view the audit log. </summary>
@@ -80,13 +80,13 @@ namespace Discord
         /// <summary> Creates a new GuildPermissions with the provided packed value. </summary>
         public GuildPermissions(ulong rawValue) { RawValue = rawValue; }
 
-        private GuildPermissions(ulong initialValue, bool? createInstantInvite = null, bool? kickMembers = null, 
-            bool? banMembers = null, bool? administrator = null, bool? manageChannels = null,  bool? manageGuild = null,
+        private GuildPermissions(ulong initialValue, bool? createInstantInvite = null, bool? kickMembers = null,
+            bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
             bool? addReactions = null, bool? viewAuditLog = null,
-            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null,  bool? manageMessages = null, 
-            bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null,  bool? mentionEveryone = null, 
-            bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null,  bool? deafenMembers = null, 
-            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null,  bool? manageNicknames = null, 
+            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
+            bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
+            bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
+            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null)
         {
             ulong value = initialValue;
@@ -124,31 +124,36 @@ namespace Discord
         }
 
         /// <summary> Creates a new GuildPermissions with the provided permissions. </summary>
-        public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false, 
+        public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false,
             bool banMembers = false, bool administrator = false, bool manageChannels = false, bool manageGuild = false,
             bool addReactions = false, bool viewAuditLog = false,
             bool readMessages = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
             bool embedLinks = false, bool attachFiles = false, bool readMessageHistory = false, bool mentionEveryone = false,
             bool useExternalEmojis = false, bool connect = false, bool speak = false, bool muteMembers = false, bool deafenMembers = false,
-            bool moveMembers = false, bool useVoiceActivation = false, bool? changeNickname = false, bool? manageNicknames = false, 
+            bool moveMembers = false, bool useVoiceActivation = false, bool? changeNickname = false, bool? manageNicknames = false,
             bool manageRoles = false, bool manageWebhooks = false, bool manageEmojis = false)
-            : this(0, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, addReactions, viewAuditLog,
-                readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, useExternalEmojis, connect, 
-                manageWebhooks, manageEmojis) { }
+            : this(0, createInstantInvite: createInstantInvite, manageRoles: manageRoles, kickMembers: kickMembers, banMembers: banMembers,
+                  administrator: administrator, manageChannels: manageChannels, manageGuild: manageGuild, addReactions: addReactions,
+                  viewAuditLog: viewAuditLog, readMessages: readMessages, sendMessages: sendMessages, sendTTSMessages: sendTTSMessages,
+                  manageMessages: manageMessages, embedLinks: embedLinks, attachFiles: attachFiles, readMessageHistory: readMessageHistory,
+                  mentionEveryone: mentionEveryone, useExternalEmojis: useExternalEmojis, connect: connect, speak: speak, muteMembers: muteMembers,
+                  deafenMembers: deafenMembers, moveMembers: moveMembers, useVoiceActivation: useVoiceActivation, changeNickname: changeNickname,
+                  manageNicknames: manageNicknames, manageWebhooks: manageWebhooks, manageEmojis: manageEmojis)
+        { }
 
         /// <summary> Creates a new GuildPermissions from this one, changing the provided non-null permissions. </summary>
-        public GuildPermissions Modify(bool? createInstantInvite = null,  bool? kickMembers = null, 
+        public GuildPermissions Modify(bool? createInstantInvite = null, bool? kickMembers = null,
             bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
             bool? addReactions = null, bool? viewAuditLog = null,
             bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
-            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null, 
+            bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null)
-            => new GuildPermissions(RawValue, createInstantInvite, manageRoles, kickMembers, banMembers, manageChannels, manageGuild, addReactions, viewAuditLog,   
-                readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles, mentionEveryone, useExternalEmojis, connect, 
-                speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, changeNickname, manageNicknames, manageRoles,
-                manageWebhooks, manageEmojis);
+            => new GuildPermissions(RawValue, kickMembers, banMembers, administrator, manageChannels, manageGuild, addReactions,
+                viewAuditLog, readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
+                readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers,
+                useVoiceActivation, changeNickname, manageNicknames, manageRoles, manageWebhooks, manageEmojis);
 
         public bool Has(GuildPermission permission) => Permissions.GetValue(RawValue, permission);
 


### PR DESCRIPTION
I was told (by `The Noodle Mummy#0339` and `Spoopy Ghost Dog#5440`)  of an issue with `GuildPermissions#Modify` producing incorrect results. My discord handle is `ChrisJ#8703`.

This code snippet:
```csharp
[Command("testing")]
public async Task testing(SocketRole role)
{
   await role.ModifyAsync(rp => rp.Permissions = Optional.Create(role.Permissions.Modify(changeNickname: false, manageNicknames: false)));
}
```
Would produce this result (as seen in Audit Logs): 
![image of audit log that shows denied change nickname and voice activity permissions](https://user-images.githubusercontent.com/16418643/32260081-c726c6a8-be82-11e7-971b-e59dd1ea3584.png)

Now appears to be working correctly:
![image of audit log showing denied permissions for change nickname and manage nicknames](https://cdn.discordapp.com/attachments/370714078378852362/375140636233564172/unknown.png)

Problem was caused by a parameter (`manageRoles`) out of order in `GuildPermissions`: https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs#L135

In addition, I was also told that the following snippet:
```csharp
SocketGuildChannel c = arg.GetTextChannel(313504029437329410);
OverwritePermissions perms = OverwritePermissions.AllowAll(c);
await c.AddPermissionOverwriteAsync(arg.GetUser(270390842923941888), perms);
```
would execute without problem, but was missing the WebHook permission. This is fixed in `ChannelPermissions`, and appears to be working properly now. 
![image](https://user-images.githubusercontent.com/16418643/32260327-68329986-be84-11e7-8736-5938e9dcdc4b.png)





