### PR TITLE
Renamed Game to Activity and implemented new activity types

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/Activity.cs
+++ b/src/Discord.Net.Core/Entities/Users/Activity.cs
@@ -3,20 +3,20 @@
 namespace Discord
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public struct Game
+    public struct Activity
     {
         public string Name { get; }
         public string StreamUrl { get; }
-        public StreamType StreamType { get; }
+        public ActivityType Type { get; }
 
-        public Game(string name, string streamUrl, StreamType type)
+        public Activity(string name, string streamUrl, ActivityType type)
         {
             Name = name;
             StreamUrl = streamUrl;
-            StreamType = type;
+            Type = type;
         }
-        private Game(string name)
-            : this(name, null, StreamType.NotStreaming) { }
+        private Activity(string name)
+            : this(name, null, ActivityType.Playing) { }
 
         public override string ToString() => Name;
         private string DebuggerDisplay => StreamUrl != null ? $"{Name} ({StreamUrl})" : Name;

--- a/src/Discord.Net.Core/Entities/Users/ActivityType.cs
+++ b/src/Discord.Net.Core/Entities/Users/ActivityType.cs
@@ -1,0 +1,10 @@
+﻿namespace Discord
+{
+    public enum ActivityType
+    {
+        Playing = 0,
+        Streaming = 1,
+        ListeningTo = 2,
+        Watching = 3
+    }
+}

--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -3,7 +3,7 @@
     public interface IPresence
     {
         /// <summary> Gets the game this user is currently playing, if any. </summary>
-        Game? Game { get; }
+        Activity? Activity { get; }
         /// <summary> Gets the current status of this user. </summary>
         UserStatus Status { get; }
     }

--- a/src/Discord.Net.Core/Entities/Users/StreamType.cs
+++ b/src/Discord.Net.Core/Entities/Users/StreamType.cs
@@ -1,8 +1,0 @@
-﻿namespace Discord
-{
-    public enum StreamType
-    {
-        NotStreaming = 0,
-        Twitch = 1
-    }
-}

--- a/src/Discord.Net.Rest/API/Common/Activity.cs
+++ b/src/Discord.Net.Rest/API/Common/Activity.cs
@@ -5,14 +5,14 @@ using System.Runtime.Serialization;
 
 namespace Discord.API
 {
-    internal class Game
+    internal class Activity
     {
         [JsonProperty("name")]
         public string Name { get; set; }
         [JsonProperty("url")]
         public Optional<string> StreamUrl { get; set; }
         [JsonProperty("type")]
-        public Optional<StreamType?> StreamType { get; set; }
+        public Optional<ActivityType?> Type { get; set; }
 
         [OnError]
         internal void OnError(StreamingContext context, ErrorContext errorContext)

--- a/src/Discord.Net.Rest/API/Common/Presence.cs
+++ b/src/Discord.Net.Rest/API/Common/Presence.cs
@@ -12,7 +12,7 @@ namespace Discord.API
         [JsonProperty("status")]
         public UserStatus Status { get; set; }
         [JsonProperty("game")]
-        public Game Game { get; set; }
+        public Activity Activity { get; set; }
 
         [JsonProperty("roles")]
         public Optional<ulong[]> Roles { get; set; }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -16,7 +16,7 @@ namespace Discord.Rest
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);
-        public virtual Game? Game => null;
+        public virtual Activity? Activity => null;
         public virtual UserStatus Status => UserStatus.Offline;
         public virtual bool IsWebhook => false;
 

--- a/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
+++ b/src/Discord.Net.Rpc/Entities/Users/RpcUser.cs
@@ -18,7 +18,7 @@ namespace Discord.Rpc
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);
         public virtual bool IsWebhook => false;
-        public virtual Game? Game => null;
+        public virtual Activity? Activity => null;
         public virtual UserStatus Status => UserStatus.Offline;
 
         internal RpcUser(DiscordRpcClient discord, ulong id)

--- a/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
@@ -13,6 +13,6 @@ namespace Discord.API.Gateway
         [JsonProperty("afk")]
         public bool IsAFK { get; set; }
         [JsonProperty("game")]
-        public Game Game { get; set; }
+        public Activity Activity { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -13,7 +13,7 @@ namespace Discord.WebSocket
         /// <summary> Gets the estimated round-trip latency, in milliseconds, to the gateway server. </summary>
         public abstract int Latency { get; protected set; }
         public abstract UserStatus Status { get; protected set; } 
-        public abstract Game? Game { get; protected set; }
+        public abstract Activity? Game { get; protected set; }
 
         internal new DiscordSocketApiClient ApiClient => base.ApiClient as DiscordSocketApiClient;
 
@@ -44,7 +44,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public abstract Task StopAsync();
         public abstract Task SetStatusAsync(UserStatus status);
-        public abstract Task SetGameAsync(string name, string streamUrl = null, StreamType streamType = StreamType.NotStreaming);
+        public abstract Task SetActivityAsync(string name, string streamUrl = null, ActivityType streamType = ActivityType.Playing);
         public abstract Task DownloadUsersAsync(IEnumerable<IGuild> guilds);  
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -22,7 +22,7 @@ namespace Discord.WebSocket
         /// <summary> Gets the estimated round-trip latency, in milliseconds, to the gateway server. </summary>
         public override int Latency { get => GetLatency(); protected set { } }
         public override UserStatus Status { get => _shards[0].Status; protected set { } }
-        public override Game? Game { get => _shards[0].Game; protected set { } }
+        public override Activity? Game { get => _shards[0].Game; protected set { } }
 
         internal new DiscordSocketApiClient ApiClient => base.ApiClient as DiscordSocketApiClient;
         public override IReadOnlyCollection<SocketGuild> Guilds => GetGuilds().ToReadOnlyCollection(() => GetGuildCount());
@@ -238,10 +238,10 @@ namespace Discord.WebSocket
             for (int i = 0; i < _shards.Length; i++)
                 await _shards[i].SetStatusAsync(status).ConfigureAwait(false);
         }
-        public override async Task SetGameAsync(string name, string streamUrl = null, StreamType streamType = StreamType.NotStreaming)
+        public override async Task SetActivityAsync(string name, string streamUrl = null, ActivityType streamType = ActivityType.Playing)
         {
             for (int i = 0; i < _shards.Length; i++)
-                await _shards[i].SetGameAsync(name, streamUrl, streamType).ConfigureAwait(false);
+                await _shards[i].SetActivityAsync(name, streamUrl, streamType).ConfigureAwait(false);
         }
 
         private void RegisterEvents(DiscordSocketClient client, bool isPrimary)

--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -253,7 +253,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
             await SendGatewayAsync(GatewayOpCode.Heartbeat, lastSeq, options: options).ConfigureAwait(false);
         }
