### PR TITLE
 Allow replacing a default TypeReader globally 

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -264,11 +264,12 @@ namespace Discord.Commands
             return null;
         }
         public void ReplaceDefaultTypereader<T>(TypeReader reader)
+            => ReplaceDefaultTypereader(typeof(T), reader);
+        public void ReplaceDefaultTypereader(Type type, TypeReader reader)
         {
-            var key = typeof(T);
-            if (_defaultTypeReaders.ContainsKey(key))
+            if (_defaultTypeReaders.ContainsKey(type))
             {
-                _defaultTypeReaders.AddOrUpdate(key, k => throw new Exception("This shouldn't happen?"), (k, v) => reader);
+                _defaultTypeReaders.AddOrUpdate(type, k => throw new Exception("This shouldn't happen?"), (k, v) => reader);
             }
         }
 

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -263,6 +263,14 @@ namespace Discord.Commands
             }
             return null;
         }
+        public void ReplaceDefaultTypereader<T>(TypeReader reader)
+        {
+            var key = typeof(T);
+            if (_defaultTypeReaders.ContainsKey(key))
+            {
+                _defaultTypeReaders.AddOrUpdate(key, k => throw new Exception("This shouldn't happen?"), (k, v) => reader);
+            }
+        }
 
         //Execution
         public SearchResult Search(ICommandContext context, int argPos)


### PR DESCRIPTION
With Paulo's critique on the latest merge, here's a method to replace a built-in TypeReader whole-sale.