### PR TITLE
Add way to replace default TypeReaders

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -291,7 +291,7 @@ namespace Discord.Commands
 
             //We dont have a cached type reader, create one
             reader = ReflectionUtils.CreateObject<TypeReader>(typeReaderType.GetTypeInfo(), service, services);
-            service.AddTypeReader(paramType, reader);
+            service.AddTypeReader(paramType, reader, false);
 
             return reader;
         }


### PR DESCRIPTION
## Summary
Currently it's not possible to replace the default TypeReaders and they have a higher priority than custom ones, so it's needed to override all of them to yours. This isn't how it used to be, it is a side effect of #941.
This PR will make it possible to change them by introducing a new overload for `AddTypeReader` that has a boolean to replace the default one if needed and change the current method to keep the legacy behaviour.

## Changes
- Added `AddTypeReader(Type type, TypeReader reader, bool replaceDefaultTypeReader)`
- Added `AddTypeReader<T>(TypeReader reader, bool replaceDefaultTypeReader)`
- Repurposed the existing `AddTypeReader` to redirect to the added methods, including a warning if it's going to replace a default one (preserve legacy behaviour and methods).
- OverrideTypeReaderAttribute now uses the new method and it won't replace default typereaders (so the same issue that changing the priorities between default and custom fixed doesn't happen again).

## Notes
I don't really like how the warning is sent when using the old method.
The old method is not a `Task` so it's not possible to properly `await` it and it's needed to `.GetAwaiter().GetResult()`.
And to not break the old method, keep the legacy behaviour, and add the warning, it needs to be like that.
Would be nice to know if we should keep the old one or just remove it entirely since we are going to a major release.