### PR TITLE
Add request info to HttpException & RateLimitedException

### DIFF
--- a/src/Discord.Net.Core/Net/HttpException.cs
+++ b/src/Discord.Net.Core/Net/HttpException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 
 namespace Discord.Net
@@ -8,11 +8,13 @@ namespace Discord.Net
         public HttpStatusCode HttpCode { get; }
         public int? DiscordCode { get; }
         public string Reason { get; }
+        public IRequest Request { get; }
 
-        public HttpException(HttpStatusCode httpCode, int? discordCode = null, string reason = null)
+        public HttpException(HttpStatusCode httpCode, IRequest request, int? discordCode = null, string reason = null)
             : base(CreateMessage(httpCode, discordCode, reason))
         {
             HttpCode = httpCode;
+            Request = request;
             DiscordCode = discordCode;
             Reason = reason;
         }

--- a/src/Discord.Net.Core/Net/IRequest.cs
+++ b/src/Discord.Net.Core/Net/IRequest.cs
@@ -1,14 +1,10 @@
 using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Discord.Net
 {
     public interface IRequest
     {
         DateTimeOffset? TimeoutAt { get; }
-        TaskCompletionSource<Stream> Promise { get; }
         RequestOptions Options { get; }
-        
     }
 }

--- a/src/Discord.Net.Core/Net/IRequest.cs
+++ b/src/Discord.Net.Core/Net/IRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Discord.Net
+{
+    public interface IRequest
+    {
+        DateTimeOffset? TimeoutAt { get; }
+        TaskCompletionSource<Stream> Promise { get; }
+        RequestOptions Options { get; }
+        
+    }
+}

--- a/src/Discord.Net.Core/Net/RateLimitedException.cs
+++ b/src/Discord.Net.Core/Net/RateLimitedException.cs
@@ -1,12 +1,15 @@
-﻿using System;
+using System;
 
 namespace Discord.Net
 {
     public class RateLimitedException : TimeoutException
     {
-        public RateLimitedException()
+        public IRequest Request { get; }
+
+        public RateLimitedException(IRequest request)
             : base("You are being rate limited.")
         {
+            Request = request;
         }
     }
 }

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -86,7 +86,7 @@ namespace Discord.Net.Queue
                                 Debug.WriteLine($"[{id}] (!) 502");
 #endif
                                 if ((request.Options.RetryMode & RetryMode.Retry502) == 0)
-                                    throw new HttpException(HttpStatusCode.BadGateway, null);
+                                    throw new HttpException(HttpStatusCode.BadGateway, request, null);
 
                                 continue; //Retry
                             default:
@@ -106,7 +106,7 @@ namespace Discord.Net.Queue
                                     }
                                     catch { }
                                 }
-                                throw new HttpException(response.StatusCode, code, reason);
+                                throw new HttpException(response.StatusCode, request, code, reason);
                         }
                     }
                     else

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 #if DEBUG_LIMITS
@@ -163,7 +163,7 @@ namespace Discord.Net.Queue
                     if (!isRateLimited)
                         throw new TimeoutException();
                     else
-                        throw new RateLimitedException();
+                        throw new RateLimitedException(request);
                 }
 
                 lock (_lock)
@@ -182,12 +182,12 @@ namespace Discord.Net.Queue
                     }
 
                     if ((request.Options.RetryMode & RetryMode.RetryRatelimit) == 0)
-                        throw new RateLimitedException();
+                        throw new RateLimitedException(request);
 
                     if (resetAt.HasValue)
                     {
                         if (resetAt > timeoutAt)
-                            throw new RateLimitedException();
+                            throw new RateLimitedException(request);
                         int millis = (int)Math.Ceiling((resetAt.Value - DateTimeOffset.UtcNow).TotalMilliseconds);
 #if DEBUG_LIMITS
                         Debug.WriteLine($"[{id}] Sleeping {millis} ms (Pre-emptive)");
@@ -198,7 +198,7 @@ namespace Discord.Net.Queue
                     else
                     {
                         if ((timeoutAt.Value - DateTimeOffset.UtcNow).TotalMilliseconds < 500.0)
-                            throw new RateLimitedException();
+                            throw new RateLimitedException(request);
 #if DEBUG_LIMITS
                         Debug.WriteLine($"[{id}] Sleeping 500* ms (Pre-emptive)");
 #endif

--- a/src/Discord.Net.Rest/Net/Queue/Requests/RestRequest.cs
+++ b/src/Discord.Net.Rest/Net/Queue/Requests/RestRequest.cs
@@ -1,11 +1,11 @@
-﻿using Discord.Net.Rest;
+using Discord.Net.Rest;
 using System;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace Discord.Net.Queue
 {
-    public class RestRequest
+    public class RestRequest : IRequest
     {
         public IRestClient Client { get; }
         public string Method { get; }

--- a/src/Discord.Net.Rest/Net/Queue/Requests/WebSocketRequest.cs
+++ b/src/Discord.Net.Rest/Net/Queue/Requests/WebSocketRequest.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Net.WebSockets;
+using Discord.Net.WebSockets;
 using System;
 using System.IO;
 using System.Threading;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Net.Queue
 {
-    public class WebSocketRequest
+    public class WebSocketRequest : IRequest
     {
         public IWebSocketClient Client { get; }
         public string BucketId { get; }


### PR DESCRIPTION
## Overview
Adds a Request property to the exception, so when caught, information of the request can be handled by the user. Mostly useful for logging when you don't have the command service up to a level where the request being made isn't logged prior to the exception being thrown.