### PR TITLE
Fix/Implement various invite-related behaviors

### DIFF
--- a/src/Discord.Net.Core/Entities/Invites/IInvite.cs
+++ b/src/Discord.Net.Core/Entities/Invites/IInvite.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -22,6 +22,10 @@ namespace Discord
         ulong GuildId { get; }
         /// <summary> Gets the name of the guild this invite is linked to. </summary>
         string GuildName { get; }
+        /// <summary> Gets the approximated count of online members in the guild. </summary>
+        int? PresenceCount { get; }
+        /// <summary> Gets the approximated count of total members in the guild. </summary>
+        int? MemberCount { get; }
 
         /// <summary> Accepts this invite and joins the target guild. This will fail on bot accounts. </summary>
         Task AcceptAsync(RequestOptions options = null);

--- a/src/Discord.Net.Core/Entities/Invites/IInvite.cs
+++ b/src/Discord.Net.Core/Entities/Invites/IInvite.cs
@@ -26,8 +26,5 @@ namespace Discord
         int? PresenceCount { get; }
         /// <summary> Gets the approximated count of total members in the guild. </summary>
         int? MemberCount { get; }
-
-        /// <summary> Accepts this invite and joins the target guild. This will fail on bot accounts. </summary>
-        Task AcceptAsync(RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/IDiscordClient.cs
+++ b/src/Discord.Net.Core/IDiscordClient.cs
@@ -27,7 +27,7 @@ namespace Discord
         Task<IReadOnlyCollection<IGuild>> GetGuildsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         Task<IGuild> CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon = null, RequestOptions options = null);
         
-        Task<IInvite> GetInviteAsync(string inviteId, RequestOptions options = null);
+        Task<IInvite> GetInviteAsync(string inviteId, bool withCount = false, RequestOptions options = null);
 
         Task<IUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         Task<IUser> GetUserAsync(string username, string discriminator, RequestOptions options = null);

--- a/src/Discord.Net.Rest/API/Common/Invite.cs
+++ b/src/Discord.Net.Rest/API/Common/Invite.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -11,5 +11,9 @@ namespace Discord.API
         public InviteGuild Guild { get; set; }
         [JsonProperty("channel")]
         public InviteChannel Channel { get; set; }