-        public async Task SendStatusUpdateAsync(UserStatus status, bool isAFK, long? since, Game game, RequestOptions options = null)
+        public async Task SendStatusUpdateAsync(UserStatus status, bool isAFK, long? since, Activity game, RequestOptions options = null)
         {
             options = RequestOptions.CreateOrClone(options);
             var args = new StatusUpdateParams
@@ -261,7 +261,7 @@ namespace Discord.API
                 Status = status,
                 IdleSince = since,
                 IsAFK = isAFK,
-                Game = game
+                Activity = game
             };
             await SendGatewayAsync(GatewayOpCode.StatusUpdate, args, options: options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -16,7 +16,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using GameModel = Discord.API.Game;
+using GameModel = Discord.API.Activity;
 
 namespace Discord.WebSocket
 {
@@ -48,7 +48,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override int Latency { get; protected set; }
         public override UserStatus Status { get; protected set; } = UserStatus.Online;
-        public override Game? Game { get; protected set; }
+        public override Activity? Game { get; protected set; }
 
         //From DiscordSocketConfig
         internal int TotalShards { get; private set; }
@@ -326,10 +326,10 @@ namespace Discord.WebSocket
                 _statusSince = null;
             await SendStatusAsync().ConfigureAwait(false);
         }
-        public override async Task SetGameAsync(string name, string streamUrl = null, StreamType streamType = StreamType.NotStreaming)
+        public override async Task SetActivityAsync(string name, string streamUrl = null, ActivityType streamType = ActivityType.Playing)
         {
             if (name != null)
-                Game = new Game(name, streamUrl, streamType);
+                Game = new Activity(name, streamUrl, streamType);
             else
                 Game = null;
             await SendStatusAsync().ConfigureAwait(false);
@@ -346,10 +346,10 @@ namespace Discord.WebSocket
             GameModel gameModel;
             if (game != null)
             {
-                gameModel = new API.Game
+                gameModel = new API.Activity
                 {
                     Name = game.Value.Name,
-                    StreamType = game.Value.StreamType,
+                    Type = game.Value.Type,
                     StreamUrl = game.Value.StreamUrl
                 };
             }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketPresence.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketPresence.cs
@@ -8,20 +8,20 @@ namespace Discord.WebSocket
     public struct SocketPresence : IPresence
     {
         public UserStatus Status { get; }
-        public Game? Game { get; }
+        public Activity? Activity { get; }
 
-        internal SocketPresence(UserStatus status, Game? game)
+        internal SocketPresence(UserStatus status, Activity? game)
         {
             Status = status;
-            Game = game;
+            Activity = game;
         }
         internal static SocketPresence Create(Model model)
         {
-            return new SocketPresence(model.Status, model.Game != null ? model.Game.ToEntity() : (Game?)null);
+            return new SocketPresence(model.Status, model.Activity != null ? model.Activity.ToEntity() : (Activity?)null);
         }
 
         public override string ToString() => Status.ToString();
-        private string DebuggerDisplay => $"{Status}{(Game != null ? $", {Game.Value.Name} ({Game.Value.StreamType})" : "")}";
+        private string DebuggerDisplay => $"{Status}{(Activity != null ? $", {Activity.Value.Name} ({Activity.Value.Type})" : "")}";
 
         internal SocketPresence Clone() => this;
     }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -18,7 +18,7 @@ namespace Discord.WebSocket
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         public string Discriminator => DiscriminatorValue.ToString("D4");
         public string Mention => MentionUtils.MentionUser(Id);
-        public Game? Game => Presence.Game;
+        public Activity? Activity => Presence.Activity;
         public UserStatus Status => Presence.Status;
 
         internal SocketUser(DiscordSocketClient discord, ulong id)

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -2,11 +2,11 @@
 {
     internal static class EntityExtensions
     {
-        public static Game ToEntity(this API.Game model)
+        public static Activity ToEntity(this API.Activity model)
         {
-            return new Game(model.Name,
+            return new Activity(model.Name,
                 model.StreamUrl.GetValueOrDefault(null),
-                model.StreamType.GetValueOrDefault(null) ?? StreamType.NotStreaming);
+                model.Type.GetValueOrDefault(null) ?? ActivityType.Playing);
         }
     }
 }


### PR DESCRIPTION
Discord recently implemented 2 new game types:

- 2 (Listening to)
- 3 (Watching)

Futhermore, these changes make it so that `Activity` now more accurately describes this part of the presence, hence the rename.

The Game -> Activity part is one thing I am not sure whether it's OK to keep. I can revert that part if necessary.