### PR TITLE
Update Dependencies and support NS2.0 builds

### DIFF
--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -16,10 +16,7 @@
     <PropertyGroup Condition=" '$(BuildNumber)' != '' And $(IsTagBuild) != 'true' ">
         <VersionSuffix Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">build-$(BuildNumber)</VersionSuffix>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.1' ">
-        <DefineConstants>$(DefineConstants);FILESYSTEM;DEFAULTUDPCLIENT;DEFAULTWEBSOCKET</DefineConstants>
-    </PropertyGroup>
+    </PropertyGroup> 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">
         <DefineConstants>$(DefineConstants);FORMATSTR;UNIXTIME;MSTRYBUFFER;UDPDISPOSE</DefineConstants>
     </PropertyGroup>

--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -17,10 +17,10 @@
         <VersionSuffix Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">build-$(BuildNumber)</VersionSuffix>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45' ">
+    <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.1' ">
         <DefineConstants>$(DefineConstants);FILESYSTEM;DEFAULTUDPCLIENT;DEFAULTWEBSOCKET</DefineConstants>
     </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">
         <DefineConstants>$(DefineConstants);FORMATSTR;UNIXTIME;MSTRYBUFFER;UDPDISPOSE</DefineConstants>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -16,10 +16,7 @@
     <PropertyGroup Condition=" '$(BuildNumber)' != '' And $(IsTagBuild) != 'true' ">
         <VersionSuffix Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">build-$(BuildNumber)</VersionSuffix>
-    </PropertyGroup> 
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">
-        <DefineConstants>$(DefineConstants);FORMATSTR;UNIXTIME;MSTRYBUFFER;UDPDISPOSE</DefineConstants>
-    </PropertyGroup>
+    </PropertyGroup>     
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <NoWarn>$(NoWarn);CS1573;CS1591</NoWarn>
         <WarningsAsErrors>true</WarningsAsErrors>

--- a/samples/02_commands_framework/02_commands_framework.csproj
+++ b/samples/02_commands_framework/02_commands_framework.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Discord.Net.Analyzers/Discord.Net.Analyzers.csproj
+++ b/src/Discord.Net.Analyzers/Discord.Net.Analyzers.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Commands\Discord.Net.Commands.csproj" />

--- a/src/Discord.Net.Analyzers/Discord.Net.Analyzers.csproj
+++ b/src/Discord.Net.Analyzers/Discord.Net.Analyzers.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Commands\Discord.Net.Commands.csproj" />

--- a/src/Discord.Net.Commands/Discord.Net.Commands.csproj
+++ b/src/Discord.Net.Commands/Discord.Net.Commands.csproj
@@ -4,12 +4,15 @@
     <AssemblyName>Discord.Net.Commands</AssemblyName>
     <RootNamespace>Discord.Commands</RootNamespace>
     <Description>A Discord.Net extension adding support for bot commands.</Description>
-    <TargetFrameworks>netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.Commands/Discord.Net.Commands.csproj
+++ b/src/Discord.Net.Commands/Discord.Net.Commands.csproj
@@ -4,7 +4,8 @@
     <AssemblyName>Discord.Net.Commands</AssemblyName>
     <RootNamespace>Discord.Commands</RootNamespace>
     <Description>A Discord.Net extension adding support for bot commands.</Description>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Commands/Discord.Net.Commands.csproj
+++ b/src/Discord.Net.Commands/Discord.Net.Commands.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Discord.Net.targets" />
   <PropertyGroup>
     <AssemblyName>Discord.Net.Commands</AssemblyName>
     <RootNamespace>Discord.Commands</RootNamespace>
     <Description>A Discord.Net extension adding support for bot commands.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -4,8 +4,8 @@
     <AssemblyName>Discord.Net.Core</AssemblyName>
     <RootNamespace>Discord</RootNamespace>
     <Description>The core components for the Discord.Net library.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -8,8 +8,8 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Interactive.Async" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -4,8 +4,8 @@
     <AssemblyName>Discord.Net.Core</AssemblyName>
     <RootNamespace>Discord</RootNamespace>
     <Description>The core components for the Discord.Net library.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Discord.Net.targets" />
   <PropertyGroup>
     <AssemblyName>Discord.Net.Core</AssemblyName>
     <RootNamespace>Discord</RootNamespace>
     <Description>The core components for the Discord.Net library.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -9,10 +9,10 @@ namespace Discord
     {
         /// <summary> Sends a message to this message channel. </summary>
         Task<IUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null);
-#if FILESYSTEM
+
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         Task<IUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
-#endif
+
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         Task<IUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
 

