### PR TITLE
Add release version to docs footer, Add doc build instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ have the correct version checked out.
 4. Build the docs using `docfx .\docs\docfx.json`. Add the `--serve` parameter
 to preview the site locally. Some elements of the page may appear incorrect
 when not hosted by a server.
-  - Remarks: According to the docfx website, this tool does work on Linux under mono.
+      - Remarks: According to the docfx website, this tool does work on Linux under mono.
 
 [docfx-main]: https://dotnet.github.io/docfx/
 [docfx-installing]: https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,5 +12,5 @@ to preview the site locally. Some elements of the page may appear incorrect
 when not hosted by a server.
   - Remarks: According to the docfx website, this tool does work on Linux under mono.
 
-[docfx-main][https://dotnet.github.io/docfx/]
-[docfx-installing][https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html]
+[docfx-main]: https://dotnet.github.io/docfx/
+[docfx-installing]: https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Instructions for Building Documentation
+
+The documentation for the Discord.NET library uses [docfx][docfx-main]. [Instructions for installing this tool can be found here.][docfx-installing]
+
+1. Navigate to the root of the repository.
+2. (Optional) If you intend to target a specific version, ensure that you
+have the correct version checked out.
+3. Build the library. Run `dotnet build` in the root of this repository.
+ Ensure that the build passes without errors.
+4. Build the docs using `docfx .\docs\docfx.json`. Add the `--serve` parameter
+to preview the site locally. Some elements of the page may appear incorrect
+when not hosted by a server.
+  - Remarks: According to the docfx website, this tool does work on Linux under mono.
+
+[docfx-main][https://dotnet.github.io/docfx/]
+[docfx-installing][https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Instructions for Building Documentation
 
-The documentation for the Discord.NET library uses [docfx][docfx-main]. [Instructions for installing this tool can be found here.][docfx-installing]
+The documentation for the Discord.NET library uses [DocFX][docfx-main]. [Instructions for installing this tool can be found here.][docfx-installing]
 
 1. Navigate to the root of the repository.
 2. (Optional) If you intend to target a specific version, ensure that you

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -67,7 +67,7 @@
       "default"
     ],
     "globalMetadata": {
-      "_appFooter": "Discord.Net (c) 2015-2017"
+      "_appFooter": "Discord.Net (c) 2015-2018 <code>2.0.0-beta</code>"
     },
     "noLangKeyword": false
   }

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -67,7 +67,7 @@
       "default"
     ],
     "globalMetadata": {
-      "_appFooter": "Discord.Net (c) 2015-2018 <code>2.0.0-beta</code>"
+      "_appFooter": "Discord.Net (c) 2015-2018 2.0.0-beta"
     },
     "noLangKeyword": false
   }


### PR DESCRIPTION
This PR does two things:

I modified the page footer of the documentation so that it includes the latest release version. This may be useful for the transition between 1.X to 2.X some time in the future, so people aren't confused.
I'm not familiar enough with docfx to know if there's a way this can be set automatically.

I also added a short readme under the `docs` directory for instructions on how to build and serve the docs locally. I have forgotten one of these steps a few times before, so I think it would help to have these written down.
The readme.md file is not included in the build process of the documentation, so it doesn't show up on the site.

I realize that some considerations have been/are being made regarding versioning (and other features) for the documentation. This might serve as a temporary solution until greater changes are made.