### PR TITLE
Fix #854 Added ViewChannel enum and property to channel permissions

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
@@ -11,7 +11,9 @@ namespace Discord
 
         // Text
         AddReactions        = 0x00_00_00_40,
-        ReadMessages        = 0x00_00_04_00,
+        [Obsolete("Use ViewChannel instead.")]
+        ReadMessages        = ViewChannel,
+        ViewChannel         = 0x00_00_04_00,
         SendMessages        = 0x00_00_08_00,
         SendTTSMessages     = 0x00_00_10_00,
         ManageMessages      = 0x00_00_20_00,

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -41,7 +41,11 @@ namespace Discord
         /// <summary> If true, a user may add reactions. </summary>
         public bool AddReactions => Permissions.GetValue(RawValue, ChannelPermission.AddReactions);
         /// <summary> If True, a user may join channels. </summary>
-        public bool ReadMessages => Permissions.GetValue(RawValue, ChannelPermission.ReadMessages);
+        [Obsolete("Use ViewChannel instead.")]
+        public bool ReadMessages => ViewChannel;
+        /// <summary> If True, a user may view channels. </summary>
+        public bool ViewChannel => Permissions.GetValue(RawValue, ChannelPermission.ReadMessages);
+
         /// <summary> If True, a user may send messages. </summary>
         public bool SendMessages => Permissions.GetValue(RawValue, ChannelPermission.SendMessages);
         /// <summary> If True, a user may send text-to-speech messages. </summary>

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -44,7 +44,7 @@ namespace Discord
         [Obsolete("Use ViewChannel instead.")]
         public bool ReadMessages => ViewChannel;
         /// <summary> If True, a user may view channels. </summary>
-        public bool ViewChannel => Permissions.GetValue(RawValue, ChannelPermission.ReadMessages);
+        public bool ViewChannel => Permissions.GetValue(RawValue, ChannelPermission.ViewChannel);
 
         /// <summary> If True, a user may send messages. </summary>
         public bool SendMessages => Permissions.GetValue(RawValue, ChannelPermission.SendMessages);
@@ -96,7 +96,7 @@ namespace Discord
             Permissions.SetValue(ref value, createInstantInvite, ChannelPermission.CreateInstantInvite);
             Permissions.SetValue(ref value, manageChannel, ChannelPermission.ManageChannels);
             Permissions.SetValue(ref value, addReactions, ChannelPermission.AddReactions);
-            Permissions.SetValue(ref value, readMessages, ChannelPermission.ReadMessages);
+            Permissions.SetValue(ref value, readMessages, ChannelPermission.ViewChannel);
             Permissions.SetValue(ref value, sendMessages, ChannelPermission.SendMessages);
             Permissions.SetValue(ref value, sendTTSMessages, ChannelPermission.SendTTSMessages);
             Permissions.SetValue(ref value, manageMessages, ChannelPermission.ManageMessages);

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -86,7 +86,7 @@ namespace Discord
 
         private ChannelPermissions(ulong initialValue, bool? createInstantInvite = null, bool? manageChannel = null,
             bool? addReactions = null,
-            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
+            bool? viewChannel = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? manageRoles = null, bool? manageWebhooks = null)
@@ -96,7 +96,7 @@ namespace Discord
             Permissions.SetValue(ref value, createInstantInvite, ChannelPermission.CreateInstantInvite);
             Permissions.SetValue(ref value, manageChannel, ChannelPermission.ManageChannels);
             Permissions.SetValue(ref value, addReactions, ChannelPermission.AddReactions);
-            Permissions.SetValue(ref value, readMessages, ChannelPermission.ViewChannel);
+            Permissions.SetValue(ref value, viewChannel, ChannelPermission.ViewChannel);
             Permissions.SetValue(ref value, sendMessages, ChannelPermission.SendMessages);
             Permissions.SetValue(ref value, sendTTSMessages, ChannelPermission.SendTTSMessages);
             Permissions.SetValue(ref value, manageMessages, ChannelPermission.ManageMessages);

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -120,11 +120,11 @@ namespace Discord
         /// <summary> Creates a new ChannelPermissions with the provided permissions. </summary>
         public ChannelPermissions(bool createInstantInvite = false, bool manageChannel = false,
             bool addReactions = false,
-            bool readMessages = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
+            bool viewChannel = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
             bool embedLinks = false, bool attachFiles = false, bool readMessageHistory = false, bool mentionEveryone = false,
             bool useExternalEmojis = false, bool connect = false, bool speak = false, bool muteMembers = false, bool deafenMembers = false,
             bool moveMembers = false, bool useVoiceActivation = false, bool manageRoles = false, bool manageWebhooks = false)