--- a/src/Discord.Net.Core/Entities/Image.cs
+++ b/src/Discord.Net.Core/Entities/Image.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 namespace Discord
 {
     /// <summary>
@@ -15,7 +15,7 @@ namespace Discord
         {
             Stream = stream;
         }
-#if FILESYSTEM
+
         /// <summary>
         /// Create the image from a file path.
         /// </summary>
@@ -27,6 +27,6 @@ namespace Discord
         {
             Stream = File.OpenRead(path);
         }
-#endif
+
     }
 }

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -32,7 +32,6 @@ namespace Discord
             return await (await user.GetOrCreateDMChannelAsync().ConfigureAwait(false)).SendFileAsync(stream, filename, text, isTTS, embed, options).ConfigureAwait(false);
         }
 
-#if FILESYSTEM
         /// <summary>
         /// Sends a file to the user via DM.
         /// </summary>
@@ -45,7 +44,6 @@ namespace Discord
         {
             return await (await user.GetOrCreateDMChannelAsync().ConfigureAwait(false)).SendFileAsync(filePath, text, isTTS, embed, options).ConfigureAwait(false);
         }
-#endif
 
         public static Task BanAsync(this IGuildUser user, int pruneDays = 0, string reason = null, RequestOptions options = null)
             => user.Guild.AddBanAsync(user, pruneDays, reason, options);

--- a/src/Discord.Net.Core/Logging/LogManager.cs
+++ b/src/Discord.Net.Core/Logging/LogManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Discord.Logging
@@ -35,7 +35,7 @@ namespace Discord.Logging
             }
             catch { }
         }
-#if FORMATSTR
+
         public async Task LogAsync(LogSeverity severity, string source, FormattableString message, Exception ex = null)
         {
             try
@@ -45,52 +45,49 @@ namespace Discord.Logging
             }
             catch { }
         }
-#endif
+
 
         public Task ErrorAsync(string source, Exception ex)
             => LogAsync(LogSeverity.Error, source, ex);
         public Task ErrorAsync(string source, string message, Exception ex = null)
             => LogAsync(LogSeverity.Error, source, message, ex);
-#if FORMATSTR
+
         public Task ErrorAsync(string source, FormattableString message, Exception ex = null)
             => LogAsync(LogSeverity.Error, source, message, ex);
-#endif
+
 
         public Task WarningAsync(string source, Exception ex)
             => LogAsync(LogSeverity.Warning, source, ex);
         public Task WarningAsync(string source, string message, Exception ex = null)
             => LogAsync(LogSeverity.Warning, source, message, ex);
-#if FORMATSTR
+
         public Task WarningAsync(string source, FormattableString message, Exception ex = null)
             => LogAsync(LogSeverity.Warning, source, message, ex);
-#endif
+
 
         public Task InfoAsync(string source, Exception ex)
             => LogAsync(LogSeverity.Info, source, ex);
         public Task InfoAsync(string source, string message, Exception ex = null)
             => LogAsync(LogSeverity.Info, source, message, ex);
-#if FORMATSTR
         public Task InfoAsync(string source, FormattableString message, Exception ex = null)
             => LogAsync(LogSeverity.Info, source, message, ex);
-#endif
+
 
         public Task VerboseAsync(string source, Exception ex)
             => LogAsync(LogSeverity.Verbose, source, ex);
         public Task VerboseAsync(string source, string message, Exception ex = null)
             => LogAsync(LogSeverity.Verbose, source, message, ex);
-#if FORMATSTR
         public Task VerboseAsync(string source, FormattableString message, Exception ex = null)
             => LogAsync(LogSeverity.Verbose, source, message, ex);
-#endif
+
 
         public Task DebugAsync(string source, Exception ex)
             => LogAsync(LogSeverity.Debug, source, ex);
         public Task DebugAsync(string source, string message, Exception ex = null)
             => LogAsync(LogSeverity.Debug, source, message, ex);
-#if FORMATSTR
         public Task DebugAsync(string source, FormattableString message, Exception ex = null)
             => LogAsync(LogSeverity.Debug, source, message, ex);
-#endif
+
 
         public Logger CreateLogger(string name) => new Logger(this, name);
 

--- a/src/Discord.Net.Core/Logging/Logger.cs
+++ b/src/Discord.Net.Core/Logging/Logger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Discord.Logging
@@ -20,54 +20,53 @@ namespace Discord.Logging
             => _manager.LogAsync(severity, Name, exception);
         public Task LogAsync(LogSeverity severity, string message, Exception exception = null)
             => _manager.LogAsync(severity, Name, message, exception);
-#if FORMATSTR
         public Task LogAsync(LogSeverity severity, FormattableString message, Exception exception = null)
             => _manager.LogAsync(severity, Name, message, exception);
-#endif
+
 
         public Task ErrorAsync(Exception exception)
             => _manager.ErrorAsync(Name, exception);
         public Task ErrorAsync(string message, Exception exception = null)
             => _manager.ErrorAsync(Name, message, exception);
-#if FORMATSTR
+
         public Task ErrorAsync(FormattableString message, Exception exception = null)
             => _manager.ErrorAsync(Name, message, exception);
