### PR TITLE
Added the ability to get the default avatar

### DIFF
--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -4,16 +4,17 @@ namespace Discord
 {
     public class DiscordConfig
     {
-        public const int APIVersion = 6;        
+        public const int APIVersion = 6;
         public static string Version { get; } =
             typeof(DiscordConfig).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
-            typeof(DiscordConfig).GetTypeInfo().Assembly.GetName().Version.ToString(3) ?? 
+            typeof(DiscordConfig).GetTypeInfo().Assembly.GetName().Version.ToString(3) ??
             "Unknown";
 
         public static string UserAgent { get; } = $"DiscordBot (https://github.com/RogueException/Discord.Net, v{Version})";
         public static readonly string APIUrl = $"https://discordapp.com/api/v{APIVersion}/";
         public const string CDNUrl = "https://cdn.discordapp.com/";
         public const string InviteUrl = "https://discord.gg/";
+        public const string MainUrl = "https://discordapp.com/";
 
         public const int DefaultRequestTimeout = 15000;
         public const int MaxMessageSize = 2000;
@@ -23,7 +24,7 @@ namespace Discord
 
         /// <summary> Gets or sets how a request should act in the case of an error, by default. </summary>
         public RetryMode DefaultRetryMode { get; set; } = RetryMode.AlwaysRetry;
-        
+
         /// <summary> Gets or sets the minimum log level severity that will be sent to the Log event. </summary>
         public LogSeverity LogLevel { get; set; } = LogSeverity.Info;
 

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -6,6 +6,10 @@ namespace Discord
     {
         /// <summary> Gets the id of this user's avatar. </summary>
         string AvatarId { get; }
+        /// <summary> Gets the url to this user's default avatar. </summary>
+        string GetDefaultAvatarUrl();
+        /// <summary> Gets the url to this user's custom avatar, if set. </summary>
+        string GetCustomAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary> Gets the url to this user's avatar. </summary>
         string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary> Gets the per-username unique id for this user. </summary>

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -57,8 +57,25 @@ namespace Discord.Rest
         public Task<RestDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null)
             => UserHelper.CreateDMChannelAsync(this, Discord, options);
 
-        public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+        public string GetCustomAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+
+        public string GetDefaultAvatarUrl()
+        {
+            switch (DiscriminatorValue % 5)
+            {
+                case 0: return DiscordConfig.MainUrl + "assets/6debd47ed13483642cf09e832ed0bc1b.png";
+                case 1: return DiscordConfig.MainUrl + "assets/322c936a8c8be1b803cd94861bdfa868.png";
+                case 2: return DiscordConfig.MainUrl + "assets/dd4dbc0016779df1378e7812eabaa04d.png";
+                case 3: return DiscordConfig.MainUrl + "assets/0e291f67c9274a1abdddeb3fd919cbaa.png";
+                case 4: return DiscordConfig.MainUrl + "assets/1cbd08c76f8af6dddce02c5138971129.png";
+            }
+        }
+
+        public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+        {
+            return GetCustomAvatarUrl(format, size) ?? GetDefaultAvatarUrl();
+        }
 
         public override string ToString() => $"{Username}#{Discriminator}";
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -37,29 +37,46 @@ namespace Discord.WebSocket
             {
                 var newVal = ushort.Parse(model.Discriminator.Value);
                 if (newVal != DiscriminatorValue)
-                { 
+                {
                     DiscriminatorValue = ushort.Parse(model.Discriminator.Value);
                     hasChanges = true;
                 }
             }
             if (model.Bot.IsSpecified && model.Bot.Value != IsBot)
-            { 
+            {
                 IsBot = model.Bot.Value;
                 hasChanges = true;
             }
             if (model.Username.IsSpecified && model.Username.Value != Username)
-            { 
+            {
                 Username = model.Username.Value;
                 hasChanges = true;
             }
             return hasChanges;
-        } 
+        }
 
         public async Task<IDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null)
             => GlobalUser.DMChannel ?? await UserHelper.CreateDMChannelAsync(this, Discord, options) as IDMChannel;
 
-        public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+        public string GetCustomAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+
+        public string GetDefaultAvatarUrl()
+        {
+            switch (DiscriminatorValue % 5)
+            {
+                case 0: return DiscordConfig.MainUrl + "assets/6debd47ed13483642cf09e832ed0bc1b.png";
+                case 1: return DiscordConfig.MainUrl + "assets/322c936a8c8be1b803cd94861bdfa868.png";
+                case 2: return DiscordConfig.MainUrl + "assets/dd4dbc0016779df1378e7812eabaa04d.png";
+                case 3: return DiscordConfig.MainUrl + "assets/0e291f67c9274a1abdddeb3fd919cbaa.png";
+                case 4: return DiscordConfig.MainUrl + "assets/1cbd08c76f8af6dddce02c5138971129.png";
+            }
+        }
+
+        public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+        {
+            return GetCustomAvatarUrl(format, size) ?? GetDefaultAvatarUrl();
+        }
 
         public override string ToString() => $"{Username}#{Discriminator}";
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";


### PR DESCRIPTION
This PR fixes #971 and adds the ability to get the default avatar of a user. This may be a breaking change to some, if people are checking against the return value of `GetAvatarUrl`. It will ignore any parameters passed to the method if returning the default avatar.