### PR TITLE
Fix flawed bulk message deletion

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -194,7 +194,8 @@ namespace Discord.Rest
                 if (i < batches)
                 {
                     batch = new ArraySegment<ulong>(msgs, i * BATCH_SIZE, BATCH_SIZE);
-                } else
+                }
+                else
                 {
                     batch = new ArraySegment<ulong>(msgs, i * BATCH_SIZE, msgs.Length - batches * BATCH_SIZE);
                     if (batch.Count == 0)


### PR DESCRIPTION
https://github.com/RogueException/Discord.Net/issues/871, consider changing DeleteMessagesParams.MessageIds type to I(Readonly)List<ulong> or IEnumerable<ulong> to avoid unnecessary copying (batch.ToArray())