### PR TITLE
Deprecates ReadMessages, introduces ViewChannel

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -16,8 +16,8 @@ namespace Discord
         // Text
         AddReactions        = 0x00_00_00_40,
         ViewAuditLog        = 0x00_00_00_80,
-        [Obsolete("Use ViewChannel instead")]
-        ReadMessages        = ViewChannel
+        [Obsolete("Use ViewChannel instead.")]
+        ReadMessages        = ViewChannel,
         ViewChannel         = 0x00_00_04_00,
         SendMessages        = 0x00_00_08_00,
         SendTTSMessages     = 0x00_00_10_00,

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Discord
 {
@@ -16,7 +16,9 @@ namespace Discord
         // Text
         AddReactions        = 0x00_00_00_40,
         ViewAuditLog        = 0x00_00_00_80,
-        ReadMessages        = 0x00_00_04_00,
+        [Obsolete("Use ViewChannel instead")]
+        ReadMessages        = ViewChannel
+        ViewChannel         = 0x00_00_04_00,
         SendMessages        = 0x00_00_08_00,
         SendTTSMessages     = 0x00_00_10_00,
         ManageMessages      = 0x00_00_20_00,

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Discord
@@ -35,7 +36,10 @@ namespace Discord
         public bool ViewAuditLog => Permissions.GetValue(RawValue, GuildPermission.ViewAuditLog);
 
         /// <summary> If True, a user may join channels. </summary>
-        public bool ReadMessages => Permissions.GetValue(RawValue, GuildPermission.ReadMessages);
+        [Obsolete("Use ViewChannel instead.")]
+        public bool ReadMessages => ViewChannel;
+        /// <summary> If True, a user may view channels. </summary>
+        public bool ViewChannel => Permissions.GetValue(RawValue, GuildPermission.ViewChannel);
         /// <summary> If True, a user may send messages. </summary>
         public bool SendMessages => Permissions.GetValue(RawValue, GuildPermission.SendMessages);
         /// <summary> If True, a user may send text-to-speech messages. </summary>


### PR DESCRIPTION
Marks `ReadMessages` as obsolete, and introduces `ViewChannel` to be used in its stead as the API does.