-#endif
+
 
         public Task WarningAsync(Exception exception)
             => _manager.WarningAsync(Name, exception);
         public Task WarningAsync(string message, Exception exception = null)
             => _manager.WarningAsync(Name, message, exception);
-#if FORMATSTR
+
         public Task WarningAsync(FormattableString message, Exception exception = null)
             => _manager.WarningAsync(Name, message, exception);
-#endif
+
 
         public Task InfoAsync(Exception exception)
             => _manager.InfoAsync(Name, exception);
         public Task InfoAsync(string message, Exception exception = null)
             => _manager.InfoAsync(Name, message, exception);
-#if FORMATSTR
+
         public Task InfoAsync(FormattableString message, Exception exception = null)
             => _manager.InfoAsync(Name, message, exception);
-#endif
+
 
         public Task VerboseAsync(Exception exception)
             => _manager.VerboseAsync(Name, exception);
         public Task VerboseAsync(string message, Exception exception = null)
             => _manager.VerboseAsync(Name, message, exception);
-#if FORMATSTR
+
         public Task VerboseAsync(FormattableString message, Exception exception = null)
             => _manager.VerboseAsync(Name, message, exception);
-#endif
+
 
         public Task DebugAsync(Exception exception)
             => _manager.DebugAsync(Name, exception);
         public Task DebugAsync(string message, Exception exception = null)
             => _manager.DebugAsync(Name, message, exception);
-#if FORMATSTR
+
         public Task DebugAsync(FormattableString message, Exception exception = null)
             => _manager.DebugAsync(Name, message, exception);
-#endif
+
     }
 }

--- a/src/Discord.Net.Core/Utils/DateTimeUtils.cs
+++ b/src/Discord.Net.Core/Utils/DateTimeUtils.cs
@@ -1,57 +1,14 @@
-﻿using System;
+using System;
 
 namespace Discord
 {
     //Source: https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/DateTimeOffset.cs
     internal static class DateTimeUtils
     {
-#if !UNIXTIME
-        private const long UnixEpochTicks = 621_355_968_000_000_000;
-        private const long UnixEpochSeconds = 62_135_596_800;
-        private const long UnixEpochMilliseconds = 62_135_596_800_000;
-#endif
-
         public static DateTimeOffset FromTicks(long ticks)
             => new DateTimeOffset(ticks, TimeSpan.Zero);
         public static DateTimeOffset? FromTicks(long? ticks)
             => ticks != null ? new DateTimeOffset(ticks.Value, TimeSpan.Zero) : (DateTimeOffset?)null;
-
-        public static DateTimeOffset FromUnixSeconds(long seconds)
-        {
-#if UNIXTIME
-            return DateTimeOffset.FromUnixTimeSeconds(seconds);
-#else
-            long ticks = seconds * TimeSpan.TicksPerSecond + UnixEpochTicks;
-            return new DateTimeOffset(ticks, TimeSpan.Zero);
-#endif
-        }
-        public static DateTimeOffset FromUnixMilliseconds(long milliseconds)
-        {
-#if UNIXTIME
-            return DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);
-#else
-            long ticks = milliseconds * TimeSpan.TicksPerMillisecond + UnixEpochTicks;
-            return new DateTimeOffset(ticks, TimeSpan.Zero);
-#endif
-        }
-
-        public static long ToUnixSeconds(DateTimeOffset dto)
-        {
-#if UNIXTIME
-            return dto.ToUnixTimeSeconds();
-#else
-            long seconds = dto.UtcDateTime.Ticks / TimeSpan.TicksPerSecond;
-            return seconds - UnixEpochSeconds;
-#endif
-        }
-        public static long ToUnixMilliseconds(DateTimeOffset dto)
-        {
-#if UNIXTIME
-            return dto.ToUnixTimeMilliseconds();
-#else
-            long milliseconds = dto.UtcDateTime.Ticks / TimeSpan.TicksPerMillisecond;
-            return milliseconds - UnixEpochMilliseconds;
-#endif
-        }
+       
     }
 }

--- a/src/Discord.Net.Core/Utils/SnowflakeUtils.cs
+++ b/src/Discord.Net.Core/Utils/SnowflakeUtils.cs
@@ -5,8 +5,8 @@ namespace Discord
     public static class SnowflakeUtils
     {
         public static DateTimeOffset FromSnowflake(ulong value)
-            => DateTimeUtils.FromUnixMilliseconds((long)((value >> 22) + 1420070400000UL));
+            => DateTimeOffset.FromUnixTimeMilliseconds((long)((value >> 22) + 1420070400000UL));
         public static ulong ToSnowflake(DateTimeOffset value)
-            => ((ulong)DateTimeUtils.ToUnixMilliseconds(value) - 1420070400000UL) << 22;
+            => ((ulong)value.ToUnixTimeMilliseconds() - 1420070400000UL) << 22;
     }
 }

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Discord.Net.targets" />
   <PropertyGroup>
     <AssemblyName>Discord.Net.Rest</AssemblyName>
