### PR TITLE
Expose the internal entity type readers

### DIFF
--- a/src/Discord.Net.Commands/Readers/ChannelTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/ChannelTypeReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Commands
 {
-    internal class ChannelTypeReader<T> : TypeReader
+    public class ChannelTypeReader<T> : TypeReader
         where T : class, IChannel
     {
         public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)

--- a/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Discord.Commands
 {
-    internal class MessageTypeReader<T> : TypeReader
+    public class MessageTypeReader<T> : TypeReader
         where T : class, IMessage
     {
         public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)

--- a/src/Discord.Net.Commands/Readers/RoleTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/RoleTypeReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Commands
 {
-    internal class RoleTypeReader<T> : TypeReader
+    public class RoleTypeReader<T> : TypeReader
         where T : class, IRole
     {
         public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Commands
 {
-    internal class UserTypeReader<T> : TypeReader
+    public class UserTypeReader<T> : TypeReader
         where T : class, IUser
     {
         public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)

--- a/src/Discord.Net.Commands/Results/TypeReaderResult.cs
+++ b/src/Discord.Net.Commands/Results/TypeReaderResult.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Discord.Commands
 {
@@ -30,6 +31,9 @@ namespace Discord.Commands
         public string ErrorReason { get; }
 
         public bool IsSuccess => !Error.HasValue;
+        public object BestMatch => IsSuccess
+            ? (Values.Count == 1 ? Values.Single().Value : Values.OrderByDescending(v => v.Score).First().Value)
+            : throw new InvalidOperationException("TypeReaderResult was not successful.");
 
         private TypeReaderResult(IReadOnlyCollection<TypeReaderValue> values, CommandError? error, string errorReason)
         {


### PR DESCRIPTION
After some discussion in #941, I thought that this might be a favorable change.

I decided not to expose the Primitive, Enum, and Nullable readers since there seems to be a bit more complexity involved with those and it seems just too unlikely someone wants to piggyback off of the existing behavior outside of the entities.