### PR TITLE
Incorrect variable assignment

### DIFF
--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -49,7 +49,7 @@ namespace Discord.Webhook
             if (username != null)
                 args.Username = username;
             if (avatarUrl != null)
-                args.AvatarUrl = username;
+                args.AvatarUrl = avatarUrl;
             if (embeds != null)
                 args.Embeds = embeds.Select(x => x.ToModel()).ToArray();
             var msg = await client.ApiClient.UploadWebhookFileAsync(client.Webhook.Id, args, options).ConfigureAwait(false);


### PR DESCRIPTION
The `username` parameter was being used to set `args.AvatarUrl` as opposed to the actual `avatarUrl` parameter provided