@@ -10,9 +10,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
- </ItemGroup>
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <!-- https://github.com/dotnet/corefx/issues/19535 -->
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -4,16 +4,15 @@
     <AssemblyName>Discord.Net.Rest</AssemblyName>
     <RootNamespace>Discord.Rest</RootNamespace>
     <Description>A core Discord.Net library containing the REST client and models.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
-    <!-- https://github.com/dotnet/corefx/issues/19535 -->
-  </ItemGroup>
+ </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -4,8 +4,8 @@
     <AssemblyName>Discord.Net.Rest</AssemblyName>
     <RootNamespace>Discord.Rest</RootNamespace>
     <Description>A core Discord.Net library containing the REST client and models.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Discord.Net.Rest</AssemblyName>
     <RootNamespace>Discord.Rest</RootNamespace>
     <Description>A core Discord.Net library containing the REST client and models.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
@@ -13,7 +13,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Discord.Rest</RootNamespace>
     <Description>A core Discord.Net library containing the REST client and models.</Description>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -168,7 +168,6 @@ namespace Discord.Rest
             return RestUserMessage.Create(client, channel, client.CurrentUser, model);
         }
 
-#if FILESYSTEM
         public static async Task<RestUserMessage> SendFileAsync(IMessageChannel channel, BaseDiscordClient client,
             string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
         {
@@ -176,7 +175,7 @@ namespace Discord.Rest
             using (var file = File.OpenRead(filePath))
                 return await SendFileAsync(channel, client, file, filename, text, isTTS, embed, options).ConfigureAwait(false);
         }
-#endif
+
         public static async Task<RestUserMessage> SendFileAsync(IMessageChannel channel, BaseDiscordClient client,
             Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
         {

--- a/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
@@ -8,10 +8,10 @@ namespace Discord.Rest
     {
         /// <summary> Sends a message to this message channel. </summary>
         new Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null);
-#if FILESYSTEM
+
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         new Task<RestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
-#endif
+
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         new Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -65,10 +65,10 @@ namespace Discord.Rest
 
         public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
-#if FILESYSTEM
+
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, embed, options);
-#endif
+
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, embed, options);
 
@@ -121,10 +121,9 @@ namespace Discord.Rest
         async Task<IReadOnlyCollection<IMessage>> IMessageChannel.GetPinnedMessagesAsync(RequestOptions options)
             => await GetPinnedMessagesAsync(options).ConfigureAwait(false);
 
-#if FILESYSTEM
         async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(filePath, text, isTTS, embed, options).ConfigureAwait(false);
-#endif
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -78,10 +78,10 @@ namespace Discord.Rest
 
         public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
-#if FILESYSTEM
+
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, embed, options);
-#endif
+
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, embed, options);
 
@@ -131,10 +131,9 @@ namespace Discord.Rest
         async Task<IReadOnlyCollection<IMessage>> IMessageChannel.GetPinnedMessagesAsync(RequestOptions options)
             => await GetPinnedMessagesAsync(options).ConfigureAwait(false);
 
-#if FILESYSTEM
         async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(filePath, text, isTTS, embed, options).ConfigureAwait(false);
-#endif
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -60,10 +60,10 @@ namespace Discord.Rest
 
         public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
-#if FILESYSTEM
+
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, embed, options);
-#endif
+
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, embed, options);
 
@@ -126,10 +126,9 @@ namespace Discord.Rest
         async Task<IReadOnlyCollection<IMessage>> IMessageChannel.GetPinnedMessagesAsync(RequestOptions options)
             => await GetPinnedMessagesAsync(options).ConfigureAwait(false);
 
-#if FILESYSTEM
         async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(filePath, text, isTTS, embed, options).ConfigureAwait(false);
-#endif
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RpcVirtualMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RpcVirtualMessageChannel.cs
@@ -35,10 +35,10 @@ namespace Discord.Rest
 
         public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
-#if FILESYSTEM
+
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, embed, options);
-#endif
+
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, embed, options);
 
@@ -81,10 +81,9 @@ namespace Discord.Rest
         async Task<IReadOnlyCollection<IMessage>> IMessageChannel.GetPinnedMessagesAsync(RequestOptions options)
             => await GetPinnedMessagesAsync(options);
 
-#if FILESYSTEM
         async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(filePath, text, isTTS, embed, options);
-#endif
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)

--- a/src/Discord.Net.Rest/Net/Converters/DiscordContractResolver.cs
+++ b/src/Discord.Net.Rest/Net/Converters/DiscordContractResolver.cs
@@ -1,4 +1,4 @@
-﻿using Discord.API;
+using Discord.API;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
@@ -25,7 +25,6 @@ namespace Discord.Net.Converters
                 if (converter != null)
                 {
                     property.Converter = converter;
-                    property.MemberConverter = converter;
                 }
             }
             else

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -230,7 +230,7 @@ namespace Discord.Net.Queue
 #endif
                 }
 
