### PR TITLE
Allow null value to reset IGuildUser nickname

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
@@ -34,7 +34,7 @@ namespace Discord
         /// Should the user have a nickname set? 
         /// </summary>
         /// <remarks>
-        /// To clear the user's nickname, this value can be set to null.
+        /// To clear the user's nickname, this value can be set to null or string.Empty.
         /// </remarks>
         public Optional<string> Nickname { get; set; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
@@ -34,7 +34,7 @@ namespace Discord
         /// Should the user have a nickname set? 
         /// </summary>
         /// <remarks>
-        /// To clear the user's nickname, this value can be set to null or string.Empty.
+        /// To clear the user's nickname, this value can be set to <see langword="null" /> or <see cref="string.Empty" />.
         /// </remarks>
         public Optional<string> Nickname { get; set; }
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
@@ -48,6 +48,14 @@ namespace Discord.Rest
             else if (args.RoleIds.IsSpecified)
                 apiArgs.RoleIds = args.RoleIds.Value.ToArray();
 
+            /*
+             * Ensure that the nick passed in the params of the request is not null.
+             * string.Empty ("") is the only way to reset the user nick in the API,
+             * a value of null does not. This is a workaround.
+             */
+            if (apiArgs.Nickname.IsSpecified && apiArgs.Nickname.Value == null)
+                apiArgs.Nickname = new Optional<string>(string.Empty);
+
             await client.ApiClient.ModifyGuildMemberAsync(user.GuildId, user.Id, apiArgs, options).ConfigureAwait(false);
             return args;
         }


### PR DESCRIPTION
This PR adds a quality of life fix to IGuildUser#ModifyAsync.

Using:
```cs
var user = client.GetGuild(123).GetUser(123) as IGuildUser;
await user.ModifyAsync( x => x.Nickname = null);
```
The nickname of the user fails to be reset [which is not the expected behavior.](https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs#L37)

Using this:
```cs
var user = client.GetGuild(123).GetUser(123) as IGuildUser;
await user.ModifyAsync( x => x.Nickname = "");
```
works as expected.

I did some look into the API & implementation, the [Json field for nick is a non-nullable string field](https://discordapp.com/developers/docs/resources/guild#modify-guild-member)
The client also sends over and empty string `""` and not a value of `null`.

When a null value is passed, at DiscordRestApiClient#SendJsonAsync (line 195) the value of `request.json` is
```cs
"{\"nick\":null}"
```
using my change, or passing string.Empty results in
```cs
"{\"nick\":\"\"}"
```

I didn't think it was the correct move to modify Optional<T> at all (used by GuildUserProperties for json serialization, but also a million other things).

This change could be tested if the test guild contains any users that the bot has permissions to modify. If that can be setup, I can add some test coverage.