### PR TITLE
Fix #995, Move Category Implementation from IGuildChannel to INestedChannel

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/ICategoryChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ICategoryChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -9,10 +9,6 @@ namespace Discord
         /// <summary> Gets the position of this channel in the guild's channel list, relative to others of the same type. </summary>
         int Position { get; }
 
-        /// <summary> Gets the parentid (category) of this channel in the guild's channel list. </summary>
-        ulong? CategoryId { get; }
-        /// <summary> Gets the parent channel (category) of this channel. </summary>
-        Task<ICategoryChannel> GetCategoryAsync();
         /// <summary> Gets the guild this channel is a member of. </summary>
         IGuild Guild { get; }
         /// <summary> Gets the id of the guild this channel is a member of. </summary>

--- a/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    /// <summary>
+    /// A type of guild channel that can be nested within a category.
+    /// Contains a CategoryId that is set to the parent category, if it is set.
+    /// </summary>
+    public interface INestedChannel : IGuildChannel
+    {
+        /// <summary> Gets the parentid (category) of this channel in the guild's channel list. </summary>
+        ulong? CategoryId { get; }
+        /// <summary> Gets the parent channel (category) of this channel, if it is set. If unset, returns null.</summary>
+        Task<ICategoryChannel> GetCategoryAsync();
+    }
+}

--- a/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
@@ -11,6 +11,6 @@ namespace Discord
         /// <summary> Gets the parentid (category) of this channel in the guild's channel list. </summary>
         ulong? CategoryId { get; }
         /// <summary> Gets the parent channel (category) of this channel, if it is set. If unset, returns null.</summary>
-        Task<ICategoryChannel> GetCategoryAsync();
+        Task<ICategoryChannel> GetCategoryAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Discord

--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface ITextChannel : IMessageChannel, IMentionable, IGuildChannel, INestedChannel
+    public interface ITextChannel : IMessageChannel, IMentionable, INestedChannel
     {
         /// <summary> Checks if the channel is NSFW. </summary>
         bool IsNsfw { get; }

--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface ITextChannel : IMessageChannel, IMentionable, IGuildChannel
+    public interface ITextChannel : IMessageChannel, IMentionable, IGuildChannel, INestedChannel
     {
         /// <summary> Checks if the channel is NSFW. </summary>
         bool IsNsfw { get; }

--- a/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface IVoiceChannel : IGuildChannel, IAudioChannel
+    public interface IVoiceChannel : IGuildChannel, IAudioChannel, INestedChannel
     {
         /// <summary> Gets the bitrate, in bits per second, clients in this voice channel are requested to use. </summary>
         int Bitrate { get; }

--- a/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface IVoiceChannel : IGuildChannel, IAudioChannel, INestedChannel
+    public interface IVoiceChannel : INestedChannel, IAudioChannel
     {
         /// <summary> Gets the bitrate, in bits per second, clients in this voice channel are requested to use. </summary>
         int Bitrate { get; }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -313,6 +313,16 @@ namespace Discord.Rest
             return models.Select(x => RestWebhook.Create(client, channel, x))
                 .ToImmutableArray();
         }
+        // Categories
+        public static async Task<ICategoryChannel> GetCategoryAsync(INestedChannel channel, BaseDiscordClient client, RequestOptions options)
+        {
+            // if no category id specified, return null
+            if (!channel.CategoryId.HasValue)
+                return null;
+            // CategoryId will contain a value here
+            var model = await client.ApiClient.GetChannelAsync(channel.CategoryId.Value, options).ConfigureAwait(false);
+            return RestCategoryChannel.Create(client, model) as ICategoryChannel;
+        }
 
         //Helpers
         private static IUser GetAuthor(BaseDiscordClient client, IGuild guild, UserModel model, ulong? webhookId)

--- a/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
@@ -25,8 +25,17 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Name} ({Id}, Category)";
 
         // IGuildChannel
+
+        /// <summary>
+        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
+        /// </summary>
+        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
         ulong? IGuildChannel.CategoryId
             => throw new NotSupportedException();
+        /// <summary>
+        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
+        /// </summary>
+        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
         Task<ICategoryChannel> IGuildChannel.GetCategoryAsync()
             => throw new NotSupportedException();
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
@@ -25,23 +25,6 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Name} ({Id}, Category)";
 
         // IGuildChannel
-
-        /// <summary>
-        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
-        /// </summary>
-        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
-        ulong? IGuildChannel.CategoryId
-            => throw new NotSupportedException();
-        /// <summary>
-        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
-        /// </summary>
-        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
-        Task<ICategoryChannel> IGuildChannel.GetCategoryAsync()
-            => throw new NotSupportedException();
-        IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
-            => throw new NotSupportedException();
-        Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
-            => throw new NotSupportedException();
         Task<IInviteMetadata> IGuildChannel.CreateInviteAsync(int? maxAge, int? maxUses, bool isTemporary, bool isUnique, RequestOptions options)
             => throw new NotSupportedException();
         Task<IReadOnlyCollection<IInviteMetadata>> IGuildChannel.GetInvitesAsync(RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -25,6 +25,8 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Name} ({Id}, Category)";
 
         // IGuildChannel
+        ulong? IGuildChannel.CategoryId
+            => throw new NotSupportedException();
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
             => throw new NotSupportedException();
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
@@ -27,6 +27,8 @@ namespace Discord.Rest
         // IGuildChannel
         ulong? IGuildChannel.CategoryId
             => throw new NotSupportedException();
+        Task<ICategoryChannel> IGuildChannel.GetCategoryAsync()
+            => throw new NotSupportedException();
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
             => throw new NotSupportedException();
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,6 +24,8 @@ namespace Discord.Rest
                 case ChannelType.DM:
                 case ChannelType.Group:
                     return CreatePrivate(discord, model) as RestChannel;
+                case ChannelType.Category:
+                    return RestCategoryChannel.Create(discord, new RestGuild(discord, model.GuildId.Value), model);
                 default:
                     return new RestChannel(discord, model.Id);
             }

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -34,7 +34,6 @@ namespace Discord.Rest
                 case ChannelType.Category:
                     return RestCategoryChannel.Create(discord, guild, model);
                 default:
