### PR TITLE
Audit Logs implementation

### DIFF
--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -4,10 +4,10 @@ namespace Discord
 {
     public class DiscordConfig
     {
-        public const int APIVersion = 6;        
+        public const int APIVersion = 6;
         public static string Version { get; } =
             typeof(DiscordConfig).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
-            typeof(DiscordConfig).GetTypeInfo().Assembly.GetName().Version.ToString(3) ?? 
+            typeof(DiscordConfig).GetTypeInfo().Assembly.GetName().Version.ToString(3) ??
             "Unknown";
 
         public static string UserAgent { get; } = $"DiscordBot (https://github.com/RogueException/Discord.Net, v{Version})";
@@ -20,10 +20,11 @@ namespace Discord
         public const int MaxMessagesPerBatch = 100;
         public const int MaxUsersPerBatch = 1000;
         public const int MaxGuildsPerBatch = 100;
+        public const int MaxAuditLogEntriesPerBatch = 100;
 
         /// <summary> Gets or sets how a request should act in the case of an error, by default. </summary>
         public RetryMode DefaultRetryMode { get; set; } = RetryMode.AlwaysRetry;
-        
+
         /// <summary> Gets or sets the minimum log level severity that will be sent to the Log event. </summary>
         public LogSeverity LogLevel { get; set; } = LogSeverity.Info;
 

--- a/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    /// <summary>
+    /// The action type within a <see cref="IAuditLogEntry"/>
+    /// </summary>
+    public enum ActionType
+    {
+        GuildUpdated = 1,
+
+        ChannelCreated = 10,
+        ChannelUpdated = 11,
+        ChannelDeleted = 12,
+
+        OverwriteCreated = 13,
+        OverwriteUpdated = 14,
+        OverwriteDeleted = 15,
+
+        Kick = 20,
+        Prune = 21,
+        Ban = 22,
+        Unban = 23,
+
+        MemberUpdated = 24,
+        MemberRoleUpdated = 25,
+
+        RoleCreated = 30,
+        RoleUpdated = 31,
+        RoleDeleted = 32,
+
+        InviteCreated = 40,
+        InviteUpdated = 41,
+        InviteDeleted = 42,
+
+        WebhookCreated = 50,
+        WebhookUpdated = 51,
+        WebhookDeleted = 52,
+
+        EmojiCreated = 60,
+        EmojiUpdated = 61,
+        EmojiDeleted = 62,
+
+        MessageDeleted = 72
+    }
+}

--- a/src/Discord.Net.Core/Entities/AuditLogs/IAuditLogData.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/IAuditLogData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    /// <summary>
+    /// Represents data applied to an <see cref="IAuditLogEntry"/>
+    /// </summary>
+    public interface IAuditLogData
+    { }
+}

--- a/src/Discord.Net.Core/Entities/AuditLogs/IAuditLogEntry.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/IAuditLogEntry.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    /// <summary>
+    /// Represents an entry in an audit log
+    /// </summary>
+    public interface IAuditLogEntry : IEntity<ulong>
+    {
+        /// <summary>
+        /// The action which occured to create this entry
+        /// </summary>
+        ActionType Action { get; }
+
+        /// <summary>
+        /// The data for this entry. May be <see cref="null"/> if no data was available.
+        /// </summary>
+        IAuditLogData Data { get; }
+
+        /// <summary>
+        /// The user responsible for causing the changes
+        /// </summary>
+        IUser User { get; }
+
+        /// <summary>
+        /// The reason behind the change. May be <see cref="null"/> if no reason was provided.
+        /// </summary>
+        string Reason { get; }
+    }
+}

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -121,6 +121,10 @@ namespace Discord
         /// <summary> Removes all users from this guild if they have not logged on in a provided number of days or, if simulate is true, returns the number of users that would be removed. </summary>
         Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null);
 
