### PR TITLE
Add callback method for when a module class has been added

### DIFF
--- a/docs/guides/getting_started/samples/intro/structure.cs
+++ b/docs/guides/getting_started/samples/intro/structure.cs
@@ -19,9 +19,8 @@ class Program
 
     private readonly DiscordSocketClient _client;
     
-    // Keep the CommandService and IServiceProvider around for use with commands.
-    // These two types require you install the Discord.Net.Commands package.
-    private readonly IServiceProvider _services;
+    // Keep the CommandService around for use with commands.
+    // This type requires you install the Discord.Net.Commands package.
     private readonly CommandService _commands;
 
     private Program()
@@ -47,6 +46,9 @@ class Program
             // Again, log level:
             LogLevel = LogSeverity.Info,
             
+            // Setup your DI container.
+            ServiceProvider = ConfigureServices(),
+            
             // There's a few more properties you can set,
             // for example, case-insensitive commands.
             CaseSensitiveCommands = false,
@@ -56,8 +58,6 @@ class Program
         _client.Log += Logger;
         _commands.Log += Logger;
         
-        // Setup your DI container.
-        _services = ConfigureServices();
     }
     
     // If any services require the client, or the CommandService, or something else you keep on hand,
@@ -161,7 +161,7 @@ class Program
             
             // Execute the command. (result does not indicate a return value, 
             // rather an object stating if the command executed successfully).
-            var result = await _commands.ExecuteAsync(context, pos, _services);
+            var result = await _commands.ExecuteAsync(context, pos);
 
             // Uncomment the following lines if you want the bot
             // to send a message if it failed (not advised for most situations).

--- a/docs/guides/getting_started/samples/intro/structure.cs
+++ b/docs/guides/getting_started/samples/intro/structure.cs
@@ -131,9 +131,9 @@ class Program
         // Module classes MUST be marked 'public' or they will be ignored.
         // You also need to pass your 'IServiceProvider' instance now,
         // so make sure that's done before you get here.
-        await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
+        await _commands.AddModulesAsync(Assembly.GetEntryAssembly());
         // Or add Modules manually if you prefer to be a little more explicit:
-        await _commands.AddModuleAsync<SomeModule>(_services);
+        await _commands.AddModuleAsync<SomeModule>();
         // Note that the first one is 'Modules' (plural) and the second is 'Module' (singular).
 
         // Subscribe a handler to see if a message invokes a command.

--- a/docs/guides/getting_started/samples/intro/structure.cs
+++ b/docs/guides/getting_started/samples/intro/structure.cs
@@ -48,6 +48,9 @@ class Program
             
             // Setup your DI container.
             ServiceProvider = ConfigureServices(),
+            // If you have a service that's dependant on the CommandService instance,
+            // use ServiceProviderFactory instead.
+            //ServiceProviderFactory = (cs => ConfigureServices(cs)),
             
             // There's a few more properties you can set,
             // for example, case-insensitive commands.

--- a/docs/guides/getting_started/samples/intro/structure.cs
+++ b/docs/guides/getting_started/samples/intro/structure.cs
@@ -164,7 +164,9 @@ class Program
             var result = await _commands.ExecuteAsync(context, pos);
 
             // Uncomment the following lines if you want the bot
-            // to send a message if it failed (not advised for most situations).
+            // to send a message if it failed.
+            // This does not catch errors from commands with 'RunMode.Async',
+            // subscribe a handler for '_commands.CommandExecuted' to see those.
             //if (!result.IsSuccess && result.Error != CommandError.UnknownCommand)
             //    await msg.Channel.SendMessageAsync(result.ErrorReason);
         }

--- a/docs/guides/getting_started/samples/intro/structure.cs
+++ b/docs/guides/getting_started/samples/intro/structure.cs
@@ -19,9 +19,10 @@ class Program
 
     private readonly DiscordSocketClient _client;
     
-    // Keep the CommandService around for use with commands.
-    // This type requires you install the Discord.Net.Commands package.
+    // Keep the CommandService and DI container around for use with commands.
+    // These two types require you install the Discord.Net.Commands package.
     private readonly CommandService _commands;