-                    // TODO: Channel categories
                     return new RestGuildChannel(discord, guild, model.Id);
             }
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -16,7 +16,6 @@ namespace Discord.Rest
         internal IGuild Guild { get; }
         public string Name { get; private set; }
         public int Position { get; private set; }
-        public ulong? CategoryId { get; private set; }
         public ulong GuildId => Guild.Id;
 
         internal RestGuildChannel(BaseDiscordClient discord, IGuild guild, ulong id)
@@ -63,13 +62,6 @@ namespace Discord.Rest
         }
         public Task DeleteAsync(RequestOptions options = null)
             => ChannelHelper.DeleteAsync(this, Discord, options);
-
-        public async Task<ICategoryChannel> GetCategoryAsync()
-        {
-            if (CategoryId.HasValue)
-                return (await Guild.GetChannelAsync(CategoryId.Value).ConfigureAwait(false)) as ICategoryChannel;
-            return null;
-        }
 
         public OverwritePermissions? GetPermissionOverwrite(IUser user)
         {

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -9,9 +9,10 @@ using Model = Discord.API.Channel;
 namespace Discord.Rest
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class RestTextChannel : RestGuildChannel, IRestMessageChannel, ITextChannel
+    public class RestTextChannel : RestGuildChannel, IRestMessageChannel, ITextChannel, INestedChannel
     {
         public string Topic { get; private set; }
+        public ulong? CategoryId { get; private set; }
 
         public string Mention => MentionUtils.MentionChannel(Id);
 
@@ -167,6 +168,14 @@ namespace Discord.Rest
                 return GetUsersAsync(options);
             else
                 return AsyncEnumerable.Empty<IReadOnlyCollection<IGuildUser>>();
+        }
+
+        // INestedChannel
+        async Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+        {
+            if (CategoryId.HasValue)
+                return (await Guild.GetChannelAsync(CategoryId.Value).ConfigureAwait(false)) as ICategoryChannel;
+            return null;
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -175,10 +175,10 @@ namespace Discord.Rest
         }
 
         // INestedChannel
-        async Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+        async Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
         {
             if (CategoryId.HasValue)
-                return (await Guild.GetChannelAsync(CategoryId.Value).ConfigureAwait(false)) as ICategoryChannel;
+                return (await Guild.GetChannelAsync(CategoryId.Value, mode, options).ConfigureAwait(false)) as ICategoryChannel;
             return null;
         }
     }

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -32,7 +32,7 @@ namespace Discord.Rest
         internal override void Update(Model model)
         {
             base.Update(model);
-
+            CategoryId = model.CategoryId;
             Topic = model.Topic.Value;
             _nsfw = model.Nsfw.GetValueOrDefault();
         }
@@ -47,7 +47,7 @@ namespace Discord.Rest
             => ChannelHelper.GetUserAsync(this, Guild, Discord, id, options);
         public IAsyncEnumerable<IReadOnlyCollection<RestGuildUser>> GetUsersAsync(RequestOptions options = null)
             => ChannelHelper.GetUsersAsync(this, Guild, Discord, null, null, options);
-
+        
         public Task<RestMessage> GetMessageAsync(ulong id, RequestOptions options = null)
             => ChannelHelper.GetMessageAsync(this, Discord, id, options);
         public IAsyncEnumerable<IReadOnlyCollection<RestMessage>> GetMessagesAsync(int limit = DiscordConfig.MaxMessagesPerBatch, RequestOptions options = null)