-            : this(0, createInstantInvite, manageChannel, addReactions, readMessages, sendMessages, sendTTSMessages, manageMessages,
+            : this(0, createInstantInvite, manageChannel, addReactions, viewChannel, sendMessages, sendTTSMessages, manageMessages,
                 embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect,
                 speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, manageRoles, manageWebhooks)
         { }
@@ -132,11 +132,11 @@ namespace Discord
         /// <summary> Creates a new ChannelPermissions from this one, changing the provided non-null permissions. </summary>
         public ChannelPermissions Modify(bool? createInstantInvite = null, bool? manageChannel = null,
             bool? addReactions = null,
-            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
+            bool? viewChannel = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool useExternalEmojis = false, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? manageRoles = null, bool? manageWebhooks = null)
-            => new ChannelPermissions(RawValue, createInstantInvite, manageChannel, addReactions, readMessages, sendMessages, sendTTSMessages, manageMessages,
+            => new ChannelPermissions(RawValue, createInstantInvite, manageChannel, addReactions, viewChannel, sendMessages, sendTTSMessages, manageMessages,
                 embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect,
                 speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, manageRoles, manageWebhooks);
 

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -41,7 +41,11 @@ namespace Discord
         /// <summary> If true, a user may add reactions. </summary>
         public bool AddReactions => Permissions.GetValue(RawValue, ChannelPermission.AddReactions);
         /// <summary> If True, a user may join channels. </summary>
-        public bool ReadMessages => Permissions.GetValue(RawValue, ChannelPermission.ReadMessages);
+        [Obsolete("Use ViewChannel instead.")]
+        public bool ReadMessages => ViewChannel;
+        /// <summary> If True, a user may view channels. </summary>
+        public bool ViewChannel => Permissions.GetValue(RawValue, ChannelPermission.ViewChannel);
+
         /// <summary> If True, a user may send messages. </summary>
         public bool SendMessages => Permissions.GetValue(RawValue, ChannelPermission.SendMessages);
         /// <summary> If True, a user may send text-to-speech messages. </summary>
@@ -82,7 +86,7 @@ namespace Discord
 
         private ChannelPermissions(ulong initialValue, bool? createInstantInvite = null, bool? manageChannel = null,
             bool? addReactions = null,
-            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
+            bool? viewChannel = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? manageRoles = null, bool? manageWebhooks = null)
@@ -92,7 +96,7 @@ namespace Discord
             Permissions.SetValue(ref value, createInstantInvite, ChannelPermission.CreateInstantInvite);
             Permissions.SetValue(ref value, manageChannel, ChannelPermission.ManageChannels);
             Permissions.SetValue(ref value, addReactions, ChannelPermission.AddReactions);
-            Permissions.SetValue(ref value, readMessages, ChannelPermission.ReadMessages);
+            Permissions.SetValue(ref value, viewChannel, ChannelPermission.ViewChannel);
             Permissions.SetValue(ref value, sendMessages, ChannelPermission.SendMessages);
             Permissions.SetValue(ref value, sendTTSMessages, ChannelPermission.SendTTSMessages);
             Permissions.SetValue(ref value, manageMessages, ChannelPermission.ManageMessages);

--- a/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Discord
@@ -27,7 +28,10 @@ namespace Discord
         /// <summary> If Allowed, a user may add reactions. </summary>
         public PermValue AddReactions => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.AddReactions);
         /// <summary> If Allowed, a user may join channels. </summary>
-        public PermValue ReadMessages => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ReadMessages);
+        [Obsolete("Use ViewChannel instead.")]
+        public PermValue ReadMessages => ViewChannel;
+        /// <summary> If Allowed, a user may join channels. </summary>
+        public PermValue ViewChannel => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ViewChannel);
         /// <summary> If Allowed, a user may send messages. </summary>
         public PermValue SendMessages => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.SendMessages);
         /// <summary> If Allowed, a user may send text-to-speech messages. </summary>
