### PR TITLE
Allow external VoiceChannel client API implementation

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
@@ -7,7 +7,7 @@ namespace Discord
     public interface IAudioChannel : IChannel
     {
         /// <summary> Connects to this audio channel. </summary>
-        Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null, bool external = false);
+        Task<IAudioClient> ConnectAsync(bool selfDeaf = false, bool selfMute = false, bool external = false);
 
         /// <summary> Disconnects from this audio channel. </summary>
         Task DisconnectAsync();

--- a/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Audio;
+using Discord.Audio;
 using System;
 using System.Threading.Tasks;
 
@@ -8,5 +8,8 @@ namespace Discord
     {
         /// <summary> Connects to this audio channel. </summary>
         Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null);
+
+        /// <summary> Connects to this audio channel but can specify if client is handled externally. </summary>
+        Task<IAudioClient> ConnectAsync(bool external, Action<IAudioClient> configAction = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
@@ -10,6 +10,9 @@ namespace Discord
         Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null);
 
         /// <summary> Connects to this audio channel but can specify if client is handled externally. </summary>
-        Task<IAudioClient> ConnectAsync(bool external, Action<IAudioClient> configAction = null);
+        Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null, bool external = false);
+
+        /// <summary> Disconnects from this audio channel if applicable. </summary>
+        Task DisconnectAsync();
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
@@ -12,7 +12,7 @@ namespace Discord
         /// <summary> Connects to this audio channel but can specify if client is handled externally. </summary>
         Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null, bool external = false);
 
-        /// <summary> Disconnects from this audio channel if applicable. </summary>
+        /// <summary> Disconnects from this audio channel. </summary>
         Task DisconnectAsync();
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IAudioChannel.cs
@@ -7,9 +7,6 @@ namespace Discord
     public interface IAudioChannel : IChannel
     {
         /// <summary> Connects to this audio channel. </summary>
-        Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null);
-
-        /// <summary> Connects to this audio channel but can specify if client is handled externally. </summary>
         Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null, bool external = false);
 
         /// <summary> Disconnects from this audio channel. </summary>

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -143,7 +143,6 @@ namespace Discord.Rest
             => EnterTypingState(options);
 
         //IAudioChannel
-        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
         Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -144,6 +144,7 @@ namespace Discord.Rest
 
         //IAudioChannel
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(bool external, Action<IAudioClient> configAction) { throw new NotSupportedException(); }
 
         //IChannel        
         Task<IUser> IChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -144,7 +144,8 @@ namespace Discord.Rest
 
         //IAudioChannel
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
-        Task<IAudioClient> IAudioChannel.ConnectAsync(bool external, Action<IAudioClient> configAction) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
+        Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 
         //IChannel        
         Task<IUser> IChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -143,7 +143,7 @@ namespace Discord.Rest
             => EnterTypingState(options);
 
         //IAudioChannel
-        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(bool selfDeaf, bool selfMute, bool external) { throw new NotSupportedException(); }
         Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 
         //IChannel        

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -41,7 +41,7 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
 
         //IAudioChannel
-        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(bool selfDeaf, bool selfMute, bool external) { throw new NotSupportedException(); }
         Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 
         //IGuildChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Audio;
+using Discord.Audio;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -42,6 +42,7 @@ namespace Discord.Rest
 
         //IAudioChannel
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(bool external, Action<IAudioClient> configAction) { throw new NotSupportedException(); }
 
         //IGuildChannel
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -41,7 +41,6 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
 
         //IAudioChannel
-        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
         Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -42,7 +42,8 @@ namespace Discord.Rest
 
         //IAudioChannel
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
-        Task<IAudioClient> IAudioChannel.ConnectAsync(bool external, Action<IAudioClient> configAction) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
+        Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 
         //IGuildChannel
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -206,7 +206,7 @@ namespace Discord.WebSocket
             => EnterTypingState(options);
 
         //IAudioChannel
-        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(bool selfDeaf, bool selfMute, bool external) { throw new NotSupportedException(); }
         Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 
         //IChannel        

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -206,7 +206,6 @@ namespace Discord.WebSocket
             => EnterTypingState(options);
 
         //IAudioChannel
-        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
         Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -207,6 +207,7 @@ namespace Discord.WebSocket
 
         //IAudioChannel
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(bool external, Action<IAudioClient> configAction) { throw new NotSupportedException(); }
 
         //IChannel        
         Task<IUser> IChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -207,7 +207,8 @@ namespace Discord.WebSocket
 
         //IAudioChannel
         Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction) { throw new NotSupportedException(); }
-        Task<IAudioClient> IAudioChannel.ConnectAsync(bool external, Action<IAudioClient> configAction) { throw new NotSupportedException(); }
+        Task<IAudioClient> IAudioChannel.ConnectAsync(Action<IAudioClient> configAction, bool external) { throw new NotSupportedException(); }
+        Task IAudioChannel.DisconnectAsync() { throw new NotSupportedException(); }
 
         //IChannel        
         Task<IUser> IChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -40,7 +40,7 @@ namespace Discord.WebSocket
         public Task ModifyAsync(Action<VoiceChannelProperties> func, RequestOptions options = null)
             => ChannelHelper.ModifyAsync(this, Discord, func, options);
 
-        public async Task<IAudioClient> ConnectAsync(bool selfDeaf = false, bool selfMute = false, bool external = false)
+        public async Task<IAudioClient> ConnectAsync(bool selfDeaf, bool selfMute, bool external)
         {
             return await Guild.ConnectAudioAsync(Id, selfDeaf, selfMute, external).ConfigureAwait(false);
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -45,10 +45,13 @@ namespace Discord.WebSocket
             return await Guild.ConnectAudioAsync(Id, false, false, configAction, false).ConfigureAwait(false);
         }
 