@@ -84,6 +84,9 @@ namespace Discord.Rest
             => ChannelHelper.GetWebhookAsync(this, Discord, id, options);
         public Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
             => ChannelHelper.GetWebhooksAsync(this, Discord, options);
+    
+        public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
+            => ChannelHelper.GetCategoryAsync(this, Discord, options);
 
         private string DebuggerDisplay => $"{Name} ({Id}, Text)";
 
@@ -110,6 +113,7 @@ namespace Discord.Rest
             else
                 return AsyncEnumerable.Empty<IReadOnlyCollection<IMessage>>();
         }
+        
         IAsyncEnumerable<IReadOnlyCollection<IMessage>> IMessageChannel.GetMessagesAsync(ulong fromMessageId, Direction dir, int limit, CacheMode mode, RequestOptions options)
         {
             if (mode == CacheMode.AllowDownload)

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -92,11 +92,11 @@ namespace Discord.Rest
 
         //ITextChannel
         async Task<IWebhook> ITextChannel.CreateWebhookAsync(string name, Stream avatar, RequestOptions options)
-            => await CreateWebhookAsync(name, avatar, options);
+            => await CreateWebhookAsync(name, avatar, options).ConfigureAwait(false);
         async Task<IWebhook> ITextChannel.GetWebhookAsync(ulong id, RequestOptions options)
-            => await GetWebhookAsync(id, options);
+            => await GetWebhookAsync(id, options).ConfigureAwait(false);
         async Task<IReadOnlyCollection<IWebhook>> ITextChannel.GetWebhooksAsync(RequestOptions options)
-            => await GetWebhooksAsync(options);
+            => await GetWebhooksAsync(options).ConfigureAwait(false);
 
         //IMessageChannel
         async Task<IMessage> IMessageChannel.GetMessageAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -9,7 +9,7 @@ using Model = Discord.API.Channel;
 namespace Discord.Rest
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class RestTextChannel : RestGuildChannel, IRestMessageChannel, ITextChannel, INestedChannel
+    public class RestTextChannel : RestGuildChannel, IRestMessageChannel, ITextChannel
     {
         public string Topic { get; private set; }
         public ulong? CategoryId { get; private set; }

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -177,7 +177,7 @@ namespace Discord.Rest
         // INestedChannel
         async Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
         {
-            if (CategoryId.HasValue)
+            if (CategoryId.HasValue && mode == CacheMode.AllowDownload)
                 return (await Guild.GetChannelAsync(CategoryId.Value, mode, options).ConfigureAwait(false)) as ICategoryChannel;
             return null;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -9,7 +9,7 @@ using Model = Discord.API.Channel;
 namespace Discord.Rest
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class RestVoiceChannel : RestGuildChannel, IVoiceChannel, IRestAudioChannel, INestedChannel
+    public class RestVoiceChannel : RestGuildChannel, IVoiceChannel, IRestAudioChannel
     {
         public int Bitrate { get; private set; }
         public int? UserLimit { get; private set; }

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -39,6 +39,9 @@ namespace Discord.Rest
             Update(model);
         }
 
+        public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
+            => ChannelHelper.GetCategoryAsync(this, Discord, options);
+
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
 
         //IAudioChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -28,7 +28,7 @@ namespace Discord.Rest
         internal override void Update(Model model)
         {
             base.Update(model);
-
+            CategoryId = model.CategoryId;
             Bitrate = model.Bitrate.Value;
             UserLimit = model.UserLimit.Value != 0 ? model.UserLimit.Value : (int?)null;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -56,7 +56,7 @@ namespace Discord.Rest
         // INestedChannel
         async Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
         {
-            if (CategoryId.HasValue)
+            if (CategoryId.HasValue && mode == CacheMode.AllowDownload)
                 return (await Guild.GetChannelAsync(CategoryId.Value, mode, options).ConfigureAwait(false)) as ICategoryChannel;
             return null;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Audio;
+using Discord.Audio;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -9,10 +9,11 @@ using Model = Discord.API.Channel;
 namespace Discord.Rest
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class RestVoiceChannel : RestGuildChannel, IVoiceChannel, IRestAudioChannel
+    public class RestVoiceChannel : RestGuildChannel, IVoiceChannel, IRestAudioChannel, INestedChannel
     {
         public int Bitrate { get; private set; }
         public int? UserLimit { get; private set; }
+        public ulong? CategoryId { get; private set; }
 
         internal RestVoiceChannel(BaseDiscordClient discord, IGuild guild, ulong id)
             : base(discord, guild, id)
@@ -48,5 +49,13 @@ namespace Discord.Rest
             => Task.FromResult<IGuildUser>(null);
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
             => AsyncEnumerable.Empty<IReadOnlyCollection<IGuildUser>>();
+
+        // INestedChannel
+        async Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+        {
+            if (CategoryId.HasValue)
+                return (await Guild.GetChannelAsync(CategoryId.Value).ConfigureAwait(false)) as ICategoryChannel;
+            return null;
+        }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -54,10 +54,10 @@ namespace Discord.Rest
             => AsyncEnumerable.Empty<IReadOnlyCollection<IGuildUser>>();
 
         // INestedChannel
-        async Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+        async Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
         {
             if (CategoryId.HasValue)
-                return (await Guild.GetChannelAsync(CategoryId.Value).ConfigureAwait(false)) as ICategoryChannel;
+                return (await Guild.GetChannelAsync(CategoryId.Value, mode, options).ConfigureAwait(false)) as ICategoryChannel;
             return null;
         }
     }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
@@ -51,8 +51,17 @@ namespace Discord.WebSocket
         internal new SocketCategoryChannel Clone() => MemberwiseClone() as SocketCategoryChannel;
 
         // IGuildChannel
+
+        /// <summary>
+        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
+        /// </summary>
+        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
         ulong? IGuildChannel.CategoryId
             => throw new NotSupportedException();
+        /// <summary>
+        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
+        /// </summary>
+        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
         Task<ICategoryChannel> IGuildChannel.GetCategoryAsync()
             => throw new NotSupportedException();
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
@@ -51,6 +51,8 @@ namespace Discord.WebSocket
         internal new SocketCategoryChannel Clone() => MemberwiseClone() as SocketCategoryChannel;
 
         // IGuildChannel
+        ulong? IGuildChannel.CategoryId
+            => throw new NotSupportedException();
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
             => ImmutableArray.Create<IReadOnlyCollection<IGuildUser>>(Users).ToAsyncEnumerable();
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
@@ -20,7 +20,7 @@ namespace Discord.WebSocket
                ChannelPermission.ViewChannel)).ToImmutableArray();
 
         public IReadOnlyCollection<SocketGuildChannel> Channels
-            => Guild.Channels.Where(x => x is INestedChannel && (x as INestedChannel).CategoryId == Id).ToImmutableArray();
+            => Guild.Channels.Where(x => x is INestedChannel nestedChannel && nestedChannel.CategoryId == Id).ToImmutableArray();
 
         internal SocketCategoryChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
             : base(discord, id, guild)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
@@ -53,6 +53,8 @@ namespace Discord.WebSocket
         // IGuildChannel
         ulong? IGuildChannel.CategoryId
             => throw new NotSupportedException();
+        Task<ICategoryChannel> IGuildChannel.GetCategoryAsync()
+            => throw new NotSupportedException();
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
             => ImmutableArray.Create<IReadOnlyCollection<IGuildUser>>(Users).ToAsyncEnumerable();
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
@@ -20,7 +20,7 @@ namespace Discord.WebSocket
                ChannelPermission.ViewChannel)).ToImmutableArray();
 
         public IReadOnlyCollection<SocketGuildChannel> Channels
-            => Guild.Channels.Where(x => x.CategoryId == Id).ToImmutableArray();
+            => Guild.Channels.Where(x => x is INestedChannel && (x as INestedChannel).CategoryId == Id).ToImmutableArray();
 
         internal SocketCategoryChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
             : base(discord, id, guild)
@@ -51,19 +51,6 @@ namespace Discord.WebSocket
         internal new SocketCategoryChannel Clone() => MemberwiseClone() as SocketCategoryChannel;
 
         // IGuildChannel
-
-        /// <summary>
-        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
-        /// </summary>
-        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
-        ulong? IGuildChannel.CategoryId
-            => throw new NotSupportedException();
-        /// <summary>
-        /// Throws a NotSupportedException because Channel Categories cannot be the child of another Channel Category.
-        /// </summary>
-        /// <exception cref="NotSupportedException">A NotSupportedException is always thrown because Channel Categories do not support being nested.</exception>
-        Task<ICategoryChannel> IGuildChannel.GetCategoryAsync()
-            => throw new NotSupportedException();
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
             => ImmutableArray.Create<IReadOnlyCollection<IGuildUser>>(Users).ToAsyncEnumerable();
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Rest;
+using Discord.Rest;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -16,10 +16,7 @@ namespace Discord.WebSocket
 
         public SocketGuild Guild { get; }
         public string Name { get; private set; }
-        public int Position { get; private set; }
-        public ulong? CategoryId { get; private set; }
-        public ICategoryChannel Category 
-            => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
+        public int Position { get; private set; }        
 
         public IReadOnlyCollection<Overwrite> PermissionOverwrites => _overwrites;
         public new virtual IReadOnlyCollection<SocketGuildUser> Users => ImmutableArray.Create<SocketGuildUser>();
@@ -48,8 +45,7 @@ namespace Discord.WebSocket
         {
             Name = model.Name.Value;
             Position = model.Position.Value;
-            CategoryId = model.CategoryId;
-
+            
             var overwrites = model.PermissionOverwrites.Value;
             var newOverwrites = ImmutableArray.CreateBuilder<Overwrite>(overwrites.Length);
             for (int i = 0; i < overwrites.Length; i++)
@@ -134,9 +130,6 @@ namespace Discord.WebSocket
         //IGuildChannel
         IGuild IGuildChannel.Guild => Guild;
         ulong IGuildChannel.GuildId => Guild.Id;
-
-        Task<ICategoryChannel> IGuildChannel.GetCategoryAsync()
-            => Task.FromResult(Category);
 
         async Task<IReadOnlyCollection<IInviteMetadata>> IGuildChannel.GetInvitesAsync(RequestOptions options)
             => await GetInvitesAsync(options).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -124,10 +124,6 @@ namespace Discord.WebSocket
         public Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
             => ChannelHelper.GetWebhooksAsync(this, Discord, options);
 
-        // Categories
-        public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
-            => ChannelHelper.GetCategoryAsync(this, Discord, options);
-
         private string DebuggerDisplay => $"{Name} ({Id}, Text)";
         internal new SocketTextChannel Clone() => MemberwiseClone() as SocketTextChannel;
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -11,11 +11,14 @@ using Model = Discord.API.Channel;
 namespace Discord.WebSocket
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class SocketTextChannel : SocketGuildChannel, ITextChannel, ISocketMessageChannel
+    public class SocketTextChannel : SocketGuildChannel, ITextChannel, ISocketMessageChannel, INestedChannel
     {
         private readonly MessageCache _messages;
 
         public string Topic { get; private set; }
+        public ulong? CategoryId { get; private set; }
+        public ICategoryChannel Category
+            => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
 
         private bool _nsfw;
         public bool IsNsfw => _nsfw || ChannelHelper.IsNsfw(this);
@@ -164,5 +167,9 @@ namespace Discord.WebSocket
             => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
         IDisposable IMessageChannel.EnterTypingState(RequestOptions options)
             => EnterTypingState(options);
+
+        // INestedChannel
+        Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+            => Task.FromResult(Category);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -11,7 +11,7 @@ using Model = Discord.API.Channel;
 namespace Discord.WebSocket
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class SocketTextChannel : SocketGuildChannel, ITextChannel, ISocketMessageChannel, INestedChannel
+    public class SocketTextChannel : SocketGuildChannel, ITextChannel, ISocketMessageChannel
     {
         private readonly MessageCache _messages;
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -169,7 +169,7 @@ namespace Discord.WebSocket
             => EnterTypingState(options);
 
         // INestedChannel
-        Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+        Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
             => Task.FromResult(Category);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -45,7 +45,7 @@ namespace Discord.WebSocket
         internal override void Update(ClientState state, Model model)
         {
             base.Update(state, model);
-
+            CategoryId = model.CategoryId;
             Topic = model.Topic.Value;
             _nsfw = model.Nsfw.GetValueOrDefault();
         }
@@ -123,6 +123,10 @@ namespace Discord.WebSocket
             => ChannelHelper.GetWebhookAsync(this, Discord, id, options);
         public Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
             => ChannelHelper.GetWebhooksAsync(this, Discord, options);
+
+        // Categories
+        public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
+            => ChannelHelper.GetCategoryAsync(this, Discord, options);
 
         private string DebuggerDisplay => $"{Name} ({Id}, Text)";
         internal new SocketTextChannel Clone() => MemberwiseClone() as SocketTextChannel;

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -56,9 +56,6 @@ namespace Discord.WebSocket
             return null;
         }
 
-        public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
-            => ChannelHelper.GetCategoryAsync(this, Discord, options);
-
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
         internal new SocketVoiceChannel Clone() => MemberwiseClone() as SocketVoiceChannel;
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Audio;
+using Discord.Audio;
 using Discord.Rest;
 using System;
 using System.Collections.Generic;
@@ -11,10 +11,13 @@ using Model = Discord.API.Channel;
 namespace Discord.WebSocket
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class SocketVoiceChannel : SocketGuildChannel, IVoiceChannel, ISocketAudioChannel
+    public class SocketVoiceChannel : SocketGuildChannel, IVoiceChannel, ISocketAudioChannel, INestedChannel
     {
         public int Bitrate { get; private set; }
         public int? UserLimit { get; private set; }
+        public ulong? CategoryId { get; private set; }
+        public ICategoryChannel Category
+            => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
 
         public override IReadOnlyCollection<SocketGuildUser> Users
             => Guild.Users.Where(x => x.VoiceChannel?.Id == Id).ToImmutableArray();
@@ -61,5 +64,9 @@ namespace Discord.WebSocket
             => Task.FromResult<IGuildUser>(GetUser(id));
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)
             => ImmutableArray.Create<IReadOnlyCollection<IGuildUser>>(Users).ToAsyncEnumerable();
+
+        // INestedChannel
+        Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+            => Task.FromResult(Category);
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -11,7 +11,7 @@ using Model = Discord.API.Channel;
 namespace Discord.WebSocket
 {
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class SocketVoiceChannel : SocketGuildChannel, IVoiceChannel, ISocketAudioChannel, INestedChannel
+    public class SocketVoiceChannel : SocketGuildChannel, IVoiceChannel, ISocketAudioChannel
     {
         public int Bitrate { get; private set; }
         public int? UserLimit { get; private set; }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -35,7 +35,7 @@ namespace Discord.WebSocket
         internal override void Update(ClientState state, Model model)
         {
             base.Update(state, model);
-
+            CategoryId = model.CategoryId;
             Bitrate = model.Bitrate.Value;
             UserLimit = model.UserLimit.Value != 0 ? model.UserLimit.Value : (int?)null;
         }
@@ -55,7 +55,10 @@ namespace Discord.WebSocket
                 return user;
             return null;
         }
-        
+
+        public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
+            => ChannelHelper.GetCategoryAsync(this, Discord, options);
+
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
         internal new SocketVoiceChannel Clone() => MemberwiseClone() as SocketVoiceChannel;
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -66,7 +66,7 @@ namespace Discord.WebSocket
             => ImmutableArray.Create<IReadOnlyCollection<IGuildUser>>(Users).ToAsyncEnumerable();
 
         // INestedChannel
-        Task<ICategoryChannel> INestedChannel.GetCategoryAsync()
+        Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
             => Task.FromResult(Category);
     }
 }

--- a/test/Discord.Net.Tests/Tests.Channels.cs
+++ b/test/Discord.Net.Tests/Tests.Channels.cs
@@ -1,4 +1,5 @@
 using Discord.Rest;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -139,6 +140,34 @@ namespace Discord
             Assert.Equal(voice3.Bitrate, 8000);
             Assert.Equal(voice3.Position, 1);
             Assert.Equal(voice3.UserLimit, 16);
+        }
+
+        [Fact]
+        public async Task TestChannelCategories()
+        {
+            CheckChannelCategories(_client, _guild);
+        }
+
+        private async static void CheckChannelCategories(DiscordRestClient client, RestGuild guild)
+        {
+            // create some channel categories
+            var cat1 = await guild.CreateCategoryChannelAsync("Cat1");
+            var cat2 = await guild.CreateCategoryChannelAsync("Cat2");
+
+            // check that both CategoryID and GetCategoryID throw NotSupportedException
+            // because Categories cannot be nested
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                var x = cat1.CategoryId;
+            });
+
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                var x = cat2.GetCategoryAsync();
+            });
+
+
+            // incomplete test, could use more coverage
         }
     }
 }

