### PR TITLE
Improve SpotifyGame

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -34,6 +34,8 @@ namespace Discord
 
         public static string GetSpotifyAlbumArtUrl(string albumArtId)
             => $"https://i.scdn.co/image/{albumArtId}";
+        public static string GetSpotifyDirectUrl(string trackId)
+            => $"https://open.spotify.com/track/{trackId}";
 
         private static string FormatToExtension(ImageFormat format, string imageId)
         {

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -8,13 +8,15 @@ namespace Discord
     public class SpotifyGame : Game
     {
         public IReadOnlyCollection<string> Artists { get; internal set; }
-        public string AlbumArt { get; internal set; }
         public string AlbumTitle { get; internal set; }
         public string TrackTitle { get; internal set; }
-        public string TrackId { get; internal set; }
-        public string TrackUrl { get; internal set; }
-        public string SessionId { get; internal set; }
         public TimeSpan? Duration { get; internal set; }
+
+        public string TrackId { get; internal set; }
+        public string SessionId { get; internal set; }
+
+        public string AlbumArtUrl { get; internal set; }
+        public string TrackUrl { get; internal set; }
 
         internal SpotifyGame() { }
 

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -7,17 +7,17 @@ namespace Discord
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SpotifyGame : Game
     {
-        public IEnumerable<string> Artists { get; internal set; }
+        public IReadOnlyCollection<string> Artists { get; internal set; }
         public string AlbumArt { get; internal set; }
         public string AlbumTitle { get; internal set; }
         public string TrackTitle { get; internal set; }
-        public string SyncId { get; internal set; }
+        public string TrackId { get; internal set; }
         public string SessionId { get; internal set; }
         public TimeSpan? Duration { get; internal set; }
 
         internal SpotifyGame() { }
 
-        public override string ToString() => Name;
+        public override string ToString() => $"{string.Join(", ", Artists)} - {TrackTitle} ({Duration})";
         private string DebuggerDisplay => $"{Name} (Spotify)";
     }
 }

--- a/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/SpotifyGame.cs
@@ -12,6 +12,7 @@ namespace Discord
         public string AlbumTitle { get; internal set; }
         public string TrackTitle { get; internal set; }
         public string TrackId { get; internal set; }
+        public string TrackUrl { get; internal set; }
         public string SessionId { get; internal set; }
         public TimeSpan? Duration { get; internal set; }
 

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -19,6 +19,7 @@ namespace Discord.WebSocket
                     Name = model.Name,
                     SessionId = model.SessionId.GetValueOrDefault(),
                     TrackId = model.SyncId.Value,
+                    TrackUrl = CDN.GetSpotifyDirectUrl(model.SyncId.Value),
                     AlbumTitle = albumText,
                     TrackTitle = model.Details.GetValueOrDefault(),
                     Artists = model.State.GetValueOrDefault()?.Split(';').Select(x=>x?.Trim()).ToImmutableArray(),

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -24,7 +24,7 @@ namespace Discord.WebSocket
                     TrackTitle = model.Details.GetValueOrDefault(),
                     Artists = model.State.GetValueOrDefault()?.Split(';').Select(x=>x?.Trim()).ToImmutableArray(),
                     Duration = timestamps?.End - timestamps?.Start,
-                    AlbumArt = albumArtId != null ? CDN.GetSpotifyAlbumArtUrl(albumArtId) : null,
+                    AlbumArtUrl = albumArtId != null ? CDN.GetSpotifyAlbumArtUrl(albumArtId) : null,
                     Type = ActivityType.Listening
                 };
             }

--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -1,3 +1,6 @@
+using System.Collections.Immutable;
+using System.Linq;
+
 namespace Discord.WebSocket
 {
     internal static class EntityExtensions
@@ -15,10 +18,10 @@ namespace Discord.WebSocket
                 {
                     Name = model.Name,
                     SessionId = model.SessionId.GetValueOrDefault(),
-                    SyncId = model.SyncId.Value,
+                    TrackId = model.SyncId.Value,
                     AlbumTitle = albumText,
                     TrackTitle = model.Details.GetValueOrDefault(),
-                    Artists = model.State.GetValueOrDefault()?.Split(';'),
+                    Artists = model.State.GetValueOrDefault()?.Split(';').Select(x=>x?.Trim()).ToImmutableArray(),
                     Duration = timestamps?.End - timestamps?.Start,
                     AlbumArt = albumArtId != null ? CDN.GetSpotifyAlbumArtUrl(albumArtId) : null,
                     Type = ActivityType.Listening


### PR DESCRIPTION
# Summary

This PR does the following,

1. Rename `SyncId` to `TrackId` as it has nothing to do with syncing
2. Add `TrackUrl` to link direct Spotify link for convenience
3. Change the override `ToString` return to a more verbose output
4. Return an `IReadOnlyCollection<string>` instead of `IEnumerable<string>` for `Artists`
5. Rename `AlbumArt` to `AlbumArtUrl` for consistency

# Additional Issue Introduced

Since there are now 2 URL properties, should we follow the lib's consistency on URL return and make them methods instead (i.e. change `AlbumArtUrl` to `GetAlbumArtUrl()` like `IUser.GetAvatarUrl()`)?