### PR TITLE
Added in an all value for category channels.

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -13,6 +13,8 @@ namespace Discord
         public static readonly ChannelPermissions Text = new ChannelPermissions(0b01100_0000000_1111111110001_010001);
         /// <summary> Gets a ChannelPermissions that grants all permissions for voice channels. </summary>
         public static readonly ChannelPermissions Voice = new ChannelPermissions(0b00100_1111110_0000000000000_010001);
+        /// <summary> Gets a ChannelPermissions that grants all permissions for category channels. </summary>
+        public static readonly ChannelPermissions Category = new ChannelPermissions(0b01100_1111110_1111111110001_010001);
         /// <summary> Gets a ChannelPermissions that grants all permissions for direct message channels. </summary>
         public static readonly ChannelPermissions DM = new ChannelPermissions(0b00000_1000110_1011100110000_000000);
         /// <summary> Gets a ChannelPermissions that grants all permissions for group channels. </summary>
@@ -24,6 +26,7 @@ namespace Discord
             {
                 case ITextChannel _: return Text;
                 case IVoiceChannel _: return Voice;
+                case ICategoryChannel _: return Category;
                 case IDMChannel _: return DM;
                 case IGroupChannel _: return Group;
                 default: throw new ArgumentException("Unknown channel type", nameof(channel));


### PR DESCRIPTION
Currently trying to get the permissions a user has on a category channel throws an argument exception because there is no all mask for category channels.

I'm not 100% certain I have the correct bit value so someone should double check that too.