### PR TITLE
Remove IGuild.DownloadUsersAsync() from SocketGuild

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -696,7 +696,6 @@ namespace Discord.WebSocket
             => Task.FromResult<IGuildUser>(CurrentUser);
         Task<IGuildUser> IGuild.GetOwnerAsync(CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuildUser>(Owner);
-        Task IGuild.DownloadUsersAsync() { throw new NotSupportedException(); }
 
         async Task<IWebhook> IGuild.GetWebhookAsync(ulong id, RequestOptions options)
             => await GetWebhookAsync(id, options);


### PR DESCRIPTION
SocketGuild implements this method and shouldn't throw. If a SocketGuild is passed as a IGuild, it'll throw.