### PR TITLE
Allow nested ModuleBase classes to be built when declared from non-module classes.

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -48,11 +48,13 @@ namespace Discord.Commands
             /*if (!validTypes.Any())
                 throw new InvalidOperationException("Could not find any valid modules from the given selection");*/
 
+            var topLevelGroups = validTypes.Where(x => x.DeclaringType == null || !IsValidModuleDefinition(x.DeclaringType.GetTypeInfo()));
+
             var builtTypes = new List<TypeInfo>();
 
             var result = new Dictionary<Type, ModuleInfo>();
 
-            foreach (var typeInfo in validTypes)
+            foreach (var typeInfo in topLevelGroups)
             {
                 // TODO: This shouldn't be the case; may be safe to remove?
                 if (result.ContainsKey(typeInfo.AsType()))

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -48,14 +48,11 @@ namespace Discord.Commands
             /*if (!validTypes.Any())
                 throw new InvalidOperationException("Could not find any valid modules from the given selection");*/
 
-            var topLevelGroups = validTypes.Where(x => x.DeclaringType == null);
-            var subGroups = validTypes.Intersect(topLevelGroups);
-
             var builtTypes = new List<TypeInfo>();
 
             var result = new Dictionary<Type, ModuleInfo>();
 
-            foreach (var typeInfo in topLevelGroups)
+            foreach (var typeInfo in validTypes)
             {
                 // TODO: This shouldn't be the case; may be safe to remove?
                 if (result.ContainsKey(typeInfo.AsType()))


### PR DESCRIPTION
## Overview

This will allow a module such as:
```cs
public class Foo 
{
    public class Module : ModuleBase { }
}
```
to be built properly by the command service. This would previously prevent being able to use the command service in places where you're executing code contained within a wrapper class, such as in LINQPad, or if, for whatever organizational reason, you want to have a module be a nested class of a non-module.

