### PR TITLE
Correct implementation of HasFlag and ResolveChannel

### DIFF
--- a/src/Discord.Net.Core/Utils/Permissions.cs
+++ b/src/Discord.Net.Core/Utils/Permissions.cs
@@ -80,7 +80,7 @@ namespace Discord
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool HasFlag(ulong value, ulong flag) => (value & flag) != 0;
+        private static bool HasFlag(ulong value, ulong flag) => (value & flag) == flag;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SetFlag(ref ulong value, ulong flag) => value |= flag;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -161,10 +161,10 @@ namespace Discord
                     else if (!GetValue(resolvedPermissions, ChannelPermission.SendMessages))
                     {
                         //No send permissions on a text channel removes all send-related permissions
-                        resolvedPermissions &= ~(1UL << (int)ChannelPermission.SendTTSMessages);
-                        resolvedPermissions &= ~(1UL << (int)ChannelPermission.MentionEveryone);
-                        resolvedPermissions &= ~(1UL << (int)ChannelPermission.EmbedLinks);
-                        resolvedPermissions &= ~(1UL << (int)ChannelPermission.AttachFiles);
+                        resolvedPermissions &= ~(ulong)ChannelPermission.SendTTSMessages;
+                        resolvedPermissions &= ~(ulong)ChannelPermission.MentionEveryone;
+                        resolvedPermissions &= ~(ulong)ChannelPermission.EmbedLinks;
+                        resolvedPermissions &= ~(ulong)ChannelPermission.AttachFiles;
                     }
                 }
                 resolvedPermissions &= mask; //Ensure we didnt get any permissions this channel doesnt support (from guildPerms, for example)


### PR DESCRIPTION
HasFlag was checking if any of the flags were set, not the ones specified, and ResolveChannel was still treating the ChannelPermission enum as before it was changed to a bitflag.

Fixes #965.