### PR TITLE
Added Overloads for the EmbedBuilder Ctor

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -24,6 +24,26 @@ namespace Discord
             Fields = new List<EmbedFieldBuilder>();
         }
 
+        public EmbedBuilder(params EmbedFieldBuilder[] EmbedFields)
+        {
+            Fields = new List<EmbedFieldBuilder>();
+            foreach (var Field in EmbedFields)
+            {
+                Fields.Add(Field);
+            }
+        }
+
+        public EmbedBuilder(EmbedAuthorBuilder Author, EmbedFooterBuilder Footer, params EmbedFieldBuilder[] EmbedFields)
+        {
+            this.Author = Author;
+            this.Footer = Footer;
+            Fields = new List<EmbedFieldBuilder>();
+            foreach (var Field in EmbedFields)
+            {
+                Fields.Add(Field);
+            }
+        }
+
         public string Title
         {
             get => _title;


### PR DESCRIPTION
Changes:
Made it so that EmbedFieldBuilders can be passed to an EmbedBuilder.
Made is so that EmbedAuthorBuilder, EmbedFooterBuilder, and EmbedFieldBuilders can be passed to an EmbedBuilder.

Should have no breaking changes