+        /// <summary> Gets the specified number of audit log entries for this guild. </summary>
+        Task<IReadOnlyCollection<IAuditLogEntry>> GetAuditLogAsync(int limit = DiscordConfig.MaxAuditLogEntriesPerBatch,
+            CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
         /// <summary> Gets the webhook in this guild with the provided id, or null if not found. </summary>
         Task<IWebhook> GetWebhookAsync(ulong id, RequestOptions options = null);
         /// <summary> Gets a collection of all webhooks for this guild. </summary>

--- a/src/Discord.Net.Core/Entities/Webhooks/WebhookType.cs
+++ b/src/Discord.Net.Core/Entities/Webhooks/WebhookType.cs
@@ -1,0 +1,14 @@
+namespace Discord
+{
+    /// <summary>
+    /// Represents the type of a webhook.
+    /// </summary>
+    /// <remarks>
+    /// This type is currently unused, and is only returned in audit log responses.
+    /// </remarks>
+    public enum WebhookType
+    {
+        /// <summary> An incoming webhook </summary>
+        Incoming = 1
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/AuditLog.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLog.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class AuditLog
+    {
+        [JsonProperty("webhooks")]
+        public Webhook[] Webhooks { get; set; }
+
+        [JsonProperty("users")]
+        public User[] Users { get; set; }
+
+        [JsonProperty("audit_log_entries")]
+        public AuditLogEntry[] Entries { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/AuditLogChange.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogChange.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Discord.API
+{
+    internal class AuditLogChange
+    {
+        [JsonProperty("key")]
+        public string ChangedProperty { get; set; }
+
+        [JsonProperty("new_value")]
+        public JToken NewValue { get; set; }
+
+        [JsonProperty("old_value")]
+        public JToken OldValue { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/AuditLogEntry.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogEntry.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class AuditLogEntry
+    {
+        [JsonProperty("target_id")]
+        public ulong? TargetId { get; set; }
+        [JsonProperty("user_id")]
+        public ulong UserId { get; set; }
+
+        [JsonProperty("changes")]
+        public AuditLogChange[] Changes { get; set; }
+        [JsonProperty("options")]
+        public AuditLogOptions Options { get; set; }
+
+        [JsonProperty("id")]
+        public ulong Id { get; set; }
+
+        [JsonProperty("action_type")]
+        public ActionType Action { get; set; }
+
+        [JsonProperty("reason")]
+        public string Reason { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
@@ -2,20 +2,19 @@
 
 namespace Discord.API
 {
-    //TODO: Complete this with all possible values for options
     internal class AuditLogOptions
     {
         //Message delete
         [JsonProperty("count")]
-        public int? MessageDeleteCount { get; set; } //TODO: what type of int? (returned as string)
+        public int? MessageDeleteCount { get; set; }
         [JsonProperty("channel_id")]
         public ulong? MessageDeleteChannelId { get; set; }
 
         //Prune
         [JsonProperty("delete_member_days")]
-        public int? PruneDeleteMemberDays { get; set; } //TODO: what type of int? (returned as string)
+        public int? PruneDeleteMemberDays { get; set; }
         [JsonProperty("members_removed")]
-        public int? PruneMembersRemoved { get; set; } //TODO: what type of int? (returned as string)
+        public int? PruneMembersRemoved { get; set; }
 
         //Overwrite Update
         [JsonProperty("role_name")]

--- a/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    //TODO: Complete this with all possible values for options
+    internal class AuditLogOptions
+    {
+        //Message delete
+        [JsonProperty("count")]
+        public int? MessageDeleteCount { get; set; } //TODO: what type of int? (returned as string)
+        [JsonProperty("channel_id")]
+        public ulong? MessageDeleteChannelId { get; set; }
+
+        //Prune
+        [JsonProperty("delete_member_days")]
+        public int? PruneDeleteMemberDays { get; set; } //TODO: what type of int? (returned as string)
+        [JsonProperty("members_removed")]
+        public int? PruneMembersRemoved { get; set; } //TODO: what type of int? (returned as string)
+
+        //Overwrite Update
+        [JsonProperty("role_name")]
+        public string OverwriteRoleName { get; set; }
+        [JsonProperty("type")]
+        public string OverwriteType { get; set; }
+        [JsonProperty("id")]
+        public ulong? OverwriteTargetId { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Rest/GetAuditLogsParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/GetAuditLogsParams.cs
@@ -1,0 +1,8 @@
+﻿namespace Discord.API.Rest
+{
+    class GetAuditLogsParams
+    {
+        public Optional<int> Limit { get; set; }
+        public Optional<ulong> BeforeEntryId { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1197,6 +1197,26 @@ namespace Discord.API
             return await SendAsync<IReadOnlyCollection<VoiceRegion>>("GET", () => $"guilds/{guildId}/regions", ids, options: options).ConfigureAwait(false);
         }
 
+        //Audit logs
+        public async Task<AuditLog> GetAuditLogsAsync(ulong guildId, GetAuditLogsParams args, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            Preconditions.NotNull(args, nameof(args));
+            options = RequestOptions.CreateOrClone(options);
+
+            int limit = args.Limit.GetValueOrDefault(int.MaxValue);
+
+            var ids = new BucketIds(guildId: guildId);
+            Expression<Func<string>> endpoint;
+
+            if (args.BeforeEntryId.IsSpecified)
+                endpoint = () => $"guilds/{guildId}/audit-logs?limit={limit}&before={args.BeforeEntryId.Value}";
+            else
+                endpoint = () => $"guilds/{guildId}/audit-logs?limit={limit}";
+
+            return await SendAsync<AuditLog>("GET", endpoint, ids, options: options).ConfigureAwait(false);
+        }
+
         //Webhooks
         public async Task<Webhook> CreateWebhookAsync(ulong channelId, CreateWebhookParams args, RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -1,0 +1,79 @@
+﻿using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    internal static class AuditLogHelper
+    {
+        public static IAuditLogData CreateData(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            switch (entry.Action)
+            {
+                case ActionType.GuildUpdated: //1
+                    return GuildUpdateAuditLogData.Create(discord, log, entry);
+
+                case ActionType.ChannelCreated: //10
+                    return ChannelCreateAuditLogData.Create(discord, log, entry);
+                case ActionType.ChannelUpdated:
+                    return ChannelUpdateAuditLogData.Create(discord, log, entry);
+                case ActionType.ChannelDeleted:
+                    return ChannelDeleteAuditLogData.Create(discord, log, entry);
+                case ActionType.OverwriteCreated:
+                    return OverwriteCreateAuditLogData.Create(discord, log, entry);
+                case ActionType.OverwriteUpdated:
+                    return OverwriteUpdateAuditLogData.Create(discord, log, entry);
+                case ActionType.OverwriteDeleted:
+                    return OverwriteDeleteAuditLogData.Create(discord, log, entry);
+
+                case ActionType.Kick: //20
+                    return KickAuditLogData.Create(discord, log, entry);
+                case ActionType.Prune:
+                    return PruneAuditLogData.Create(discord, log, entry);
+                case ActionType.Ban:
+                    return BanAuditLogData.Create(discord, log, entry);
+                case ActionType.Unban:
+                    return UnbanAuditLogData.Create(discord, log, entry);
+                case ActionType.MemberUpdated:
+                    return MemberUpdateAuditLogData.Create(discord, log, entry);
+                case ActionType.MemberRoleUpdated:
+                    return MemberRoleAuditLogData.Create(discord, log, entry);
+
+                case ActionType.RoleCreated: //30
+                    return RoleCreateAuditLogData.Create(discord, log, entry);
+                case ActionType.RoleUpdated:
+                    return RoleUpdateAuditLogData.Create(discord, log, entry);
+                case ActionType.RoleDeleted:
+                    return RoleDeleteAuditLogData.Create(discord, log, entry);
+
+                case ActionType.InviteCreated: //40
+                    return InviteCreateAuditLogData.Create(discord, log, entry);
+                case ActionType.InviteUpdated:
+                    break;
+                case ActionType.InviteDeleted:
+                    return InviteDeleteAuditLogData.Create(discord, log, entry);
+
+                case ActionType.WebhookCreated: //50
+                    return WebhookCreateAuditLogData.Create(discord, log, entry);
+                case ActionType.WebhookUpdated:
+                    return WebhookUpdateAuditLogData.Create(discord, log, entry);
+                case ActionType.WebhookDeleted:
+                    return WebhookDeleteAuditLogData.Create(discord, log, entry);
+
+                case ActionType.EmojiCreated: //60
+                    return EmoteCreateAuditLogData.Create(discord, log, entry);
+                case ActionType.EmojiUpdated:
+                    return EmoteUpdateAuditLogData.Create(discord, log, entry);
+                case ActionType.EmojiDeleted:
+                    return EmoteDeleteAuditLogData.Create(discord, log, entry);
+
+                case ActionType.MessageDeleted: //72
+                    return MessageDeleteAuditLogData.Create(discord, log, entry);
+
+                default: //Unknown
+                    return null;
+            }
+            return null;
+            //throw new NotImplementedException($"{nameof(AuditLogHelper)} does not implement the {entry.Action} audit log event.");
+        }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -1,79 +1,58 @@
-﻿using Model = Discord.API.AuditLog;
+﻿using System;
+using System.Collections.Generic;
+
+using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
 namespace Discord.Rest
 {
     internal static class AuditLogHelper
     {
+        private static readonly Dictionary<ActionType, Func<BaseDiscordClient, Model, EntryModel, IAuditLogData>> CreateMapping
+            = new Dictionary<ActionType, Func<BaseDiscordClient, Model, EntryModel, IAuditLogData>>()
+        {
+            [ActionType.GuildUpdated] = GuildUpdateAuditLogData.Create,
+
+            [ActionType.ChannelCreated] = ChannelCreateAuditLogData.Create,
+            [ActionType.ChannelUpdated] = ChannelUpdateAuditLogData.Create,
+            [ActionType.ChannelDeleted] = ChannelDeleteAuditLogData.Create,
+
+            [ActionType.OverwriteCreated] = OverwriteCreateAuditLogData.Create,
+            [ActionType.OverwriteUpdated] = OverwriteUpdateAuditLogData.Create,
+            [ActionType.OverwriteDeleted] = OverwriteDeleteAuditLogData.Create,
+
+            [ActionType.Kick] = KickAuditLogData.Create,
+            [ActionType.Prune] = PruneAuditLogData.Create,
+            [ActionType.Ban] = BanAuditLogData.Create,
+            [ActionType.Unban] = UnbanAuditLogData.Create,
+            [ActionType.MemberUpdated] = MemberUpdateAuditLogData.Create,
+            [ActionType.MemberRoleUpdated] = MemberRoleAuditLogData.Create,
+
+            [ActionType.RoleCreated] = RoleCreateAuditLogData.Create,
+            [ActionType.RoleUpdated] = RoleUpdateAuditLogData.Create,
+            [ActionType.RoleDeleted] = RoleDeleteAuditLogData.Create,
+
+            [ActionType.InviteCreated] = InviteCreateAuditLogData.Create,
+            [ActionType.InviteUpdated] = InviteUpdateAuditLogData.Create,
+            [ActionType.InviteDeleted] = InviteDeleteAuditLogData.Create,
+
+            [ActionType.WebhookCreated] = WebhookCreateAuditLogData.Create,
+            [ActionType.WebhookUpdated] = WebhookUpdateAuditLogData.Create,
+            [ActionType.WebhookDeleted] = WebhookDeleteAuditLogData.Create,
+
+            [ActionType.EmojiCreated] = EmoteCreateAuditLogData.Create,
+            [ActionType.EmojiUpdated] = EmoteUpdateAuditLogData.Create,
+            [ActionType.EmojiDeleted] = EmoteDeleteAuditLogData.Create,
+
+            [ActionType.MessageDeleted] = MessageDeleteAuditLogData.Create,
+        };
+
         public static IAuditLogData CreateData(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            switch (entry.Action)
-            {
-                case ActionType.GuildUpdated: //1
-                    return GuildUpdateAuditLogData.Create(discord, log, entry);
+            if (CreateMapping.TryGetValue(entry.Action, out var func))
+                return func(discord, log, entry);
 
-                case ActionType.ChannelCreated: //10
-                    return ChannelCreateAuditLogData.Create(discord, log, entry);
-                case ActionType.ChannelUpdated:
-                    return ChannelUpdateAuditLogData.Create(discord, log, entry);
-                case ActionType.ChannelDeleted:
-                    return ChannelDeleteAuditLogData.Create(discord, log, entry);
-                case ActionType.OverwriteCreated:
-                    return OverwriteCreateAuditLogData.Create(discord, log, entry);
-                case ActionType.OverwriteUpdated:
-                    return OverwriteUpdateAuditLogData.Create(discord, log, entry);
-                case ActionType.OverwriteDeleted:
-                    return OverwriteDeleteAuditLogData.Create(discord, log, entry);
-
-                case ActionType.Kick: //20
-                    return KickAuditLogData.Create(discord, log, entry);
-                case ActionType.Prune:
-                    return PruneAuditLogData.Create(discord, log, entry);
-                case ActionType.Ban:
-                    return BanAuditLogData.Create(discord, log, entry);
-                case ActionType.Unban:
-                    return UnbanAuditLogData.Create(discord, log, entry);
-                case ActionType.MemberUpdated:
-                    return MemberUpdateAuditLogData.Create(discord, log, entry);
-                case ActionType.MemberRoleUpdated:
-                    return MemberRoleAuditLogData.Create(discord, log, entry);
-
-                case ActionType.RoleCreated: //30
-                    return RoleCreateAuditLogData.Create(discord, log, entry);
-                case ActionType.RoleUpdated:
-                    return RoleUpdateAuditLogData.Create(discord, log, entry);
-                case ActionType.RoleDeleted:
-                    return RoleDeleteAuditLogData.Create(discord, log, entry);
-
-                case ActionType.InviteCreated: //40
-                    return InviteCreateAuditLogData.Create(discord, log, entry);
-                case ActionType.InviteUpdated:
-                    break;
-                case ActionType.InviteDeleted:
-                    return InviteDeleteAuditLogData.Create(discord, log, entry);
-
-                case ActionType.WebhookCreated: //50
-                    return WebhookCreateAuditLogData.Create(discord, log, entry);
-                case ActionType.WebhookUpdated:
-                    return WebhookUpdateAuditLogData.Create(discord, log, entry);
-                case ActionType.WebhookDeleted:
-                    return WebhookDeleteAuditLogData.Create(discord, log, entry);
-
-                case ActionType.EmojiCreated: //60
-                    return EmoteCreateAuditLogData.Create(discord, log, entry);
-                case ActionType.EmojiUpdated:
-                    return EmoteUpdateAuditLogData.Create(discord, log, entry);
-                case ActionType.EmojiDeleted:
-                    return EmoteDeleteAuditLogData.Create(discord, log, entry);
-
-                case ActionType.MessageDeleted: //72
-                    return MessageDeleteAuditLogData.Create(discord, log, entry);
-
-                default: //Unknown
-                    return null;
-            }
             return null;
-            //throw new NotImplementedException($"{nameof(AuditLogHelper)} does not implement the {entry.Action} audit log event.");
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BanAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BanAuditLogData.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class BanAuditLogData : IAuditLogData
+    {
+        private BanAuditLogData(IUser user)
+        {
+            Target = user;
+        }
+
+        internal static BanAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            return new BanAuditLogData(RestUser.Create(discord, userInfo));
+        }
+
+        public IUser Target { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
@@ -1,0 +1,52 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class ChannelCreateAuditLogData : IAuditLogData
+    {
+        private ChannelCreateAuditLogData(ulong id, string name, ChannelType type, IReadOnlyCollection<Overwrite> overwrites)
+        {
+            ChannelId = id;
+            ChannelName = name;
+            ChannelType = type;
+            Overwrites = overwrites;
+        }
+
+        internal static ChannelCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+            var overwrites = new List<Overwrite>();
+
+            var overwritesModel = changes.FirstOrDefault(x => x.ChangedProperty == "permission_overwrites");
+            var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+
+            var type = typeModel.NewValue.ToObject<ChannelType>();
+            var name = nameModel.NewValue.ToObject<string>();
+
+            foreach (var overwrite in overwritesModel.NewValue)
+            {
+                var deny = overwrite.Value<ulong>("deny");
+                var _type = overwrite.Value<string>("type");
+                var id = overwrite.Value<ulong>("id");
+                var allow = overwrite.Value<ulong>("allow");
+
+                PermissionTarget permType = _type == "member" ? PermissionTarget.User : PermissionTarget.Role;
+
+                overwrites.Add(new Overwrite(id, permType, new OverwritePermissions(allow, deny)));
+            }
+
+            return new ChannelCreateAuditLogData(entry.TargetId.Value, name, type, overwrites.ToReadOnlyCollection());
+        }
+
+        public ulong ChannelId { get; }
+        public string ChannelName { get; }
+        public ChannelType ChannelType { get; }
+        public IReadOnlyCollection<Overwrite> Overwrites { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class ChannelDeleteAuditLogData : IAuditLogData
+    {
+        private ChannelDeleteAuditLogData(ulong id, string name, ChannelType type, IReadOnlyCollection<Overwrite> overwrites)
+        {
+            ChannelId = id;
+            ChannelName = name;
+            ChannelType = type;
+            Overwrites = overwrites;
+        }
+
+        internal static ChannelDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var overwritesModel = changes.FirstOrDefault(x => x.ChangedProperty == "permission_overwrites");
+            var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+
+            var overwrites = overwritesModel.OldValue.ToObject<API.Overwrite[]>()
+                .Select(x => new Overwrite(x.TargetId, x.TargetType, new OverwritePermissions(x.Allow, x.Deny)))
+                .ToList();
+            var type = typeModel.OldValue.ToObject<ChannelType>();
+            var name = nameModel.OldValue.ToObject<string>();
+            var id = entry.TargetId.Value;
+
+            return new ChannelDeleteAuditLogData(id, name, type, overwrites.ToReadOnlyCollection());
+        }
+
+        public ulong ChannelId { get; }
+        public string ChannelName { get; }
+        public ChannelType ChannelType { get; }
+        public IReadOnlyCollection<Overwrite> Overwrites { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
@@ -1,0 +1,18 @@
+namespace Discord.Rest
+{
+    public struct ChannelInfo
+    {
+        internal ChannelInfo(string name, string topic, int? bitrate, int? limit)
+        {
+            Name = name;
+            Topic = topic;
+            Bitrate = bitrate;
+            UserLimit = limit;
+        }
+
+        public string Name { get; }
+        public string Topic { get; }
+        public int? Bitrate { get; }
+        public int? UserLimit { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class ChannelUpdateAuditLogData : IAuditLogData
+    {
+        private ChannelUpdateAuditLogData(ulong id, ChannelInfo before, ChannelInfo after)
+        {
+            ChannelId = id;
+            Before = before;
+            After = after;
+        }
+
+        internal static ChannelUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var topicModel = changes.FirstOrDefault(x => x.ChangedProperty == "topic");
+            var bitrateModel = changes.FirstOrDefault(x => x.ChangedProperty == "bitrate");
+            var userLimitModel = changes.FirstOrDefault(x => x.ChangedProperty == "user_limit");
+
+            string oldName = nameModel?.OldValue?.ToObject<string>(),
+                newName = nameModel?.NewValue?.ToObject<string>();
+            string oldTopic = topicModel?.OldValue?.ToObject<string>(),
+                newTopic = topicModel?.NewValue?.ToObject<string>();
+            int? oldBitrate = bitrateModel?.OldValue?.ToObject<int>(),
+                newBitrate = bitrateModel?.NewValue?.ToObject<int>();
+            int? oldLimit = userLimitModel?.OldValue?.ToObject<int>(),
+                newLimit = userLimitModel?.NewValue?.ToObject<int>();
+
+            var before = new ChannelInfo(oldName, oldTopic, oldBitrate, oldLimit);
+            var after = new ChannelInfo(newName, newTopic, newBitrate, newLimit);
+
+            // TODO: check category channels
+            return new ChannelUpdateAuditLogData(entry.TargetId.Value, before, after);
+        }
+
+        public ulong ChannelId { get; }
+        public ChannelInfo Before { get; set; }
+        public ChannelInfo After { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
@@ -35,7 +35,6 @@ namespace Discord.Rest
             var before = new ChannelInfo(oldName, oldTopic, oldBitrate, oldLimit);
             var after = new ChannelInfo(newName, newTopic, newBitrate, newLimit);
 
-            // TODO: check category channels
             return new ChannelUpdateAuditLogData(entry.TargetId.Value, before, after);
         }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteCreateAuditLogData.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class EmoteCreateAuditLogData : IAuditLogData
+    {
+        private EmoteCreateAuditLogData(ulong id, string name)
+        {
+            EmoteId = id;
+            Name = name;
+        }
+
+        internal static EmoteCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var change = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
+
+            var emoteName = change.NewValue?.ToObject<string>();
+            return new EmoteCreateAuditLogData(entry.TargetId.Value, emoteName);
+        }
+
+        public ulong EmoteId { get; }
+        public string Name { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteDeleteAuditLogData.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class EmoteDeleteAuditLogData : IAuditLogData
+    {
+        private EmoteDeleteAuditLogData(ulong id, string name)
+        {
+            EmoteId = id;
+            Name = name;
+        }
+
+        internal static EmoteDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var change = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
+
+            var emoteName = change.OldValue?.ToObject<string>();
+
+            return new EmoteDeleteAuditLogData(entry.TargetId.Value, emoteName);
+        }
+
+        public ulong EmoteId { get; }
+        public string Name { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteUpdateAuditLogData.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class EmoteUpdateAuditLogData : IAuditLogData
+    {
+        private EmoteUpdateAuditLogData(ulong id, string oldName, string newName)
+        {
+            EmoteId = id;
+            OldName = oldName;
+            NewName = newName;
+        }
+
+        internal static EmoteUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var change = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
+
+            var newName = change.NewValue?.ToObject<string>();
+            var oldName = change.OldValue?.ToObject<string>();
+
+            return new EmoteUpdateAuditLogData(entry.TargetId.Value, oldName, newName);
+        }
+
+        public ulong EmoteId { get; }
+        public string NewName { get; }
+        public string OldName { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
@@ -1,0 +1,32 @@
+namespace Discord.Rest
+{
+    public struct GuildInfo
+    {
+        internal GuildInfo(int? afkTimeout, DefaultMessageNotifications? defaultNotifs,
+            ulong? afkChannel, string name, string region, string icon,
+            VerificationLevel? verification, IUser owner, MfaLevel? mfa, int? filter)
+        {
+            AfkTimeout = afkTimeout;
+            DefaultMessageNotifications = defaultNotifs;
+            AfkChannelId = afkChannel;
+            Name = name;
+            RegionId = region;
+            IconHash = icon;
+            VerificationLevel = verification;
+            Owner = owner;
+            MfaLevel = mfa;
+            ContentFilterLevel = filter;
+        }
+
+        public int? AfkTimeout { get; }
+        public DefaultMessageNotifications? DefaultMessageNotifications { get; }
+        public ulong? AfkChannelId { get; }
+        public string Name { get; }
+        public string RegionId { get; }
+        public string IconHash { get; }
+        public VerificationLevel? VerificationLevel { get; }
+        public IUser Owner { get; }
+        public MfaLevel? MfaLevel { get; }
+        public int? ContentFilterLevel { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
@@ -17,73 +17,37 @@ namespace Discord.Rest
         {
             var changes = entry.Changes;
 
-            int? oldAfkTimeout = null,
-                newAfkTimeout = null;
-            DefaultMessageNotifications? oldDefaultMessageNotifications = null,
-                newDefaultMessageNotifications = null;
-            ulong? oldAfkChannelId = null,
-                newAfkChannelId = null;
-            string oldName = null,
-                newName = null;
-            string oldRegionId = null,
-                newRegionId = null;
-            string oldIconHash = null,
-                newIconHash = null;
-            VerificationLevel? oldVerificationLevel = null,
-                newVerificationLevel = null;
-            ulong? oldOwnerId = null,
-                newOwnerId = null;
-            MfaLevel? oldMfaLevel = null,
-                newMfaLevel = null;
-            int? oldContentFilter = null,
-                newContentFilter = null;
+            var afkTimeoutModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var defaultMessageNotificationsModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var afkChannelModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var regionIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var iconHashModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var verificationLevelModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var ownerIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var mfaLevelModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
+            var contentFilterModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
 
-            foreach (var change in changes)
-            {
-                switch (change.ChangedProperty)
-                {
-                    case "afk_timeout":
-                        oldAfkTimeout = change.OldValue?.ToObject<int>();
-                        newAfkTimeout = change.NewValue?.ToObject<int>();
-                        break;
-                    case "default_message_notifications":
-                        oldDefaultMessageNotifications = change.OldValue?.ToObject<DefaultMessageNotifications>();
-                        newDefaultMessageNotifications = change.OldValue?.ToObject<DefaultMessageNotifications>();
-                        break;
-                    case "afk_channel_id":
-                        oldAfkChannelId = change.OldValue?.ToObject<ulong>();
-                        newAfkChannelId = change.NewValue?.ToObject<ulong>();
-                        break;
-                    case "name":
-                        oldName = change.OldValue?.ToObject<string>();
-                        newName = change.NewValue?.ToObject<string>();
-                        break;
-                    case "region":
-                        oldRegionId = change.OldValue?.ToObject<string>();
-                        newRegionId = change.NewValue?.ToObject<string>();
-                        break;
-                    case "icon_hash":
-                        oldIconHash = change.OldValue?.ToObject<string>();
-                        newIconHash = change.NewValue?.ToObject<string>();
-                        break;
-                    case "verification_level":
-                        oldVerificationLevel = change.OldValue?.ToObject<VerificationLevel>();
-                        newVerificationLevel = change.NewValue?.ToObject<VerificationLevel>();
-                        break;
-                    case "owner":
-                        oldOwnerId = change.OldValue?.ToObject<ulong>();
-                        newOwnerId = change.NewValue?.ToObject<ulong>();
-                        break;
-                    case "mfa_level":
-                        oldMfaLevel = change.OldValue?.ToObject<MfaLevel>();
-                        newMfaLevel = change.OldValue?.ToObject<MfaLevel>();
-                        break;
-                    case "explicit_content_filter":
-                        oldContentFilter = change.OldValue?.ToObject<int>();
-                        newContentFilter = change.NewValue?.ToObject<int>();
-                        break;
-                }
-            }
+            int? oldAfkTimeout = afkTimeoutModel?.OldValue?.ToObject<int>(),
+                newAfkTimeout = afkTimeoutModel?.NewValue?.ToObject<int>();
+            DefaultMessageNotifications? oldDefaultMessageNotifications = defaultMessageNotificationsModel?.OldValue?.ToObject<DefaultMessageNotifications>(),
+                newDefaultMessageNotifications = defaultMessageNotificationsModel?.NewValue?.ToObject<DefaultMessageNotifications>();
+            ulong? oldAfkChannelId = afkChannelModel?.OldValue?.ToObject<ulong>(),
+                newAfkChannelId = afkChannelModel?.NewValue?.ToObject<ulong>();
+            string oldName = nameModel?.OldValue?.ToObject<string>(),
+                newName = nameModel?.NewValue?.ToObject<string>();
+            string oldRegionId = regionIdModel?.OldValue?.ToObject<string>(),
+                newRegionId = regionIdModel?.NewValue?.ToObject<string>();
+            string oldIconHash = iconHashModel?.OldValue?.ToObject<string>(),
+                newIconHash = iconHashModel?.NewValue?.ToObject<string>();
+            VerificationLevel? oldVerificationLevel = verificationLevelModel?.OldValue?.ToObject<VerificationLevel>(),
+                newVerificationLevel = verificationLevelModel?.NewValue?.ToObject<VerificationLevel>();
+            ulong? oldOwnerId = ownerIdModel?.OldValue?.ToObject<ulong>(),
+                newOwnerId = ownerIdModel?.NewValue?.ToObject<ulong>();
+            MfaLevel? oldMfaLevel = mfaLevelModel?.OldValue?.ToObject<MfaLevel>(),
+                newMfaLevel = mfaLevelModel?.NewValue?.ToObject<MfaLevel>();
+            int? oldContentFilter = contentFilterModel?.OldValue?.ToObject<int>(),
+                newContentFilter = contentFilterModel?.NewValue?.ToObject<int>();
 
             IUser oldOwner = null;
             if (oldOwnerId != null)

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
@@ -1,0 +1,115 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class GuildUpdateAuditLogData : IAuditLogData
+    {
+        private GuildUpdateAuditLogData(GuildInfo before, GuildInfo after)
+        {
+            Before = before;
+            After = after;
+        }
+
+        internal static GuildUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            int? oldAfkTimeout = null,
+                newAfkTimeout = null;
+            DefaultMessageNotifications? oldDefaultMessageNotifications = null,
+                newDefaultMessageNotifications = null;
+            ulong? oldAfkChannelId = null,
+                newAfkChannelId = null;
+            string oldName = null,
+                newName = null;
+            string oldRegionId = null,
+                newRegionId = null;
+            string oldIconHash = null,
+                newIconHash = null;
+            VerificationLevel? oldVerificationLevel = null,
+                newVerificationLevel = null;
+            ulong? oldOwnerId = null,
+                newOwnerId = null;
+            MfaLevel? oldMfaLevel = null,
+                newMfaLevel = null;
+            int? oldContentFilter = null,
+                newContentFilter = null;
+
+            foreach (var change in changes)
+            {
+                switch (change.ChangedProperty)
+                {
+                    case "afk_timeout":
+                        oldAfkTimeout = change.OldValue?.ToObject<int>();
+                        newAfkTimeout = change.NewValue?.ToObject<int>();
+                        break;
+                    case "default_message_notifications":
+                        oldDefaultMessageNotifications = change.OldValue?.ToObject<DefaultMessageNotifications>();
+                        newDefaultMessageNotifications = change.OldValue?.ToObject<DefaultMessageNotifications>();
+                        break;
+                    case "afk_channel_id":
+                        oldAfkChannelId = change.OldValue?.ToObject<ulong>();
+                        newAfkChannelId = change.NewValue?.ToObject<ulong>();
+                        break;
+                    case "name":
+                        oldName = change.OldValue?.ToObject<string>();
+                        newName = change.NewValue?.ToObject<string>();
+                        break;
+                    case "region":
+                        oldRegionId = change.OldValue?.ToObject<string>();
+                        newRegionId = change.NewValue?.ToObject<string>();
+                        break;
+                    case "icon_hash":
+                        oldIconHash = change.OldValue?.ToObject<string>();
+                        newIconHash = change.NewValue?.ToObject<string>();
+                        break;
+                    case "verification_level":
+                        oldVerificationLevel = change.OldValue?.ToObject<VerificationLevel>();
+                        newVerificationLevel = change.NewValue?.ToObject<VerificationLevel>();
+                        break;
+                    case "owner":
+                        oldOwnerId = change.OldValue?.ToObject<ulong>();
+                        newOwnerId = change.NewValue?.ToObject<ulong>();
+                        break;
+                    case "mfa_level":
+                        oldMfaLevel = change.OldValue?.ToObject<MfaLevel>();
+                        newMfaLevel = change.OldValue?.ToObject<MfaLevel>();
+                        break;
+                    case "explicit_content_filter":
+                        oldContentFilter = change.OldValue?.ToObject<int>();
+                        newContentFilter = change.NewValue?.ToObject<int>();
+                        break;
+                }
+            }
+
+            IUser oldOwner = null;
+            if (oldOwnerId != null)
+            {
+                var oldOwnerInfo = log.Users.FirstOrDefault(x => x.Id == oldOwnerId.Value);
+                oldOwner = RestUser.Create(discord, oldOwnerInfo);
+            }
+
+            IUser newOwner = null;
+            if (newOwnerId != null)
+            {
+                var newOwnerInfo = log.Users.FirstOrDefault(x => x.Id == newOwnerId.Value);
+                newOwner = RestUser.Create(discord, newOwnerInfo);
+            }
+
+            var before = new GuildInfo(oldAfkTimeout, oldDefaultMessageNotifications,
+                oldAfkChannelId, oldName, oldRegionId, oldIconHash, oldVerificationLevel, oldOwner,
+                oldMfaLevel, oldContentFilter);
+            var after = new GuildInfo(newAfkTimeout, newDefaultMessageNotifications,
+                newAfkChannelId, newName, newRegionId, newIconHash, newVerificationLevel, newOwner,
+                newMfaLevel, newContentFilter);
+
+            return new GuildUpdateAuditLogData(before, after);
+        }
+
+        public GuildInfo Before { get; }
+        public GuildInfo After { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class InviteCreateAuditLogData : IAuditLogData
+    {
+        private InviteCreateAuditLogData(int maxAge, string code, bool temporary, IUser inviter, ulong channelId, int uses, int maxUses)
+        {
+            MaxAge = maxAge;
+            Code = code;
+            Temporary = temporary;
+            Creator = inviter;
+            ChannelId = channelId;
+            Uses = uses;
+            MaxUses = maxUses;
+        }
+
+        internal static InviteCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var maxAgeModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_age");
+            var codeModel = changes.FirstOrDefault(x => x.ChangedProperty == "code");
+            var temporaryModel = changes.FirstOrDefault(x => x.ChangedProperty == "temporary");
+            var inviterIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "inviter_id");
+            var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
+            var usesModel = changes.FirstOrDefault(x => x.ChangedProperty == "uses");
+            var maxUsesModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_uses");
+
+            var maxAge = maxAgeModel.NewValue.ToObject<int>();
+            var code = codeModel.NewValue.ToObject<string>();
+            var temporary = temporaryModel.NewValue.ToObject<bool>();
+            var inviterId = inviterIdModel.NewValue.ToObject<ulong>();
+            var channelId = channelIdModel.NewValue.ToObject<ulong>();
+            var uses = usesModel.NewValue.ToObject<int>();
+            var maxUses = maxUsesModel.NewValue.ToObject<int>();
+
+            var inviterInfo = log.Users.FirstOrDefault(x => x.Id == inviterId);
+            var inviter = RestUser.Create(discord, inviterInfo);
+
+            return new InviteCreateAuditLogData(maxAge, code, temporary, inviter, channelId, uses, maxUses);
+        }
+
+        public int MaxAge { get; }
+        public string Code { get; }
+        public bool Temporary { get; }
+        public IUser Creator { get; }
+        public ulong ChannelId { get; }
+        public int Uses { get; }
+        public int MaxUses { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class InviteDeleteAuditLogData : IAuditLogData
+    {
+        private InviteDeleteAuditLogData(int maxAge, string code, bool temporary, IUser inviter, ulong channelId, int uses, int maxUses)
+        {
+            MaxAge = maxAge;
+            Code = code;
+            Temporary = temporary;
+            Creator = inviter;
+            ChannelId = channelId;
+            Uses = uses;
+            MaxUses = maxUses;
+        }
+
+        internal static InviteDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var maxAgeModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_age");
+            var codeModel = changes.FirstOrDefault(x => x.ChangedProperty == "code");
+            var temporaryModel = changes.FirstOrDefault(x => x.ChangedProperty == "temporary");
+            var inviterIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "inviter_id");
+            var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
+            var usesModel = changes.FirstOrDefault(x => x.ChangedProperty == "uses");
+            var maxUsesModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_uses");
+
+            var maxAge = maxAgeModel.OldValue.ToObject<int>();
+            var code = codeModel.OldValue.ToObject<string>();
+            var temporary = temporaryModel.OldValue.ToObject<bool>();
+            var inviterId = inviterIdModel.OldValue.ToObject<ulong>();
+            var channelId = channelIdModel.OldValue.ToObject<ulong>();
+            var uses = usesModel.OldValue.ToObject<int>();
+            var maxUses = maxUsesModel.OldValue.ToObject<int>();
+
+            var inviterInfo = log.Users.FirstOrDefault(x => x.Id == inviterId);
+            var inviter = RestUser.Create(discord, inviterInfo);
+
+            return new InviteDeleteAuditLogData(maxAge, code, temporary, inviter, channelId, uses, maxUses);
+        }
+
+        public int MaxAge { get; }
+        public string Code { get; }
+        public bool Temporary { get; }
+        public IUser Creator { get; }
+        public ulong ChannelId { get; }
+        public int Uses { get; }
+        public int MaxUses { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteInfo.cs
@@ -1,0 +1,20 @@
+namespace Discord.Rest
+{
+    public struct InviteInfo
+    {
+        internal InviteInfo(int? maxAge, string code, bool? temporary, ulong? channelId, int? maxUses)
+        {
+            MaxAge = maxAge;
+            Code = code;
+            Temporary = temporary;
+            ChannelId = channelId;
+            MaxUses = maxUses;
+        }
+
+        public int? MaxAge { get; }
+        public string Code { get; }
+        public bool? Temporary { get; }
+        public ulong? ChannelId { get; }
+        public int? MaxUses { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteUpdateAuditLogData.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class InviteUpdateAuditLogData : IAuditLogData
+    {
+        private InviteUpdateAuditLogData(InviteInfo before, InviteInfo after)
+        {
+            Before = before;
+            After = after;
+        }
+
+        internal static InviteUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var maxAgeModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_age");
+            var codeModel = changes.FirstOrDefault(x => x.ChangedProperty == "code");
+            var temporaryModel = changes.FirstOrDefault(x => x.ChangedProperty == "temporary");
+            var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
+            var maxUsesModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_uses");
+
+            int? oldMaxAge = maxAgeModel?.OldValue?.ToObject<int>(),
+                newMaxAge = maxAgeModel?.NewValue?.ToObject<int>();
+            string oldCode = codeModel?.OldValue?.ToObject<string>(),
+                newCode = codeModel?.NewValue?.ToObject<string>();
+            bool? oldTemporary = temporaryModel?.OldValue?.ToObject<bool>(),
+                newTemporary = temporaryModel?.NewValue?.ToObject<bool>();
+            ulong? oldChannelId = channelIdModel?.OldValue?.ToObject<ulong>(),
+                newChannelId = channelIdModel?.NewValue?.ToObject<ulong>();
+            int? oldMaxUses = maxUsesModel?.OldValue?.ToObject<int>(),
+                newMaxUses = maxUsesModel?.NewValue?.ToObject<int>();
+
+            var before = new InviteInfo(oldMaxAge, oldCode, oldTemporary, oldChannelId, oldMaxUses);
+            var after = new InviteInfo(newMaxAge, newCode, newTemporary, newChannelId, newMaxUses);
+
+            return new InviteUpdateAuditLogData(before, after);
+        }
+
+        public InviteInfo Before { get; }
+        public InviteInfo After { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/KickAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/KickAuditLogData.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class KickAuditLogData : IAuditLogData
+    {
+        private KickAuditLogData(RestUser user)
+        {
+            Target = user;
+        }
+
+        internal static KickAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            return new KickAuditLogData(RestUser.Create(discord, userInfo));
+        }
+
+        public IUser Target { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleAuditLogData.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class MemberRoleAuditLogData : IAuditLogData
+    {
+        private MemberRoleAuditLogData(IReadOnlyCollection<RoleInfo> roles, IUser target)
+        {
+            Roles = roles;
+            Target = target;
+        }
+
+        internal static MemberRoleAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var roleInfos = changes.SelectMany(x => x.NewValue.ToObject<API.Role[]>(),
+                (model, role) => new { model.ChangedProperty, Role = role })
+                .Select(x => new RoleInfo(x.Role.Name, x.Role.Id, x.ChangedProperty == "$add"))
+                .ToList();
+
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            var user = RestUser.Create(discord, userInfo);
+
+            return new MemberRoleAuditLogData(roleInfos.ToReadOnlyCollection(), user);
+        }
+
+        public IReadOnlyCollection<RoleInfo> Roles { get; }
+        public IUser Target { get; }
+
+        public struct RoleInfo
+        {
+            internal RoleInfo(string name, ulong roleId, bool added)
+            {
+                Name = name;
+                RoleId = roleId;
+                Added = added;
+            }
+
+            public string Name { get; }
+            public ulong RoleId { get; }
+            public bool Added { get; }
+        }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
@@ -17,7 +17,7 @@ namespace Discord.Rest
 
         internal static MemberUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            var changes = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "nick"); //TODO: only change?
+            var changes = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "nick");
 
             var newNick = changes.NewValue?.ToObject<string>();
             var oldNick = changes.OldValue?.ToObject<string>();

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+using ChangeModel = Discord.API.AuditLogChange;
+
+namespace Discord.Rest
+{
+    public class MemberUpdateAuditLogData : IAuditLogData
+    {
+        private MemberUpdateAuditLogData(IUser target, string newNick, string oldNick)
+        {
+            Target = target;
+            NewNick = newNick;
+            OldNick = oldNick;
+        }
+
+        internal static MemberUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "nick"); //TODO: only change?
+
+            var newNick = changes.NewValue?.ToObject<string>();
+            var oldNick = changes.OldValue?.ToObject<string>();
+
+            var targetInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            var user = RestUser.Create(discord, targetInfo);
+
+            return new MemberUpdateAuditLogData(user, newNick, oldNick);
+        }
+
+        public IUser Target { get; }
+        public string NewNick { get; }
+        public string OldNick { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
@@ -1,0 +1,22 @@
+﻿using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class MessageDeleteAuditLogData : IAuditLogData
+    {
+        private MessageDeleteAuditLogData(ulong channelId, int count)
+        {
+            ChannelId = channelId;
+            MessageCount = count;
+        }
+
+        internal static MessageDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new MessageDeleteAuditLogData(entry.Options.MessageDeleteChannelId.Value, entry.Options.MessageDeleteCount.Value);
+        }
+
+        public int MessageCount { get; }
+        public ulong ChannelId { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteCreateAuditLogData.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class OverwriteCreateAuditLogData : IAuditLogData
+    {
+        private OverwriteCreateAuditLogData(Overwrite overwrite)
+        {
+            Overwrite = overwrite;
+        }
+
+        internal static OverwriteCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var denyModel = changes.FirstOrDefault(x => x.ChangedProperty == "deny");
+            var allowModel = changes.FirstOrDefault(x => x.ChangedProperty == "allow");
+
+            var deny = denyModel.NewValue.ToObject<ulong>();
+            var allow = allowModel.NewValue.ToObject<ulong>();
+
+            var permissions = new OverwritePermissions(allow, deny);
+
+            var id = entry.Options.OverwriteTargetId.Value;
+            var type = entry.Options.OverwriteType;
+
+            PermissionTarget target = type == "member" ? PermissionTarget.User : PermissionTarget.Role;
+
+            return new OverwriteCreateAuditLogData(new Overwrite(id, target, permissions));
+        }
+
+        public Overwrite Overwrite { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteDeleteAuditLogData.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+using ChangeModel = Discord.API.AuditLogChange;
+using OptionModel = Discord.API.AuditLogOptions;
+
+namespace Discord.Rest
+{
+    public class OverwriteDeleteAuditLogData : IAuditLogData
+    {
+        private OverwriteDeleteAuditLogData(Overwrite deletedOverwrite)
+        {
+            Overwrite = deletedOverwrite;
+        }
+
+        internal static OverwriteDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var denyModel = changes.FirstOrDefault(x => x.ChangedProperty == "deny");
+            var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
+            var idModel = changes.FirstOrDefault(x => x.ChangedProperty == "id");
+            var allowModel = changes.FirstOrDefault(x => x.ChangedProperty == "allow");
+
+            var deny = denyModel.OldValue.ToObject<ulong>();
+            var type = typeModel.OldValue.ToObject<string>();
+            var id = idModel.OldValue.ToObject<ulong>();
+            var allow = allowModel.OldValue.ToObject<ulong>();
+
+            PermissionTarget target = type == "member" ? PermissionTarget.User : PermissionTarget.Role;
+
+            return new OverwriteDeleteAuditLogData(new Overwrite(id, target, new OverwritePermissions(allow, deny)));
+        }
+
+        public Overwrite Overwrite { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class OverwriteUpdateAuditLogData : IAuditLogData
+    {
+        private OverwriteUpdateAuditLogData(OverwritePermissions before, OverwritePermissions after, ulong targetId, PermissionTarget targetType)
+        {
+            OldPermissions = before;
+            NewPermissions = after;
+            OverwriteTargetId = targetId;
+            OverwriteType = targetType;
+        }
+
+        internal static OverwriteUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var denyModel = changes.FirstOrDefault(x => x.ChangedProperty == "deny");
+            var allowModel = changes.FirstOrDefault(x => x.ChangedProperty == "allow");
+
+            var beforeAllow = allowModel?.OldValue?.ToObject<ulong>();
+            var afterAllow = allowModel?.NewValue?.ToObject<ulong>();
+            var beforeDeny = denyModel?.OldValue?.ToObject<ulong>();
+            var afterDeny = denyModel?.OldValue?.ToObject<ulong>();
+
+            var beforePermissions = new OverwritePermissions(beforeAllow ?? 0, beforeDeny ?? 0);
+            var afterPermissions = new OverwritePermissions(afterAllow ?? 0, afterDeny ?? 0);
+
+            PermissionTarget target = entry.Options.OverwriteType == "member" ? PermissionTarget.User : PermissionTarget.Role;
+
+            return new OverwriteUpdateAuditLogData(beforePermissions, afterPermissions, entry.Options.OverwriteTargetId.Value, target);
+        }
+
+        public OverwritePermissions OldPermissions { get; }
+        public OverwritePermissions NewPermissions { get; }
+
+        public ulong OverwriteTargetId { get; }
+        public PermissionTarget OverwriteType { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/PruneAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/PruneAuditLogData.cs
@@ -1,0 +1,22 @@
+﻿using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class PruneAuditLogData : IAuditLogData
+    {
+        private PruneAuditLogData(int pruneDays, int membersRemoved)
+        {
+            PruneDays = pruneDays;
+            MembersRemoved = membersRemoved;
+        }
+
+        internal static PruneAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new PruneAuditLogData(entry.Options.PruneDeleteMemberDays.Value, entry.Options.PruneMembersRemoved.Value);
+        }
+
+        public int PruneDays { get; }
+        public int MembersRemoved { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleCreateAuditLogData.cs
@@ -1,0 +1,58 @@
+﻿using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class RoleCreateAuditLogData : IAuditLogData
+    {
+        private RoleCreateAuditLogData(ulong id, RoleInfo props)
+        {
+            RoleId = id;
+            Properties = props;
+        }
+
+        internal static RoleCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            Color? color = null;
+            bool? mentionable = null,
+                hoist = null;
+            string name = null;
+            GuildPermissions? permissions = null;
+
+            foreach (var model in changes)
+            {
+                switch (model.ChangedProperty)
+                {
+                    case "color":
+                        if (model.NewValue != null)
+                            color = new Color(model.NewValue.ToObject<uint>());
+                        break;
+                    case "mentionable":
+                        if (model.NewValue != null)
+                            mentionable = model.NewValue.ToObject<bool>();
+                        break;
+                    case "hoist":
+                        if (model.NewValue != null)
+                            hoist = model.NewValue.ToObject<bool>();
+                        break;
+                    case "name":
+                        if (model.NewValue != null)
+                            name = model.NewValue.ToObject<string>();
+                        break;
+                    case "permissions":
+                        if (model.NewValue != null)
+                            permissions = new GuildPermissions(model.NewValue.ToObject<ulong>());
+                        break;
+                }
+            }
+
+            return new RoleCreateAuditLogData(entry.TargetId.Value,
+                new RoleInfo(color, mentionable, hoist, name, permissions));
+        }
+
+        public ulong RoleId { get; }
+        public RoleInfo Properties { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleCreateAuditLogData.cs
@@ -1,4 +1,6 @@
-﻿using Model = Discord.API.AuditLog;
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
 namespace Discord.Rest
@@ -15,38 +17,25 @@ namespace Discord.Rest
         {
             var changes = entry.Changes;
 
+            var colorModel = changes.FirstOrDefault(x => x.ChangedProperty == "color");
+            var mentionableModel = changes.FirstOrDefault(x => x.ChangedProperty == "mentionable");
+            var hoistModel = changes.FirstOrDefault(x => x.ChangedProperty == "hoist");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var permissionsModel = changes.FirstOrDefault(x => x.ChangedProperty == "permissions");
+
+            uint? colorRaw = colorModel?.NewValue?.ToObject<uint>();
+            bool? mentionable = mentionableModel?.NewValue?.ToObject<bool>();
+            bool? hoist = hoistModel?.NewValue?.ToObject<bool>();
+            string name = nameModel?.NewValue?.ToObject<string>();
+            ulong? permissionsRaw = permissionsModel?.NewValue?.ToObject<ulong>();
+
             Color? color = null;
-            bool? mentionable = null,
-                hoist = null;
-            string name = null;
             GuildPermissions? permissions = null;
 
-            foreach (var model in changes)
-            {
-                switch (model.ChangedProperty)
-                {
-                    case "color":
-                        if (model.NewValue != null)
-                            color = new Color(model.NewValue.ToObject<uint>());
-                        break;
-                    case "mentionable":
-                        if (model.NewValue != null)
-                            mentionable = model.NewValue.ToObject<bool>();
-                        break;
-                    case "hoist":
-                        if (model.NewValue != null)
-                            hoist = model.NewValue.ToObject<bool>();
-                        break;
-                    case "name":
-                        if (model.NewValue != null)
-                            name = model.NewValue.ToObject<string>();
-                        break;
-                    case "permissions":
-                        if (model.NewValue != null)
-                            permissions = new GuildPermissions(model.NewValue.ToObject<ulong>());
-                        break;
-                }
-            }
+            if (colorRaw.HasValue)
+                color = new Color(colorRaw.Value);
+            if (permissionsRaw.HasValue)
+                permissions = new GuildPermissions(permissionsRaw.Value);
 
             return new RoleCreateAuditLogData(entry.TargetId.Value,
                 new RoleInfo(color, mentionable, hoist, name, permissions));

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleDeleteAuditLogData.cs
@@ -1,0 +1,58 @@
+﻿using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class RoleDeleteAuditLogData : IAuditLogData
+    {
+        private RoleDeleteAuditLogData(ulong id, RoleInfo props)
+        {
+            RoleId = id;
+            Properties = props;
+        }
+
+        internal static RoleDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            Color? color = null;
+            bool? mentionable = null,
+                hoist = null;
+            string name = null;
+            GuildPermissions? permissions = null;
+
+            foreach (var model in changes)
+            {
+                switch (model.ChangedProperty)
+                {
+                    case "color":
+                        if (model.OldValue != null)
+                            color = new Color(model.OldValue.ToObject<uint>());
+                        break;
+                    case "mentionable":
+                        if (model.OldValue != null)
+                            mentionable = model.OldValue.ToObject<bool>();
+                        break;
+                    case "hoist":
+                        if (model.OldValue != null)
+                            hoist = model.OldValue.ToObject<bool>();
+                        break;
+                    case "name":
+                        if (model.OldValue != null)
+                            name = model.OldValue.ToObject<string>();
+                        break;
+                    case "permissions":
+                        if (model.OldValue != null)
+                            permissions = new GuildPermissions(model.OldValue.ToObject<ulong>());
+                        break;
+                }
+            }
+
+            return new RoleDeleteAuditLogData(entry.TargetId.Value,
+                new RoleInfo(color, mentionable, hoist, name, permissions));
+        }
+
+        public ulong RoleId { get; }
+        public RoleInfo Properties { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleDeleteAuditLogData.cs
@@ -1,4 +1,6 @@
-﻿using Model = Discord.API.AuditLog;
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
 namespace Discord.Rest
@@ -15,38 +17,25 @@ namespace Discord.Rest
         {
             var changes = entry.Changes;
 
+            var colorModel = changes.FirstOrDefault(x => x.ChangedProperty == "color");
+            var mentionableModel = changes.FirstOrDefault(x => x.ChangedProperty == "mentionable");
+            var hoistModel = changes.FirstOrDefault(x => x.ChangedProperty == "hoist");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var permissionsModel = changes.FirstOrDefault(x => x.ChangedProperty == "permissions");
+
+            uint? colorRaw = colorModel?.OldValue?.ToObject<uint>();
+            bool? mentionable = mentionableModel?.OldValue?.ToObject<bool>();
+            bool? hoist = hoistModel?.OldValue?.ToObject<bool>();
+            string name = nameModel?.OldValue?.ToObject<string>();
+            ulong? permissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>();
+
             Color? color = null;
-            bool? mentionable = null,
-                hoist = null;
-            string name = null;
             GuildPermissions? permissions = null;
 
-            foreach (var model in changes)
-            {
-                switch (model.ChangedProperty)
-                {
-                    case "color":
-                        if (model.OldValue != null)
-                            color = new Color(model.OldValue.ToObject<uint>());
-                        break;
-                    case "mentionable":
-                        if (model.OldValue != null)
-                            mentionable = model.OldValue.ToObject<bool>();
-                        break;
-                    case "hoist":
-                        if (model.OldValue != null)
-                            hoist = model.OldValue.ToObject<bool>();
-                        break;
-                    case "name":
-                        if (model.OldValue != null)
-                            name = model.OldValue.ToObject<string>();
-                        break;
-                    case "permissions":
-                        if (model.OldValue != null)
-                            permissions = new GuildPermissions(model.OldValue.ToObject<ulong>());
-                        break;
-                }
-            }
+            if (colorRaw.HasValue)
+                color = new Color(colorRaw.Value);
+            if (permissionsRaw.HasValue)
+                permissions = new GuildPermissions(permissionsRaw.Value);
 
             return new RoleDeleteAuditLogData(entry.TargetId.Value,
                 new RoleInfo(color, mentionable, hoist, name, permissions));

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleInfo.cs
@@ -1,0 +1,21 @@
+namespace Discord.Rest
+{
+    public struct RoleInfo
+        {
+            internal RoleInfo(Color? color, bool? mentionable, bool? hoist, string name,
+                GuildPermissions? permissions)
+            {
+                Color = color;
+                Mentionable = mentionable;
+                Hoist = hoist;
+                Name = name;
+                Permissions = permissions;
+            }
+
+            public Color? Color { get; }
+            public bool? Mentionable { get; }
+            public bool? Hoist { get; }
+            public string Name { get; }
+            public GuildPermissions? Permissions { get; }
+        }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
@@ -1,0 +1,77 @@
+﻿using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class RoleUpdateAuditLogData : IAuditLogData
+    {
+        private RoleUpdateAuditLogData(ulong id, RoleInfo oldProps, RoleInfo newProps)
+        {
+            RoleId = id;
+            Before = oldProps;
+            After = newProps;
+        }
+
+        internal static RoleUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            Color? oldColor = null,
+                newColor = null;
+            bool? oldMentionable = null,
+                newMentionable = null;
+            bool? oldHoist = null,
+                newHoist = null;
+            string oldName = null,
+                newName = null;
+            GuildPermissions? oldPermissions = null,
+                newPermissions = null;
+
+            foreach (var model in changes)
+            {
+                switch (model.ChangedProperty)
+                {
+                    case "color":
+                        if (model.NewValue != null)
+                            newColor = new Color(model.NewValue.ToObject<uint>());
+                        if (model.OldValue != null)
+                            oldColor = new Color(model.OldValue.ToObject<uint>());
+                        break;
+                    case "mentionable":
+                        if (model.NewValue != null)
+                            newMentionable = model.NewValue.ToObject<bool>();
+                        if (model.OldValue != null)
+                            oldMentionable = model.OldValue.ToObject<bool>();
+                        break;
+                    case "hoist":
+                        if (model.NewValue != null)
+                            newHoist = model.NewValue.ToObject<bool>();
+                        if (model.OldValue != null)
+                            oldHoist = model.OldValue.ToObject<bool>();
+                        break;
+                    case "name":
+                        if (model.NewValue != null)
+                            newName = model.NewValue.ToObject<string>();
+                        if (model.OldValue != null)
+                            oldName = model.OldValue.ToObject<string>();
+                        break;
+                    case "permissions":
+                        if (model.NewValue != null)
+                            newPermissions = new GuildPermissions(model.NewValue.ToObject<ulong>());
+                        if (model.OldValue != null)
+                            oldPermissions = new GuildPermissions(model.OldValue.ToObject<ulong>());
+                        break;
+                }
+            }
+
+            var oldProps = new RoleInfo(oldColor, oldMentionable, oldHoist, oldName, oldPermissions);
+            var newProps = new RoleInfo(newColor, newMentionable, newHoist, newName, newPermissions);
+
+            return new RoleUpdateAuditLogData(entry.TargetId.Value, oldProps, newProps);
+        }
+
+        public ulong RoleId { get; }
+        public RoleInfo Before { get; }
+        public RoleInfo After { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
@@ -1,4 +1,6 @@
-﻿using Model = Discord.API.AuditLog;
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
 namespace Discord.Rest
@@ -16,53 +18,36 @@ namespace Discord.Rest
         {
             var changes = entry.Changes;
 
+            var colorModel = changes.FirstOrDefault(x => x.ChangedProperty == "color");
+            var mentionableModel = changes.FirstOrDefault(x => x.ChangedProperty == "mentionable");
+            var hoistModel = changes.FirstOrDefault(x => x.ChangedProperty == "hoist");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var permissionsModel = changes.FirstOrDefault(x => x.ChangedProperty == "permissions");
+
+            uint? oldColorRaw = colorModel?.OldValue?.ToObject<uint>(),
+                newColorRaw = colorModel?.NewValue?.ToObject<uint>();
+            bool? oldMentionable = mentionableModel?.OldValue?.ToObject<bool>(),
+                newMentionable = mentionableModel?.NewValue?.ToObject<bool>();
+            bool? oldHoist = hoistModel?.OldValue?.ToObject<bool>(),
+                newHoist = hoistModel?.NewValue?.ToObject<bool>();
+            string oldName = nameModel?.OldValue?.ToObject<string>(),
+                newName = nameModel?.NewValue?.ToObject<string>();
+            ulong? oldPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>(),
+                newPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>();
+
             Color? oldColor = null,
                 newColor = null;
-            bool? oldMentionable = null,
-                newMentionable = null;
-            bool? oldHoist = null,
-                newHoist = null;
-            string oldName = null,
-                newName = null;
             GuildPermissions? oldPermissions = null,
                 newPermissions = null;
 
-            foreach (var model in changes)
-            {
-                switch (model.ChangedProperty)
-                {
-                    case "color":
-                        if (model.NewValue != null)
-                            newColor = new Color(model.NewValue.ToObject<uint>());
-                        if (model.OldValue != null)
-                            oldColor = new Color(model.OldValue.ToObject<uint>());
-                        break;
-                    case "mentionable":
-                        if (model.NewValue != null)
-                            newMentionable = model.NewValue.ToObject<bool>();
-                        if (model.OldValue != null)
-                            oldMentionable = model.OldValue.ToObject<bool>();
-                        break;
-                    case "hoist":
-                        if (model.NewValue != null)
-                            newHoist = model.NewValue.ToObject<bool>();
-                        if (model.OldValue != null)
-                            oldHoist = model.OldValue.ToObject<bool>();
-                        break;
-                    case "name":
-                        if (model.NewValue != null)
-                            newName = model.NewValue.ToObject<string>();
-                        if (model.OldValue != null)
-                            oldName = model.OldValue.ToObject<string>();
-                        break;
-                    case "permissions":
-                        if (model.NewValue != null)
-                            newPermissions = new GuildPermissions(model.NewValue.ToObject<ulong>());
-                        if (model.OldValue != null)
-                            oldPermissions = new GuildPermissions(model.OldValue.ToObject<ulong>());
-                        break;
-                }
-            }
+            if (oldColorRaw.HasValue)
+                oldColor = new Color(oldColorRaw.Value);
+            if (newColorRaw.HasValue)
+                newColor = new Color(newColorRaw.Value);
+            if (oldPermissionsRaw.HasValue)
+                oldPermissions = new GuildPermissions(oldPermissionsRaw.Value);
+            if (newPermissionsRaw.HasValue)
+                newPermissions = new GuildPermissions(newPermissionsRaw.Value);
 
             var oldProps = new RoleInfo(oldColor, oldMentionable, oldHoist, oldName, oldPermissions);
             var newProps = new RoleInfo(newColor, newMentionable, newHoist, newName, newPermissions);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/UnbanAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/UnbanAuditLogData.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class UnbanAuditLogData : IAuditLogData
+    {
+        private UnbanAuditLogData(IUser user)
+        {
+            Target = user;
+        }
+
+        internal static UnbanAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            return new UnbanAuditLogData(RestUser.Create(discord, userInfo));
+        }
+
+        public IUser Target { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class WebhookCreateAuditLogData : IAuditLogData
+    {
+        private WebhookCreateAuditLogData(IWebhook webhook, string name, ulong channelId)
+        {
+            Webhook = webhook;
+            Name = name;
+            ChannelId = channelId;
+        }
+
+        internal static WebhookCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
+            var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+
+            var channelId = channelIdModel.NewValue.ToObject<ulong>();
+            var type = typeModel.NewValue.ToObject<int>(); //TODO: what on *earth* is this for
+            var name = nameModel.NewValue.ToObject<string>();
+
+            var webhookInfo = log.Webhooks?.FirstOrDefault(x => x.Id == entry.TargetId);
+            var webhook = RestWebhook.Create(discord, (IGuild)null, webhookInfo);
+
+            return new WebhookCreateAuditLogData(webhook, name, channelId);
+        }
+
+        //Corresponds to the *current* data
+        public IWebhook Webhook { get; }
+
+        //Corresponds to the *audit log* data
+        public string Name { get; }
+        public ulong ChannelId { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
@@ -7,10 +7,11 @@ namespace Discord.Rest
 {
     public class WebhookCreateAuditLogData : IAuditLogData
     {
-        private WebhookCreateAuditLogData(IWebhook webhook, string name, ulong channelId)
+        private WebhookCreateAuditLogData(IWebhook webhook, WebhookType type, string name, ulong channelId)
         {
             Webhook = webhook;
             Name = name;
+            Type = type;
             ChannelId = channelId;
         }
 
@@ -23,19 +24,20 @@ namespace Discord.Rest
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
 
             var channelId = channelIdModel.NewValue.ToObject<ulong>();
-            var type = typeModel.NewValue.ToObject<int>(); //TODO: what on *earth* is this for
+            var type = typeModel.NewValue.ToObject<WebhookType>();
             var name = nameModel.NewValue.ToObject<string>();
 
             var webhookInfo = log.Webhooks?.FirstOrDefault(x => x.Id == entry.TargetId);
             var webhook = RestWebhook.Create(discord, (IGuild)null, webhookInfo);
 
-            return new WebhookCreateAuditLogData(webhook, name, channelId);
+            return new WebhookCreateAuditLogData(webhook, type, name, channelId);
         }
 
         //Corresponds to the *current* data
         public IWebhook Webhook { get; }
 
         //Corresponds to the *audit log* data
+        public WebhookType Type { get; }
         public string Name { get; }
         public ulong ChannelId { get; }
     }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookDeleteAuditLogData.cs
@@ -11,11 +11,12 @@ namespace Discord.Rest
 {
     public class WebhookDeleteAuditLogData : IAuditLogData
     {
-        private WebhookDeleteAuditLogData(ulong id, ulong channel, string name, string avatar)
+        private WebhookDeleteAuditLogData(ulong id, ulong channel, WebhookType type, string name, string avatar)
         {
             WebhookId = id;
             ChannelId = channel;
             Name = name;
+            Type = type;
             Avatar = avatar;
         }
 
@@ -29,15 +30,16 @@ namespace Discord.Rest
             var avatarHashModel = changes.FirstOrDefault(x => x.ChangedProperty == "avatar_hash");
 
             var channelId = channelIdModel.OldValue.ToObject<ulong>();
-            var type = typeModel.OldValue.ToObject<int>(); //TODO: what on *earth* is this for
+            var type = typeModel.OldValue.ToObject<WebhookType>();
             var name = nameModel.OldValue.ToObject<string>();
             var avatarHash = avatarHashModel?.OldValue?.ToObject<string>();
 
-            return new WebhookDeleteAuditLogData(entry.TargetId.Value, channelId, name, avatarHash);
+            return new WebhookDeleteAuditLogData(entry.TargetId.Value, channelId, type, name, avatarHash);
         }
 
         public ulong WebhookId { get; }
         public ulong ChannelId { get; }
+        public WebhookType Type { get; }
         public string Name { get; }
         public string Avatar { get; }
     }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookDeleteAuditLogData.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class WebhookDeleteAuditLogData : IAuditLogData
+    {
+        private WebhookDeleteAuditLogData(ulong id, ulong channel, string name, string avatar)
+        {
+            WebhookId = id;
+            ChannelId = channel;
+            Name = name;
+            Avatar = avatar;
+        }
+
+        internal static WebhookDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
+            var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var avatarHashModel = changes.FirstOrDefault(x => x.ChangedProperty == "avatar_hash");
+
+            var channelId = channelIdModel.OldValue.ToObject<ulong>();
+            var type = typeModel.OldValue.ToObject<int>(); //TODO: what on *earth* is this for
+            var name = nameModel.OldValue.ToObject<string>();
+            var avatarHash = avatarHashModel?.OldValue?.ToObject<string>();
+
+            return new WebhookDeleteAuditLogData(entry.TargetId.Value, channelId, name, avatarHash);
+        }
+
+        public ulong WebhookId { get; }
+        public ulong ChannelId { get; }
+        public string Name { get; }
+        public string Avatar { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookInfo.cs
@@ -1,0 +1,16 @@
+namespace Discord.Rest
+{
+    public struct WebhookInfo
+    {
+        internal WebhookInfo(string name, ulong? channelId, string avatar)
+        {
+            Name = name;
+            ChannelId = channelId;
+            Avatar = avatar;
+        }
+
+        public string Name { get; }
+        public ulong? ChannelId { get; }
+        public string Avatar { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookUpdateAuditLogData.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class WebhookUpdateAuditLogData : IAuditLogData
+    {
+        private WebhookUpdateAuditLogData(IWebhook webhook, WebhookInfo before, WebhookInfo after)
+        {
+            Webhook = webhook;
+            Before = before;
+            After = after;
+        }
+
+        internal static WebhookUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
+            var avatarHashModel = changes.FirstOrDefault(x => x.ChangedProperty == "avatar_hash");
+
+            var oldName = nameModel?.OldValue?.ToObject<string>();
+            var oldChannelId = channelIdModel?.OldValue?.ToObject<ulong>();
+            var oldAvatar = avatarHashModel?.OldValue?.ToObject<string>();
+            var before = new WebhookInfo(oldName, oldChannelId, oldAvatar);
+
+            var newName = nameModel?.NewValue?.ToObject<string>();
+            var newChannelId = channelIdModel?.NewValue?.ToObject<ulong>();
+            var newAvatar = avatarHashModel?.NewValue?.ToObject<string>();
+            var after = new WebhookInfo(newName, newChannelId, newAvatar);
+
+            var webhookInfo = log.Webhooks?.FirstOrDefault(x => x.Id == entry.TargetId);
+            var webhook = RestWebhook.Create(discord, (IGuild)null, webhookInfo);
+
+            return new WebhookUpdateAuditLogData(webhook, before, after);
+        }
+
+        //Again, the *current* data
+        public IWebhook Webhook { get; }
+
+        //And the *audit log* data
+        public WebhookInfo Before { get; }
+        public WebhookInfo After { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/RestAuditLogEntry.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/RestAuditLogEntry.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    public class RestAuditLogEntry : RestEntity<ulong>, IAuditLogEntry
+    {
+        private RestAuditLogEntry(BaseDiscordClient discord, Model fullLog, EntryModel model, IUser user)
+            : base(discord, model.Id)
+        {
+            Action = model.Action;
+            Data = AuditLogHelper.CreateData(discord, fullLog, model);
+            User = user;
+            Reason = model.Reason;
+        }
+
+        internal static RestAuditLogEntry Create(BaseDiscordClient discord, Model fullLog, EntryModel model)
+        {
+            var userInfo = fullLog.Users.FirstOrDefault(x => x.Id == model.UserId);
+            IUser user = null;
+            if (userInfo != null)
+                user = RestUser.Create(discord, userInfo);
+
+            return new RestAuditLogEntry(discord, fullLog, model, user);
+        }
+
+        /// <inheritdoc/>
+        public ActionType Action { get; }
+        /// <inheritdoc/>
+        public IAuditLogData Data { get; }
+        /// <inheritdoc/>
+        public IUser User { get; }
+        /// <inheritdoc/>
+        public string Reason { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -264,6 +264,10 @@ namespace Discord.Rest
         public Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null)
             => GuildHelper.PruneUsersAsync(this, Discord, days, simulate, options);
 
+        //Audit logs
+        public IAsyncEnumerable<IReadOnlyCollection<RestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null)
+            => GuildHelper.GetAuditLogsAsync(this, Discord, null, limit, options);
+
         //Webhooks
         public Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetWebhookAsync(this, Discord, id, options);
@@ -418,6 +422,14 @@ namespace Discord.Rest
                 return ImmutableArray.Create<IGuildUser>();
         }
         Task IGuild.DownloadUsersAsync() { throw new NotSupportedException(); }
+
+        async Task<IReadOnlyCollection<IAuditLogEntry>> IGuild.GetAuditLogAsync(int limit, CacheMode cacheMode, RequestOptions options)
+        {
+            if (cacheMode == CacheMode.AllowDownload)
+                return (await GetAuditLogsAsync(limit, options).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
+            else
+                return ImmutableArray.Create<IAuditLogEntry>();
+        }
 
         async Task<IWebhook> IGuild.GetWebhookAsync(ulong id, RequestOptions options)
             => await GetWebhookAsync(id, options);

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -434,6 +434,10 @@ namespace Discord.WebSocket
             _downloaderPromise.TrySetResultAsync(true);
         }
 
+        //Audit logs
+        public IAsyncEnumerable<IReadOnlyCollection<RestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null)
+            => GuildHelper.GetAuditLogsAsync(this, Discord, null, limit, options);
+
         //Webhooks
         public Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetWebhookAsync(this, Discord, id, options);
@@ -692,6 +696,14 @@ namespace Discord.WebSocket
             => Task.FromResult<IGuildUser>(CurrentUser);
         Task<IGuildUser> IGuild.GetOwnerAsync(CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuildUser>(Owner);
+
+        async Task<IReadOnlyCollection<IAuditLogEntry>> IGuild.GetAuditLogAsync(int limit, CacheMode cacheMode, RequestOptions options)
+        {
+            if (cacheMode == CacheMode.AllowDownload)
+                return (await GetAuditLogsAsync(limit, options).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
+            else
+                return ImmutableArray.Create<IAuditLogEntry>();
+        }
 
         async Task<IWebhook> IGuild.GetWebhookAsync(ulong id, RequestOptions options)
             => await GetWebhookAsync(id, options);


### PR DESCRIPTION
I suck at git, so after fucking up one branch locally I'm just gonna brute-force copy files in and save myself the hassle.

Apparently audit logs have changed a little, but I'm not sure what has changed so things may be missing. However, I did manage to successfully pull 1000 audit log entries from Discord API and they all seemed to be complete.

I have changed some things since the last PR, namely adding read-only structs to store values instead of using the built-in read-write types I had before. I also removed a bunch of TODOs as I realise it wouldn't be worth grabbing channels for each entry.