--- a/test/Discord.Net.Tests/Tests.Channels.cs
+++ b/test/Discord.Net.Tests/Tests.Channels.cs
@@ -168,7 +168,29 @@ namespace Discord
                 var x = cat2.GetCategoryAsync();
             });
 
-            // incomplete test, could use more coverage, incluing behavior of nested Text and Voice channels
+            var text1 = await guild.CreateTextChannelAsync("nestedText1");
+            var voice1 = await guild.CreateVoiceChannelAsync("nestedVoice1");
+            // set the text channel parent to Cat 1
+            await text1.ModifyAsync(x =>
+            {
+                x.CategoryId = cat1.Id;
+            });
+
+            await voice1.ModifyAsync(x =>
+            {
+                x.CategoryId = cat2.Id;
+            });
+
+            // these shouldn't throw because they are not channel categories
+
+            // assert that CategoryId works for text channels
+            Assert.Equal(text1.CategoryId, cat1.Id);
+            Assert.Equal((await text1.GetCategoryAsync()).Id, cat1.Id);
+            // and for voice channels
+            Assert.Equal(voice1.CategoryId, cat2.Id);
+            Assert.Equal((await voice1.GetCategoryAsync()).Id, cat2.Id);
+
+            // incomplete test, could use more coverage of other methods
         }
     }
 }

