### PR TITLE
Add GuildPermissions and ChannelPermissions Unit Tests

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -11,7 +11,7 @@ namespace Discord
         /// <summary> Gets a GuildPermissions that grants all guild permissions for webhook users. </summary>
         public static readonly GuildPermissions Webhook = new GuildPermissions(0b00000_0000000_0001101100000_000000);
         /// <summary> Gets a GuildPermissions that grants all guild permissions. </summary>
-        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111110_11111111110011_111111);
+        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111110_1111111110011_111111);
 
         /// <summary> Gets a packed value representing all the permissions in this GuildPermissions. </summary>
         public ulong RawValue { get; }

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -1,10 +1,324 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace Discord
 {
     public partial class Tests
     {
+        [Fact]
+        public async Task TestChannelPermission()
+        {
+            var perm = new ChannelPermissions();
+
+            // check initial values
+            Assert.Equal((ulong)0, perm.RawValue);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // permissions list empty by default
+            Assert.Empty(perm.ToList());
+
+            // test modify with no parameters
+            var copy = perm.Modify();
+            Assert.Equal((ulong)0, copy.RawValue);
+
+            // test the values that are returned by ChannelPermission.All
+            Assert.Equal((ulong)0, ChannelPermissions.None.RawValue);
+
+            // for text channels
+            ulong textChannel = (ulong)( ChannelPermission.CreateInstantInvite
+                | ChannelPermission.ManageChannels
+                | ChannelPermission.AddReactions
+                | ChannelPermission.ReadMessages
+                | ChannelPermission.SendMessages
+                | ChannelPermission.SendTTSMessages
+                | ChannelPermission.ManageMessages
+                | ChannelPermission.EmbedLinks
+                | ChannelPermission.AttachFiles
+                | ChannelPermission.ReadMessageHistory
+                | ChannelPermission.MentionEveryone
+                | ChannelPermission.UseExternalEmojis
+                | ChannelPermission.ManageRoles
+                | ChannelPermission.ManageWebhooks);
+
+            Assert.Equal(textChannel, ChannelPermissions.Text.RawValue);
+
+            // voice channels
+            ulong voiceChannel = (ulong)(
+                ChannelPermission.CreateInstantInvite
+                | ChannelPermission.ManageChannels
+                | ChannelPermission.Connect
+                | ChannelPermission.Speak
+                | ChannelPermission.MuteMembers
+                | ChannelPermission.DeafenMembers
+                | ChannelPermission.MoveMembers
+                | ChannelPermission.UseVAD
+                | ChannelPermission.ManageRoles);
+
+            Assert.Equal(voiceChannel, ChannelPermissions.Voice.RawValue);
+
+            // DM Channels
+            ulong dmChannel = (ulong)(
+                ChannelPermission.ReadMessages
+                | ChannelPermission.SendMessages
+                | ChannelPermission.EmbedLinks 
+                | ChannelPermission.AttachFiles
+                | ChannelPermission.ReadMessageHistory
+                | ChannelPermission.UseExternalEmojis
+                | ChannelPermission.Connect
+                | ChannelPermission.Speak
+                | ChannelPermission.UseVAD
+                );
+            Assert.Equal(dmChannel, ChannelPermissions.DM.RawValue);
+
+            // group channel
+            ulong groupChannel = (ulong)(
+                ChannelPermission.SendMessages
+                | ChannelPermission.EmbedLinks
+                | ChannelPermission.AttachFiles
+                | ChannelPermission.SendTTSMessages
+                | ChannelPermission.Connect
+                | ChannelPermission.Speak
+                | ChannelPermission.UseVAD
+                );
+            Assert.Equal(groupChannel, ChannelPermissions.Group.RawValue);
+        }
+
+        public async Task TestChannelPermissionModify()
+        {
+            // test channel permission modify
+
+            var perm = new ChannelPermissions();
+
+            // ensure that the permission is initially false
+            Assert.False(perm.CreateInstantInvite);
+
+            // ensure that when modified it works
+            perm = perm.Modify(createInstantInvite: true);
+            Assert.True(perm.CreateInstantInvite);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.CreateInstantInvite);
+
+            // set false again, move on to next permission
+            perm = perm.Modify(createInstantInvite: false);
+            Assert.False(perm.CreateInstantInvite);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.ManageChannel);
+
+            perm = perm.Modify(manageChannel: true);
+            Assert.True(perm.ManageChannel);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageChannels);
+
+            perm = perm.Modify(manageChannel: false);
+            Assert.False(perm.ManageChannel);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.AddReactions);
+
+            perm = perm.Modify(addReactions: true);
+            Assert.True(perm.AddReactions);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.AddReactions);
+
+            perm = perm.Modify(addReactions: false);
+            Assert.False(perm.AddReactions);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.ReadMessages);
+
+            perm = perm.Modify(readMessages: true);
+            Assert.True(perm.ReadMessages);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ReadMessages);
+
+            perm = perm.Modify(readMessages: false);
+            Assert.False(perm.ReadMessages);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.SendMessages);
+
+            perm = perm.Modify(sendMessages: true);
+            Assert.True(perm.SendMessages);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.SendMessages);
+
+            perm = perm.Modify(sendMessages: false);
+            Assert.False(perm.SendMessages);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.SendTTSMessages);
+
+            perm = perm.Modify(sendTTSMessages: true);
+            Assert.True(perm.SendTTSMessages);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.SendTTSMessages);
+
+            perm = perm.Modify(sendTTSMessages: false);
+            Assert.False(perm.SendTTSMessages);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.ManageMessages);
+
+            perm = perm.Modify(manageMessages: true);
+            Assert.True(perm.ManageMessages);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageMessages);
+
+            perm = perm.Modify(manageMessages: false);
+            Assert.False(perm.ManageMessages);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.EmbedLinks);
+
+            perm = perm.Modify(embedLinks: true);
+            Assert.True(perm.EmbedLinks);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.EmbedLinks);
+
+            perm = perm.Modify(embedLinks: false);
+            Assert.False(perm.EmbedLinks);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.AttachFiles);
+
+            perm = perm.Modify(attachFiles: true);
+            Assert.True(perm.AttachFiles);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.AttachFiles);
+
+            perm = perm.Modify(attachFiles: false);
+            Assert.False(perm.AttachFiles);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.ReadMessageHistory);
+
+            perm = perm.Modify(readMessageHistory: true);
+            Assert.True(perm.ReadMessageHistory);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ReadMessageHistory);
+
+            perm = perm.Modify(readMessageHistory: false);
+            Assert.False(perm.ReadMessageHistory);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.MentionEveryone);
+
+            perm = perm.Modify(mentionEveryone: true);
+            Assert.True(perm.MentionEveryone);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MentionEveryone);
+
+            perm = perm.Modify(mentionEveryone: false);
+            Assert.False(perm.MentionEveryone);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.UseExternalEmojis);
+
+            perm = perm.Modify(useExternalEmojis: true);
+            Assert.True(perm.UseExternalEmojis);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.UseExternalEmojis);
+
+            perm = perm.Modify(useExternalEmojis: false);
+            Assert.False(perm.UseExternalEmojis);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.Connect);
+
+            perm = perm.Modify(connect: true);
+            Assert.True(perm.Connect);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.Connect);
+
+            perm = perm.Modify(connect: false);
+            Assert.False(perm.Connect);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+            
+            // individual permission test
+            Assert.False(perm.Speak);
+
+            perm = perm.Modify(speak: true);
+            Assert.True(perm.Speak);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.Speak);
+
+            perm = perm.Modify(speak: false);
+            Assert.False(perm.Speak);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.MuteMembers);
+
+            perm = perm.Modify(muteMembers: true);
+            Assert.True(perm.MuteMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MuteMembers);
+
+            perm = perm.Modify(muteMembers: false);
+            Assert.False(perm.MuteMembers);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.DeafenMembers);
+
+            perm = perm.Modify(deafenMembers: true);
+            Assert.True(perm.DeafenMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.DeafenMembers);
+
+            perm = perm.Modify(deafenMembers: false);
+            Assert.False(perm.DeafenMembers);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.MoveMembers);
+
+            perm = perm.Modify(moveMembers: true);
+            Assert.True(perm.MoveMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MoveMembers);
+
+            perm = perm.Modify(moveMembers: false);
+            Assert.False(perm.MoveMembers);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.UseVAD);
+
+            perm = perm.Modify(useVoiceActivation: true);
+            Assert.True(perm.UseVAD);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.UseVAD);
+
+            perm = perm.Modify(useVoiceActivation: false);
+            Assert.False(perm.UseVAD);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.ManageRoles);
+
+            perm = perm.Modify(manageRoles: true);
+            Assert.True(perm.ManageRoles);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageRoles);
+
+            perm = perm.Modify(manageRoles: false);
+            Assert.False(perm.ManageRoles);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+
+            // individual permission test
+            Assert.False(perm.ManageWebhooks);
+
+            perm = perm.Modify(manageWebhooks: true);
+            Assert.True(perm.ManageWebhooks);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageWebhooks);
+
+            perm = perm.Modify(manageWebhooks: false);
+            Assert.False(perm.ManageWebhooks);
+            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+        }
+
+        [Fact]
+        public async Task TestChannelTypeResolution()
+        {
+            ITextChannel someChannel = null;
+            // null channels will throw exception
+            Assert.Throws<ArgumentException>(() => ChannelPermissions.All(someChannel));
+        }
     }
 }

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Discord
+{
+    public partial class Tests
+    {
+    }
+}