@@ -72,7 +76,7 @@ namespace Discord
 
         private OverwritePermissions(ulong allowValue, ulong denyValue, PermValue? createInstantInvite = null, PermValue? manageChannel = null, 
             PermValue? addReactions = null,
-            PermValue? readMessages = null, PermValue? sendMessages = null, PermValue? sendTTSMessages = null, PermValue? manageMessages = null, 
+            PermValue? viewChannel = null, PermValue? sendMessages = null, PermValue? sendTTSMessages = null, PermValue? manageMessages = null, 
             PermValue? embedLinks = null, PermValue? attachFiles = null, PermValue? readMessageHistory = null, PermValue? mentionEveryone = null, 
             PermValue? useExternalEmojis = null, PermValue? connect = null, PermValue? speak = null, PermValue? muteMembers = null, 
             PermValue? deafenMembers = null, PermValue? moveMembers = null, PermValue? useVoiceActivation = null, PermValue? manageRoles = null, 
@@ -81,7 +85,7 @@ namespace Discord
             Permissions.SetValue(ref allowValue, ref denyValue, createInstantInvite, ChannelPermission.CreateInstantInvite);
             Permissions.SetValue(ref allowValue, ref denyValue, manageChannel, ChannelPermission.ManageChannels);
             Permissions.SetValue(ref allowValue, ref denyValue, addReactions, ChannelPermission.AddReactions);
-            Permissions.SetValue(ref allowValue, ref denyValue, readMessages, ChannelPermission.ReadMessages);
+            Permissions.SetValue(ref allowValue, ref denyValue, viewChannel, ChannelPermission.ViewChannel);
             Permissions.SetValue(ref allowValue, ref denyValue, sendMessages, ChannelPermission.SendMessages);
             Permissions.SetValue(ref allowValue, ref denyValue, sendTTSMessages, ChannelPermission.SendTTSMessages);
             Permissions.SetValue(ref allowValue, ref denyValue, manageMessages, ChannelPermission.ManageMessages);

--- a/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
@@ -27,7 +27,7 @@ namespace Discord
         /// <summary> If Allowed, a user may add reactions. </summary>
         public PermValue AddReactions => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.AddReactions);
         /// <summary> If Allowed, a user may join channels. </summary>
-        public PermValue ReadMessages => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ReadMessages);
+        public PermValue ReadMessages => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ViewChannel);
         /// <summary> If Allowed, a user may send messages. </summary>
         public PermValue SendMessages => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.SendMessages);
         /// <summary> If Allowed, a user may send text-to-speech messages. </summary>
@@ -72,7 +72,7 @@ namespace Discord
 
         private OverwritePermissions(ulong allowValue, ulong denyValue, PermValue? createInstantInvite = null, PermValue? manageChannel = null, 
             PermValue? addReactions = null,
-            PermValue? readMessages = null, PermValue? sendMessages = null, PermValue? sendTTSMessages = null, PermValue? manageMessages = null, 
+            PermValue? viewChannel = null, PermValue? sendMessages = null, PermValue? sendTTSMessages = null, PermValue? manageMessages = null, 
             PermValue? embedLinks = null, PermValue? attachFiles = null, PermValue? readMessageHistory = null, PermValue? mentionEveryone = null, 
             PermValue? useExternalEmojis = null, PermValue? connect = null, PermValue? speak = null, PermValue? muteMembers = null, 
             PermValue? deafenMembers = null, PermValue? moveMembers = null, PermValue? useVoiceActivation = null, PermValue? manageRoles = null, 
@@ -81,7 +81,7 @@ namespace Discord
             Permissions.SetValue(ref allowValue, ref denyValue, createInstantInvite, ChannelPermission.CreateInstantInvite);
             Permissions.SetValue(ref allowValue, ref denyValue, manageChannel, ChannelPermission.ManageChannels);
             Permissions.SetValue(ref allowValue, ref denyValue, addReactions, ChannelPermission.AddReactions);
-            Permissions.SetValue(ref allowValue, ref denyValue, readMessages, ChannelPermission.ReadMessages);
+            Permissions.SetValue(ref allowValue, ref denyValue, viewChannel, ChannelPermission.ViewChannel);
             Permissions.SetValue(ref allowValue, ref denyValue, sendMessages, ChannelPermission.SendMessages);
             Permissions.SetValue(ref allowValue, ref denyValue, sendTTSMessages, ChannelPermission.SendTTSMessages);
             Permissions.SetValue(ref allowValue, ref denyValue, manageMessages, ChannelPermission.ManageMessages);

--- a/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Discord
@@ -27,7 +28,10 @@ namespace Discord
         /// <summary> If Allowed, a user may add reactions. </summary>
         public PermValue AddReactions => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.AddReactions);
         /// <summary> If Allowed, a user may join channels. </summary>
