### PR TITLE
Set usage of TokenType.User as an error rather than a warning.

### DIFF
--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
@@ -1,4 +1,3 @@
-#pragma warning disable CS0618
 using System;
 using System.Threading.Tasks;
 
@@ -20,10 +19,6 @@ namespace Discord.Commands
                     if (context.User.Id != application.Owner.Id)
                         return PreconditionResult.FromError("Command can only be run by the owner of the bot");
                     return PreconditionResult.FromSuccess();
-                //case TokenType.User:
-                //    if (context.User.Id != context.Client.CurrentUser.Id)
-                //        return PreconditionResult.FromError("Command can only be run by the owner of the bot");
-                //    return PreconditionResult.FromSuccess();
                 default:
                     return PreconditionResult.FromError($"{nameof(RequireOwnerAttribute)} is not supported by this {nameof(TokenType)}.");                    
             }

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
@@ -20,10 +20,10 @@ namespace Discord.Commands
                     if (context.User.Id != application.Owner.Id)
                         return PreconditionResult.FromError("Command can only be run by the owner of the bot");
                     return PreconditionResult.FromSuccess();
-                case TokenType.User:
-                    if (context.User.Id != context.Client.CurrentUser.Id)
-                        return PreconditionResult.FromError("Command can only be run by the owner of the bot");
-                    return PreconditionResult.FromSuccess();
+                //case TokenType.User:
+                //    if (context.User.Id != context.Client.CurrentUser.Id)
+                //        return PreconditionResult.FromError("Command can only be run by the owner of the bot");
+                //    return PreconditionResult.FromSuccess();
                 default:
                     return PreconditionResult.FromError($"{nameof(RequireOwnerAttribute)} is not supported by this {nameof(TokenType)}.");                    
             }