--- a/test/Discord.Net.Tests/Tests.Channels.cs
+++ b/test/Discord.Net.Tests/Tests.Channels.cs
@@ -16,17 +16,28 @@ namespace Discord
             var text4 = await guild.CreateTextChannelAsync("text4");
             var text5 = await guild.CreateTextChannelAsync("text5");
 
+            // create a channel category
+            var cat1 = await guild.CreateCategoryChannelAsync("cat1");
+
+            if (text1 == null)
+            {
+                // the guild did not have a default channel, so make a new one
+                text1 = await guild.CreateTextChannelAsync("default");
+            }
+
             //Modify #general
             await text1.ModifyAsync(x =>
             {
                 x.Name = "text1";
                 x.Position = 1;
                 x.Topic = "Topic1";
+                x.CategoryId = cat1.Id;
             });
 
             await text2.ModifyAsync(x =>
             {
                 x.Position = 2;
+                x.CategoryId = cat1.Id;
             });
             await text3.ModifyAsync(x =>
             {
@@ -90,10 +101,13 @@ namespace Discord
             var voice2 = await guild.CreateVoiceChannelAsync("voice2");
             var voice3 = await guild.CreateVoiceChannelAsync("voice3");
 
+            var cat2 = await guild.CreateCategoryChannelAsync("cat2");
+
             await voice1.ModifyAsync(x =>
             {
                 x.Bitrate = 96000;
                 x.Position = 1;
+                x.CategoryId = cat2.Id;
             });
             await voice2.ModifyAsync(x =>
             {
@@ -104,6 +118,7 @@ namespace Discord
                 x.Bitrate = 8000;
                 x.Position = 1;
                 x.UserLimit = 16;
+                x.CategoryId = cat2.Id;
             });
 
             CheckVoiceChannels(voice1, voice2, voice3);
@@ -143,49 +158,61 @@ namespace Discord
         }
 
         [Fact]
-        public Task TestChannelCategories()
+        public async Task TestChannelCategories()
         {
-            CheckChannelCategories(_client, _guild);
+            // (await _guild.GetVoiceChannelsAsync()).ToArray()
+            var channels = await _guild.GetCategoryChannelsAsync();
 
-            return Task.CompletedTask;
+            await CheckChannelCategories(channels.ToArray(), (await _guild.GetChannelsAsync()).ToArray());
         }
 
-        private async static void CheckChannelCategories(DiscordRestClient client, RestGuild guild)
+        private async Task CheckChannelCategories(RestCategoryChannel[] categories, RestGuildChannel[] allChannels)
         {
-            // create some channel categories
-            var cat1 = await guild.CreateCategoryChannelAsync("Cat1");
-            var cat2 = await guild.CreateCategoryChannelAsync("Cat2");
+            // 2 categories
+            Assert.Equal(categories.Length, 2);
 
-            var text1 = await guild.CreateTextChannelAsync("nestedText1");
-            var voice1 = await guild.CreateVoiceChannelAsync("nestedVoice1");
-            // set the text channel parent to Cat 1
-            await text1.ModifyAsync(x =>
-            {
-                x.CategoryId = cat1.Id;
-            });
+            var cat1 = categories.Where(x => x.Name == "cat1").FirstOrDefault();
+            var cat2 = categories.Where(x => x.Name == "cat2").FirstOrDefault();
 
-            await voice1.ModifyAsync(x =>
-            {
-                x.CategoryId = cat2.Id;
-            });
+            Assert.NotNull(cat1);
+            Assert.NotNull(cat2);
 
-            // these shouldn't throw because they are not channel categories
+            // get text1, text2, ensure they have category id == cat1
+            var text1 = allChannels.Where(x => x.Name == "text1").FirstOrDefault() as RestTextChannel;
+            var text2 = allChannels.Where(x => x.Name == "text2").FirstOrDefault() as RestTextChannel;
 
-            // assert that CategoryId works for text channels
+            Assert.NotNull(text1);
+            Assert.NotNull(text2);
+
+            // check that CategoryID and .GetCategoryAsync work correctly
+            // for both of the text channels
             Assert.Equal(text1.CategoryId, cat1.Id);
-            Assert.True(text1 is INestedChannel);
-            Assert.Equal((await (text1 as INestedChannel).GetCategoryAsync()).Id, cat1.Id);
-            Assert.Equal((await text1.GetCategoryAsync()).Id, cat1.Id);
-            Assert.Equal(text1.CategoryId, cat1.Id);
+            var text1Cat = await text1.GetCategoryAsync();
+            Assert.Equal(text1Cat.Id, cat1.Id);
+            Assert.Equal(text1Cat.Name, cat1.Name);
 
-            // and for voice channels
+            Assert.Equal(text2.CategoryId, cat1.Id);
+            var text2Cat = await text2.GetCategoryAsync();
+            Assert.Equal(text2Cat.Id, cat1.Id);
+            Assert.Equal(text2Cat.Name, cat1.Name);
+
+            // do the same for the voice channels
+            var voice1 = allChannels.Where(x => x.Name == "voice1").FirstOrDefault() as RestVoiceChannel;
+            var voice3 = allChannels.Where(x => x.Name == "voice3").FirstOrDefault() as RestVoiceChannel;
+
+            Assert.NotNull(voice1);
+            Assert.NotNull(voice3);
+            
             Assert.Equal(voice1.CategoryId, cat2.Id);
-            Assert.True(voice1 is INestedChannel);
-            Assert.Equal((await (voice1 as INestedChannel).GetCategoryAsync()).Id, cat2.Id);
-            Assert.Equal((await voice1.GetCategoryAsync()).Id, cat2.Id);
-            Assert.Equal(voice1.CategoryId, cat1.Id);
+            var voice1Cat = await voice1.GetCategoryAsync();
+            Assert.Equal(voice1Cat.Id, cat2.Id);
+            Assert.Equal(voice1Cat.Name, cat2.Name);
 
-            // incomplete test, could use more coverage of other methods
+            Assert.Equal(voice3.CategoryId, cat2.Id);
+            var voice3Cat = await voice3.GetCategoryAsync();
+            Assert.Equal(voice3Cat.Id, cat2.Id);
+            Assert.Equal(voice3Cat.Name, cat2.Name);
+
         }
     }
 }

