### PR TITLE
Add Missing Parameter For WebSocket4Net Constructor

### DIFF
--- a/src/Discord.Net.Providers.WS4Net/Discord.Net.Providers.WS4Net.csproj
+++ b/src/Discord.Net.Providers.WS4Net/Discord.Net.Providers.WS4Net.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WebSocket4Net" Version="0.15.0" />
+    <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.Providers.WS4Net/WS4NetClient.cs
+++ b/src/Discord.Net.Providers.WS4Net/WS4NetClient.cs
@@ -66,7 +66,7 @@ namespace Discord.Net.Providers.WS4Net
             _cancelTokenSource = new CancellationTokenSource();
             _cancelToken = CancellationTokenSource.CreateLinkedTokenSource(_parentToken, _cancelTokenSource.Token).Token;
 
-            _client = new WS4NetSocket(host, customHeaderItems: _headers.ToList())
+            _client = new WS4NetSocket(host, "", customHeaderItems: _headers.ToList())
             {
                 EnableAutoSendPing = false,
                 NoDelay = true,


### PR DESCRIPTION
Due to changes with WebSocket4Net, new-ish versions need another parameter for the constructor in order to avoid the `MissingMethodException`. This Fixes that issue.

```
System.MissingMethodException: Method not found: 'Void WebSocket4Net.WebSocket..ctor(System.String, System.String, System.Collections.Generic.List`1<System.Collections.Generic.KeyValuePair`2<System.String,System.String>>, System.Collections.Generic.List`1<System.Collections.Generic.KeyValuePair`2<System.String,System.String>>, System.String, System.String, WebSocket4Net.WebSocketVersion, System.Net.EndPoint)'.
   at Discord.Net.Providers.WS4Net.WS4NetClient.<ConnectInternalAsync>d__21.MoveNext()
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
   at Discord.Net.Providers.WS4Net.WS4NetClient.ConnectInternalAsync(String host)
   at Discord.Net.Providers.WS4Net.WS4NetClient.<ConnectAsync>d__20.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.API.DiscordSocketApiClient.<ConnectInternalAsync>d__25.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Discord.API.DiscordSocketApiClient.<ConnectInternalAsync>d__25.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.API.DiscordSocketApiClient.<ConnectAsync>d__24.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.WebSocket.DiscordSocketClient.<OnConnectingAsync>d__93.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Discord.WebSocket.DiscordSocketClient.<OnConnectingAsync>d__93.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.ConnectionManager.<ConnectAsync>d__30.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.ConnectionManager.<>c__DisplayClass28_0.<<StartAsync>b__0>d.MoveNext()
15:11:43 Gateway     Disconnecting
15:11:43 Gateway     Disconnected
15:11:43 SteamCB     Steam connected!
15:11:44 Gateway     Connecting
15:11:44 Rest        GET gateway: 42.37 ms
15:11:44 Gateway     System.MissingMethodException: Method not found: 'Void WebSocket4Net.WebSocket..ctor(System.String, System.String, System.Collections.Generic.List`1<System.Collections.Generic.KeyValuePair`2<System.String,System.String>>, System.Collections.Generic.List`1<System.Collections.Generic.KeyValuePair`2<System.String,System.String>>, System.String, System.String, WebSocket4Net.WebSocketVersion, System.Net.EndPoint)'.
   at Discord.Net.Providers.WS4Net.WS4NetClient.<ConnectInternalAsync>d__21.MoveNext()
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
   at Discord.Net.Providers.WS4Net.WS4NetClient.ConnectInternalAsync(String host)
   at Discord.Net.Providers.WS4Net.WS4NetClient.<ConnectAsync>d__20.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.API.DiscordSocketApiClient.<ConnectInternalAsync>d__25.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Discord.API.DiscordSocketApiClient.<ConnectInternalAsync>d__25.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.API.DiscordSocketApiClient.<ConnectAsync>d__24.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.WebSocket.DiscordSocketClient.<OnConnectingAsync>d__93.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Discord.WebSocket.DiscordSocketClient.<OnConnectingAsync>d__93.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.ConnectionManager.<ConnectAsync>d__30.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Discord.ConnectionManager.<>c__DisplayClass28_0.<<StartAsync>b__0>d.MoveNext()
```