### PR TITLE
Fix message not being created when user has no guild specific data, resolve #1024

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -479,14 +479,14 @@ namespace Discord.WebSocket
                                             await TimedInvokeAsync(_readyEvent, nameof(Ready)).ConfigureAwait(false);
                                             await _gatewayLogger.InfoAsync("Ready").ConfigureAwait(false);
                                         });
-                                    var _ = _connection.CompleteAsync();
+                                    _ = _connection.CompleteAsync();
                                 }
                                 break;
                             case "RESUMED":
                                 {
                                     await _gatewayLogger.DebugAsync("Received Dispatch (RESUMED)").ConfigureAwait(false);
 
-                                    var _ = _connection.CompleteAsync();
+                                    _ = _connection.CompleteAsync();
 
                                     //Notify the client that these guilds are available again
                                     foreach (var guild in State.Guilds)
@@ -1095,8 +1095,10 @@ namespace Discord.WebSocket
                                             else if (channel is SocketGroupChannel)
                                                 author = (channel as SocketGroupChannel).GetOrAddUser(data.Author.Value);
                                             else
+                                            {
                                                 await UnknownChannelUserAsync(type, data.Author.Value.Id, channel.Id).ConfigureAwait(false);
-                                            return;
+                                                return;
+                                            }
                                         }
 
                                         var msg = SocketMessage.Create(this, State, author, channel, data);


### PR DESCRIPTION
# Summary

This should resolve #1024, where messages are being ditched when the message author could still be added. It also replaces 'var _' with simple '_' discard within the same method.