### PR TITLE
Allows command arguments to consist of only 'escaped' characters

### DIFF
--- a/src/Discord.Net.Commands/CommandParser.cs
+++ b/src/Discord.Net.Commands/CommandParser.cs
@@ -33,6 +33,13 @@ namespace Discord.Commands
                 else
                     c = '\0';
 
+                //If we're processing a remainder parameter, ignore all other logic
+                if (curParam != null && curParam.IsRemainder && curPos != endPos)
+                {
+                    argBuilder.Append(c);
+                    continue;
+                }
+
                 //If we're not currently processing one, are we starting the next argument yet?
                 if (curPart == ParserPart.None)
                 {
@@ -73,13 +80,6 @@ namespace Discord.Commands
                 if (c == '\\' && (curParam == null || !curParam.IsRemainder))
                 {
                     isEscaping = true;
-                    continue;
-                }
-
-                //If we're processing a remainder parameter, ignore all other logic
-                if (curParam != null && curParam.IsRemainder && curPos != endPos)
-                {
-                    argBuilder.Append(c);
                     continue;
                 }
 

--- a/src/Discord.Net.Commands/CommandParser.cs
+++ b/src/Discord.Net.Commands/CommandParser.cs
@@ -33,30 +33,6 @@ namespace Discord.Commands
                 else
                     c = '\0';
 
-                //If this character is escaped, skip it
-                if (isEscaping)
-                {
-                    if (curPos != endPos)
-                    {
-                        argBuilder.Append(c);
-                        isEscaping = false;
-                        continue;
-                    }
-                }
-                //Are we escaping the next character?
-                if (c == '\\' && (curParam == null || !curParam.IsRemainder))
-                {
-                    isEscaping = true;
-                    continue;
-                }
-
-                //If we're processing an remainder parameter, ignore all other logic
-                if (curParam != null && curParam.IsRemainder && curPos != endPos)
-                {
-                    argBuilder.Append(c);
-                    continue;
-                }
-
                 //If we're not currently processing one, are we starting the next argument yet?
                 if (curPart == ParserPart.None)
                 {
@@ -81,6 +57,30 @@ namespace Discord.Commands
                         }
                         curPart = ParserPart.Parameter;
                     }
+                }
+
+                //If this character is escaped, skip it
+                if (isEscaping)
+                {
+                    if (curPos != endPos)
+                    {
+                        argBuilder.Append(c);
+                        isEscaping = false;
+                        continue;
+                    }
+                }
+                //Are we escaping the next character?
+                if (c == '\\' && (curParam == null || !curParam.IsRemainder))
+                {
+                    isEscaping = true;
+                    continue;
+                }
+
+                //If we're processing a remainder parameter, ignore all other logic
+                if (curParam != null && curParam.IsRemainder && curPos != endPos)
+                {
+                    argBuilder.Append(c);
+                    continue;
                 }
 
                 //Has this parameter ended yet?


### PR DESCRIPTION
Say, we have a command that looks like this:
```cs
[Command("test")]
public Task TestAsync(string parameter)
    => ReplyAsync(parameter);
```
Our prefix will be an exclamation mark.
Invoking it as `!test :x:` will work perfectly fine, but invoking it as `!test \:x:` will fail, returning a ParseResult with the error message: `The input text has too few parameters.`.
Also, invoking commands this way with `params T[] parameters` will invoke the actual command, but with an empty array.

I tested it after my changes, and it seemed to work as expected.

~~I hope I don't break the lib with this.~~