-        public async Task<IAudioClient> ConnectAsync(bool external, Action<IAudioClient> configAction = null)
+        public async Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null, bool external = false)
         {
             return await Guild.ConnectAudioAsync(Id, false, false, configAction, external).ConfigureAwait(false);
         }
+
+        public async Task DisconnectAsync()
+            => await Guild.DisconnectAudioAsync();
 
         public override SocketGuildUser GetUser(ulong id)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -40,9 +40,9 @@ namespace Discord.WebSocket
         public Task ModifyAsync(Action<VoiceChannelProperties> func, RequestOptions options = null)
             => ChannelHelper.ModifyAsync(this, Discord, func, options);
 
-        public async Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null, bool external = false)
+        public async Task<IAudioClient> ConnectAsync(bool selfDeaf = false, bool selfMute = false, bool external = false)
         {
-            return await Guild.ConnectAudioAsync(Id, false, false, configAction, external).ConfigureAwait(false);
+            return await Guild.ConnectAudioAsync(Id, selfDeaf, selfMute, external).ConfigureAwait(false);
         }
 
         public async Task DisconnectAsync()

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -40,11 +40,6 @@ namespace Discord.WebSocket
         public Task ModifyAsync(Action<VoiceChannelProperties> func, RequestOptions options = null)
             => ChannelHelper.ModifyAsync(this, Discord, func, options);
 
-        public async Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null)
-        {
-            return await Guild.ConnectAudioAsync(Id, false, false, configAction, false).ConfigureAwait(false);
-        }
-
         public async Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null, bool external = false)
         {
             return await Guild.ConnectAudioAsync(Id, false, false, configAction, external).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Audio;
+using Discord.Audio;
 using Discord.Rest;
 using System;
 using System.Collections.Generic;
@@ -42,7 +42,12 @@ namespace Discord.WebSocket
 
         public async Task<IAudioClient> ConnectAsync(Action<IAudioClient> configAction = null)
         {
-            return await Guild.ConnectAudioAsync(Id, false, false, configAction).ConfigureAwait(false);
+            return await Guild.ConnectAudioAsync(Id, false, false, configAction, false).ConfigureAwait(false);
+        }
+
+        public async Task<IAudioClient> ConnectAsync(bool external, Action<IAudioClient> configAction = null)
+        {
+            return await Guild.ConnectAudioAsync(Id, false, false, configAction, external).ConfigureAwait(false);
         }
 
         public override SocketGuildUser GetUser(ulong id)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -606,8 +606,11 @@ namespace Discord.WebSocket
             await _audioLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                await RepopulateAudioStreamsAsync().ConfigureAwait(false);
-                await _audioClient.StartAsync(url, Discord.CurrentUser.Id, voiceState.VoiceSessionId, token).ConfigureAwait(false);
+                if (_audioClient != null)
+                {
+                    await RepopulateAudioStreamsAsync().ConfigureAwait(false);
+                    await _audioClient.StartAsync(url, Discord.CurrentUser.Id, voiceState.VoiceSessionId, token).ConfigureAwait(false);
+                }
             }
             catch (OperationCanceledException)
             {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -504,11 +504,8 @@ namespace Discord.WebSocket
         {
             return _audioClient?.GetInputStream(userId);
         }
-        internal async Task<IAudioClient> ConnectAudioAsync(ulong channelId, bool selfDeaf, bool selfMute, Action<IAudioClient> configAction, bool external)
+        internal async Task<IAudioClient> ConnectAudioAsync(ulong channelId, bool selfDeaf, bool selfMute, bool external)
         {
-            selfDeaf = false;
-            selfMute = false;
-
             TaskCompletionSource<AudioClient> promise;
 
             await _audioLock.WaitAsync().ConfigureAwait(false);
@@ -548,7 +545,6 @@ namespace Discord.WebSocket
                         var _ = promise.TrySetResultAsync(_audioClient);
                         return Task.Delay(0);
                     };
-                    configAction?.Invoke(audioClient);
                     _audioClient = audioClient;
                 }
 


### PR DESCRIPTION
Following what #984 offered and building upon the knowledge of being able to implement Lavalink there was a few inconsistencies with it that seemed to cause a lot of problems and didn't let Lavalink work properly. These changes are meant to allow developers to mark connections to a Discord voice channel as externally handled like with a Lavalink implementation.

These API changes just bypass the Discord.Net AudioClient creation process and just go straight to sending the voice state update payload.

**Reasoning for change regarding #984**
This pull request was to add the VoiceServerUpdate event to DiscordSocketClient but was also modified to allow an exception to be thrown back to prevent the default AudioClient, this had *major* problems and did not work as expected. The session id was still getting invalidated, discord.net was still creating a client and throwing session invalid errors, and if the VoiceServerUpdate event was Task.Delay'd the AudioClient would not throw a session invalid error on the websocket but the session id when used by Lavalink was invalid (This basically left a sort of dead AudioClient created that logged unnecessarily)

**API Changes**
IAudioChannel.ConnectAsync(Action<AudioClient> configAction, bool external) 
    => If external is true AudioClient is null and configAction is not called
IAudioChannel.DisconnectAsync()
    => DisconnectAsync calls the SocketGuild.DisconnectAudioAsync() method. In the case of an external audio client this API exists to send a voice state update payload where an AudioClient doesn't exist.

~~*These API changes **DO NOT** affect anything majorly but just add onto the current API*~~
Edit: After review and other changes not related to to the "opening pr commits" it now has breaking API changes but was stated that it was apis which were likely never used and won't break any current bots