### PR TITLE
Enforce a maximum value when parsing unix timestamps

### DIFF
--- a/src/Discord.Net.Rest/Net/Converters/OptionalConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/OptionalConverter.cs
@@ -18,15 +18,20 @@ namespace Discord.Net.Converters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            object obj;
+            T obj;
+            // custom converters need to be able to safely fail; move this check in here to prevent wasteful casting when parsing primitives
             if (_innerConverter != null)
-                obj = _innerConverter.ReadJson(reader, typeof(T), null, serializer);
+            {
+                object o = _innerConverter.ReadJson(reader, typeof(T), null, serializer);
+                if (o is Optional<T>)
+                    return o;
+
+                obj = (T)o;
+            }
             else
                 obj = serializer.Deserialize<T>(reader);
 
-            if (obj is Optional<T>)
-                return obj;
-            return new Optional<T>((T)obj);
+            return new Optional<T>(obj);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Discord.Net.Rest/Net/Converters/OptionalConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/OptionalConverter.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 
 namespace Discord.Net.Converters
@@ -18,12 +18,15 @@ namespace Discord.Net.Converters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            T obj;
+            object obj;
             if (_innerConverter != null)
-                obj = (T)_innerConverter.ReadJson(reader, typeof(T), null, serializer);
+                obj = _innerConverter.ReadJson(reader, typeof(T), null, serializer);
             else
                 obj = serializer.Deserialize<T>(reader);
-            return new Optional<T>(obj);
+
+            if (obj is Optional<T>)
+                return obj;
+            return new Optional<T>((T)obj);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Discord.Net.Rest/Net/Converters/UnixTimestampConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/UnixTimestampConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 
 namespace Discord.Net.Converters
@@ -11,13 +11,18 @@ namespace Discord.Net.Converters
         public override bool CanRead => true;
         public override bool CanWrite => true;
 
+        // 1e13 unix ms = year 2286
+        // necessary to prevent discord.js from sending values in the e15 and overflowing a DTO
+        private const long MaxSaneMs = 1_000_000_000_000_0;
+
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            // Discord doesn't validate if timestamps contain decimals or not
-            if (reader.Value is double d)
+            // Discord doesn't validate if timestamps contain decimals or not, and they also don't validate if timestamps are reasonably sized
+            if (reader.Value is double d && d < MaxSaneMs)
                 return new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero).AddMilliseconds(d);
-            long offset = (long)reader.Value;
-            return new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero).AddMilliseconds(offset);
+            else if (reader.Value is long l && l < MaxSaneMs)
+                return new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero).AddMilliseconds(l);
+            return Optional<DateTimeOffset>.Unspecified;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)


### PR DESCRIPTION
## Summary

This change allows inner Optional<T> converters to return an unspecified Optional<T>. UnixTimestampConverter utilizes this to implement a soft-cap on values it parses - when it receives a value too large, it will silently fail and leave the value unspecified, rather than throwing an exception and breaking the entire presence for the owning user.

### Changes

When unmarshaling a value into an `Optional<T>` with a specialized converter, we will now check whether or not the inner converter returned an `Optional<T>` itself. When an inner converter returns an Optional, we will return this value early.

The `UnixTimestampConverter` now enforces a maximum unix timestamp value of 10<sup>13</sup>ms. No well-intentioned timestamp sent should exceed this value: it falls in 2286. This is necessary to prevent timestamps from overflowing a DateTimeOffset and throwing an ArgumentException.

## Motivations

Since Discord does not implement any validation on their backend for activities, certain Rich Presence libraries (discord.js) are able to send unix timestamps in the 10<sup>16</sup>ms range, which are simply too large for our time library to handle correctly.

Currently, these timestamps throw an ArgumentException, which is fine, but also means that users' consoles will be spammed with countless errors if their bots are in any large public guilds.