-        public PermValue ReadMessages => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ViewChannel);
+        [Obsolete("Use ViewChannel instead.")]
+        public PermValue ReadMessages => ViewChannel;
+        /// <summary> If Allowed, a user may join channels. </summary>
+        public PermValue ViewChannel => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ViewChannel);
         /// <summary> If Allowed, a user may send messages. </summary>
         public PermValue SendMessages => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.SendMessages);
         /// <summary> If Allowed, a user may send text-to-speech messages. </summary>

--- a/src/Discord.Net.Core/Utils/Permissions.cs
+++ b/src/Discord.Net.Core/Utils/Permissions.cs
@@ -152,7 +152,7 @@ namespace Discord
 
                 if (channel is ITextChannel textChannel)
                 {
-                    if (!GetValue(resolvedPermissions, ChannelPermission.ReadMessages))
+                    if (!GetValue(resolvedPermissions, ChannelPermission.ViewChannel))
                     {
                         //No read permission on a text channel removes all other permissions
                         resolvedPermissions = 0;

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -234,7 +234,7 @@ namespace Discord.Rest
             if (model == null)
                 return null;
             var user = RestGuildUser.Create(client, guild, model);
-            if (!user.GetPermissions(channel).ReadMessages)
+            if (!user.GetPermissions(channel).ViewChannel)
                 return null;
 
             return user;
@@ -255,7 +255,7 @@ namespace Discord.Rest
                     var models = await client.ApiClient.GetGuildMembersAsync(guild.Id, args, options).ConfigureAwait(false);
                     return models
                         .Select(x => RestGuildUser.Create(client, guild, x))
-                        .Where(x => x.GetPermissions(channel).ReadMessages)
+                        .Where(x => x.GetPermissions(channel).ViewChannel)
                         .ToImmutableArray();
                 },
                 nextPage: (info, lastPage) =>

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -192,7 +192,7 @@ namespace Discord.Rest
             var channels = await GetTextChannelsAsync(options).ConfigureAwait(false);
             var user = await GetCurrentUserAsync(options).ConfigureAwait(false);
             return channels
-                .Where(c => user.GetPermissions(c).ReadMessages)
+                .Where(c => user.GetPermissions(c).ViewChannel)
                 .OrderBy(c => c.Position)
                 .FirstOrDefault();
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -25,7 +25,7 @@ namespace Discord.WebSocket
         public override IReadOnlyCollection<SocketGuildUser> Users
             => Guild.Users.Where(x => Permissions.GetValue(
                 Permissions.ResolveChannel(Guild, x, this, Permissions.ResolveGuild(Guild, x)), 
-                ChannelPermission.ReadMessages)).ToImmutableArray();
+                ChannelPermission.ViewChannel)).ToImmutableArray();
         
         internal SocketTextChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
             : base(discord, id, guild)
@@ -107,7 +107,7 @@ namespace Discord.WebSocket
             {
                 var guildPerms = Permissions.ResolveGuild(Guild, user);
                 var channelPerms = Permissions.ResolveChannel(Guild, user, this, guildPerms);
-                if (Permissions.GetValue(channelPerms, ChannelPermission.ReadMessages))
+                if (Permissions.GetValue(channelPerms, ChannelPermission.ViewChannel))
                     return user;
             }
             return null;

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -7,7 +7,7 @@ namespace Discord
     public partial class Tests
     {
         [Fact]
-        public async Task TestChannelPermission()
+        public Task TestChannelPermission()
         {
             var perm = new ChannelPermissions();
 
@@ -82,9 +82,10 @@ namespace Discord
                 | ChannelPermission.UseVAD
                 );
             Assert.Equal(groupChannel, ChannelPermissions.Group.RawValue);
+            return Task.CompletedTask;
         }
 
-        public async Task TestChannelPermissionModify()
+        public Task TestChannelPermissionModify()
         {
             // test channel permission modify
 
@@ -311,14 +312,16 @@ namespace Discord
             perm = perm.Modify(manageWebhooks: false);
             Assert.False(perm.ManageWebhooks);
             Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+            return Task.CompletedTask;
         }
 
         [Fact]
-        public async Task TestChannelTypeResolution()
+        public Task TestChannelTypeResolution()
         {
             ITextChannel someChannel = null;
             // null channels will throw exception
             Assert.Throws<ArgumentException>(() => ChannelPermissions.All(someChannel));
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -96,7 +96,7 @@ namespace Discord
             // ensure that when modified it works
             perm = perm.Modify(createInstantInvite: true);
             Assert.True(perm.CreateInstantInvite);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.CreateInstantInvite);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.CreateInstantInvite);
 
             // set false again, move on to next permission
             perm = perm.Modify(createInstantInvite: false);
