### PR TITLE
Add the ability to sync guild channel permission to category

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
@@ -1,4 +1,4 @@
-﻿namespace Discord
+namespace Discord
 {
     /// <summary>
     /// Modify an IGuildChannel with the specified changes.
@@ -30,5 +30,9 @@
         /// Sets the category for this channel
         /// </summary>
         public Optional<ulong?> CategoryId { get; set; }
+        /// <summary>
+        /// Syncs the permission with the channel's parent (category).
+        /// </summary>
+        public Optional<bool> SyncWithParent { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
@@ -33,6 +33,6 @@ namespace Discord
         /// <summary>
         /// Syncs the permission with the channel's parent (category).
         /// </summary>
-        public Optional<bool> SyncWithParent { get; set; }
+        public Optional<bool> SyncWithCategory { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Overwrite.cs
+++ b/src/Discord.Net.Rest/API/Common/Overwrite.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -13,5 +13,13 @@ namespace Discord.API
         public ulong Deny { get; set; }
         [JsonProperty("allow"), Int53]
         public ulong Allow { get; set; }
+
+        public Overwrite(ulong targetId, PermissionTarget targetType, ulong allowValue, ulong denyValue)
+        {
+            TargetId = targetId;
+            TargetType = targetType;
+            Allow = allowValue;
+            Deny = denyValue;
+        }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
@@ -12,5 +12,7 @@ namespace Discord.API.Rest
         public Optional<int> Position { get; set; }
         [JsonProperty("parent_id")]
         public Optional<ulong?> CategoryId { get; set; }
+        [JsonProperty("permission_overwrites")]
+        public Optional<Overwrite[]> Overwrites { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -26,13 +26,13 @@ namespace Discord.Rest
         {
             var args = new GuildChannelProperties();
             func(args);
-            var apiArgs = new ModifyGuildChannelParams
+            var apiArgs = new API.Rest.ModifyGuildChannelParams
             {
                 Name = args.Name,
                 Position = args.Position,
                 CategoryId = args.CategoryId
             };
-            if (args.SyncWithParent.IsSpecified && args.SyncWithParent.Value)
+            if (args.SyncWithCategory.IsSpecified && args.SyncWithCategory.Value)
             {
                 var categoryChannel = await channel.GetCategoryAsync().ConfigureAwait(false);
                 if (categoryChannel != null)

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -19,17 +19,25 @@ namespace Discord.Rest
         {
             await client.ApiClient.DeleteChannelAsync(channel.Id, options).ConfigureAwait(false);
         }
+
         public static async Task<Model> ModifyAsync(IGuildChannel channel, BaseDiscordClient client,
             Action<GuildChannelProperties> func,
+            IEnumerable<Overwrite> overwrites,
             RequestOptions options)
         {
             var args = new GuildChannelProperties();
             func(args);
-            var apiArgs = new API.Rest.ModifyGuildChannelParams
+            var apiArgs = new ModifyGuildChannelParams
             {
                 Name = args.Name,
                 Position = args.Position,
-                CategoryId = args.CategoryId
+                CategoryId = args.CategoryId,
+                Overwrites = args.SyncWithParent.Value
+                    ? overwrites
+                        .Select(overwrite => new API.Overwrite(overwrite.TargetId, overwrite.TargetType,
+                            overwrite.Permissions.AllowValue, overwrite.Permissions.DenyValue))
+                        .ToArray()
+                    : null
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -35,11 +35,13 @@ namespace Discord.Rest
             if (args.SyncWithParent.IsSpecified && args.SyncWithParent.Value)
             {
                 var categoryChannel = await channel.GetCategoryAsync().ConfigureAwait(false);
-                apiArgs.Overwrites = categoryChannel.PermissionOverwrites
-                    .Select(overwrite => new API.Overwrite(overwrite.TargetId, overwrite.TargetType,
-                        overwrite.Permissions.AllowValue, overwrite.Permissions.DenyValue))
-                    .ToArray();
+                if (categoryChannel != null)
+                    apiArgs.Overwrites = categoryChannel.PermissionOverwrites
+                        .Select(overwrite => new API.Overwrite(overwrite.TargetId, overwrite.TargetType,
+                            overwrite.Permissions.AllowValue, overwrite.Permissions.DenyValue))
+                        .ToArray();
             }
+
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }
         public static async Task<Model> ModifyAsync(ITextChannel channel, BaseDiscordClient client,

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -58,8 +58,7 @@ namespace Discord.Rest
         }
         public async Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
         {
-            var categoryChannel = await GetCategoryAsync().ConfigureAwait(false);
-            var model = await ChannelHelper.ModifyAsync(this, Discord, func, categoryChannel.PermissionOverwrites, options).ConfigureAwait(false);
+            var model = await ChannelHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
             Update(model);
         }
         public Task DeleteAsync(RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -58,7 +58,8 @@ namespace Discord.Rest
         }
         public async Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
         {
-            var model = await ChannelHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var categoryChannel = await GetCategoryAsync().ConfigureAwait(false);
+            var model = await ChannelHelper.ModifyAsync(this, Discord, func, categoryChannel.PermissionOverwrites, options).ConfigureAwait(false);
             Update(model);
         }
         public Task DeleteAsync(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Rest;
+using Discord.Rest;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -58,7 +58,7 @@ namespace Discord.WebSocket
         }
 
         public Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
-            => ChannelHelper.ModifyAsync(this, Discord, func, options);
+            => ChannelHelper.ModifyAsync(this, Discord, func, Category.PermissionOverwrites, options);
         public Task DeleteAsync(RequestOptions options = null)
             => ChannelHelper.DeleteAsync(this, Discord, options);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -58,7 +58,7 @@ namespace Discord.WebSocket
         }
 
         public Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
-            => ChannelHelper.ModifyAsync(this, Discord, func, Category.PermissionOverwrites, options);
+            => ChannelHelper.ModifyAsync(this, Discord, func, options);
         public Task DeleteAsync(RequestOptions options = null)
             => ChannelHelper.DeleteAsync(this, Discord, options);
 


### PR DESCRIPTION
## Summary

This PR will add a new bool under `GuildChannelProperties` called `SyncWithCategory`, allowing the permission of a guild channel to be synced up with its parent/category. 