--- a/test/Discord.Net.Tests/Tests.GuildPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.GuildPermissions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Discord
+{
+    public partial class Tests
+    {
+    }
+}

--- a/test/Discord.Net.Tests/Tests.GuildPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.GuildPermissions.cs
@@ -1,10 +1,284 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace Discord
 {
     public partial class Tests
     {
+        [Fact]
+        public async Task TestGuildPermission()
+        {
+            // Test Guild Permission Constructors
+            var perm = new GuildPermissions();
+
+            // the default raw value is 0
+            Assert.Equal((ulong)0, perm.RawValue);
+            // also check that it is the same as none
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
+
+            // permissions list is empty by default
+            Assert.Empty(perm.ToList());
+            Assert.NotNull(perm.ToList());
+
+            // Test modify with no parameters
+            var copy = perm = perm.Modify();
+            // ensure that the raw values match
+            Assert.Equal((ulong)0, copy.RawValue);
+
+            // test GuildPermissions.All
+            ulong sumOfAllGuildPermissions = 0;
+            foreach(var v in Enum.GetValues(typeof(GuildPermission)))
+            {
+                sumOfAllGuildPermissions |= (ulong)v;
+            }
+
+            // assert that the raw values match
+            Assert.Equal(sumOfAllGuildPermissions, GuildPermissions.All.RawValue);
+            Assert.Equal((ulong)0, GuildPermissions.None.RawValue);
+
+            // assert that GuildPermissions.All contains the same number of permissions as the 
+            // GuildPermissions enum
+            Assert.Equal(Enum.GetValues(typeof(GuildPermission)).Length, GuildPermissions.All.ToList().Count);
+
+            // assert that webhook has the same raw value
+            ulong webHookPermissions = (ulong)(
+                GuildPermission.SendMessages | GuildPermission.SendTTSMessages | GuildPermission.EmbedLinks |
+                GuildPermission.AttachFiles);
+            Assert.Equal(webHookPermissions, GuildPermissions.Webhook.RawValue);
+        }
+
+        [Fact]
+        public async Task TestGuildPermissionModify()
+        {
+            var perm = new GuildPermissions();
+
+            // tests each of the parameters of Modify one by one
+
+            // test modify with each of the parameters
+            // test initially false state
+            Assert.False(perm.CreateInstantInvite);
+
+            // ensure that when we modify it the parameter works
+            perm = perm.Modify(createInstantInvite: true);
+            Assert.True(perm.CreateInstantInvite);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.CreateInstantInvite);
+
+            // set it false again, then move on to the next permission
+            perm = perm.Modify(createInstantInvite: false);
+            Assert.False(perm.CreateInstantInvite);
+
+            // individual permission test
+            perm = perm.Modify(kickMembers: true);
+            Assert.True(perm.KickMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.KickMembers);
+
+            perm = perm.Modify(kickMembers: false);
+            Assert.False(perm.KickMembers);
+
+            // individual permission test
+            perm = perm.Modify(banMembers: true);
+            Assert.True(perm.BanMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.BanMembers);
+
+            perm = perm.Modify(banMembers: false);
+            Assert.False(perm.BanMembers);
+
+            // individual permission test
+            perm = perm.Modify(administrator: true);
+            Assert.True(perm.Administrator);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.Administrator);
+
+            perm = perm.Modify(administrator: false);
+            Assert.False(perm.Administrator);
+
+            // individual permission test
+            perm = perm.Modify(manageChannels: true);
+            Assert.True(perm.ManageChannels);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageChannels);
+
+            perm = perm.Modify(manageChannels: false);
+            Assert.False(perm.ManageChannels);
+
+            // individual permission test
+            perm = perm.Modify(manageGuild: true);
+            Assert.True(perm.ManageGuild);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageGuild);
+
+            perm = perm.Modify(manageGuild: false);
+            Assert.False(perm.ManageGuild);
+
+
+            // individual permission test
+            perm = perm.Modify(addReactions: true);
+            Assert.True(perm.AddReactions);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.AddReactions);
+
+            perm = perm.Modify(addReactions: false);
+            Assert.False(perm.AddReactions);
+
+
+            // individual permission test
+            perm = perm.Modify(viewAuditLog: true);
+            Assert.True(perm.ViewAuditLog);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ViewAuditLog);
+
+            perm = perm.Modify(viewAuditLog: false);
+            Assert.False(perm.ViewAuditLog);
+
+
+            // individual permission test
+            perm = perm.Modify(readMessages: true);
+            Assert.True(perm.ReadMessages);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ReadMessages);
+
+            perm = perm.Modify(readMessages: false);
+            Assert.False(perm.ReadMessages);
+
+
+            // individual permission test
+            perm = perm.Modify(sendMessages: true);
+            Assert.True(perm.SendMessages);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.SendMessages);
+
+            perm = perm.Modify(sendMessages: false);
+            Assert.False(perm.SendMessages);
+
+
+            // individual permission test
+            perm = perm.Modify(embedLinks: true);
+            Assert.True(perm.EmbedLinks);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.EmbedLinks);
+
+            perm = perm.Modify(embedLinks: false);
+            Assert.False(perm.EmbedLinks);
+
+
+            // individual permission test
+            perm = perm.Modify(attachFiles: true);
+            Assert.True(perm.AttachFiles);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.AttachFiles);
+
+            perm = perm.Modify(attachFiles: false);
+            Assert.False(perm.AttachFiles);
+
+            // individual permission test
+            perm = perm.Modify(readMessageHistory: true);
+            Assert.True(perm.ReadMessageHistory);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ReadMessageHistory);
+
+            perm = perm.Modify(readMessageHistory: false);
+            Assert.False(perm.ReadMessageHistory);
+
+
+            // individual permission test
+            perm = perm.Modify(mentionEveryone: true);
+            Assert.True(perm.MentionEveryone);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MentionEveryone);
+
+            perm = perm.Modify(mentionEveryone: false);
+            Assert.False(perm.MentionEveryone);
+
+
+            // individual permission test
+            perm = perm.Modify(useExternalEmojis: true);
+            Assert.True(perm.UseExternalEmojis);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.UseExternalEmojis);
+
+            perm = perm.Modify(useExternalEmojis: false);
+            Assert.False(perm.UseExternalEmojis);
+
+
+            // individual permission test
+            perm = perm.Modify(connect: true);
+            Assert.True(perm.Connect);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.Connect);
+
+            perm = perm.Modify(connect: false);
+            Assert.False(perm.Connect);
+
+
+            // individual permission test
+            perm = perm.Modify(speak: true);
+            Assert.True(perm.Speak);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.Speak);
+
+            perm = perm.Modify(speak: false);
+            Assert.False(perm.Speak);
+
+            // individual permission test
+            perm = perm.Modify(muteMembers: true);
+            Assert.True(perm.MuteMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MuteMembers);
+
+            perm = perm.Modify(muteMembers: false);
+            Assert.False(perm.MuteMembers);
+
+            // individual permission test
+            perm = perm.Modify(deafenMembers: true);
+            Assert.True(perm.DeafenMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.DeafenMembers);
+
+            perm = perm.Modify(deafenMembers: false);
+            Assert.False(perm.DeafenMembers);
+
+            // individual permission test
+            perm = perm.Modify(moveMembers: true);
+            Assert.True(perm.MoveMembers);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MoveMembers);
+
+            perm = perm.Modify(moveMembers: false);
+            Assert.False(perm.MoveMembers);
+            
+            // individual permission test
+            perm = perm.Modify(useVoiceActivation: true);
+            Assert.True(perm.UseVAD);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.UseVAD);
+
+            perm = perm.Modify(useVoiceActivation: false);
+            Assert.False(perm.UseVAD);
+
+            // individual permission test
+            perm = perm.Modify(changeNickname: true);
+            Assert.True(perm.ChangeNickname);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ChangeNickname);
+
+            perm = perm.Modify(changeNickname: false);
+            Assert.False(perm.ChangeNickname);
+
+            // individual permission test
+            perm = perm.Modify(manageNicknames: true);
+            Assert.True(perm.ManageNicknames);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageNicknames);
+
+            perm = perm.Modify(manageNicknames: false);
+            Assert.False(perm.ManageNicknames);
+
+            // individual permission test
+            perm = perm.Modify(manageRoles: true);
+            Assert.True(perm.ManageRoles);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageRoles);
+
+            perm = perm.Modify(manageRoles: false);
+            Assert.False(perm.ManageRoles);
+
+            // individual permission test
+            perm = perm.Modify(manageWebhooks: true);
+            Assert.True(perm.ManageWebhooks);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageWebhooks);
+
+            perm = perm.Modify(manageWebhooks: false);
+            Assert.False(perm.ManageWebhooks);
+
+            // individual permission test
+            perm = perm.Modify(manageEmojis: true);
+            Assert.True(perm.ManageEmojis);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageEmojis);
+
+            perm = perm.Modify(manageEmojis: false);
+            Assert.False(perm.ManageEmojis);
+            
+        }
+
     }
 }

