### PR TITLE
Add more tests for Permissions class

### DIFF
--- a/test/Discord.Net.Tests/Discord.Net.Tests.csproj
+++ b/test/Discord.Net.Tests/Discord.Net.Tests.csproj
@@ -27,7 +27,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit.runner.reporters" Version="2.2.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>

--- a/test/Discord.Net.Tests/Discord.Net.Tests.csproj
+++ b/test/Discord.Net.Tests/Discord.Net.Tests.csproj
@@ -11,6 +11,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Tests.Permissions.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="../../src/Discord.Net.Commands/Discord.Net.Commands.csproj" />
     <ProjectReference Include="../../src/Discord.Net.Core/Discord.Net.Core.csproj" />
     <ProjectReference Include="../../src/Discord.Net.Rest/Discord.Net.Rest.csproj" />
@@ -23,5 +26,8 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit.runner.reporters" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Discord
 {
-    public partial class Tests
+    public class ChannelPermissionsTests
     {
         [Fact]
         public Task TestChannelPermission()

--- a/test/Discord.Net.Tests/Tests.GuildPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.GuildPermissions.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Discord
 {
-    public partial class Tests
+    public class GuidPermissionsTests
     {
         [Fact]
         public Task TestGuildPermission()

--- a/test/Discord.Net.Tests/Tests.Permissions.cs
+++ b/test/Discord.Net.Tests/Tests.Permissions.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Discord
 {
-    public partial class Tests
+    public class PermissionsTests
     {
         private void TestHelper(ChannelPermissions value, ChannelPermission permission, bool expected = false)
             => TestHelper(value.RawValue, (ulong)permission, expected);
@@ -119,6 +119,7 @@ namespace Discord
         /// from the Has method.
         /// </summary>
         /// <returns></returns>
+        [Fact]
         public Task TestPermissionsHasChannelPermissionNone()
         {
             // check that none will fail all
@@ -155,6 +156,7 @@ namespace Discord
         /// from the Has method.
         /// </summary>
         /// <returns></returns>
+        [Fact]
         public Task TestPermissionsHasChannelPermissionDM()
         {
             // check that none will fail all
@@ -191,6 +193,7 @@ namespace Discord
         /// from the Has method.
         /// </summary>
         /// <returns></returns>
+        [Fact]
         public Task TestPermissionsHasChannelPermissionGroup()
         {
             var value = ChannelPermissions.Group;

--- a/test/Discord.Net.Tests/Tests.Permissions.cs
+++ b/test/Discord.Net.Tests/Tests.Permissions.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Discord
+{
+    public partial class Tests
+    {
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Tests that text channel permissions get the right value
+        /// from the Has method.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public Task TestPermissionsHasChannelPermissionText()
+        {
+            var value = ChannelPermissions.Text;
+            // check that the result of GetValue matches for all properties of text channel
+            Assert.True(value.Has(ChannelPermission.CreateInstantInvite));
+            Assert.True(value.Has(ChannelPermission.ManageChannels));
+            Assert.True(value.Has(ChannelPermission.AddReactions));
+            Assert.True(value.Has(ChannelPermission.ViewChannel));
+            Assert.True(value.Has(ChannelPermission.SendMessages));
+            Assert.True(value.Has(ChannelPermission.SendTTSMessages));
+            Assert.True(value.Has(ChannelPermission.ManageMessages));
+            Assert.True(value.Has(ChannelPermission.EmbedLinks));
+            Assert.True(value.Has(ChannelPermission.AttachFiles));
+            Assert.True(value.Has(ChannelPermission.ReadMessageHistory));
+            Assert.True(value.Has(ChannelPermission.MentionEveryone));
+            Assert.True(value.Has(ChannelPermission.UseExternalEmojis));
+            Assert.True(value.Has(ChannelPermission.ManageRoles));
+            Assert.True(value.Has(ChannelPermission.ManageWebhooks));
+
+            Assert.False(value.Has(ChannelPermission.Connect));
+            Assert.False(value.Has(ChannelPermission.Speak));
+            Assert.False(value.Has(ChannelPermission.MuteMembers));
+            Assert.False(value.Has(ChannelPermission.DeafenMembers));
+            Assert.False(value.Has(ChannelPermission.MoveMembers));
+            Assert.False(value.Has(ChannelPermission.UseVAD));
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Tests that no channel permissions get the right value
+        /// from the Has method.
+        /// </summary>
+        /// <returns></returns>
+        public Task TestPermissionsHasChannelPermissionNone()
+        {
+            // check that none will fail all
+            var value = ChannelPermissions.None;
+
+            Assert.False(value.Has(ChannelPermission.CreateInstantInvite));
+            Assert.False(value.Has(ChannelPermission.ManageChannels));
+            Assert.False(value.Has(ChannelPermission.AddReactions));
+            Assert.False(value.Has(ChannelPermission.ViewChannel));
+            Assert.False(value.Has(ChannelPermission.SendMessages));
+            Assert.False(value.Has(ChannelPermission.SendTTSMessages));
+            Assert.False(value.Has(ChannelPermission.ManageMessages));
+            Assert.False(value.Has(ChannelPermission.EmbedLinks));
+            Assert.False(value.Has(ChannelPermission.AttachFiles));
+            Assert.False(value.Has(ChannelPermission.ReadMessageHistory));
+            Assert.False(value.Has(ChannelPermission.MentionEveryone));
+            Assert.False(value.Has(ChannelPermission.UseExternalEmojis));
+            Assert.False(value.Has(ChannelPermission.ManageRoles));
+            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
+            Assert.False(value.Has(ChannelPermission.Connect));
+            Assert.False(value.Has(ChannelPermission.Speak));
+            Assert.False(value.Has(ChannelPermission.MuteMembers));
+            Assert.False(value.Has(ChannelPermission.DeafenMembers));
+            Assert.False(value.Has(ChannelPermission.MoveMembers));
+            Assert.False(value.Has(ChannelPermission.UseVAD));
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Tests that the dm channel permissions get the right value
+        /// from the Has method.
+        /// </summary>
+        /// <returns></returns>
+        public Task TestPermissionsHasChannelPermissionDM()
+        {
+            // check that none will fail all
+            var value = ChannelPermissions.DM;
+
+            Assert.False(value.Has(ChannelPermission.CreateInstantInvite));
+            Assert.False(value.Has(ChannelPermission.ManageChannels));
+            Assert.False(value.Has(ChannelPermission.AddReactions));
+            Assert.True(value.Has(ChannelPermission.ViewChannel));
+            Assert.True(value.Has(ChannelPermission.SendMessages));
+            Assert.False(value.Has(ChannelPermission.SendTTSMessages));
+            Assert.False(value.Has(ChannelPermission.ManageMessages));
+            Assert.True(value.Has(ChannelPermission.EmbedLinks));
+            Assert.True(value.Has(ChannelPermission.AttachFiles));
+            Assert.True(value.Has(ChannelPermission.ReadMessageHistory));
+            Assert.False(value.Has(ChannelPermission.MentionEveryone));
+            Assert.True(value.Has(ChannelPermission.UseExternalEmojis));
+            Assert.False(value.Has(ChannelPermission.ManageRoles));
+            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
+            Assert.True(value.Has(ChannelPermission.Connect));
+            Assert.True(value.Has(ChannelPermission.Speak));
+            Assert.False(value.Has(ChannelPermission.MuteMembers));
+            Assert.False(value.Has(ChannelPermission.DeafenMembers));
+            Assert.False(value.Has(ChannelPermission.MoveMembers));
+            Assert.True(value.Has(ChannelPermission.UseVAD));
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Tests that the group channel permissions get the right value
+        /// from the Has method.
+        /// </summary>
+        /// <returns></returns>
+        public Task TestPermissionsHasChannelPermissionGroup()
+        {
+            var value = ChannelPermissions.Group;
+
+            Assert.False(value.Has(ChannelPermission.CreateInstantInvite));
+            Assert.False(value.Has(ChannelPermission.ManageChannels));
+            Assert.False(value.Has(ChannelPermission.AddReactions));
+            Assert.False(value.Has(ChannelPermission.ViewChannel));
+            Assert.True(value.Has(ChannelPermission.SendMessages));
+            Assert.True(value.Has(ChannelPermission.SendTTSMessages));
+            Assert.False(value.Has(ChannelPermission.ManageMessages));
+            Assert.True(value.Has(ChannelPermission.EmbedLinks));
+            Assert.True(value.Has(ChannelPermission.AttachFiles));
+            Assert.False(value.Has(ChannelPermission.ReadMessageHistory));
+            Assert.False(value.Has(ChannelPermission.MentionEveryone));
+            Assert.False(value.Has(ChannelPermission.UseExternalEmojis));
+            Assert.False(value.Has(ChannelPermission.ManageRoles));
+            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
+            Assert.True(value.Has(ChannelPermission.Connect));
+            Assert.True(value.Has(ChannelPermission.Speak));
+            Assert.False(value.Has(ChannelPermission.MuteMembers));
+            Assert.False(value.Has(ChannelPermission.DeafenMembers));
+            Assert.False(value.Has(ChannelPermission.MoveMembers));
+            Assert.True(value.Has(ChannelPermission.UseVAD));
+
+            return Task.CompletedTask;
+        }
+
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Tests that the voice channel permissions get the right value
+        /// from the Has method.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public Task TestPermissionsHasChannelPermissionVoice()
+        {
+            // make a flag with all possible values for Voice channel permissions
+            var value = ChannelPermissions.Voice;
+          
+            Assert.True(value.Has(ChannelPermission.CreateInstantInvite));
+            Assert.True(value.Has(ChannelPermission.ManageChannels));
+            Assert.False(value.Has(ChannelPermission.AddReactions));
+            Assert.False(value.Has(ChannelPermission.ViewChannel));
+            Assert.False(value.Has(ChannelPermission.SendMessages));
+            Assert.False(value.Has(ChannelPermission.SendTTSMessages));
+            Assert.False(value.Has(ChannelPermission.ManageMessages));
+            Assert.False(value.Has(ChannelPermission.EmbedLinks));
+            Assert.False(value.Has(ChannelPermission.AttachFiles));
+            Assert.False(value.Has(ChannelPermission.ReadMessageHistory));
+            Assert.False(value.Has(ChannelPermission.MentionEveryone));
+            Assert.False(value.Has(ChannelPermission.UseExternalEmojis));
+            Assert.True(value.Has(ChannelPermission.ManageRoles));
+            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
+            Assert.True(value.Has(ChannelPermission.Connect));
+            Assert.True(value.Has(ChannelPermission.Speak));
+            Assert.True(value.Has(ChannelPermission.MuteMembers));
+            Assert.True(value.Has(ChannelPermission.DeafenMembers));
+            Assert.True(value.Has(ChannelPermission.MoveMembers));
+            Assert.True(value.Has(ChannelPermission.UseVAD));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Discord.Net.Tests/Tests.Permissions.cs
+++ b/test/Discord.Net.Tests/Tests.Permissions.cs
@@ -188,5 +188,50 @@ namespace Discord
 
             return Task.CompletedTask;
         }
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Test that that the Has method of <see cref="Discord.GuildPermissions"/> 
+        /// returns the correct value when no permissions are set.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public Task TestPermissionsHasGuildPermissionNone()
+        {
+            var value = GuildPermissions.None;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Test that that the Has method of <see cref="Discord.GuildPermissions"/> 
+        /// returns the correct value when all permissions are set.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public Task TestPermissionsHasGuildPermissionAll()
+        {
+            var value = GuildPermissions.All;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Tests for the <see cref="Discord.Permissions"/> class.
+        /// 
+        /// Test that that the Has method of <see cref="Discord.GuildPermissions"/> 
+        /// returns the correct value when webhook permissions are set.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public Task TestPermissionsHasGuildPermissionWebhook()
+        {
+            var value = GuildPermissions.All;
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/Discord.Net.Tests/Tests.Permissions.cs
+++ b/test/Discord.Net.Tests/Tests.Permissions.cs
@@ -7,6 +7,29 @@ namespace Discord
     public partial class Tests
     {
 
+        private void TestHelper(ChannelPermissions value, ChannelPermission permission, bool expected = false)
+            => TestHelper(value.RawValue, (ulong)permission, expected);
+
+        private void TestHelper(GuildPermissions value, GuildPermission permission, bool expected = false)
+            => TestHelper(value.RawValue, (ulong)permission, expected);
+
+        private void TestHelper(ulong rawValue, ulong flagValue, bool expected)
+        {
+            Assert.Equal(expected, Permissions.GetValue(rawValue, flagValue));
+
+            // check that toggling the bit works
+            Permissions.UnsetFlag(ref rawValue, flagValue);
+            Assert.Equal(false, Permissions.GetValue(rawValue, flagValue));
+            Permissions.SetFlag(ref rawValue, flagValue);
+            Assert.Equal(true, Permissions.GetValue(rawValue, flagValue));
+
+            // do the same, but with the SetValue method
+            Permissions.SetValue(ref rawValue, true, flagValue);
+            Assert.Equal(true, Permissions.GetValue(rawValue, flagValue));
+            Permissions.SetValue(ref rawValue, false, flagValue);
+            Assert.Equal(false, Permissions.GetValue(rawValue, flagValue));
+        }
+
         /// <summary>
         /// Tests for the <see cref="Discord.Permissions"/> class.
         /// 
@@ -19,27 +42,27 @@ namespace Discord
         {
             var value = ChannelPermissions.Text;
             // check that the result of GetValue matches for all properties of text channel
-            Assert.True(value.Has(ChannelPermission.CreateInstantInvite));
-            Assert.True(value.Has(ChannelPermission.ManageChannels));
-            Assert.True(value.Has(ChannelPermission.AddReactions));
-            Assert.True(value.Has(ChannelPermission.ViewChannel));
-            Assert.True(value.Has(ChannelPermission.SendMessages));
-            Assert.True(value.Has(ChannelPermission.SendTTSMessages));
-            Assert.True(value.Has(ChannelPermission.ManageMessages));
-            Assert.True(value.Has(ChannelPermission.EmbedLinks));
-            Assert.True(value.Has(ChannelPermission.AttachFiles));
-            Assert.True(value.Has(ChannelPermission.ReadMessageHistory));
-            Assert.True(value.Has(ChannelPermission.MentionEveryone));
-            Assert.True(value.Has(ChannelPermission.UseExternalEmojis));
-            Assert.True(value.Has(ChannelPermission.ManageRoles));
-            Assert.True(value.Has(ChannelPermission.ManageWebhooks));
+            TestHelper(value, ChannelPermission.CreateInstantInvite, true);
+            TestHelper(value, ChannelPermission.ManageChannels, true);
+            TestHelper(value, ChannelPermission.AddReactions, true);
+            TestHelper(value, ChannelPermission.ViewChannel, true);
+            TestHelper(value, ChannelPermission.SendMessages, true);
+            TestHelper(value, ChannelPermission.SendTTSMessages, true);
+            TestHelper(value, ChannelPermission.ManageMessages, true);
+            TestHelper(value, ChannelPermission.EmbedLinks, true);
+            TestHelper(value, ChannelPermission.AttachFiles, true);
+            TestHelper(value, ChannelPermission.ReadMessageHistory, true);
+            TestHelper(value, ChannelPermission.MentionEveryone, true);
+            TestHelper(value, ChannelPermission.UseExternalEmojis, true);
+            TestHelper(value, ChannelPermission.ManageRoles, true);
+            TestHelper(value, ChannelPermission.ManageWebhooks, true);
 
-            Assert.False(value.Has(ChannelPermission.Connect));
-            Assert.False(value.Has(ChannelPermission.Speak));
-            Assert.False(value.Has(ChannelPermission.MuteMembers));
-            Assert.False(value.Has(ChannelPermission.DeafenMembers));
-            Assert.False(value.Has(ChannelPermission.MoveMembers));
-            Assert.False(value.Has(ChannelPermission.UseVAD));
+            TestHelper(value, ChannelPermission.Connect, false);
+            TestHelper(value, ChannelPermission.Speak, false);
+            TestHelper(value, ChannelPermission.MuteMembers, false);
+            TestHelper(value, ChannelPermission.DeafenMembers, false);
+            TestHelper(value, ChannelPermission.MoveMembers, false);
+            TestHelper(value, ChannelPermission.UseVAD, false);
 
             return Task.CompletedTask;
         }
@@ -56,26 +79,26 @@ namespace Discord
             // check that none will fail all
             var value = ChannelPermissions.None;
 
-            Assert.False(value.Has(ChannelPermission.CreateInstantInvite));
-            Assert.False(value.Has(ChannelPermission.ManageChannels));
-            Assert.False(value.Has(ChannelPermission.AddReactions));
-            Assert.False(value.Has(ChannelPermission.ViewChannel));
-            Assert.False(value.Has(ChannelPermission.SendMessages));
-            Assert.False(value.Has(ChannelPermission.SendTTSMessages));
-            Assert.False(value.Has(ChannelPermission.ManageMessages));
-            Assert.False(value.Has(ChannelPermission.EmbedLinks));
-            Assert.False(value.Has(ChannelPermission.AttachFiles));
-            Assert.False(value.Has(ChannelPermission.ReadMessageHistory));
-            Assert.False(value.Has(ChannelPermission.MentionEveryone));
-            Assert.False(value.Has(ChannelPermission.UseExternalEmojis));
-            Assert.False(value.Has(ChannelPermission.ManageRoles));
-            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
-            Assert.False(value.Has(ChannelPermission.Connect));
-            Assert.False(value.Has(ChannelPermission.Speak));
-            Assert.False(value.Has(ChannelPermission.MuteMembers));
-            Assert.False(value.Has(ChannelPermission.DeafenMembers));
-            Assert.False(value.Has(ChannelPermission.MoveMembers));
-            Assert.False(value.Has(ChannelPermission.UseVAD));
+            TestHelper(value, ChannelPermission.CreateInstantInvite, false);
+            TestHelper(value, ChannelPermission.ManageChannels, false);
+            TestHelper(value, ChannelPermission.AddReactions, false);
+            TestHelper(value, ChannelPermission.ViewChannel, false);
+            TestHelper(value, ChannelPermission.SendMessages, false);
+            TestHelper(value, ChannelPermission.SendTTSMessages, false);
+            TestHelper(value, ChannelPermission.ManageMessages, false);
+            TestHelper(value, ChannelPermission.EmbedLinks, false);
+            TestHelper(value, ChannelPermission.AttachFiles, false);
+            TestHelper(value, ChannelPermission.ReadMessageHistory, false);
+            TestHelper(value, ChannelPermission.MentionEveryone, false);
+            TestHelper(value, ChannelPermission.UseExternalEmojis, false);
+            TestHelper(value, ChannelPermission.ManageRoles, false);
+            TestHelper(value, ChannelPermission.ManageWebhooks, false);
+            TestHelper(value, ChannelPermission.Connect, false);
+            TestHelper(value, ChannelPermission.Speak, false);
+            TestHelper(value, ChannelPermission.MuteMembers, false);
+            TestHelper(value, ChannelPermission.DeafenMembers, false);
+            TestHelper(value, ChannelPermission.MoveMembers, false);
+            TestHelper(value, ChannelPermission.UseVAD, false);
 
             return Task.CompletedTask;
         }
@@ -92,26 +115,26 @@ namespace Discord
             // check that none will fail all
             var value = ChannelPermissions.DM;
 
-            Assert.False(value.Has(ChannelPermission.CreateInstantInvite));
-            Assert.False(value.Has(ChannelPermission.ManageChannels));
-            Assert.False(value.Has(ChannelPermission.AddReactions));
-            Assert.True(value.Has(ChannelPermission.ViewChannel));
-            Assert.True(value.Has(ChannelPermission.SendMessages));
-            Assert.False(value.Has(ChannelPermission.SendTTSMessages));
-            Assert.False(value.Has(ChannelPermission.ManageMessages));
-            Assert.True(value.Has(ChannelPermission.EmbedLinks));
-            Assert.True(value.Has(ChannelPermission.AttachFiles));
-            Assert.True(value.Has(ChannelPermission.ReadMessageHistory));
-            Assert.False(value.Has(ChannelPermission.MentionEveryone));
-            Assert.True(value.Has(ChannelPermission.UseExternalEmojis));
-            Assert.False(value.Has(ChannelPermission.ManageRoles));
-            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
-            Assert.True(value.Has(ChannelPermission.Connect));
-            Assert.True(value.Has(ChannelPermission.Speak));
-            Assert.False(value.Has(ChannelPermission.MuteMembers));
-            Assert.False(value.Has(ChannelPermission.DeafenMembers));
-            Assert.False(value.Has(ChannelPermission.MoveMembers));
-            Assert.True(value.Has(ChannelPermission.UseVAD));
+            TestHelper(value, ChannelPermission.CreateInstantInvite, false);
+            TestHelper(value, ChannelPermission.ManageChannels, false);
+            TestHelper(value, ChannelPermission.AddReactions, false);
+            TestHelper(value, ChannelPermission.ViewChannel, true);
+            TestHelper(value, ChannelPermission.SendMessages, true);
+            TestHelper(value, ChannelPermission.SendTTSMessages, false);
+            TestHelper(value, ChannelPermission.ManageMessages, false);
+            TestHelper(value, ChannelPermission.EmbedLinks, true);
+            TestHelper(value, ChannelPermission.AttachFiles, true);
+            TestHelper(value, ChannelPermission.ReadMessageHistory, true);
+            TestHelper(value, ChannelPermission.MentionEveryone, false);
+            TestHelper(value, ChannelPermission.UseExternalEmojis, true);
+            TestHelper(value, ChannelPermission.ManageRoles, false);
+            TestHelper(value, ChannelPermission.ManageWebhooks, false);
+            TestHelper(value, ChannelPermission.Connect, true);
+            TestHelper(value, ChannelPermission.Speak,  true);
+            TestHelper(value, ChannelPermission.MuteMembers, false);
+            TestHelper(value, ChannelPermission.DeafenMembers, false);
+            TestHelper(value, ChannelPermission.MoveMembers, false);
+            TestHelper(value, ChannelPermission.UseVAD, true);
 
             return Task.CompletedTask;
         }
@@ -127,26 +150,26 @@ namespace Discord
         {
             var value = ChannelPermissions.Group;
 
-            Assert.False(value.Has(ChannelPermission.CreateInstantInvite));
-            Assert.False(value.Has(ChannelPermission.ManageChannels));
-            Assert.False(value.Has(ChannelPermission.AddReactions));
-            Assert.False(value.Has(ChannelPermission.ViewChannel));
-            Assert.True(value.Has(ChannelPermission.SendMessages));
-            Assert.True(value.Has(ChannelPermission.SendTTSMessages));
-            Assert.False(value.Has(ChannelPermission.ManageMessages));
-            Assert.True(value.Has(ChannelPermission.EmbedLinks));
-            Assert.True(value.Has(ChannelPermission.AttachFiles));
-            Assert.False(value.Has(ChannelPermission.ReadMessageHistory));
-            Assert.False(value.Has(ChannelPermission.MentionEveryone));
-            Assert.False(value.Has(ChannelPermission.UseExternalEmojis));
-            Assert.False(value.Has(ChannelPermission.ManageRoles));
-            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
-            Assert.True(value.Has(ChannelPermission.Connect));
-            Assert.True(value.Has(ChannelPermission.Speak));
-            Assert.False(value.Has(ChannelPermission.MuteMembers));
-            Assert.False(value.Has(ChannelPermission.DeafenMembers));
-            Assert.False(value.Has(ChannelPermission.MoveMembers));
-            Assert.True(value.Has(ChannelPermission.UseVAD));
+            TestHelper(value, ChannelPermission.CreateInstantInvite, false);
+            TestHelper(value, ChannelPermission.ManageChannels, false);
+            TestHelper(value, ChannelPermission.AddReactions, false);
+            TestHelper(value, ChannelPermission.ViewChannel, false);
+            TestHelper(value, ChannelPermission.SendMessages, true);
+            TestHelper(value, ChannelPermission.SendTTSMessages, true);
+            TestHelper(value, ChannelPermission.ManageMessages, false);
+            TestHelper(value, ChannelPermission.EmbedLinks, true);
+            TestHelper(value, ChannelPermission.AttachFiles, true);
+            TestHelper(value, ChannelPermission.ReadMessageHistory, false);
+            TestHelper(value, ChannelPermission.MentionEveryone, false);
+            TestHelper(value, ChannelPermission.UseExternalEmojis, false);
+            TestHelper(value, ChannelPermission.ManageRoles, false);
+            TestHelper(value, ChannelPermission.ManageWebhooks, false);
+            TestHelper(value, ChannelPermission.Connect, true);
+            TestHelper(value, ChannelPermission.Speak, true);
+            TestHelper(value, ChannelPermission.MuteMembers, false);
+            TestHelper(value, ChannelPermission.DeafenMembers, false);
+            TestHelper(value, ChannelPermission.MoveMembers, false);
+            TestHelper(value, ChannelPermission.UseVAD, true);
 
             return Task.CompletedTask;
         }
@@ -165,26 +188,26 @@ namespace Discord
             // make a flag with all possible values for Voice channel permissions
             var value = ChannelPermissions.Voice;
           
-            Assert.True(value.Has(ChannelPermission.CreateInstantInvite));
-            Assert.True(value.Has(ChannelPermission.ManageChannels));
-            Assert.False(value.Has(ChannelPermission.AddReactions));
-            Assert.False(value.Has(ChannelPermission.ViewChannel));
-            Assert.False(value.Has(ChannelPermission.SendMessages));
-            Assert.False(value.Has(ChannelPermission.SendTTSMessages));
-            Assert.False(value.Has(ChannelPermission.ManageMessages));
-            Assert.False(value.Has(ChannelPermission.EmbedLinks));
-            Assert.False(value.Has(ChannelPermission.AttachFiles));
-            Assert.False(value.Has(ChannelPermission.ReadMessageHistory));
-            Assert.False(value.Has(ChannelPermission.MentionEveryone));
-            Assert.False(value.Has(ChannelPermission.UseExternalEmojis));
-            Assert.True(value.Has(ChannelPermission.ManageRoles));
-            Assert.False(value.Has(ChannelPermission.ManageWebhooks));
-            Assert.True(value.Has(ChannelPermission.Connect));
-            Assert.True(value.Has(ChannelPermission.Speak));
-            Assert.True(value.Has(ChannelPermission.MuteMembers));
-            Assert.True(value.Has(ChannelPermission.DeafenMembers));
-            Assert.True(value.Has(ChannelPermission.MoveMembers));
-            Assert.True(value.Has(ChannelPermission.UseVAD));
+            TestHelper(value, ChannelPermission.CreateInstantInvite, true);
+            TestHelper(value, ChannelPermission.ManageChannels, true);
+            TestHelper(value, ChannelPermission.AddReactions, false);
+            TestHelper(value, ChannelPermission.ViewChannel, false);
+            TestHelper(value, ChannelPermission.SendMessages, false);
+            TestHelper(value, ChannelPermission.SendTTSMessages, false);
+            TestHelper(value, ChannelPermission.ManageMessages, false);
+            TestHelper(value, ChannelPermission.EmbedLinks, false);
+            TestHelper(value, ChannelPermission.AttachFiles, false);
+            TestHelper(value, ChannelPermission.ReadMessageHistory, false);
+            TestHelper(value, ChannelPermission.MentionEveryone, false);
+            TestHelper(value, ChannelPermission.UseExternalEmojis, false);
+            TestHelper(value, ChannelPermission.ManageRoles, true);
+            TestHelper(value, ChannelPermission.ManageWebhooks, false);
+            TestHelper(value, ChannelPermission.Connect, true);
+            TestHelper(value, ChannelPermission.Speak, true);
+            TestHelper(value, ChannelPermission.MuteMembers, true);
+            TestHelper(value, ChannelPermission.DeafenMembers, true);
+            TestHelper(value, ChannelPermission.MoveMembers, true);
+            TestHelper(value, ChannelPermission.UseVAD, true);
 
             return Task.CompletedTask;
         }
@@ -201,6 +224,34 @@ namespace Discord
         {
             var value = GuildPermissions.None;
 
+            TestHelper(value, GuildPermission.CreateInstantInvite, false);
+            TestHelper(value, GuildPermission.KickMembers, false);
+            TestHelper(value, GuildPermission.BanMembers, false);
+            TestHelper(value, GuildPermission.Administrator, false);
+            TestHelper(value, GuildPermission.ManageChannels, false);
+            TestHelper(value, GuildPermission.ManageGuild, false);
+            TestHelper(value, GuildPermission.AddReactions, false);
+            TestHelper(value, GuildPermission.ViewAuditLog, false);
+            TestHelper(value, GuildPermission.ReadMessages, false);
+            TestHelper(value, GuildPermission.SendMessages, false);
+            TestHelper(value, GuildPermission.SendTTSMessages, false);
+            TestHelper(value, GuildPermission.ManageMessages, false);
+            TestHelper(value, GuildPermission.EmbedLinks, false);
+            TestHelper(value, GuildPermission.AttachFiles, false);
+            TestHelper(value, GuildPermission.ReadMessageHistory, false);
+            TestHelper(value, GuildPermission.MentionEveryone, false);
+            TestHelper(value, GuildPermission.UseExternalEmojis, false);
+            TestHelper(value, GuildPermission.Connect, false);
+            TestHelper(value, GuildPermission.Speak, false);
+            TestHelper(value, GuildPermission.MuteMembers, false);
+            TestHelper(value, GuildPermission.MoveMembers, false);
+            TestHelper(value, GuildPermission.UseVAD, false);
+            TestHelper(value, GuildPermission.ChangeNickname, false);
+            TestHelper(value, GuildPermission.ManageNicknames, false);
+            TestHelper(value, GuildPermission.ManageRoles, false);
+            TestHelper(value, GuildPermission.ManageWebhooks, false);
+            TestHelper(value, GuildPermission.ManageEmojis, false);
+
             return Task.CompletedTask;
         }
 
@@ -216,6 +267,35 @@ namespace Discord
         {
             var value = GuildPermissions.All;
 
+            TestHelper(value, GuildPermission.CreateInstantInvite, true);
+            TestHelper(value, GuildPermission.KickMembers, true);
+            TestHelper(value, GuildPermission.BanMembers, true);
+            TestHelper(value, GuildPermission.Administrator, true);
+            TestHelper(value, GuildPermission.ManageChannels, true);
+            TestHelper(value, GuildPermission.ManageGuild, true);
+            TestHelper(value, GuildPermission.AddReactions, true);
+            TestHelper(value, GuildPermission.ViewAuditLog, true);
+            TestHelper(value, GuildPermission.ReadMessages, true);
+            TestHelper(value, GuildPermission.SendMessages, true);
+            TestHelper(value, GuildPermission.SendTTSMessages, true);
+            TestHelper(value, GuildPermission.ManageMessages, true);
+            TestHelper(value, GuildPermission.EmbedLinks, true);
+            TestHelper(value, GuildPermission.AttachFiles, true);
+            TestHelper(value, GuildPermission.ReadMessageHistory, true);
+            TestHelper(value, GuildPermission.MentionEveryone, true);
+            TestHelper(value, GuildPermission.UseExternalEmojis, true);
+            TestHelper(value, GuildPermission.Connect, true);
+            TestHelper(value, GuildPermission.Speak, true);
+            TestHelper(value, GuildPermission.MuteMembers, true);
+            TestHelper(value, GuildPermission.MoveMembers, true);
+            TestHelper(value, GuildPermission.UseVAD, true);
+            TestHelper(value, GuildPermission.ChangeNickname, true);
+            TestHelper(value, GuildPermission.ManageNicknames, true);
+            TestHelper(value, GuildPermission.ManageRoles, true);
+            TestHelper(value, GuildPermission.ManageWebhooks, true);
+            TestHelper(value, GuildPermission.ManageEmojis, true);
+
+
             return Task.CompletedTask;
         }
 
@@ -229,7 +309,35 @@ namespace Discord
         [Fact]
         public Task TestPermissionsHasGuildPermissionWebhook()
         {
-            var value = GuildPermissions.All;
+            var value = GuildPermissions.Webhook;
+
+            TestHelper(value, GuildPermission.CreateInstantInvite, false);
+            TestHelper(value, GuildPermission.KickMembers, false);
+            TestHelper(value, GuildPermission.BanMembers, false);
+            TestHelper(value, GuildPermission.Administrator, false);
+            TestHelper(value, GuildPermission.ManageChannels, false);
+            TestHelper(value, GuildPermission.ManageGuild, false);
+            TestHelper(value, GuildPermission.AddReactions, false);
+            TestHelper(value, GuildPermission.ViewAuditLog, false);
+            TestHelper(value, GuildPermission.ReadMessages, false);
+            TestHelper(value, GuildPermission.SendMessages, true);
+            TestHelper(value, GuildPermission.SendTTSMessages, true);
+            TestHelper(value, GuildPermission.ManageMessages, false);
+            TestHelper(value, GuildPermission.EmbedLinks, true);
+            TestHelper(value, GuildPermission.AttachFiles, true);
+            TestHelper(value, GuildPermission.ReadMessageHistory, false);
+            TestHelper(value, GuildPermission.MentionEveryone, false);
+            TestHelper(value, GuildPermission.UseExternalEmojis, false);
+            TestHelper(value, GuildPermission.Connect, false);
+            TestHelper(value, GuildPermission.Speak, false);
+            TestHelper(value, GuildPermission.MuteMembers, false);
+            TestHelper(value, GuildPermission.MoveMembers, false);
+            TestHelper(value, GuildPermission.UseVAD, false);
+            TestHelper(value, GuildPermission.ChangeNickname, false);
+            TestHelper(value, GuildPermission.ManageNicknames, false);
+            TestHelper(value, GuildPermission.ManageRoles, false);
+            TestHelper(value, GuildPermission.ManageWebhooks, false);
+            TestHelper(value, GuildPermission.ManageEmojis, false);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Added more tests to the `Permissions` class that tries to cover more of the methods than were already being tested. These are similar to the existing tests for `GuildPermissions` and `ChannelPermissions` but work more closely with `Permissions` by converting them to `ulong` raw values first.

Added tests for `OverwritePermissions` that checks that values are set correctly and that flags can be toggled correctly, including when both allow and deny are set for the same bit.

Tried to make tests fail with issue described in #965 but I was unable to find a case that broke the tests. Would appreciate input and any suggestions on making a test case for that. (CC: @FiniteReality )

My discord handle is `@ChrisJ#8703` should you need to ping/DM me.