+    private readonly IServiceProvider _services;
 
     private Program()
     {
@@ -46,12 +47,6 @@ class Program
             // Again, log level:
             LogLevel = LogSeverity.Info,
             
-            // Setup your DI container.
-            ServiceProvider = ConfigureServices(),
-            // If you have a service that's dependant on the CommandService instance,
-            // use ServiceProviderFactory instead.
-            //ServiceProviderFactory = (cs => ConfigureServices(cs)),
-            
             // There's a few more properties you can set,
             // for example, case-insensitive commands.
             CaseSensitiveCommands = false,
@@ -60,6 +55,9 @@ class Program
         // Subscribe the logging handler to both the client and the CommandService.
         _client.Log += Logger;
         _commands.Log += Logger;
+        
+        // Setup your DI container.
+        _services = ConfigureServices(),
         
     }
     
@@ -131,9 +129,9 @@ class Program
         // Module classes MUST be marked 'public' or they will be ignored.
         // You also need to pass your 'IServiceProvider' instance now,
         // so make sure that's done before you get here.
-        await _commands.AddModulesAsync(Assembly.GetEntryAssembly());
+        await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
         // Or add Modules manually if you prefer to be a little more explicit:
-        await _commands.AddModuleAsync<SomeModule>();
+        await _commands.AddModuleAsync<SomeModule>(_services);
         // Note that the first one is 'Modules' (plural) and the second is 'Module' (singular).
 
         // Subscribe a handler to see if a message invokes a command.

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -19,6 +19,7 @@ namespace Discord.Commands.Builders
         public string Name { get; set; }
         public string Summary { get; set; }
         public string Remarks { get; set; }
+        public string Group { get; set; }
 
         public IReadOnlyList<CommandBuilder> Commands => _commands;
         public IReadOnlyList<ModuleBuilder> Modules => _submodules;

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -122,8 +122,6 @@ namespace Discord.Commands.Builders
 
             if (TypeInfo != null)
             {
-                //keep this for safety?
-                //services = services ?? EmptyServiceProvider.Instance;
                 try
                 {
                     var moduleInstance = ReflectionUtils.CreateObject<IModuleBase>(TypeInfo, service, service._serviceProvider);

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -114,7 +114,7 @@ namespace Discord.Commands.Builders
             return this;
         }
 
-        private ModuleInfo BuildImpl(CommandService service, ModuleInfo parent = null)
+        private ModuleInfo BuildImpl(CommandService service, IServiceProvider services, ModuleInfo parent = null)
         {
             //Default name to first alias
             if (Name == null)
@@ -124,7 +124,7 @@ namespace Discord.Commands.Builders
             {
                 try
                 {
-                    var moduleInstance = ReflectionUtils.CreateObject<IModuleBase>(TypeInfo, service, service._serviceProvider);
+                    var moduleInstance = ReflectionUtils.CreateObject<IModuleBase>(TypeInfo, service, services);
                     moduleInstance.OnModuleBuilding(service);
                 }
                 catch (Exception)
@@ -134,11 +134,11 @@ namespace Discord.Commands.Builders
                 }
             }
 
-            return new ModuleInfo(this, service, parent);
+            return new ModuleInfo(this, service, services, parent);
         }
 
-        public ModuleInfo Build(CommandService service) => BuildImpl(service);
+        public ModuleInfo Build(CommandService service, IServiceProvider services) => BuildImpl(service, services);
 
-        internal ModuleInfo Build(CommandService service, ModuleInfo parent) => BuildImpl(service, parent);
+        internal ModuleInfo Build(CommandService service, IServiceProvider services, ModuleInfo parent) => BuildImpl(service, services, parent);
     }
 }

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -26,7 +26,7 @@ namespace Discord.Commands.Builders
         public IReadOnlyList<Attribute> Attributes => _attributes;
         public IReadOnlyList<string> Aliases => _aliases;
 
-        internal Optional<TypeInfo> TypeInfo { get; set; }
+        internal TypeInfo TypeInfo { get; set; }
 
         //Automatic
         internal ModuleBuilder(CommandService service, ModuleBuilder parent)
@@ -119,6 +119,22 @@ namespace Discord.Commands.Builders
             //Default name to first alias
             if (Name == null)
                 Name = _aliases[0];
+
+            if (TypeInfo != null)
+            {
+                //keep this for safety?
+                //services = services ?? EmptyServiceProvider.Instance;
+                try
+                {
+                    var moduleInstance = ReflectionUtils.CreateObject<IModuleBase>(TypeInfo, service, service._serviceProvider);
+                    moduleInstance.OnModuleBuilding(service);
+                }
+                catch (Exception)
+                {
+                    //unsure of what to do here
+                    throw;
+                }
+            }
 
             return new ModuleInfo(this, service, parent);
         }