@@ -108,7 +108,7 @@ namespace Discord
 
             perm = perm.Modify(manageChannel: true);
             Assert.True(perm.ManageChannel);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageChannels);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ManageChannels);
 
             perm = perm.Modify(manageChannel: false);
             Assert.False(perm.ManageChannel);
@@ -119,7 +119,7 @@ namespace Discord
 
             perm = perm.Modify(addReactions: true);
             Assert.True(perm.AddReactions);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.AddReactions);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.AddReactions);
 
             perm = perm.Modify(addReactions: false);
             Assert.False(perm.AddReactions);
@@ -130,7 +130,7 @@ namespace Discord
 
             perm = perm.Modify(readMessages: true);
             Assert.True(perm.ReadMessages);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ReadMessages);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ReadMessages);
 
             perm = perm.Modify(readMessages: false);
             Assert.False(perm.ReadMessages);
@@ -141,7 +141,7 @@ namespace Discord
 
             perm = perm.Modify(sendMessages: true);
             Assert.True(perm.SendMessages);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.SendMessages);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.SendMessages);
 
             perm = perm.Modify(sendMessages: false);
             Assert.False(perm.SendMessages);
@@ -152,7 +152,7 @@ namespace Discord
 
             perm = perm.Modify(sendTTSMessages: true);
             Assert.True(perm.SendTTSMessages);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.SendTTSMessages);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.SendTTSMessages);
 
             perm = perm.Modify(sendTTSMessages: false);
             Assert.False(perm.SendTTSMessages);
@@ -163,7 +163,7 @@ namespace Discord
 
             perm = perm.Modify(manageMessages: true);
             Assert.True(perm.ManageMessages);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageMessages);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ManageMessages);
 
             perm = perm.Modify(manageMessages: false);
             Assert.False(perm.ManageMessages);
@@ -174,7 +174,7 @@ namespace Discord
 
             perm = perm.Modify(embedLinks: true);
             Assert.True(perm.EmbedLinks);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.EmbedLinks);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.EmbedLinks);
 
             perm = perm.Modify(embedLinks: false);
             Assert.False(perm.EmbedLinks);
@@ -185,7 +185,7 @@ namespace Discord
 
             perm = perm.Modify(attachFiles: true);
             Assert.True(perm.AttachFiles);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.AttachFiles);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.AttachFiles);
 
             perm = perm.Modify(attachFiles: false);
             Assert.False(perm.AttachFiles);
@@ -196,7 +196,7 @@ namespace Discord
 
             perm = perm.Modify(readMessageHistory: true);
             Assert.True(perm.ReadMessageHistory);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ReadMessageHistory);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ReadMessageHistory);
 
             perm = perm.Modify(readMessageHistory: false);
             Assert.False(perm.ReadMessageHistory);
@@ -207,7 +207,7 @@ namespace Discord
 
             perm = perm.Modify(mentionEveryone: true);
             Assert.True(perm.MentionEveryone);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MentionEveryone);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.MentionEveryone);
 
             perm = perm.Modify(mentionEveryone: false);
             Assert.False(perm.MentionEveryone);
@@ -218,7 +218,7 @@ namespace Discord
 
             perm = perm.Modify(useExternalEmojis: true);
             Assert.True(perm.UseExternalEmojis);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.UseExternalEmojis);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.UseExternalEmojis);
 
             perm = perm.Modify(useExternalEmojis: false);
             Assert.False(perm.UseExternalEmojis);
@@ -229,7 +229,7 @@ namespace Discord
 
             perm = perm.Modify(connect: true);
             Assert.True(perm.Connect);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.Connect);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.Connect);
 
             perm = perm.Modify(connect: false);
             Assert.False(perm.Connect);
@@ -240,7 +240,7 @@ namespace Discord
 
             perm = perm.Modify(speak: true);
             Assert.True(perm.Speak);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.Speak);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.Speak);
 
             perm = perm.Modify(speak: false);
             Assert.False(perm.Speak);
@@ -251,7 +251,7 @@ namespace Discord
 
             perm = perm.Modify(muteMembers: true);
             Assert.True(perm.MuteMembers);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MuteMembers);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.MuteMembers);
 
             perm = perm.Modify(muteMembers: false);
             Assert.False(perm.MuteMembers);
@@ -262,7 +262,7 @@ namespace Discord
 
             perm = perm.Modify(deafenMembers: true);
             Assert.True(perm.DeafenMembers);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.DeafenMembers);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.DeafenMembers);
 
             perm = perm.Modify(deafenMembers: false);
             Assert.False(perm.DeafenMembers);