--- a/test/Discord.Net.Tests/Tests.GuildPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.GuildPermissions.cs
@@ -22,7 +22,7 @@ namespace Discord
             Assert.NotNull(perm.ToList());
 
             // Test modify with no parameters
-            var copy = perm = perm.Modify();
+            var copy = perm.Modify();
             // ensure that the raw values match
             Assert.Equal((ulong)0, copy.RawValue);
 
@@ -67,6 +67,7 @@ namespace Discord
             // set it false again, then move on to the next permission
             perm = perm.Modify(createInstantInvite: false);
             Assert.False(perm.CreateInstantInvite);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(kickMembers: true);
@@ -75,6 +76,7 @@ namespace Discord
 
             perm = perm.Modify(kickMembers: false);
             Assert.False(perm.KickMembers);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(banMembers: true);
@@ -83,6 +85,7 @@ namespace Discord
 
             perm = perm.Modify(banMembers: false);
             Assert.False(perm.BanMembers);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(administrator: true);
@@ -91,6 +94,7 @@ namespace Discord
 
             perm = perm.Modify(administrator: false);
             Assert.False(perm.Administrator);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(manageChannels: true);
@@ -99,6 +103,7 @@ namespace Discord
 
             perm = perm.Modify(manageChannels: false);
             Assert.False(perm.ManageChannels);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(manageGuild: true);