--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,6 +25,8 @@ namespace Discord.Commands.Builders
         public IReadOnlyList<PreconditionAttribute> Preconditions => _preconditions;
         public IReadOnlyList<Attribute> Attributes => _attributes;
         public IReadOnlyList<string> Aliases => _aliases;
+
+        internal Optional<TypeInfo> TypeInfo { get; set; }
 
         //Automatic
         internal ModuleBuilder(CommandService service, ModuleBuilder parent)

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -98,6 +98,7 @@ namespace Discord.Commands
         private static void BuildModule(ModuleBuilder builder, TypeInfo typeInfo, CommandService service)
         {
             var attributes = typeInfo.GetCustomAttributes();
+            builder.TypeInfo = typeInfo;
 
             foreach (var attribute in attributes)
             {

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -297,7 +297,7 @@ namespace Discord.Commands
             }
 
             //We dont have a cached type reader, create one
-            reader = ReflectionUtils.CreateObject<TypeReader>(typeReaderType.GetTypeInfo(), service, EmptyServiceProvider.Instance);
+            reader = ReflectionUtils.CreateObject<TypeReader>(typeReaderType.GetTypeInfo(), service, service._serviceProvider);
             service.AddTypeReader(paramType, reader);
 
             return reader;

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -118,6 +118,7 @@ namespace Discord.Commands
                         break;
                     case GroupAttribute group:
                         builder.Name = builder.Name ?? group.Prefix;
+                        builder.Group = group.Prefix;
                         builder.AddAliases(group.Prefix);
                         break;
                     case PreconditionAttribute precondition:

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -43,7 +43,10 @@ namespace Discord.Commands
         public CommandService() : this(new CommandServiceConfig()) { }
         public CommandService(CommandServiceConfig config)
         {
-            _serviceProvider = config.ServiceProvider ?? EmptyServiceProvider.Instance;
+            _serviceProvider = config.ServiceProvider
+                ?? config.ServiceProviderFactory?.Invoke(this)
+                ?? EmptyServiceProvider.Instance;
+
             _caseSensitive = config.CaseSensitiveCommands;
             _throwOnError = config.ThrowOnError;
             _ignoreExtraArgs = config.IgnoreExtraArgs;
@@ -91,7 +94,6 @@ namespace Discord.Commands
 
                 var module = builder.Build(this, null);
 
-                //should be fine to pass null here since it'll never get checked from this path anyway
                 return LoadModuleInternal(module);
             }
             finally
@@ -148,22 +150,6 @@ namespace Discord.Commands
         private ModuleInfo LoadModuleInternal(ModuleInfo module)
         {
             _moduleDefs.Add(module);
-
-            //if (module.TypeInfo.IsSpecified)
-            //{
-            //    //keep this for safety?
-            //    services = services ?? EmptyServiceProvider.Instance;
-            //    try
-            //    {
-            //        var moduleInstance = ReflectionUtils.CreateObject<IModuleBase>(module.TypeInfo.Value, this, services);
-            //        moduleInstance.OnModuleBuilding(this);
-            //    }
-            //    catch(Exception)
-            //    {
-            //        //unsure of what to do here
-            //        throw;
-            //    }
-            //}
 
             foreach (var command in module.Commands)
                 _map.AddCommand(command);

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -150,7 +150,7 @@ namespace Discord.Commands
                 try
                 {
                     var moduleInstance = ReflectionUtils.CreateObject<IModuleBase>(module.TypeInfo.Value, this, services);
-                    moduleInstance.OnModuleAdded(this);
+                    moduleInstance.OnModuleBuilding(this);
                 }
                 catch(Exception)
                 {

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -21,10 +21,10 @@ namespace Discord.Commands
         /// <summary> Determines whether extra parameters should be ignored. </summary>
         public bool IgnoreExtraArgs { get; set; } = false;
 
-        /// <summary> Gets or sets the <see cref="IServiceProvider"/> to use. </summary>
-        public IServiceProvider ServiceProvider { get; set; } = null;
+        ///// <summary> Gets or sets the <see cref="IServiceProvider"/> to use. </summary>
+        //public IServiceProvider ServiceProvider { get; set; } = null;
 
-        /// <summary> Gets or sets a factory function for the <see cref="IServiceProvider"/> to use. </summary>
-        public Func<CommandService, IServiceProvider> ServiceProviderFactory { get; set; } = null;
+        ///// <summary> Gets or sets a factory function for the <see cref="IServiceProvider"/> to use. </summary>
+        //public Func<CommandService, IServiceProvider> ServiceProviderFactory { get; set; } = null;
     }
 }

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -21,6 +21,8 @@ namespace Discord.Commands
         /// <summary> Determines whether extra parameters should be ignored. </summary>
         public bool IgnoreExtraArgs { get; set; } = false;
 
-        public IServiceProvider ServiceProvider { get; set; } = EmptyServiceProvider.Instance;
+        public IServiceProvider ServiceProvider { get; set; }
+
+        public Func<CommandService, IServiceProvider> ServiceProviderFactory { get; set; }
     }
 }

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -21,8 +21,10 @@ namespace Discord.Commands
         /// <summary> Determines whether extra parameters should be ignored. </summary>
         public bool IgnoreExtraArgs { get; set; } = false;
 
