### PR TITLE
Add Spotify track support

### DIFF
--- a/src/Discord.Net.Core/Entities/Activities/Game.cs
+++ b/src/Discord.Net.Core/Entities/Activities/Game.cs
@@ -1,14 +1,15 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace Discord
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class Game : IActivity
     {
+        internal Game() { }
+
         public string Name { get; internal set; }
         public ActivityType Type { get; internal set; }
 
-        internal Game() { }
         public Game(string name, ActivityType type = ActivityType.Playing)
         {
             Name = name;

--- a/src/Discord.Net.Core/Entities/Activities/Game.cs
+++ b/src/Discord.Net.Core/Entities/Activities/Game.cs
@@ -5,11 +5,10 @@ namespace Discord
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class Game : IActivity
     {
-        internal Game() { }
-
         public string Name { get; internal set; }
         public ActivityType Type { get; internal set; }
 
+        internal Game() { }
         public Game(string name, ActivityType type = ActivityType.Playing)
         {
             Name = name;

--- a/src/Discord.Net.Core/Entities/Activities/GameAsset.cs
+++ b/src/Discord.Net.Core/Entities/Activities/GameAsset.cs
@@ -1,15 +1,15 @@
-﻿namespace Discord
+namespace Discord
 {
     public class GameAsset
     {
         internal GameAsset() { }
 
-        internal ulong ApplicationId { get; set; }
+        internal ulong? ApplicationId { get; set; }
         
         public string Text { get; internal set; }
         public string ImageId { get; internal set; }
         
         public string GetImageUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetRichAssetUrl(ApplicationId, ImageId, size, format);
+            => ApplicationId.HasValue ? CDN.GetRichAssetUrl(ApplicationId.Value, ImageId, size, format) : null;
     }
 }

--- a/src/Discord.Net.Core/Entities/Activities/RichGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/RichGame.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace Discord
 {
@@ -7,8 +7,8 @@ namespace Discord
     {
         internal RichGame() { }
 
-        public string Details { get; internal set;}
-        public string State { get; internal set;}
+        public string Details { get; internal set; }
+        public string State { get; internal set; }
         public ulong ApplicationId { get; internal set; }
         public GameAsset SmallAsset { get; internal set; }
         public GameAsset LargeAsset { get; internal set; }

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -7,8 +7,6 @@ namespace Discord
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SpotifyGame : Game
     {
-        internal SpotifyGame() { }
-
         public string[] Artists { get; internal set; }
         public string AlbumArt { get; internal set; }
         public string AlbumTitle { get; internal set; }
@@ -16,6 +14,8 @@ namespace Discord
         public string SyncId { get; internal set; }
         public string SessionId { get; internal set; }
         public TimeSpan? Duration { get; internal set; }
+
+        internal SpotifyGame() { }
 
         public override string ToString() => Name;
         private string DebuggerDisplay => $"{Name} (Spotify)";

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+
+namespace Discord
+{
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class SpotifyGame : Game
+    {
+        internal SpotifyGame() { }
+
+        public string TrackTitle { get; internal set; }
+        public string TrackAlbum { get; internal set; }
+        public string SyncId { get; internal set; }
+        public string SessionId { get; internal set; }
+
+        public override string ToString() => Name;
+        private string DebuggerDisplay => $"{Name} (Spotify)";
+    }
+}

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -9,11 +9,12 @@ namespace Discord
     {
         internal SpotifyGame() { }
 
+        public string[] Artists { get; internal set; }
+        public string AlbumArt { get; internal set; }
+        public string AlbumTitle { get; internal set; }
         public string TrackTitle { get; internal set; }
-        public string TrackAlbum { get; internal set; }
         public string SyncId { get; internal set; }
         public string SessionId { get; internal set; }
-        public string[] Artists { get; internal set; }
         public TimeSpan? Duration { get; internal set; }
 
         public override string ToString() => Name;

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Discord
@@ -11,6 +12,7 @@ namespace Discord
         public string TrackAlbum { get; internal set; }
         public string SyncId { get; internal set; }
         public string SessionId { get; internal set; }
+        public string[] Artists { get; internal set; }
 
         public override string ToString() => Name;
         private string DebuggerDisplay => $"{Name} (Spotify)";

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -13,6 +14,7 @@ namespace Discord
         public string SyncId { get; internal set; }
         public string SessionId { get; internal set; }
         public string[] Artists { get; internal set; }
+        public TimeSpan? Duration { get; internal set; }
 
         public override string ToString() => Name;
         private string DebuggerDisplay => $"{Name} (Spotify)";

--- a/src/Discord.Net.Rest/API/Common/Game.cs
+++ b/src/Discord.Net.Rest/API/Common/Game.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System.Runtime.Serialization;
@@ -29,6 +29,10 @@ namespace Discord.API
         public Optional<API.GameTimestamps> Timestamps { get; set; }
         [JsonProperty("instance")]
         public Optional<bool> Instance { get; set; }
+        [JsonProperty("sync_id")]
+        public Optional<string> SyncId { get; set; }
+        [JsonProperty("session_id")]
+        public Optional<string> SessionId { get; set; }
 
         [OnError]
         internal void OnError(StreamingContext context, ErrorContext errorContext)

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1294,7 +1294,7 @@ namespace Discord.WebSocket
                             case "PRESENCE_UPDATE":
                                 {
                                     await _gatewayLogger.DebugAsync("Received Dispatch (PRESENCE_UPDATE)").ConfigureAwait(false);
-
+                                    await _gatewayLogger.DebugAsync(payload.ToString());
                                     var data = (payload as JToken).ToObject<API.Presence>(_serializer);
 
                                     if (data.GuildId.IsSpecified)

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1294,7 +1294,7 @@ namespace Discord.WebSocket
                             case "PRESENCE_UPDATE":
                                 {
                                     await _gatewayLogger.DebugAsync("Received Dispatch (PRESENCE_UPDATE)").ConfigureAwait(false);
-                                    await _gatewayLogger.DebugAsync(payload.ToString());
+
                                     var data = (payload as JToken).ToObject<API.Presence>(_serializer);
 
                                     if (data.GuildId.IsSpecified)

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -55,7 +55,7 @@ namespace Discord.WebSocket
         }
 
         // (Small, Large)
-        public static GameAsset[] ToEntity(this API.GameAssets model, ulong appId = 0)
+        public static GameAsset[] ToEntity(this API.GameAssets model, ulong? appId = null)
         {
             return new GameAsset[]
             {

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -7,8 +7,15 @@ namespace Discord.WebSocket
             // Spotify Game
             if (model.SyncId.IsSpecified)
             {
-                return new SpotifyGame()
+                var assets = model.Assets.GetValueOrDefault()?.ToEntity();
+                return new SpotifyGame
                 {
+                    Name = model.Name,
+                    SessionId = model.SessionId.GetValueOrDefault(),
+                    SyncId = model.SyncId.Value,
+                    TrackAlbum = assets?[1]?.Text,
+                    TrackTitle = model.Details.GetValueOrDefault(),
+                    Artists = model.State.GetValueOrDefault()?.Split(';')
                 };
             }
 

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -4,6 +4,14 @@ namespace Discord.WebSocket
     {
         public static IActivity ToEntity(this API.Game model)
         {
+            // Spotify Game
+            if (model.SyncId.IsSpecified)
+            {
+                return new SpotifyGame()
+                {
+                };
+            }
+
             // Rich Game
             if (model.ApplicationId.IsSpecified)
             {

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -20,7 +20,8 @@ namespace Discord.WebSocket
                     TrackTitle = model.Details.GetValueOrDefault(),
                     Artists = model.State.GetValueOrDefault()?.Split(';'),
                     Duration = timestamps?.End - timestamps?.Start,
-                    AlbumArt = albumArtId != null ? $"https://i.scdn.co/image/{albumArtId}" : null ,
+                    AlbumArt = albumArtId != null ? $"https://i.scdn.co/image/{albumArtId}" : null,
+                    Type = ActivityType.Listening
                 };
             }
 

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -8,6 +8,7 @@ namespace Discord.WebSocket
             if (model.SyncId.IsSpecified)
             {
                 var assets = model.Assets.GetValueOrDefault()?.ToEntity();
+                var timestamps = model.Timestamps.IsSpecified ? model.Timestamps.Value.ToEntity() : null;
                 return new SpotifyGame
                 {
                     Name = model.Name,
@@ -15,7 +16,8 @@ namespace Discord.WebSocket
                     SyncId = model.SyncId.Value,
                     TrackAlbum = assets?[1]?.Text,
                     TrackTitle = model.Details.GetValueOrDefault(),
-                    Artists = model.State.GetValueOrDefault()?.Split(';')
+                    Artists = model.State.GetValueOrDefault()?.Split(';'),
+                    Duration = timestamps?.End - timestamps?.Start
                 };
             }
 

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -8,16 +8,19 @@ namespace Discord.WebSocket
             if (model.SyncId.IsSpecified)
             {
                 var assets = model.Assets.GetValueOrDefault()?.ToEntity();
+                string albumText = assets?[1]?.Text;
+                string albumArtId = assets?[1]?.ImageId?.Replace("spotify:","");
                 var timestamps = model.Timestamps.IsSpecified ? model.Timestamps.Value.ToEntity() : null;
                 return new SpotifyGame
                 {
                     Name = model.Name,
                     SessionId = model.SessionId.GetValueOrDefault(),
                     SyncId = model.SyncId.Value,
-                    TrackAlbum = assets?[1]?.Text,
+                    AlbumTitle = albumText,
                     TrackTitle = model.Details.GetValueOrDefault(),
                     Artists = model.State.GetValueOrDefault()?.Split(';'),
-                    Duration = timestamps?.End - timestamps?.Start
+                    Duration = timestamps?.End - timestamps?.Start,
+                    AlbumArt = albumArtId != null ? $"https://i.scdn.co/image/{albumArtId}" : null ,
                 };
             }
 
@@ -25,7 +28,7 @@ namespace Discord.WebSocket
             if (model.ApplicationId.IsSpecified)
             {
                 ulong appId = model.ApplicationId.Value;
-                var assets = model.Assets.GetValueOrDefault()?.ToEntity();
+                var assets = model.Assets.GetValueOrDefault()?.ToEntity(appId);
                 return new RichGame
                 {
                     ApplicationId = appId,
@@ -51,17 +54,19 @@ namespace Discord.WebSocket
         }
 
         // (Small, Large)
-        public static GameAsset[] ToEntity(this API.GameAssets model)
+        public static GameAsset[] ToEntity(this API.GameAssets model, ulong appId = 0)
         {
             return new GameAsset[]
             {
                 model.SmallImage.IsSpecified ? new GameAsset
                 {
+                    ApplicationId = appId,
                     ImageId = model.SmallImage.GetValueOrDefault(),
                     Text = model.SmallText.GetValueOrDefault()
                 } : null,
                 model.LargeImage.IsSpecified ? new GameAsset
                 {
+                    ApplicationId = appId,
                     ImageId = model.LargeImage.GetValueOrDefault(),
                     Text = model.LargeText.GetValueOrDefault()
                 } : null,

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -16,7 +16,7 @@ namespace Discord.WebSocket
             if (model.ApplicationId.IsSpecified)
             {
                 ulong appId = model.ApplicationId.Value;
-                var assets = model.Assets.GetValueOrDefault()?.ToEntity(appId);
+                var assets = model.Assets.GetValueOrDefault()?.ToEntity();
                 return new RichGame
                 {
                     ApplicationId = appId,
@@ -42,19 +42,17 @@ namespace Discord.WebSocket
         }
 
         // (Small, Large)
-        public static GameAsset[] ToEntity(this API.GameAssets model, ulong appId)
+        public static GameAsset[] ToEntity(this API.GameAssets model)
         {
             return new GameAsset[]
             {
                 model.SmallImage.IsSpecified ? new GameAsset
                 {
-                    ApplicationId = appId,
                     ImageId = model.SmallImage.GetValueOrDefault(),
                     Text = model.SmallText.GetValueOrDefault()
                 } : null,
                 model.LargeImage.IsSpecified ? new GameAsset
                 {
-                    ApplicationId = appId,
                     ImageId = model.LargeImage.GetValueOrDefault(),
                     Text = model.LargeText.GetValueOrDefault()
                 } : null,


### PR DESCRIPTION
This PR: 
1. Implements rudimentary `SpotifyGame` support
2. Sets a default `appId` value for `GameAssets` because Spotify does not return an application ID (not during my testing anyways)

There is one thing I'm unsure about, though, that is the inclusion of Spotify CDN URL. Discord does not appear to host the album image, which makes sense, but that requires us to use Spotify CDN to get the album URL. Should we include the full album URL, or just the track ID?