-                var now = DateTimeUtils.ToUnixSeconds(DateTimeOffset.UtcNow);
+                var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 DateTimeOffset? resetTick = null;
 
                 //Using X-RateLimit-Remaining causes a race condition

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Discord.Net
@@ -21,7 +21,7 @@ namespace Discord.Net
             Remaining = headers.TryGetValue("X-RateLimit-Remaining", out temp) && 
                 int.TryParse(temp, out var remaining) ? remaining : (int?)null;
             Reset = headers.TryGetValue("X-RateLimit-Reset", out temp) && 
-                int.TryParse(temp, out var reset) ? DateTimeUtils.FromUnixSeconds(reset) : (DateTimeOffset?)null;
+                int.TryParse(temp, out var reset) ? DateTimeOffset.FromUnixTimeSeconds(reset) : (DateTimeOffset?)null;
             RetryAfter = headers.TryGetValue("Retry-After", out temp) &&
                 int.TryParse(temp, out var retryAfter) ? retryAfter : (int?)null;
             Lag = headers.TryGetValue("Date", out temp) &&

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\Discord.Net.Rest\Discord.Net.Rest.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Discord.Net.WebSocket</AssemblyName>
     <RootNamespace>Discord.WebSocket</RootNamespace>
     <Description>A core Discord.Net library containing the WebSocket client and models.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Discord.Net.targets" />
   <PropertyGroup>
     <AssemblyName>Discord.Net.WebSocket</AssemblyName>
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
     <ProjectReference Include="..\Discord.Net.Rest\Discord.Net.Rest.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
@@ -4,15 +4,15 @@
     <AssemblyName>Discord.Net.WebSocket</AssemblyName>
     <RootNamespace>Discord.WebSocket</RootNamespace>
     <Description>A core Discord.Net library containing the WebSocket client and models.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
     <ProjectReference Include="..\Discord.Net.Rest\Discord.Net.Rest.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
@@ -4,15 +4,15 @@
     <AssemblyName>Discord.Net.WebSocket</AssemblyName>
     <RootNamespace>Discord.WebSocket</RootNamespace>
     <Description>A core Discord.Net library containing the WebSocket client and models.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
     <ProjectReference Include="..\Discord.Net.Rest\Discord.Net.Rest.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -365,7 +365,7 @@ namespace Discord.WebSocket
             await ApiClient.SendStatusUpdateAsync(
                 status,
                 status == UserStatus.AFK,
-                statusSince != null ? DateTimeUtils.ToUnixMilliseconds(_statusSince.Value) : (long?)null,
+                statusSince != null ? _statusSince.Value.ToUnixTimeMilliseconds() : (long?)null,
                 gameModel).ConfigureAwait(false);
         }
 

--- a/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Discord.API;
 using Discord.API.Voice;
 using Discord.Net.Converters;
@@ -129,7 +129,7 @@ namespace Discord.Audio
         //WebSocket
         public async Task SendHeartbeatAsync(RequestOptions options = null)
         {
-            await SendAsync(VoiceOpCode.Heartbeat, DateTimeUtils.ToUnixMilliseconds(DateTimeOffset.UtcNow), options: options).ConfigureAwait(false);
+            await SendAsync(VoiceOpCode.Heartbeat, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), options: options).ConfigureAwait(false);
         }
         public async Task SendIdentityAsync(ulong userId, string sessionId, string token)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -12,10 +12,10 @@ namespace Discord.WebSocket
 
         /// <summary> Sends a message to this message channel. </summary>
         new Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null);
-#if FILESYSTEM
+
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         new Task<RestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
-#endif
+
         /// <summary> Sends a file to this text channel, with an optional caption. </summary>
         new Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -69,10 +69,10 @@ namespace Discord.WebSocket
 
         public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
-#if FILESYSTEM
+
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, embed, options);
-#endif
+
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, embed, options);
 
@@ -130,10 +130,8 @@ namespace Discord.WebSocket
             => SocketChannelHelper.GetMessagesAsync(this, Discord, _messages, fromMessage.Id, dir, limit, mode, options);
         async Task<IReadOnlyCollection<IMessage>> IMessageChannel.GetPinnedMessagesAsync(RequestOptions options)
             => await GetPinnedMessagesAsync(options).ConfigureAwait(false);
-#if FILESYSTEM
         async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(filePath, text, isTTS, embed, options).ConfigureAwait(false);
-#endif
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -97,10 +97,10 @@ namespace Discord.WebSocket
 
         public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
-#if FILESYSTEM
+
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, embed, options);
-#endif
+
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, embed, options);
 