+        [JsonProperty("approximate_presence_count")]
+        public Optional<int?> PresenceCount { get; set; }
+        [JsonProperty("approximate_member_count")]
+        public Optional<int?> MemberCount { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/GetInviteParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/GetInviteParams.cs
@@ -1,10 +1,7 @@
-using Newtonsoft.Json;
-
 namespace Discord.API.Rest
 {
     internal class GetInviteParams
     {
-        [JsonProperty("with_counts")]
         public Optional<bool?> WithCounts { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/GetInviteParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/GetInviteParams.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace Discord.API.Rest
+{
+    internal class GetInviteParams
+    {
+        [JsonProperty("with_counts")]
+        public Optional<bool?> WithCounts { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -148,7 +148,7 @@ namespace Discord.Rest
         Task<IReadOnlyCollection<IConnection>> IDiscordClient.GetConnectionsAsync(RequestOptions options)
             => Task.FromResult<IReadOnlyCollection<IConnection>>(ImmutableArray.Create<IConnection>());
 
-        Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, RequestOptions options)
+        Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, bool withCount, RequestOptions options)
             => Task.FromResult<IInvite>(null);
 
         Task<IGuild> IDiscordClient.GetGuildAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -51,9 +51,13 @@ namespace Discord.Rest
         }
         
         public static async Task<RestInvite> GetInviteAsync(BaseDiscordClient client,
-            string inviteId, RequestOptions options)
+            string inviteId, bool withCount, RequestOptions options)
         {
-            var model = await client.ApiClient.GetInviteAsync(inviteId, options).ConfigureAwait(false);
+            var args = new GetInviteParams
+            {
+                WithCounts = withCount
+            };
+            var model = await client.ApiClient.GetInviteAsync(inviteId, args, options).ConfigureAwait(false);
             if (model != null)
                 return RestInvite.Create(client, null, null, model);
             return null;

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -50,7 +50,7 @@ namespace Discord.Rest
             return models.Select(x => RestConnection.Create(x)).ToImmutableArray();
         }
         
-        public static async Task<RestInvite> GetInviteAsync(BaseDiscordClient client,
+        public static async Task<RestInviteMetadata> GetInviteAsync(BaseDiscordClient client,
             string inviteId, bool withCount, RequestOptions options)
         {
             var args = new GetInviteParams
@@ -59,7 +59,7 @@ namespace Discord.Rest
             };
             var model = await client.ApiClient.GetInviteAsync(inviteId, args, options).ConfigureAwait(false);
             if (model != null)
-                return RestInvite.Create(client, null, null, model);
+                return RestInviteMetadata.Create(client, null, null, model);
             return null;
         }
         

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -897,7 +897,7 @@ namespace Discord.API
         }
 
         //Guild Invites
-        public async Task<Invite> GetInviteAsync(string inviteId, RequestOptions options = null)
+        public async Task<Invite> GetInviteAsync(string inviteId, GetInviteParams args, RequestOptions options = null)
         {
             Preconditions.NotNullOrEmpty(inviteId, nameof(inviteId));
             options = RequestOptions.CreateOrClone(options);
@@ -912,7 +912,7 @@ namespace Discord.API
 
             try
             {
-                return await SendAsync<Invite>("GET", () => $"invites/{inviteId}", new BucketIds(), options: options).ConfigureAwait(false);
+                return await SendJsonAsync<Invite>("GET", () => $"invites/{inviteId}", args, new BucketIds(), options: options).ConfigureAwait(false);
             }
             catch (HttpException ex) when (ex.HttpCode == HttpStatusCode.NotFound) { return null; }
         }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -952,13 +952,6 @@ namespace Discord.API
             
             return await SendAsync<Invite>("DELETE", () => $"invites/{inviteId}", new BucketIds(), options: options).ConfigureAwait(false);
         }
-        public async Task AcceptInviteAsync(string inviteId, RequestOptions options = null)
-        {
-            Preconditions.NotNullOrEmpty(inviteId, nameof(inviteId));
-            options = RequestOptions.CreateOrClone(options);
-            
-            await SendAsync("POST", () => $"invites/{inviteId}", new BucketIds(), options: options).ConfigureAwait(false);
-        }
 
         //Guild Members
         public async Task<GuildMember> GetGuildMemberAsync(ulong guildId, ulong userId, RequestOptions options = null)

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -910,9 +910,11 @@ namespace Discord.API
             if (index >= 0)
                 inviteId = inviteId.Substring(index + 1);
 
+            var withCounts = args.WithCounts.GetValueOrDefault(false);
+
             try
             {
-                return await SendJsonAsync<InviteMetadata>("GET", () => $"invites/{inviteId}", args, new BucketIds(), options: options).ConfigureAwait(false);
+                return await SendAsync<InviteMetadata>("GET", () => $"invites/{inviteId}?with_counts={withCounts}", new BucketIds(), options: options).ConfigureAwait(false);
             }
             catch (HttpException ex) when (ex.HttpCode == HttpStatusCode.NotFound) { return null; }
         }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -897,7 +897,7 @@ namespace Discord.API
         }
 
         //Guild Invites
-        public async Task<Invite> GetInviteAsync(string inviteId, GetInviteParams args, RequestOptions options = null)
+        public async Task<InviteMetadata> GetInviteAsync(string inviteId, GetInviteParams args, RequestOptions options = null)
         {
             Preconditions.NotNullOrEmpty(inviteId, nameof(inviteId));
             options = RequestOptions.CreateOrClone(options);
@@ -912,7 +912,7 @@ namespace Discord.API
 
             try
             {
-                return await SendJsonAsync<Invite>("GET", () => $"invites/{inviteId}", args, new BucketIds(), options: options).ConfigureAwait(false);
+                return await SendJsonAsync<InviteMetadata>("GET", () => $"invites/{inviteId}", args, new BucketIds(), options: options).ConfigureAwait(false);
             }
             catch (HttpException ex) when (ex.HttpCode == HttpStatusCode.NotFound) { return null; }
         }

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -56,8 +56,8 @@ namespace Discord.Rest
             => ClientHelper.GetConnectionsAsync(this, options);
 
         /// <inheritdoc />
