### PR TITLE
Update VoiceRegion model

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IVoiceRegion.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IVoiceRegion.cs
@@ -1,4 +1,4 @@
-﻿namespace Discord
+namespace Discord
 {
     public interface IVoiceRegion
     {
@@ -10,9 +10,9 @@
         bool IsVip { get; }
         /// <summary> Returns true if this voice region is the closest to your machine. </summary>
         bool IsOptimal { get; }
-        /// <summary> Gets an example hostname for this voice region. </summary>
-        string SampleHostname { get; }
-        /// <summary> Gets an example port for this voice region. </summary>
-        int SamplePort { get; }
+        /// <summary> Returns true if this is a deprecated voice region (avoid switching to these). </summary>
+        bool IsDeprecated { get; }
+        /// <summary> Returns true if this is a custom voice region (used for events/etc) </summary>
+        bool IsCustom { get; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/VoiceRegion.cs
+++ b/src/Discord.Net.Rest/API/Common/VoiceRegion.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -13,9 +13,9 @@ namespace Discord.API
         public bool IsVip { get; set; }
         [JsonProperty("optimal")]
         public bool IsOptimal { get; set; }
-        [JsonProperty("sample_hostname")]
-        public string SampleHostname { get; set; }
-        [JsonProperty("sample_port")]
-        public int SamplePort { get; set; }
+        [JsonProperty("deprecated")]
+        public bool IsDeprecated { get; set; }
+        [JsonProperty("custom")]
+        public bool IsCustom { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/RestVoiceRegion.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestVoiceRegion.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Rest;
+using Discord.Rest;
 using System.Diagnostics;
 using Model = Discord.API.VoiceRegion;
 
@@ -7,11 +7,16 @@ namespace Discord
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RestVoiceRegion : RestEntity<string>, IVoiceRegion
     {
+        /// <inheritdoc />
         public string Name { get; private set; }
+        /// <inheritdoc />
         public bool IsVip { get; private set; }
+        /// <inheritdoc />
         public bool IsOptimal { get; private set; }
-        public string SampleHostname { get; private set; }
-        public int SamplePort { get; private set; }
+        /// <inheritdoc />
+        public bool IsDeprecated { get; private set; }
+        /// <inheritdoc />
+        public bool IsCustom { get; private set; }
 
         internal RestVoiceRegion(BaseDiscordClient client, string id)
             : base(client, id)
@@ -28,8 +33,8 @@ namespace Discord
             Name = model.Name;
             IsVip = model.IsVip;
             IsOptimal = model.IsOptimal;
-            SampleHostname = model.SampleHostname;
-            SamplePort = model.SamplePort;
+            IsDeprecated = model.IsDeprecated;
+            IsCustom = model.IsCustom;
         }
 
         public override string ToString() => Name;


### PR DESCRIPTION
# Summary

Updates the `VoiceRegion` API model. Sample prefixed properties were long deprecated and replaced with `custom` and `deprecated` bools.