@@ -194,10 +194,10 @@ namespace Discord.WebSocket
             => SocketChannelHelper.GetMessagesAsync(this, Discord, _messages, fromMessage.Id, dir, limit, mode, options);
         async Task<IReadOnlyCollection<IMessage>> IMessageChannel.GetPinnedMessagesAsync(RequestOptions options)
             => await GetPinnedMessagesAsync(options).ConfigureAwait(false);
-#if FILESYSTEM
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(filePath, text, isTTS, embed, options).ConfigureAwait(false);
-#endif
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -77,10 +77,10 @@ namespace Discord.WebSocket
 
         public Task<RestUserMessage> SendMessageAsync(string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
-#if FILESYSTEM
+
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, filePath, text, isTTS, embed, options);
-#endif
+
         public Task<RestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)
             => ChannelHelper.SendFileAsync(this, Discord, stream, filename, text, isTTS, embed, options);
 
@@ -154,10 +154,10 @@ namespace Discord.WebSocket
             => SocketChannelHelper.GetMessagesAsync(this, Discord, _messages, fromMessage.Id, dir, limit, mode, options);
         async Task<IReadOnlyCollection<IMessage>> IMessageChannel.GetPinnedMessagesAsync(RequestOptions options)
             => await GetPinnedMessagesAsync(options).ConfigureAwait(false);
-#if FILESYSTEM
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(filePath, text, isTTS, embed, options).ConfigureAwait(false);
-#endif
+
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Net/DefaultUdpSocket.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultUdpSocket.cs
@@ -84,11 +84,7 @@ namespace Discord.Net.Udp
 
             if (_udp != null)
             {
-#if UDPDISPOSE
                 try { _udp.Dispose(); }
-#else
-                try { _udp.Close(); }
-#endif
                 catch { }
                 _udp = null;
             }

--- a/src/Discord.Net.WebSocket/Net/DefaultUdpSocket.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultUdpSocket.cs
@@ -1,4 +1,3 @@
-﻿#if DEFAULTUDPCLIENT
 using System;
 using System.Net;
 using System.Net.Sockets;
@@ -132,4 +131,3 @@ namespace Discord.Net.Udp
         }
     }
 }
-#endif

--- a/src/Discord.Net.WebSocket/Net/DefaultUdpSocketProvider.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultUdpSocketProvider.cs
@@ -4,7 +4,6 @@ namespace Discord.Net.Udp
 {
     public static class DefaultUdpSocketProvider
     {
-#if DEFAULTUDPCLIENT
         public static readonly UdpSocketProvider Instance = () => 
         {
             try
@@ -16,12 +15,5 @@ namespace Discord.Net.Udp
                 throw new PlatformNotSupportedException("The default UdpSocketProvider is not supported on this platform.", ex);
             }
         };
-#else
-        public static readonly UdpSocketProvider Instance = () => 
-        {
-            throw new PlatformNotSupportedException("The default UdpSocketProvider is not supported on this platform.\n" +
-                "You must specify a UdpSocketProvider or target a runtime supporting .NET Standard 1.3, such as .NET Framework 4.6+.");
-        };
-#endif
     }
 }

--- a/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
@@ -208,14 +208,9 @@ namespace Discord.Net.WebSockets
 
                             //Use the internal buffer if we can get it
                             resultCount = (int)stream.Length;
-#if MSTRYBUFFER
-                            if (stream.TryGetBuffer(out var streamBuffer))
-                                result = streamBuffer.Array;
-                            else
-                                result = stream.ToArray();
-#else
-                                result = stream.GetBuffer();
-#endif
+
+                            result = stream.TryGetBuffer(out var streamBuffer) ? streamBuffer.Array : stream.ToArray();
+
                         }
                     }
                     else

--- a/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
@@ -1,4 +1,3 @@
-﻿#if DEFAULTWEBSOCKET
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -248,4 +247,3 @@ namespace Discord.Net.WebSockets
         }
     }
 }
-#endif

--- a/src/Discord.Net.WebSocket/Net/DefaultWebSocketClientProvider.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultWebSocketClientProvider.cs
@@ -5,7 +5,6 @@ namespace Discord.Net.WebSockets
 {
     public static class DefaultWebSocketProvider
     {
-#if DEFAULTWEBSOCKET
         public static readonly WebSocketProvider Instance = Create();
 
         public static WebSocketProvider Create(IWebProxy proxy = null)
@@ -22,12 +21,5 @@ namespace Discord.Net.WebSockets
                 }
             };
         }
-#else
-        public static readonly WebSocketProvider Instance = () =>
-        {
-            throw new PlatformNotSupportedException("The default WebSocketProvider is not supported on this platform.\n" +
-                "You must specify a WebSocketProvider or target a runtime supporting .NET Standard 1.3, such as .NET Framework 4.6+.");
-        };
-#endif
     }
 }

--- a/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
+++ b/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
@@ -1,11 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Discord.Net.targets" />
   <PropertyGroup>
     <AssemblyName>Discord.Net.Webhook</AssemblyName>
     <RootNamespace>Discord.Webhook</RootNamespace>
     <Description>A core Discord.Net library containing the Webhook client and models.</Description>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
