### PR TITLE
Throw when attempting to modify a message not made by the current user

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -1,4 +1,4 @@
-﻿using Discord.API.Rest;
+using Discord.API.Rest;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -13,6 +13,9 @@ namespace Discord.Rest
         public static async Task<Model> ModifyAsync(IMessage msg, BaseDiscordClient client, Action<MessageProperties> func,
             RequestOptions options)
         {
+            if (msg.Author.Id != client.CurrentUser.Id)
+                throw new InvalidOperationException("Discord allows only the author of a message to change it.");
+
             var args = new MessageProperties();
             func(args);
             var apiArgs = new API.Rest.ModifyMessageParams

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -14,7 +14,7 @@ namespace Discord.Rest
             RequestOptions options)
         {
             if (msg.Author.Id != client.CurrentUser.Id)
-                throw new InvalidOperationException("Discord allows only the author of a message to change it.");
+                throw new InvalidOperationException("Only the author of a message may change it.");
 
             var args = new MessageProperties();
             func(args);

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -126,8 +126,6 @@ namespace Discord.Rest
 
         public async Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
         {
-            if (Author.Id != Discord.CurrentUser.Id)
-                throw new InvalidOperationException("Discord allows only the author of a message to change it.");
             var model = await MessageHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
             Update(model);
         }

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -126,6 +126,8 @@ namespace Discord.Rest
 
         public async Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
         {
+            if (Author.Id != Discord.CurrentUser.Id)
+                throw new InvalidOperationException("Discord allows only the author of a message to change it.");
             var model = await MessageHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
             Update(model);
         }

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Rest;
+using Discord.Rest;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -122,7 +122,11 @@ namespace Discord.WebSocket
         }
 
         public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
-            => MessageHelper.ModifyAsync(this, Discord, func, options);
+        {
+            if (Author.Id != Discord.CurrentUser.Id)
+                throw new InvalidOperationException("Discord allows only the author of a message to change it.");
+            return MessageHelper.ModifyAsync(this, Discord, func, options);
+        }
 
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
             => MessageHelper.AddReactionAsync(this, emote, Discord, options);

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -122,11 +122,7 @@ namespace Discord.WebSocket
         }
 
         public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
-        {
-            if (Author.Id != Discord.CurrentUser.Id)
-                throw new InvalidOperationException("Discord allows only the author of a message to change it.");
-            return MessageHelper.ModifyAsync(this, Discord, func, options);
-        }
+            => MessageHelper.ModifyAsync(this, Discord, func, options);
 
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
             => MessageHelper.AddReactionAsync(this, emote, Discord, options);


### PR DESCRIPTION
Too many times people forget that they cannot change the contents of another user's message, and we are not communicating that fact properly.