--- a/src/Discord.Net.Core/TokenType.cs
+++ b/src/Discord.Net.Core/TokenType.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 
 namespace Discord
 {
     public enum TokenType
     {
-        [Obsolete("User logins are being deprecated and may result in a ToS strike against your account - please see https://github.com/RogueException/Discord.Net/issues/827")]
+        [Obsolete("User logins are deprecated and may result in a ToS strike against your account - please see https://github.com/RogueException/Discord.Net/issues/827", error: true)]
         User,
         Bearer,
         Bot,

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -74,8 +74,8 @@ namespace Discord.API
                     return $"Bot {token}";
                 case TokenType.Bearer:
                     return $"Bearer {token}";
-                case TokenType.User:
-                    return token;
+                //case TokenType.User:
+                //    return token;
                 default:
                     throw new ArgumentException("Unknown OAuth token type", nameof(tokenType));
             }
@@ -113,7 +113,7 @@ namespace Discord.API
             {
                 _loginCancelToken = new CancellationTokenSource();
 
-                AuthTokenType = TokenType.User;
+                //AuthTokenType = TokenType.User;
                 AuthToken = null;
                 await RequestQueue.SetCancelTokenAsync(_loginCancelToken.Token).ConfigureAwait(false);
                 RestClient.SetCancelToken(_loginCancelToken.Token);
@@ -172,8 +172,8 @@ namespace Discord.API
         {
             options = options ?? new RequestOptions();
             options.HeaderOnly = true;
-            options.BucketId = AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id : bucketId;
-            options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
+            //options.IsClientBucket = AuthTokenType == TokenType.User;
 
             var request = new RestRequest(RestClient, method, endpoint, options);
             await SendInternalAsync(method, endpoint, request).ConfigureAwait(false);
@@ -187,8 +187,8 @@ namespace Discord.API
         {
             options = options ?? new RequestOptions();
             options.HeaderOnly = true;
-            options.BucketId = AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id : bucketId;
-            options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
+            //options.IsClientBucket = AuthTokenType == TokenType.User;
 
             string json = payload != null ? SerializeJson(payload) : null;
             var request = new JsonRestRequest(RestClient, method, endpoint, json, options);
@@ -203,8 +203,8 @@ namespace Discord.API
         {
             options = options ?? new RequestOptions();
             options.HeaderOnly = true;
-            options.BucketId = AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id : bucketId;
-            options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
+            //options.IsClientBucket = AuthTokenType == TokenType.User;
 
             var request = new MultipartRestRequest(RestClient, method, endpoint, multipartArgs, options);
             await SendInternalAsync(method, endpoint, request).ConfigureAwait(false);
@@ -217,8 +217,8 @@ namespace Discord.API
             string bucketId = null, ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null) where TResponse : class
         {
             options = options ?? new RequestOptions();
-            options.BucketId = AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id : bucketId;
-            options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
+            //options.IsClientBucket = AuthTokenType == TokenType.User;
 
             var request = new RestRequest(RestClient, method, endpoint, options);
             return DeserializeJson<TResponse>(await SendInternalAsync(method, endpoint, request).ConfigureAwait(false));
@@ -231,8 +231,8 @@ namespace Discord.API
             string bucketId = null, ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null) where TResponse : class
         {
             options = options ?? new RequestOptions();
-            options.BucketId = AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id : bucketId;
-            options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
+            //options.IsClientBucket = AuthTokenType == TokenType.User;
 
             string json = payload != null ? SerializeJson(payload) : null;
             var request = new JsonRestRequest(RestClient, method, endpoint, json, options);
@@ -246,8 +246,8 @@ namespace Discord.API
             string bucketId = null, ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null)
         {
             options = options ?? new RequestOptions();
-            options.BucketId = AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id : bucketId;
-            options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
+            //options.IsClientBucket = AuthTokenType == TokenType.User;
 
             var request = new MultipartRestRequest(RestClient, method, endpoint, multipartArgs, options);
             return DeserializeJson<TResponse>(await SendInternalAsync(method, endpoint, request).ConfigureAwait(false));

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1,5 +1,4 @@
 #pragma warning disable CS1591
-#pragma warning disable CS0618
 using Discord.API.Rest;
 using Discord.Net;
 using Discord.Net.Converters;
@@ -74,8 +73,6 @@ namespace Discord.API
                     return $"Bot {token}";
                 case TokenType.Bearer:
                     return $"Bearer {token}";
-                //case TokenType.User:
-                //    return token;
                 default:
                     throw new ArgumentException("Unknown OAuth token type", nameof(tokenType));
             }
@@ -113,7 +110,6 @@ namespace Discord.API
             {
                 _loginCancelToken = new CancellationTokenSource();
 
-                //AuthTokenType = TokenType.User;
                 AuthToken = null;
                 await RequestQueue.SetCancelTokenAsync(_loginCancelToken.Token).ConfigureAwait(false);
                 RestClient.SetCancelToken(_loginCancelToken.Token);
@@ -172,8 +168,7 @@ namespace Discord.API
         {
             options = options ?? new RequestOptions();
             options.HeaderOnly = true;
-            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
-            //options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = bucketId;
 
             var request = new RestRequest(RestClient, method, endpoint, options);
             await SendInternalAsync(method, endpoint, request).ConfigureAwait(false);
@@ -187,8 +182,7 @@ namespace Discord.API
         {
             options = options ?? new RequestOptions();
             options.HeaderOnly = true;
-            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
-            //options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = bucketId;
 
             string json = payload != null ? SerializeJson(payload) : null;
             var request = new JsonRestRequest(RestClient, method, endpoint, json, options);
@@ -203,8 +197,7 @@ namespace Discord.API
         {
             options = options ?? new RequestOptions();
             options.HeaderOnly = true;
-            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
-            //options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = bucketId;
 
             var request = new MultipartRestRequest(RestClient, method, endpoint, multipartArgs, options);
             await SendInternalAsync(method, endpoint, request).ConfigureAwait(false);
@@ -217,8 +210,7 @@ namespace Discord.API
             string bucketId = null, ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null) where TResponse : class
         {
             options = options ?? new RequestOptions();
-            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
-            //options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = bucketId;
 
             var request = new RestRequest(RestClient, method, endpoint, options);
             return DeserializeJson<TResponse>(await SendInternalAsync(method, endpoint, request).ConfigureAwait(false));
@@ -231,8 +223,7 @@ namespace Discord.API
             string bucketId = null, ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null) where TResponse : class
         {
             options = options ?? new RequestOptions();
-            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
-            //options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = bucketId;
 
             string json = payload != null ? SerializeJson(payload) : null;
             var request = new JsonRestRequest(RestClient, method, endpoint, json, options);
@@ -246,8 +237,7 @@ namespace Discord.API
             string bucketId = null, ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null)
         {
             options = options ?? new RequestOptions();
-            options.BucketId = /*AuthTokenType == TokenType.User ? ClientBucket.Get(clientBucket).Id :*/ bucketId;
-            //options.IsClientBucket = AuthTokenType == TokenType.User;
+            options.BucketId = bucketId;
 
             var request = new MultipartRestRequest(RestClient, method, endpoint, multipartArgs, options);
             return DeserializeJson<TResponse>(await SendInternalAsync(method, endpoint, request).ConfigureAwait(false));

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1,4 +1,3 @@
-#pragma warning disable CS0618
 using Discord.API;
 using Discord.API.Gateway;
 using Discord.Logging;
@@ -446,7 +445,7 @@ namespace Discord.WebSocket
                                         {
                                             var model = data.Guilds[i];
                                             var guild = AddGuild(model, state);
-                                            if (!guild.IsAvailable /*|| ApiClient.AuthTokenType == TokenType.User*/)
+                                            if (!guild.IsAvailable)
                                                 unavailableGuilds++;
                                             else
                                                 await GuildAvailableAsync(guild).ConfigureAwait(false);
@@ -464,9 +463,6 @@ namespace Discord.WebSocket
                                         _connection.CriticalError(new Exception("Processing READY failed", ex));
                                         return;
                                     }
-
-                                    //if (ApiClient.AuthTokenType == TokenType.User)
-                                    //    await SyncGuildsAsync().ConfigureAwait(false);
 
                                     _lastGuildAvailableTime = Environment.TickCount;
                                     _guildDownloadTask = WaitForGuildsAsync(_connection.CancelToken, _gatewayLogger)
@@ -542,8 +538,6 @@ namespace Discord.WebSocket
                                         var guild = AddGuild(data, State);
                                         if (guild != null)
                                         {
-                                            //if (ApiClient.AuthTokenType == TokenType.User)
-                                            //    await SyncGuildsAsync().ConfigureAwait(false);
                                             await TimedInvokeAsync(_joinedGuildEvent, nameof(JoinedGuild), guild).ConfigureAwait(false);
                                         }
                                         else

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -446,7 +446,7 @@ namespace Discord.WebSocket
                                         {
                                             var model = data.Guilds[i];
                                             var guild = AddGuild(model, state);
-                                            if (!guild.IsAvailable || ApiClient.AuthTokenType == TokenType.User)
+                                            if (!guild.IsAvailable /*|| ApiClient.AuthTokenType == TokenType.User*/)
                                                 unavailableGuilds++;
                                             else
                                                 await GuildAvailableAsync(guild).ConfigureAwait(false);
@@ -465,8 +465,8 @@ namespace Discord.WebSocket
                                         return;
                                     }
 
-                                    if (ApiClient.AuthTokenType == TokenType.User)
-                                        await SyncGuildsAsync().ConfigureAwait(false);
+                                    //if (ApiClient.AuthTokenType == TokenType.User)
+                                    //    await SyncGuildsAsync().ConfigureAwait(false);
 
                                     _lastGuildAvailableTime = Environment.TickCount;
                                     _guildDownloadTask = WaitForGuildsAsync(_connection.CancelToken, _gatewayLogger)
@@ -542,8 +542,8 @@ namespace Discord.WebSocket
                                         var guild = AddGuild(data, State);
                                         if (guild != null)
                                         {
-                                            if (ApiClient.AuthTokenType == TokenType.User)
-                                                await SyncGuildsAsync().ConfigureAwait(false);
+                                            //if (ApiClient.AuthTokenType == TokenType.User)
+                                            //    await SyncGuildsAsync().ConfigureAwait(false);
                                             await TimedInvokeAsync(_joinedGuildEvent, nameof(JoinedGuild), guild).ConfigureAwait(false);
                                         }
                                         else

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1,4 +1,3 @@
-#pragma warning disable CS0618
 using Discord.Audio;
 using Discord.Rest;
 using System;
@@ -64,7 +63,7 @@ namespace Discord.WebSocket
         public Task DownloaderPromise => _downloaderPromise.Task;
         public IAudioClient AudioClient => _audioClient;
         public SocketTextChannel DefaultChannel => TextChannels
-            .Where(c => CurrentUser.GetPermissions(c).ReadMessages)
+            .Where(c => CurrentUser.GetPermissions(c).ViewChannel)
             .OrderBy(c => c.Position)
             .FirstOrDefault();
         public SocketVoiceChannel AFKChannel
@@ -192,12 +191,9 @@ namespace Discord.WebSocket
 
             _syncPromise = new TaskCompletionSource<bool>();
             _downloaderPromise = new TaskCompletionSource<bool>();
-            //if (Discord.ApiClient.AuthTokenType != TokenType.User)
-            //{
-                var _ = _syncPromise.TrySetResultAsync(true);
-                /*if (!model.Large)
-                    _ = _downloaderPromise.TrySetResultAsync(true);*/
-            //}
+            var _ = _syncPromise.TrySetResultAsync(true);
+            /*if (!model.Large)
+                _ = _downloaderPromise.TrySetResultAsync(true);*/
         }
         internal void Update(ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS0618
+#pragma warning disable CS0618
 using Discord.Audio;
 using Discord.Rest;
 using System;
@@ -192,12 +192,12 @@ namespace Discord.WebSocket
 
             _syncPromise = new TaskCompletionSource<bool>();
             _downloaderPromise = new TaskCompletionSource<bool>();
-            if (Discord.ApiClient.AuthTokenType != TokenType.User)
-            {
+            //if (Discord.ApiClient.AuthTokenType != TokenType.User)
+            //{
                 var _ = _syncPromise.TrySetResultAsync(true);
                 /*if (!model.Large)
                     _ = _downloaderPromise.TrySetResultAsync(true);*/
-            }
+            //}
         }
         internal void Update(ClientState state, Model model)
         {


### PR DESCRIPTION
I think waiting for 3.0 to do this is taking too long. Discord disallowed external API access with user tokens since November, so we should be stopping users *completely* from continuing that practice ASAP.