--- a/test/Discord.Net.Tests/Tests.Channels.cs
+++ b/test/Discord.Net.Tests/Tests.Channels.cs
@@ -143,9 +143,11 @@ namespace Discord
         }
 
         [Fact]
-        public async Task TestChannelCategories()
+        public Task TestChannelCategories()
         {
             CheckChannelCategories(_client, _guild);
+
+            return Task.CompletedTask;
         }
 
         private async static void CheckChannelCategories(DiscordRestClient client, RestGuild guild)
@@ -166,8 +168,7 @@ namespace Discord
                 var x = cat2.GetCategoryAsync();
             });
 
-
-            // incomplete test, could use more coverage
+            // incomplete test, could use more coverage, incluing behavior of nested Text and Voice channels
         }
     }
 }

--- a/test/Discord.Net.Tests/Tests.Channels.cs
+++ b/test/Discord.Net.Tests/Tests.Channels.cs
@@ -156,18 +156,6 @@ namespace Discord
             var cat1 = await guild.CreateCategoryChannelAsync("Cat1");
             var cat2 = await guild.CreateCategoryChannelAsync("Cat2");
 
-            // check that both CategoryID and GetCategoryID throw NotSupportedException
-            // because Categories cannot be nested
-            Assert.Throws<NotSupportedException>(() =>
-            {
-                var x = cat1.CategoryId;
-            });
-
-            Assert.Throws<NotSupportedException>(() =>
-            {
-                var x = cat2.GetCategoryAsync();
-            });
-
             var text1 = await guild.CreateTextChannelAsync("nestedText1");
             var voice1 = await guild.CreateVoiceChannelAsync("nestedVoice1");
             // set the text channel parent to Cat 1