-        public Task<RestInvite> GetInviteAsync(string inviteId, RequestOptions options = null)
-            => ClientHelper.GetInviteAsync(this, inviteId, options);
+        public Task<RestInvite> GetInviteAsync(string inviteId, bool withCount = false, RequestOptions options = null)
+            => ClientHelper.GetInviteAsync(this, inviteId, withCount, options);
 
         /// <inheritdoc />
         public Task<RestGuild> GetGuildAsync(ulong id, RequestOptions options = null)
@@ -131,8 +131,8 @@ namespace Discord.Rest
         async Task<IReadOnlyCollection<IConnection>> IDiscordClient.GetConnectionsAsync(RequestOptions options)
             => await GetConnectionsAsync(options).ConfigureAwait(false);
 
-        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, RequestOptions options)
-            => await GetInviteAsync(inviteId, options).ConfigureAwait(false);
+        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, bool withCount, RequestOptions options)
+            => await GetInviteAsync(inviteId, withCount, options).ConfigureAwait(false);
 
         async Task<IGuild> IDiscordClient.GetGuildAsync(ulong id, CacheMode mode, RequestOptions options)
         {

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -56,7 +56,7 @@ namespace Discord.Rest
             => ClientHelper.GetConnectionsAsync(this, options);
 
         /// <inheritdoc />
-        public Task<RestInvite> GetInviteAsync(string inviteId, bool withCount = false, RequestOptions options = null)
+        public Task<RestInviteMetadata> GetInviteAsync(string inviteId, bool withCount = false, RequestOptions options = null)
             => ClientHelper.GetInviteAsync(this, inviteId, withCount, options);
 
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Invites/InviteHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Invites/InviteHelper.cs
@@ -1,14 +1,9 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace Discord.Rest
 {
     internal static class InviteHelper
     {
-        public static async Task AcceptAsync(IInvite invite, BaseDiscordClient client, 
-            RequestOptions options)
-        {
-            await client.ApiClient.AcceptInviteAsync(invite.Code, options).ConfigureAwait(false);
-        }
         public static async Task DeleteAsync(IInvite invite, BaseDiscordClient client, 
             RequestOptions options)
         {

--- a/src/Discord.Net.Rest/Entities/Invites/RestInvite.cs
+++ b/src/Discord.Net.Rest/Entities/Invites/RestInvite.cs
@@ -54,9 +54,6 @@ namespace Discord.Rest
         public Task DeleteAsync(RequestOptions options = null)
             => InviteHelper.DeleteAsync(this, Discord, options);
 
-        public Task AcceptAsync(RequestOptions options = null)
-            => InviteHelper.AcceptAsync(this, Discord, options);
-
         public override string ToString() => Url;
         private string DebuggerDisplay => $"{Url} ({GuildName} / {ChannelName})";
         

--- a/src/Discord.Net.Rest/Entities/Invites/RestInvite.cs
+++ b/src/Discord.Net.Rest/Entities/Invites/RestInvite.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Discord.API.Rest;
 using Model = Discord.API.Invite;
 
 namespace Discord.Rest
@@ -10,6 +11,8 @@ namespace Discord.Rest
     {
         public string ChannelName { get; private set; }
         public string GuildName { get; private set; }
+        public int? PresenceCount { get; private set; }
+        public int? MemberCount { get; private set; }
         public ulong ChannelId { get; private set; }
         public ulong GuildId { get; private set; }
         internal IChannel Channel { get; private set; }
@@ -36,11 +39,16 @@ namespace Discord.Rest
             ChannelId = model.Channel.Id;
             GuildName = model.Guild.Name;
             ChannelName = model.Channel.Name;
+            MemberCount = model.MemberCount.IsSpecified ? model.MemberCount.Value : null;
+            PresenceCount = model.PresenceCount.IsSpecified ? model.PresenceCount.Value : null;
         }
         
         public async Task UpdateAsync(RequestOptions options = null)
         {
-            var model = await Discord.ApiClient.GetInviteAsync(Code, options).ConfigureAwait(false);
+            var args = new GetInviteParams();
+            if (MemberCount != null || PresenceCount != null)
+                args.WithCounts = true;
+            var model = await Discord.ApiClient.GetInviteAsync(Code, args, options).ConfigureAwait(false);
             Update(model);
         }
         public Task DeleteAsync(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -55,8 +55,8 @@ namespace Discord.WebSocket
         public Task<IReadOnlyCollection<RestConnection>> GetConnectionsAsync(RequestOptions options = null)
             => ClientHelper.GetConnectionsAsync(this, options ?? RequestOptions.Default);
         /// <inheritdoc />
-        public Task<RestInvite> GetInviteAsync(string inviteId, RequestOptions options = null)
-            => ClientHelper.GetInviteAsync(this, inviteId, options ?? RequestOptions.Default);
+        public Task<RestInviteMetadata> GetInviteAsync(string inviteId, bool withCount = false, RequestOptions options = null)
+            => ClientHelper.GetInviteAsync(this, inviteId, withCount, options ?? RequestOptions.Default);
         
         // IDiscordClient
         async Task<IApplication> IDiscordClient.GetApplicationInfoAsync(RequestOptions options)
@@ -70,8 +70,8 @@ namespace Discord.WebSocket
         async Task<IReadOnlyCollection<IConnection>> IDiscordClient.GetConnectionsAsync(RequestOptions options)
             => await GetConnectionsAsync(options).ConfigureAwait(false);
 
-        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, RequestOptions options)
-            => await GetInviteAsync(inviteId, options).ConfigureAwait(false);
+        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, bool withCount, RequestOptions options)
+            => await GetInviteAsync(inviteId, withCount, options).ConfigureAwait(false);
 
         Task<IGuild> IDiscordClient.GetGuildAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuild>(GetGuild(id));

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -327,8 +327,8 @@ namespace Discord.WebSocket
         async Task<IReadOnlyCollection<IConnection>> IDiscordClient.GetConnectionsAsync(RequestOptions options)
             => await GetConnectionsAsync().ConfigureAwait(false);
 
-        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, RequestOptions options)
-            => await GetInviteAsync(inviteId).ConfigureAwait(false);
+        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, bool withCount, RequestOptions options)
+            => await GetInviteAsync(inviteId, withCount, options).ConfigureAwait(false);
 
         Task<IGuild> IDiscordClient.GetGuildAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuild>(GetGuild(id));

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1796,8 +1796,8 @@ namespace Discord.WebSocket
         async Task<IReadOnlyCollection<IConnection>> IDiscordClient.GetConnectionsAsync(RequestOptions options)
             => await GetConnectionsAsync().ConfigureAwait(false);
 
-        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, RequestOptions options)
-            => await GetInviteAsync(inviteId).ConfigureAwait(false);
+        async Task<IInvite> IDiscordClient.GetInviteAsync(string inviteId, bool withCount, RequestOptions options)
+            => await GetInviteAsync(inviteId, withCount, options).ConfigureAwait(false);
 
         Task<IGuild> IDiscordClient.GetGuildAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuild>(GetGuild(id));


### PR DESCRIPTION
# Summary

This PR does 3 things.

1. Fix `IDiscordClient.GetInviteAsync` behaviour
    - Previously, this method would have returned much less information than what the API provided. This is fixed by changing the return type from `RestInvite` to `RestInviteMetadata`. 

2. Add the ability to get the approximated member/presence count provided by the API
    - The current design is debatable; I feel like we should just always return this count instead of having to add a new parameter asking whether the user want the count included.

3.  Deprecate the `IInvite.AcceptAsync` method
    - The accept endpoint has been deprecated by Discord around the end of March.