+++ b/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
@@ -4,7 +4,8 @@
     <AssemblyName>Discord.Net.Webhook</AssemblyName>
     <RootNamespace>Discord.Webhook</RootNamespace>
     <Description>A core Discord.Net library containing the Webhook client and models.</Description>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
+++ b/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Discord.Net.Webhook</AssemblyName>
     <RootNamespace>Discord.Webhook</RootNamespace>
     <Description>A core Discord.Net library containing the Webhook client and models.</Description>
-    <TargetFrameworks>netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -67,12 +67,11 @@ namespace Discord.Webhook
             string username = null, string avatarUrl = null, RequestOptions options = null)
             => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, options);
 
-#if FILESYSTEM
         /// <summary> Send a message to the channel for this webhook with an attachment. Returns the ID of the created message. </summary>
         public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null)
             => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl, options);
-#endif
+
         /// <summary> Send a message to the channel for this webhook with an attachment. Returns the ID of the created message. </summary>
         public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null)

--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -33,7 +33,6 @@ namespace Discord.Webhook
             var model = await client.ApiClient.CreateWebhookMessageAsync(client.Webhook.Id, args, options: options).ConfigureAwait(false);
             return model.Id;
         }
-#if FILESYSTEM
         public static async Task<ulong> SendFileAsync(DiscordWebhookClient client, string filePath, string text, bool isTTS, 
             IEnumerable<Embed> embeds, string username, string avatarUrl, RequestOptions options)
         {
@@ -41,7 +40,6 @@ namespace Discord.Webhook
             using (var file = File.OpenRead(filePath))
                 return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, options).ConfigureAwait(false);
         }
-#endif
         public static async Task<ulong> SendFileAsync(DiscordWebhookClient client, Stream stream, string filename, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, RequestOptions options)
         {

--- a/test/Discord.Net.Tests/Discord.Net.Tests.csproj
+++ b/test/Discord.Net.Tests/Discord.Net.Tests.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akavache" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.reporters" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.reporters" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/test/Discord.Net.Tests/Discord.Net.Tests.csproj
+++ b/test/Discord.Net.Tests/Discord.Net.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akavache" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -84,7 +84,7 @@ namespace Discord
             Assert.Equal(groupChannel, ChannelPermissions.Group.RawValue);
             return Task.CompletedTask;
         }
-      
+        [Fact]
         public Task TestChannelPermissionModify()
         {
             // test channel permission modify

--- a/test/Discord.Net.Tests/Tests.Channels.cs
+++ b/test/Discord.Net.Tests/Tests.Channels.cs
@@ -49,35 +49,35 @@ namespace Discord
         }
         private static void CheckTextChannels(RestGuild guild, params RestTextChannel[] textChannels)
         {
-            Assert.Equal(textChannels.Length, 5);
+            Assert.Equal(5, textChannels.Length);
             Assert.All(textChannels, x =>
             {
                 Assert.NotNull(x);
-                Assert.NotEqual(x.Id, 0UL);
+                Assert.NotEqual(0UL, x.Id);
                 Assert.True(x.Position >= 0);
             });
 
-            var text1 = textChannels.Where(x => x.Name == "text1").FirstOrDefault();
-            var text2 = textChannels.Where(x => x.Name == "text2").FirstOrDefault();
-            var text3 = textChannels.Where(x => x.Name == "text3").FirstOrDefault();
-            var text4 = textChannels.Where(x => x.Name == "text4").FirstOrDefault();
-            var text5 = textChannels.Where(x => x.Name == "text5").FirstOrDefault();
+            var text1 = textChannels.FirstOrDefault(x => x.Name == "text1");
+            var text2 = textChannels.FirstOrDefault(x => x.Name == "text2");
+            var text3 = textChannels.FirstOrDefault(x => x.Name == "text3");
+            var text4 = textChannels.FirstOrDefault(x => x.Name == "text4");
+            var text5 = textChannels.FirstOrDefault(x => x.Name == "text5");
 
             Assert.NotNull(text1);
             //Assert.True(text1.Id == guild.DefaultChannelId);
-            Assert.Equal(text1.Position, 1);
-            Assert.Equal(text1.Topic, "Topic1");
+            Assert.Equal(1, text1.Position);
+            Assert.Equal("Topic1", text1.Topic);
 
             Assert.NotNull(text2);
-            Assert.Equal(text2.Position, 2);
+            Assert.Equal(2, text2.Position);
             Assert.Null(text2.Topic);
 
             Assert.NotNull(text3);
-            Assert.Equal(text3.Topic, "Topic2");
+            Assert.Equal("Topic2", text3.Topic);
 
             Assert.NotNull(text4);
-            Assert.Equal(text4.Position, 3);
-            Assert.Equal(text4.Topic, "Topic2");
+            Assert.Equal(3, text4.Position);
+            Assert.Equal("Topic2", text4.Topic);
 
             Assert.NotNull(text5);
             Assert.Null(text5.Topic);
@@ -114,31 +114,31 @@ namespace Discord
         }
         private static void CheckVoiceChannels(params RestVoiceChannel[] voiceChannels)
         {
-            Assert.Equal(voiceChannels.Length, 3);
+            Assert.Equal(3, voiceChannels.Length);
             Assert.All(voiceChannels, x =>
             {
                 Assert.NotNull(x);
-                Assert.NotEqual(x.Id, 0UL);
-                Assert.NotEqual(x.UserLimit, 0);
+                Assert.NotEqual(0UL, x.Id);
+                Assert.NotEqual(0, x.UserLimit);
                 Assert.True(x.Bitrate > 0);
                 Assert.True(x.Position >= 0);
             });
 
-            var voice1 = voiceChannels.Where(x => x.Name == "voice1").FirstOrDefault();
-            var voice2 = voiceChannels.Where(x => x.Name == "voice2").FirstOrDefault();
-            var voice3 = voiceChannels.Where(x => x.Name == "voice3").FirstOrDefault();
+            var voice1 = voiceChannels.FirstOrDefault(x => x.Name == "voice1");
+            var voice2 = voiceChannels.FirstOrDefault(x => x.Name == "voice2");
+            var voice3 = voiceChannels.FirstOrDefault(x => x.Name == "voice3");
 
             Assert.NotNull(voice1);
-            Assert.Equal(voice1.Bitrate, 96000);
-            Assert.Equal(voice1.Position, 1);
+            Assert.Equal(96000, voice1.Bitrate);
+            Assert.Equal(1, voice1.Position);
 
             Assert.NotNull(voice2);
-            Assert.Equal(voice2.UserLimit, null);
+            Assert.Null(voice2.UserLimit);
 
             Assert.NotNull(voice3);
-            Assert.Equal(voice3.Bitrate, 8000);
-            Assert.Equal(voice3.Position, 1);
-            Assert.Equal(voice3.UserLimit, 16);
+            Assert.Equal(8000, voice3.Bitrate);
+            Assert.Equal(1, voice3.Position);
+            Assert.Equal(16, voice3.UserLimit);
         }
     }
 }