@@ -273,7 +273,7 @@ namespace Discord
 
             perm = perm.Modify(moveMembers: true);
             Assert.True(perm.MoveMembers);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.MoveMembers);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.MoveMembers);
 
             perm = perm.Modify(moveMembers: false);
             Assert.False(perm.MoveMembers);
@@ -284,7 +284,7 @@ namespace Discord
 
             perm = perm.Modify(useVoiceActivation: true);
             Assert.True(perm.UseVAD);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.UseVAD);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.UseVAD);
 
             perm = perm.Modify(useVoiceActivation: false);
             Assert.False(perm.UseVAD);
@@ -295,7 +295,7 @@ namespace Discord
 
             perm = perm.Modify(manageRoles: true);
             Assert.True(perm.ManageRoles);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageRoles);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ManageRoles);
 
             perm = perm.Modify(manageRoles: false);
             Assert.False(perm.ManageRoles);
@@ -306,7 +306,7 @@ namespace Discord
 
             perm = perm.Modify(manageWebhooks: true);
             Assert.True(perm.ManageWebhooks);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ManageWebhooks);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ManageWebhooks);
 
             perm = perm.Modify(manageWebhooks: false);
             Assert.False(perm.ManageWebhooks);

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -29,7 +29,7 @@ namespace Discord
             ulong textChannel = (ulong)( ChannelPermission.CreateInstantInvite
                 | ChannelPermission.ManageChannels
                 | ChannelPermission.AddReactions
-                | ChannelPermission.ReadMessages
+                | ChannelPermission.ViewChannel
                 | ChannelPermission.SendMessages
                 | ChannelPermission.SendTTSMessages
                 | ChannelPermission.ManageMessages
@@ -59,7 +59,7 @@ namespace Discord
 
             // DM Channels
             ulong dmChannel = (ulong)(
-                ChannelPermission.ReadMessages
+                ChannelPermission.ViewChannel
                 | ChannelPermission.SendMessages
                 | ChannelPermission.EmbedLinks 
                 | ChannelPermission.AttachFiles
@@ -126,14 +126,14 @@ namespace Discord
             Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test
-            Assert.False(perm.ReadMessages);
+            Assert.False(perm.ViewChannel);
 
-            perm = perm.Modify(readMessages: true);
-            Assert.True(perm.ReadMessages);
-            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ReadMessages);
+            perm = perm.Modify(viewChannel: true);
+            Assert.True(perm.ViewChannel);
+            Assert.Equal(perm.RawValue, (ulong)ChannelPermission.ViewChannel);
 
-            perm = perm.Modify(readMessages: false);
-            Assert.False(perm.ReadMessages);
+            perm = perm.Modify(viewChannel: false);
+            Assert.False(perm.ViewChannel);
             Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
 
             // individual permission test

--- a/test/Discord.Net.Tests/Tests.GuildPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.GuildPermissions.cs
@@ -7,7 +7,7 @@ namespace Discord
     public partial class Tests
     {
         [Fact]
-        public async Task TestGuildPermission()
+        public Task TestGuildPermission()
         {
             // Test Guild Permission Constructors
             var perm = new GuildPermissions();
@@ -46,10 +46,12 @@ namespace Discord
                 GuildPermission.SendMessages | GuildPermission.SendTTSMessages | GuildPermission.EmbedLinks |
                 GuildPermission.AttachFiles);
             Assert.Equal(webHookPermissions, GuildPermissions.Webhook.RawValue);
+
+            return Task.CompletedTask;
         }
 
         [Fact]
-        public async Task TestGuildPermissionModify()
+        public Task TestGuildPermissionModify()
         {
             var perm = new GuildPermissions();
 
@@ -298,6 +300,7 @@ namespace Discord
             Assert.False(perm.ManageEmojis);
             Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
+            return Task.CompletedTask;
         }
 
     }


### PR DESCRIPTION
#854 proposed adding an enum and property to channel permissions that obsoletes `ReadMessages` in favor of `ViewChannel`.

I could see this being an issue with existing code, making `ReadMessages` obsolete will give unnecessary warnings. In addition, the name now differs from how it is defined in the API.

In addition, there is a discrepancy in the naming of ManageChannel(s) for ChannelPermissions.

https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs#L39

https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs#L10

https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs#L13

Would this also be something worth changing, obsoleting one in favor of another? Or could/should this be a breaking change?