### PR TITLE
Add method to handle default avatars

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -13,6 +13,8 @@ namespace Discord
             string extension = FormatToExtension(format, avatarId);
             return $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.{extension}?size={size}";
         }
+        public static string GetUserDefaultAvatarUrl(ushort discriminator)
+            => $"{DiscordConfig.CDNUrl}embed/avatars/{discriminator % 5}.png";
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
         public static string GetGuildSplashUrl(ulong guildId, string splashId)

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -6,8 +6,13 @@ namespace Discord
     {
         /// <summary> Gets the id of this user's avatar. </summary>
         string AvatarId { get; }
-        /// <summary> Gets the url to this user's avatar. </summary>
+        /// <summary> Gets the url to this user's avatar or null if it's the default one. </summary>
         string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
+        /// <summary>
+        /// <para>Gets the url to this user's avatar or the default one if he doesn't have a custom one.</para>
+        /// <para>The default avatar image is a 256x256 PNG.</para>
+        /// </summary>
+        string GetAvatarUrlOrDefault(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary> Gets the per-username unique id for this user. </summary>
         string Discriminator { get; }
         /// <summary> Gets the per-username unique id for this user. </summary>

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Model = Discord.API.User;
@@ -59,6 +59,9 @@ namespace Discord.Rest
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+
+        public string GetAvatarUrlOrDefault(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetUserAvatarUrl(Id, AvatarId, size, format) ?? CDN.GetUserDefaultAvatarUrl(DiscriminatorValue);
 
         public override string ToString() => $"{Username}#{Discriminator}";
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Rest;
+using Discord.Rest;
 using System;
 using System.Threading.Tasks;
 using Model = Discord.API.User;
@@ -60,6 +60,9 @@ namespace Discord.WebSocket
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+
+        public string GetAvatarUrlOrDefault(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetUserAvatarUrl(Id, AvatarId, size, format) ?? CDN.GetUserDefaultAvatarUrl(DiscriminatorValue);
 
         public override string ToString() => $"{Username}#{Discriminator}";
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";


### PR DESCRIPTION
## Summary
This PR aims to facilitate getting the user's avatar without changing the behaviour of the current `GetAvatarUrl`, adressing #971 .
I couldn't think a use case that would warrant to get the user's default url without checking if they didn't have a custom one already directly from `IUser`, but it's still possible to do it with the CDN static method.

## Changes
- Added `IUser.GetAvatarUrlOrDefault`: returns the user's avatar url or the default one if they don't have one.
- Added `CDN.GetUserDefaultAvatarUrl`: returns the user's default avatar url

\#contest :^)
