### PR TITLE
Add a dedicated TimeSpan reader so it doesn't suck

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -66,6 +66,10 @@ namespace Discord.Commands
                 _defaultTypeReaders[typeof(Nullable<>).MakeGenericType(type)] = NullableTypeReader.Create(type, _defaultTypeReaders[type]);
             }
 
+            var tsreader = new TimeSpanTypeReader();
+            _defaultTypeReaders[typeof(TimeSpan)] = tsreader;
+            _defaultTypeReaders[typeof(TimeSpan?)] = NullableTypeReader.Create(typeof(TimeSpan), tsreader);
+
             _defaultTypeReaders[typeof(string)] =
                 new PrimitiveTypeReader<string>((string x, out string y) => { y = x; return true; }, 0);
 

--- a/src/Discord.Net.Commands/PrimitiveParsers.cs
+++ b/src/Discord.Net.Commands/PrimitiveParsers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -29,7 +29,7 @@ namespace Discord.Commands
             parserBuilder[typeof(decimal)] = (TryParseDelegate<decimal>)decimal.TryParse;
             parserBuilder[typeof(DateTime)] = (TryParseDelegate<DateTime>)DateTime.TryParse;
             parserBuilder[typeof(DateTimeOffset)] = (TryParseDelegate<DateTimeOffset>)DateTimeOffset.TryParse;
-            parserBuilder[typeof(TimeSpan)] = (TryParseDelegate<TimeSpan>)TimeSpan.TryParse;
+            //parserBuilder[typeof(TimeSpan)] = (TryParseDelegate<TimeSpan>)TimeSpan.TryParse;
             parserBuilder[typeof(char)] = (TryParseDelegate<char>)char.TryParse;
             return parserBuilder.ToImmutable();
         }

--- a/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
@@ -27,7 +27,7 @@ namespace Discord.Commands
 
         public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
-            return (TimeSpan.TryParseExact(input, _formats, CultureInfo.InvariantCulture, out var timeSpan))
+            return (TimeSpan.TryParseExact(input.ToLowerInvariant(), _formats, CultureInfo.InvariantCulture, out var timeSpan))
                 ? Task.FromResult(TypeReaderResult.FromSuccess(timeSpan))
                 : Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));
         }

--- a/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace Discord.Commands
+{
+    internal class TimeSpanTypeReader : TypeReader
+    {
+        private static readonly string[] _formats = new[]
+        {
+            "%d'd'%h'h'%m'm'%s's'", //4d3h2m1s
+            "%d'd'%h'h'%m'm'",      //4d3h2m
+            "%d'd'%h'h'%s's'",      //4d3h  1s
+            "%d'd'%h'h'",           //4d3h
+            "%d'd'%m'm'%s's'",      //4d  2m1s
+            "%d'd'%m'm'",           //4d  2m
+            "%d'd'%s's'",           //4d    1s
+            "%d'd'",                //4d
+            "%h'h'%m'm'%s's'",      //  3h2m1s
+            "%h'h'%m'm'",           //  3h2m
+            "%h'h'%s's'",           //  3h  1s
+            "%h'h'",                //  3h
+            "%m'm'%s's'",           //    2m1s
+            "%m'm'",                //    2m
+            "%s's'",                //      1s
+        };
+
+        public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+        {
+            return (TimeSpan.TryParseExact(input, _formats, CultureInfo.InvariantCulture, out var timeSpan))
+                ? Task.FromResult(TypeReaderResult.FromSuccess(timeSpan))
+                : Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));
+        }
+    }
+}


### PR DESCRIPTION
I considered also adding a dedicated reader for `DateTime{Offset}`, but because timezones and cultural differences in notation, I decided against it.