### PR TITLE
Fix null channel being passed in RequirePermission preconditions

### DIFF
--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
@@ -63,7 +63,7 @@ namespace Discord.Commands
                 if (guildChannel != null)
                     perms = guildUser.GetPermissions(guildChannel);
                 else
-                    perms = ChannelPermissions.All(guildChannel);
+                    perms = ChannelPermissions.All(context.Channel);
 
                 if (!perms.Has(ChannelPermission.Value))
                     return PreconditionResult.FromError($"Bot requires channel permission {ChannelPermission.Value}");

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
@@ -57,10 +57,8 @@ namespace Discord.Commands
 
             if (ChannelPermission.HasValue)
             {
-                var guildChannel = context.Channel as IGuildChannel;
-
                 ChannelPermissions perms;
-                if (guildChannel != null)
+                if (context.Channel is IGuildChannel guildChannel)
                     perms = guildUser.GetPermissions(guildChannel);
                 else
                     perms = ChannelPermissions.All(context.Channel);

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
@@ -56,10 +56,8 @@ namespace Discord.Commands
 
             if (ChannelPermission.HasValue)
             {
-                var guildChannel = context.Channel as IGuildChannel;
-
                 ChannelPermissions perms;
-                if (guildChannel != null)
+                if (context.Channel is IGuildChannel guildChannel)
                     perms = guildUser.GetPermissions(guildChannel);
                 else
                     perms = ChannelPermissions.All(context.Channel);

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
@@ -62,7 +62,7 @@ namespace Discord.Commands
                 if (guildChannel != null)
                     perms = guildUser.GetPermissions(guildChannel);
                 else
-                    perms = ChannelPermissions.All(guildChannel);
+                    perms = ChannelPermissions.All(context.Channel);
 
                 if (!perms.Has(ChannelPermission.Value))
                     return Task.FromResult(PreconditionResult.FromError($"User requires channel permission {ChannelPermission.Value}"));


### PR DESCRIPTION
## Abstract

This pull-request resolves #885, wherein commands flagged with a `RequirePermission` configured for a `ChannelPermission` would throw a null-reference in a DM.

The underlying issue was that in the else-branch for a DM, which gave the bot (or user) all permissions, we were passing an `IGuildChannel` that was guaranteed to be null, rather than the `IChannel`, which is guaranteed to have a value.

## Possible Caveats

Discord's permissions are not 1-to-1 between Private Channels and Guild Channels. We give the user/bot `ChannelPermissions.All` in DMs, as this is the closest to Discord's real behavior. However, some permissions do not work the same in Private Channels -- e.g., a bot may assume that because it has `ChannelPermission.ManageMessages`, it is safe to remove all messages in the channel. This change would allow a precondition requiring `ChannelPermission.ManageMessages` to pass, even in a DM, which is not entirely correct -- as the bot may not delete other recipients messages (the most likely use a bot would have for Manage Messages), while it may still pin them,