### PR TITLE
Expose VoiceServerUpdate events

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -1,4 +1,3 @@
-using Discord.WebSocket.Entities.Guilds;
 using System;
 using System.Threading.Tasks;
 

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -165,7 +165,7 @@ namespace Discord.WebSocket
             remove { _userVoiceStateUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>> _userVoiceStateUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>>();
-        /// <summary> Fired when the bot connects/disconnects to a Discord voice server. </summary>
+        /// <summary> Fired when the bot connects to a Discord voice server. </summary>
         public event Func<SocketVoiceServer, Task> VoiceServerUpdated
         {
             add { _voiceServerUpdatedEvent.Add(value);  }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using Discord.WebSocket.Entities.Guilds;
+using System;
 using System.Threading.Tasks;
 
 namespace Discord.WebSocket
@@ -165,6 +166,13 @@ namespace Discord.WebSocket
             remove { _userVoiceStateUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>> _userVoiceStateUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketVoiceState, SocketVoiceState, Task>>();
+        /// <summary> Fired when the bot connects/disconnects to a Discord voice server. </summary>
+        public event Func<SocketVoiceServer, Task> VoiceServerUpdated
+        {
+            add { _voiceServerUpdatedEvent.Add(value);  }
+            remove { _voiceServerUpdatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketVoiceServer, Task>> _voiceServerUpdatedEvent = new AsyncEvent<Func<SocketVoiceServer, Task>>();
         /// <summary> Fired when the connected account is updated. </summary>
         public event Func<SocketSelfUser, SocketSelfUser, Task> CurrentUserUpdated {
             add { _selfUpdatedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -5,6 +5,7 @@ using Discord.Net.Converters;
 using Discord.Net.Udp;
 using Discord.Net.WebSockets;
 using Discord.Rest;
+using Discord.WebSocket.Entities.Guilds;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -1474,6 +1475,9 @@ namespace Discord.WebSocket
                                         await UnknownGuildAsync(type, data.GuildId).ConfigureAwait(false);
                                         return;
                                     }
+
+                                    SocketVoiceServer VoiceServer = new SocketVoiceServer(data.GuildId, data.Endpoint, data.Token);
+                                    await TimedInvokeAsync(_voiceServerUpdatedEvent, nameof(UserVoiceStateUpdated), VoiceServer).ConfigureAwait(false);
                                 }
                                 break;
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1465,7 +1465,7 @@ namespace Discord.WebSocket
                                     var data = (payload as JToken).ToObject<VoiceServerUpdateEvent>(_serializer);
                                     var guild = State.GetGuild(data.GuildId);
                                     var cacheable = new Cacheable<IGuild, ulong>(guild, data.GuildId, guild != null,
-                                        async () => (IGuild) await ApiClient.GetGuildAsync(data.GuildId));
+                                        async () => await ApiClient.GetGuildAsync(data.GuildId).ConfigureAwait(false) as IGuild);
 
                                     var voiceServer = new SocketVoiceServer(cacheable, data.GuildId, data.Endpoint, data.Token);
                                     await TimedInvokeAsync(_voiceServerUpdatedEvent, nameof(UserVoiceStateUpdated), voiceServer).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -5,7 +5,6 @@ using Discord.Net.Converters;
 using Discord.Net.Udp;
 using Discord.Net.WebSockets;
 using Discord.Rest;
-using Discord.WebSocket;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -5,7 +5,7 @@ using Discord.Net.Converters;
 using Discord.Net.Udp;
 using Discord.Net.WebSockets;
 using Discord.Rest;
-using Discord.WebSocket.Entities.Guilds;
+using Discord.WebSocket;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -1465,6 +1465,10 @@ namespace Discord.WebSocket
 
                                     var data = (payload as JToken).ToObject<VoiceServerUpdateEvent>(_serializer);
                                     var guild = State.GetGuild(data.GuildId);
+
+                                    var voiceServer = new Entities.Guilds.SocketVoiceServer(data.GuildId, data.Endpoint, data.Token);
+                                    await TimedInvokeAsync(_voiceServerUpdatedEvent, nameof(UserVoiceStateUpdated), voiceServer).ConfigureAwait(false);
+
                                     if (guild != null)
                                     {
                                         string endpoint = data.Endpoint.Substring(0, data.Endpoint.LastIndexOf(':'));
@@ -1476,8 +1480,6 @@ namespace Discord.WebSocket
                                         return;
                                     }
 
-                                    SocketVoiceServer VoiceServer = new SocketVoiceServer(data.GuildId, data.Endpoint, data.Token);
-                                    await TimedInvokeAsync(_voiceServerUpdatedEvent, nameof(UserVoiceStateUpdated), VoiceServer).ConfigureAwait(false);
                                 }
                                 break;
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1464,8 +1464,10 @@ namespace Discord.WebSocket
 
                                     var data = (payload as JToken).ToObject<VoiceServerUpdateEvent>(_serializer);
                                     var guild = State.GetGuild(data.GuildId);
+                                    var cacheable = new Cacheable<IGuild, ulong>(guild, data.GuildId, guild != null,
+                                        async () => (IGuild) await ApiClient.GetGuildAsync(data.GuildId));
 
-                                    var voiceServer = new SocketVoiceServer(data.GuildId, data.Endpoint, data.Token);
+                                    var voiceServer = new SocketVoiceServer(cacheable, data.GuildId, data.Endpoint, data.Token);
                                     await TimedInvokeAsync(_voiceServerUpdatedEvent, nameof(UserVoiceStateUpdated), voiceServer).ConfigureAwait(false);
 
                                     if (guild != null)

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1466,7 +1466,7 @@ namespace Discord.WebSocket
                                     var data = (payload as JToken).ToObject<VoiceServerUpdateEvent>(_serializer);
                                     var guild = State.GetGuild(data.GuildId);
 
-                                    var voiceServer = new Entities.Guilds.SocketVoiceServer(data.GuildId, data.Endpoint, data.Token);
+                                    var voiceServer = new SocketVoiceServer(data.GuildId, data.Endpoint, data.Token);
                                     await TimedInvokeAsync(_voiceServerUpdatedEvent, nameof(UserVoiceStateUpdated), voiceServer).ConfigureAwait(false);
 
                                     if (guild != null)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketVoiceServer.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketVoiceServer.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Discord.WebSocket.Entities.Guilds
+{
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class SocketVoiceServer
+    {
+        public ulong GuildId { get; private set; }
+        public string Endpoint { get; private set; }
+        public string Token { get; private set; }
+
+        internal SocketVoiceServer(ulong GuildId, string Endpoint, string Token)
+        {
+            this.GuildId = GuildId;
+            this.Endpoint = Endpoint;
+            this.Token = Token;
+        }
+    }
+}

--- a/src/Discord.Net.WebSocket/SocketVoiceServer.cs
+++ b/src/Discord.Net.WebSocket/SocketVoiceServer.cs
@@ -9,11 +9,13 @@ namespace Discord.WebSocket
         public string Endpoint { get; private set; }
         public string Token { get; private set; }
 
-        internal SocketVoiceServer(ulong GuildId, string Endpoint, string Token)
+        internal SocketVoiceServer(ulong guildId, string endpoint, string token)
         {
-            this.GuildId = GuildId;
-            this.Endpoint = Endpoint;
-            this.Token = Token;
+            GuildId = guildId;
+            Endpoint = endpoint;
+            Token = token;
         }
+
+        private string DebuggerDisplay => $"SocketVoiceServer ({GuildId})";
     }
 }

--- a/src/Discord.Net.WebSocket/SocketVoiceServer.cs
+++ b/src/Discord.Net.WebSocket/SocketVoiceServer.cs
@@ -5,17 +5,17 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketVoiceServer
     {
-        public ulong GuildId { get; private set; }
+        public Cacheable<IGuild, ulong> Guild { get; private set; }
         public string Endpoint { get; private set; }
         public string Token { get; private set; }
 
-        internal SocketVoiceServer(ulong guildId, string endpoint, string token)
+        internal SocketVoiceServer(Cacheable<IGuild, ulong> guild, ulong guildId, string endpoint, string token)
         {
-            GuildId = guildId;
+            Guild = guild;
             Endpoint = endpoint;
             Token = token;
         }
 
-        private string DebuggerDisplay => $"SocketVoiceServer ({GuildId})";
+        private string DebuggerDisplay => $"SocketVoiceServer ({Guild.Id})";
     }
 }

--- a/src/Discord.Net.WebSocket/SocketVoiceServer.cs
+++ b/src/Discord.Net.WebSocket/SocketVoiceServer.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 
-namespace Discord.WebSocket.Entities.Guilds
+namespace Discord.WebSocket
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketVoiceServer


### PR DESCRIPTION
Resolves #983 by exposing VoiceServerUpdates to the user.

This should not break any existing functionality within the lib, and adds an event that will be helpful in supporting external audio clients such as Lavalink.