### PR TITLE
Allow users to opt-in to proxies

### DIFF
--- a/src/Discord.Net.Rest/Net/DefaultRestClient.cs
+++ b/src/Discord.Net.Rest/Net/DefaultRestClient.cs
@@ -22,7 +22,7 @@ namespace Discord.Net.Rest
         private CancellationToken _cancelToken;
         private bool _isDisposed;
 
-        public DefaultRestClient(string baseUrl)
+        public DefaultRestClient(string baseUrl, bool useProxy = false)
         {
             _baseUrl = baseUrl;
 
@@ -30,7 +30,7 @@ namespace Discord.Net.Rest
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
                 UseCookies = false,
-                UseProxy = false
+                UseProxy = useProxy,
             });
             SetHeader("accept-encoding", "gzip, deflate");
 

--- a/src/Discord.Net.Rest/Net/DefaultRestClientProvider.cs
+++ b/src/Discord.Net.Rest/Net/DefaultRestClientProvider.cs
@@ -4,16 +4,21 @@ namespace Discord.Net.Rest
 {
     public static class DefaultRestClientProvider
     {
-        public static readonly RestClientProvider Instance = url => 
+        public static readonly RestClientProvider Instance = Create();
+
+        public static RestClientProvider Create(bool useProxy = false)
         {
-            try
+            return url =>
             {
-                return new DefaultRestClient(url);                    
-            }
-            catch (PlatformNotSupportedException ex)
-            {
-                throw new PlatformNotSupportedException("The default RestClientProvider is not supported on this platform.", ex);
-            }
-        };
+                try
+                {
+                    return new DefaultRestClient(url, useProxy);
+                }
+                catch (PlatformNotSupportedException ex)
+                {
+                    throw new PlatformNotSupportedException("The default RestClientProvider is not supported on this platform.", ex);
+                }
+            };
+        }
     }
 }

--- a/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Net;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
@@ -23,18 +24,20 @@ namespace Discord.Net.WebSockets
         private readonly SemaphoreSlim _lock;
         private readonly Dictionary<string, string> _headers;
         private ClientWebSocket _client;
+        private IWebProxy _proxy;
         private Task _task;
         private CancellationTokenSource _cancelTokenSource;
         private CancellationToken _cancelToken, _parentToken;
         private bool _isDisposed, _isDisconnecting;
 
-        public DefaultWebSocketClient()
+        public DefaultWebSocketClient(IWebProxy proxy = null)
         {
             _lock = new SemaphoreSlim(1, 1);
             _cancelTokenSource = new CancellationTokenSource();
             _cancelToken = CancellationToken.None;
             _parentToken = CancellationToken.None;
             _headers = new Dictionary<string, string>();
+            _proxy = proxy;
         }
         private void Dispose(bool disposing)
         {
@@ -70,7 +73,7 @@ namespace Discord.Net.WebSockets
             _cancelToken = CancellationTokenSource.CreateLinkedTokenSource(_parentToken, _cancelTokenSource.Token).Token;
 
             _client = new ClientWebSocket();
-            _client.Options.Proxy = null;
+            _client.Options.Proxy = _proxy;
             _client.Options.KeepAliveInterval = TimeSpan.Zero;
             foreach (var header in _headers)
             {

--- a/src/Discord.Net.WebSocket/Net/DefaultWebSocketClientProvider.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultWebSocketClientProvider.cs
@@ -1,21 +1,27 @@
 using System;
+using System.Net;
 
 namespace Discord.Net.WebSockets
 {
     public static class DefaultWebSocketProvider
     {
 #if DEFAULTWEBSOCKET
-        public static readonly WebSocketProvider Instance = () => 
+        public static readonly WebSocketProvider Instance = Create();
+
+        public static WebSocketProvider Create(IWebProxy proxy = null)
         {
-            try
+            return () =>
             {
-                return new DefaultWebSocketClient();                    
-            }
-            catch (PlatformNotSupportedException ex)
-            {
-                throw new PlatformNotSupportedException("The default WebSocketProvider is not supported on this platform.", ex);
-            }
-        };
+                try
+                {
+                    return new DefaultWebSocketClient(proxy);
+                }
+                catch (PlatformNotSupportedException ex)
+                {
+                    throw new PlatformNotSupportedException("The default WebSocketProvider is not supported on this platform.", ex);
+                }
+            };
+        }
 #else
         public static readonly WebSocketProvider Instance = () =>
         {


### PR DESCRIPTION
## Abstract

This pull request resolves #836.

To opt-in to proxies, the user must use a custom Rest Client provider:

```cs
var config = new DiscordRestConfig // or DiscordSocketConfig, if using a Socket client
{
    RestClientProvider = DefaultRestClientProvider.Create(useProxy: true);
}
```

## Possible Caveats

When opting in to proxies, client performance may degrade. Before this option was disabled (on older versions of CoreCLR -- this may have been before the 1.0 release, so the issue could be fixed now!), requests were prone to take >5x the time to complete, regardless of using a proxy.