### PR TITLE
Fix Embed.Length behavior

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/Embed.cs
+++ b/src/Discord.Net.Core/Entities/Messages/Embed.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -57,7 +57,18 @@ namespace Discord
             Fields = fields;
         }
 
-        public int Length => Title?.Length + Author?.Name?.Length + Description?.Length + Footer?.Text?.Length + Fields.Sum(f => f.Name.Length + f.Value.ToString().Length) ?? 0;
+        public int Length
+        {
+            get
+            {
+                int titleLength = Title?.Length ?? 0;
+                int authorLength = Author?.Name?.Length ?? 0;
+                int descriptionLength = Description?.Length ?? 0;
+                int footerLength = Footer?.Text?.Length ?? 0;
+                int fieldSum = Fields.Sum(f => f.Name?.Length + f.Value?.ToString().Length) ?? 0;
+                return titleLength + authorLength + descriptionLength + footerLength + fieldSum;
+            }
+        }
 
         public override string ToString() => Title;
         private string DebuggerDisplay => $"{Title} ({Type})";


### PR DESCRIPTION
This should resolve #1011. 

## Summary
- The `get` method is now split up into various lines to better debug any value that may be `null`. 
- Each property now falls back to `0` in case any of them is null.