@@ -107,6 +112,7 @@ namespace Discord
 
             perm = perm.Modify(manageGuild: false);
             Assert.False(perm.ManageGuild);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
 
             // individual permission test
@@ -116,6 +122,7 @@ namespace Discord
 
             perm = perm.Modify(addReactions: false);
             Assert.False(perm.AddReactions);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
 
             // individual permission test
@@ -125,6 +132,7 @@ namespace Discord
 
             perm = perm.Modify(viewAuditLog: false);
             Assert.False(perm.ViewAuditLog);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
 
             // individual permission test
@@ -134,6 +142,7 @@ namespace Discord
 
             perm = perm.Modify(readMessages: false);
             Assert.False(perm.ReadMessages);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
 
             // individual permission test
@@ -143,7 +152,7 @@ namespace Discord
 
             perm = perm.Modify(sendMessages: false);
             Assert.False(perm.SendMessages);
-
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(embedLinks: true);
@@ -152,7 +161,7 @@ namespace Discord
 
             perm = perm.Modify(embedLinks: false);
             Assert.False(perm.EmbedLinks);
-
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(attachFiles: true);
@@ -161,6 +170,7 @@ namespace Discord
 
             perm = perm.Modify(attachFiles: false);
             Assert.False(perm.AttachFiles);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(readMessageHistory: true);