-        public IServiceProvider ServiceProvider { get; set; }
+        /// <summary> Gets or sets the <see cref="IServiceProvider"/> to use. </summary>
+        public IServiceProvider ServiceProvider { get; set; } = null;
 
-        public Func<CommandService, IServiceProvider> ServiceProviderFactory { get; set; }
+        /// <summary> Gets or sets a factory function for the <see cref="IServiceProvider"/> to use. </summary>
+        public Func<CommandService, IServiceProvider> ServiceProviderFactory { get; set; } = null;
     }
 }

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Discord.Commands
+using System;
+
+namespace Discord.Commands
 {
     public class CommandServiceConfig
     {
@@ -18,5 +20,7 @@
 
         /// <summary> Determines whether extra parameters should be ignored. </summary>
         public bool IgnoreExtraArgs { get; set; } = false;
+
+        public IServiceProvider ServiceProvider { get; set; } = EmptyServiceProvider.Instance;
     }
 }

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -8,6 +8,6 @@ namespace Discord.Commands
         
         void AfterExecute(CommandInfo command);
 
-        void OnModuleAdded(CommandService commandService);
+        void OnModuleBuilding(CommandService commandService);
     }
 }

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -1,4 +1,4 @@
-﻿namespace Discord.Commands
+namespace Discord.Commands
 {
     internal interface IModuleBase
     {
@@ -7,5 +7,7 @@
         void BeforeExecute(CommandInfo command);
         
         void AfterExecute(CommandInfo command);
+
+        void OnModuleAdded(CommandService commandService);
     }
 }

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-
+using System.Reflection;
 using Discord.Commands.Builders;
 
 namespace Discord.Commands
@@ -22,6 +22,8 @@ namespace Discord.Commands
         public ModuleInfo Parent { get; }
         public bool IsSubmodule => Parent != null;
 