--- a/test/Discord.Net.Tests/Tests.Colors.cs
+++ b/test/Discord.Net.Tests/Tests.Colors.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 
 namespace Discord
@@ -12,6 +12,7 @@ namespace Discord
             Assert.Equal(uint.MinValue, new Color(uint.MinValue).RawValue);
             Assert.Equal(uint.MaxValue, new Color(uint.MaxValue).RawValue);
         }
+        [Fact]
         public void Color_Default()
         {
             Assert.Equal(0u, Color.Default.RawValue);

--- a/test/Discord.Net.Tests/Tests.Emotes.cs
+++ b/test/Discord.Net.Tests/Tests.Emotes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 
 namespace Discord
@@ -34,6 +34,7 @@ namespace Discord
             Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1514056829775), emote.CreatedAt);
             Assert.EndsWith("gif", emote.Url);
         }
+        [Fact]
         public void Test_Invalid_Amimated_Emote_Parse()
         {
             Assert.False(Emote.TryParse("<x:typingstatus:394207658351263745>", out _));

--- a/test/Discord.Net.Tests/Tests.Permissions.cs
+++ b/test/Discord.Net.Tests/Tests.Permissions.cs
@@ -25,15 +25,15 @@ namespace Discord
 
             // check that toggling the bit works
             Permissions.UnsetFlag(ref rawValue, flagValue);
-            Assert.Equal(false, Permissions.GetValue(rawValue, flagValue));
+            Assert.False(Permissions.GetValue(rawValue, flagValue));
             Permissions.SetFlag(ref rawValue, flagValue);
-            Assert.Equal(true, Permissions.GetValue(rawValue, flagValue));
+            Assert.True(Permissions.GetValue(rawValue, flagValue));
 
             // do the same, but with the SetValue method
             Permissions.SetValue(ref rawValue, true, flagValue);
-            Assert.Equal(true, Permissions.GetValue(rawValue, flagValue));
+            Assert.True(Permissions.GetValue(rawValue, flagValue));
             Permissions.SetValue(ref rawValue, false, flagValue);
-            Assert.Equal(false, Permissions.GetValue(rawValue, flagValue));
+            Assert.False(Permissions.GetValue(rawValue, flagValue));
         }
 
         /// <summary>


### PR DESCRIPTION
* Since #1043 is adding NS2.0 to Core, I thought I'd go through and add it to all packages.
* Remove NS 1.1 support since net45+ns1.3 builds essentially cover the [exact same platforms](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) without the need for constants
* Removed obsolete JSON.net call in DiscordContractResolver.
* Also fixed various warnings within Tests due to the updates