@@ -169,7 +179,7 @@ namespace Discord
 
             perm = perm.Modify(readMessageHistory: false);
             Assert.False(perm.ReadMessageHistory);
-
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(mentionEveryone: true);
@@ -178,7 +188,7 @@ namespace Discord
 
             perm = perm.Modify(mentionEveryone: false);
             Assert.False(perm.MentionEveryone);
-
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(useExternalEmojis: true);
@@ -187,7 +197,7 @@ namespace Discord
 
             perm = perm.Modify(useExternalEmojis: false);
             Assert.False(perm.UseExternalEmojis);
-
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(connect: true);
@@ -196,7 +206,7 @@ namespace Discord
 
             perm = perm.Modify(connect: false);
             Assert.False(perm.Connect);
-
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(speak: true);
@@ -205,6 +215,7 @@ namespace Discord
 
             perm = perm.Modify(speak: false);
             Assert.False(perm.Speak);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(muteMembers: true);
@@ -213,6 +224,7 @@ namespace Discord
 
             perm = perm.Modify(muteMembers: false);
             Assert.False(perm.MuteMembers);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(deafenMembers: true);
@@ -221,6 +233,7 @@ namespace Discord
 
             perm = perm.Modify(deafenMembers: false);
             Assert.False(perm.DeafenMembers);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(moveMembers: true);