+        internal Optional<TypeInfo> TypeInfo { get; }
+
         internal ModuleInfo(ModuleBuilder builder, CommandService service, ModuleInfo parent = null)
         {
             Service = service;
@@ -30,6 +32,8 @@ namespace Discord.Commands
             Summary = builder.Summary;
             Remarks = builder.Remarks;
             Parent = parent;
+
+            TypeInfo = builder.TypeInfo;
 
             Aliases = BuildAliases(builder, service).ToImmutableArray();
             Commands = builder.Commands.Select(x => x.Build(this, service)).ToImmutableArray();

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -13,7 +13,7 @@ namespace Discord.Commands
         public string Name { get; }
         public string Summary { get; }
         public string Remarks { get; }
-        public string Group { get; set; }
+        public string Group { get; }
 
         public IReadOnlyList<string> Aliases { get; }
         public IReadOnlyList<CommandInfo> Commands { get; }

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -22,7 +22,7 @@ namespace Discord.Commands
         public ModuleInfo Parent { get; }
         public bool IsSubmodule => Parent != null;
 
-        internal Optional<TypeInfo> TypeInfo { get; }
+        //public TypeInfo TypeInfo { get; }
 
         internal ModuleInfo(ModuleBuilder builder, CommandService service, ModuleInfo parent = null)
         {
@@ -33,7 +33,7 @@ namespace Discord.Commands
             Remarks = builder.Remarks;
             Parent = parent;
 
-            TypeInfo = builder.TypeInfo;
+            //TypeInfo = builder.TypeInfo;
 
             Aliases = BuildAliases(builder, service).ToImmutableArray();
             Commands = builder.Commands.Select(x => x.Build(this, service)).ToImmutableArray();

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -24,7 +24,7 @@ namespace Discord.Commands
 
         //public TypeInfo TypeInfo { get; }
 
-        internal ModuleInfo(ModuleBuilder builder, CommandService service, ModuleInfo parent = null)
+        internal ModuleInfo(ModuleBuilder builder, CommandService service, IServiceProvider services, ModuleInfo parent = null)
         {
             Service = service;
 
@@ -40,7 +40,7 @@ namespace Discord.Commands
             Preconditions = BuildPreconditions(builder).ToImmutableArray();
             Attributes = BuildAttributes(builder).ToImmutableArray();
 
-            Submodules = BuildSubmodules(builder, service).ToImmutableArray();
+            Submodules = BuildSubmodules(builder, service, services).ToImmutableArray();
         }
 
         private static IEnumerable<string> BuildAliases(ModuleBuilder builder, CommandService service)
@@ -70,12 +70,12 @@ namespace Discord.Commands
             return result;
         }
 
-        private List<ModuleInfo> BuildSubmodules(ModuleBuilder parent, CommandService service)
+        private List<ModuleInfo> BuildSubmodules(ModuleBuilder parent, CommandService service, IServiceProvider services)
         {
             var result = new List<ModuleInfo>();
 
             foreach (var submodule in parent.Modules)
-                result.Add(submodule.Build(service, this));
+                result.Add(submodule.Build(service, services, this));
 
             return result;
         }

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -13,6 +13,7 @@ namespace Discord.Commands
         public string Name { get; }
         public string Summary { get; }
         public string Remarks { get; }
+        public string Group { get; set; }
 
         public IReadOnlyList<string> Aliases { get; }
         public IReadOnlyList<CommandInfo> Commands { get; }
@@ -31,6 +32,7 @@ namespace Discord.Commands
             Name = builder.Name;
             Summary = builder.Summary;
             Remarks = builder.Remarks;
+            Group = builder.Group;
             Parent = parent;
 
             //TypeInfo = builder.TypeInfo;

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Discord.Commands
@@ -23,6 +23,10 @@ namespace Discord.Commands
         {
         }
 
+        protected virtual void OnModuleAdded(CommandService commandService)
+        {
+        }
+
         //IModuleBase
         void IModuleBase.SetContext(ICommandContext context)
         {
@@ -33,5 +37,7 @@ namespace Discord.Commands
         void IModuleBase.BeforeExecute(CommandInfo command) => BeforeExecute(command);
 
         void IModuleBase.AfterExecute(CommandInfo command) => AfterExecute(command);
+
+        void IModuleBase.OnModuleAdded(CommandService commandService) => OnModuleAdded(commandService);
     }
 }

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -23,7 +23,7 @@ namespace Discord.Commands
         {
         }
 
-        protected virtual void OnModuleAdded(CommandService commandService)
+        protected virtual void OnModuleBuilding(CommandService commandService)
         {
         }
 
@@ -38,6 +38,6 @@ namespace Discord.Commands
 
         void IModuleBase.AfterExecute(CommandInfo command) => AfterExecute(command);
 
-        void IModuleBase.OnModuleAdded(CommandService commandService) => OnModuleAdded(commandService);
+        void IModuleBase.OnModuleBuilding(CommandService commandService) => OnModuleBuilding(commandService);
     }
 }


### PR DESCRIPTION
This is potentially breaking depending on how users have their code laid out. Previously, the following would just work:
```cs
_serviceCollection.AddSingleton(new MyService());
await _commands.AddModuleAsync<MyModule>();
// where 'MyModule' has 'MyService' as a constructor argument
```
With this PR right now, this code would throw an exception because the `IServiceProvider` isn't built yet, so the dependency can't get resolved. I could make the parameter required, but I wanted to get a review of the rest first.

The expected use-case is for something like adding a custom TypeReader for an associated module. Especially for `MpGame` where I want to provide the type reader as an implementation detail.