@@ -185,10 +173,17 @@ namespace Discord
 
             // assert that CategoryId works for text channels
             Assert.Equal(text1.CategoryId, cat1.Id);
+            Assert.True(text1 is INestedChannel);
+            Assert.Equal((await (text1 as INestedChannel).GetCategoryAsync()).Id, cat1.Id);
             Assert.Equal((await text1.GetCategoryAsync()).Id, cat1.Id);
+            Assert.Equal(text1.CategoryId, cat1.Id);
+
             // and for voice channels
             Assert.Equal(voice1.CategoryId, cat2.Id);
+            Assert.True(voice1 is INestedChannel);
+            Assert.Equal((await (voice1 as INestedChannel).GetCategoryAsync()).Id, cat2.Id);
             Assert.Equal((await voice1.GetCategoryAsync()).Id, cat2.Id);
+            Assert.Equal(voice1.CategoryId, cat1.Id);
 
             // incomplete test, could use more coverage of other methods
         }


### PR DESCRIPTION
This change adds the `INestedChannel` interface and extends `ITextChannel` and `IVoiceChannel` with this interface. All category-related stuff like CategoryID and GetCategoryAsync are moved from `IGuildChannel` to `INestedChannel`. `INestedChannel`s are only channels that can be nested within a category in a guild.

This is a breaking change, not all `IGuildChannel`s will have the category property or methods anymore. The types have also changed slightly.

~~~This change makes `ICategoryChannel#CategoryID` throw a `NotSupportedException`. This also includes `RestGuildChannel#GetCategoryAsync` and `SocketGuildChannel#GetCategoryAsync`, since they call `CategoryId#get`.~~~

~~~This could be done in a more OOP way, but may end up with a more significant change to the code base, I would make a `INestedChannel` interface that provides `CategoryID`, and remove that from the `IGuildChannel` interface. (Actually now that I think about it, it doesn't sound too bad. If this is preferred I could try this instead.)~~~

~~~Edit: @Still34 made a great point for keeping the exceptions, `parent_id` is defined for all channel types at the api level, and this would prevent future issues should discord allow nested channel categories. Also there's other stuff that throws during runtime already.~~~

~~~Expected output is outlined in the tests, when `CategoryId` is accessed or when `GetCategoryAsync` is called, both should throw `NotSupportedException`.~~

This PR also adds minimal tests for channel categories. This should be more complete, but could be addressed in a different PR.