@@ -229,7 +242,8 @@ namespace Discord
 
             perm = perm.Modify(moveMembers: false);
             Assert.False(perm.MoveMembers);
-            
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
+
             // individual permission test
             perm = perm.Modify(useVoiceActivation: true);
             Assert.True(perm.UseVAD);
@@ -237,6 +251,7 @@ namespace Discord
 
             perm = perm.Modify(useVoiceActivation: false);
             Assert.False(perm.UseVAD);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(changeNickname: true);
@@ -245,6 +260,7 @@ namespace Discord
 
             perm = perm.Modify(changeNickname: false);
             Assert.False(perm.ChangeNickname);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(manageNicknames: true);
@@ -253,6 +269,7 @@ namespace Discord
 
             perm = perm.Modify(manageNicknames: false);
             Assert.False(perm.ManageNicknames);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(manageRoles: true);
@@ -261,6 +278,7 @@ namespace Discord
 
             perm = perm.Modify(manageRoles: false);
             Assert.False(perm.ManageRoles);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(manageWebhooks: true);
@@ -269,6 +287,7 @@ namespace Discord
 
             perm = perm.Modify(manageWebhooks: false);
             Assert.False(perm.ManageWebhooks);
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
             perm = perm.Modify(manageEmojis: true);
@@ -277,7 +296,8 @@ namespace Discord
 
             perm = perm.Modify(manageEmojis: false);
             Assert.False(perm.ManageEmojis);
-            
+            Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
+
         }
 
     }


### PR DESCRIPTION
Added tests for `GuildPermissions` and `ChannelPermissions` that were asked for recently. Focused heavily on the "All" values to ensure that the constants that are used in `Utils/Permissions.cs` are correct, and that the parameters in `Modify` function correctly.

Modified the value of `GuildPermissions.All` constant flag. The previous value had added an additional digit. While the old value would resolve to the correct boolean flags (a flag with a value that is skipped was set), the `RawValue` didn't match. These tests fix and confirm that issue and will hopefully prevent related issues like it from popping up again (should discord add a new permission).

These tests currently do not make use of the client.

A few leftover things that might need attention:

- `ChannelPermissions.All` for group channels does not include the `ReadMessages` permission. I don't know enough about how permissions work for groups to know if that is intended/correct.
- `ChannelPermissions.All` still needs to be tested with text channels, voice channels, DM channels and group channels (and categories eventually). This sounds like it would require use of the client. Text channels and voice channels should be fine, as this is done in `TestTextChannels`, but I'm not sure the best way to test the others.
- This does not include `OverwritePermissions` tests, however it looks really similar.

I'm open to add test cases that I may have missed. My handle in the discord API server is `@ChrisJ#8703`.