### PR TITLE
Fix Build Warnings for usage of obsolete GuildPermission ReadMessages

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -87,7 +87,7 @@ namespace Discord
         private GuildPermissions(ulong initialValue, bool? createInstantInvite = null, bool? kickMembers = null,
             bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
             bool? addReactions = null, bool? viewAuditLog = null,
-            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
+            bool? viewChannel = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
@@ -103,7 +103,7 @@ namespace Discord
             Permissions.SetValue(ref value, manageGuild, GuildPermission.ManageGuild);
             Permissions.SetValue(ref value, addReactions, GuildPermission.AddReactions);
             Permissions.SetValue(ref value, viewAuditLog, GuildPermission.ViewAuditLog);
-            Permissions.SetValue(ref value, readMessages, GuildPermission.ReadMessages);
+            Permissions.SetValue(ref value, viewChannel, GuildPermission.ViewChannel);
             Permissions.SetValue(ref value, sendMessages, GuildPermission.SendMessages);
             Permissions.SetValue(ref value, sendTTSMessages, GuildPermission.SendTTSMessages);
             Permissions.SetValue(ref value, manageMessages, GuildPermission.ManageMessages);
@@ -131,14 +131,14 @@ namespace Discord
         public GuildPermissions(bool createInstantInvite = false, bool kickMembers = false,
             bool banMembers = false, bool administrator = false, bool manageChannels = false, bool manageGuild = false,
             bool addReactions = false, bool viewAuditLog = false,
-            bool readMessages = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
+            bool viewChannel = false, bool sendMessages = false, bool sendTTSMessages = false, bool manageMessages = false,
             bool embedLinks = false, bool attachFiles = false, bool readMessageHistory = false, bool mentionEveryone = false,
             bool useExternalEmojis = false, bool connect = false, bool speak = false, bool muteMembers = false, bool deafenMembers = false,
             bool moveMembers = false, bool useVoiceActivation = false, bool? changeNickname = false, bool? manageNicknames = false,
             bool manageRoles = false, bool manageWebhooks = false, bool manageEmojis = false)
             : this(0, createInstantInvite: createInstantInvite, manageRoles: manageRoles, kickMembers: kickMembers, banMembers: banMembers,
                   administrator: administrator, manageChannels: manageChannels, manageGuild: manageGuild, addReactions: addReactions,
-                  viewAuditLog: viewAuditLog, readMessages: readMessages, sendMessages: sendMessages, sendTTSMessages: sendTTSMessages,
+                  viewAuditLog: viewAuditLog, viewChannel: viewChannel, sendMessages: sendMessages, sendTTSMessages: sendTTSMessages,
                   manageMessages: manageMessages, embedLinks: embedLinks, attachFiles: attachFiles, readMessageHistory: readMessageHistory,
                   mentionEveryone: mentionEveryone, useExternalEmojis: useExternalEmojis, connect: connect, speak: speak, muteMembers: muteMembers,
                   deafenMembers: deafenMembers, moveMembers: moveMembers, useVoiceActivation: useVoiceActivation, changeNickname: changeNickname,
@@ -149,13 +149,13 @@ namespace Discord
         public GuildPermissions Modify(bool? createInstantInvite = null, bool? kickMembers = null,
             bool? banMembers = null, bool? administrator = null, bool? manageChannels = null, bool? manageGuild = null,
             bool? addReactions = null, bool? viewAuditLog = null,
-            bool? readMessages = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
+            bool? viewChannel = null, bool? sendMessages = null, bool? sendTTSMessages = null, bool? manageMessages = null,
             bool? embedLinks = null, bool? attachFiles = null, bool? readMessageHistory = null, bool? mentionEveryone = null,
             bool? useExternalEmojis = null, bool? connect = null, bool? speak = null, bool? muteMembers = null, bool? deafenMembers = null,
             bool? moveMembers = null, bool? useVoiceActivation = null, bool? changeNickname = null, bool? manageNicknames = null,
             bool? manageRoles = null, bool? manageWebhooks = null, bool? manageEmojis = null)
             => new GuildPermissions(RawValue, createInstantInvite, kickMembers, banMembers, administrator, manageChannels, manageGuild, addReactions,
-                viewAuditLog, readMessages, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
+                viewAuditLog, viewChannel, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
                 readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers,
                 useVoiceActivation, changeNickname, manageNicknames, manageRoles, manageWebhooks, manageEmojis);
 

--- a/test/Discord.Net.Tests/Tests.GuildPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.GuildPermissions.cs
@@ -138,12 +138,12 @@ namespace Discord
 
 
             // individual permission test
-            perm = perm.Modify(readMessages: true);
-            Assert.True(perm.ReadMessages);
-            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ReadMessages);
+            perm = perm.Modify(viewChannel: true);
+            Assert.True(perm.ViewChannel);
+            Assert.Equal(perm.RawValue, (ulong)GuildPermission.ViewChannel);
 
-            perm = perm.Modify(readMessages: false);
-            Assert.False(perm.ReadMessages);
+            perm = perm.Modify(viewChannel: false);
+            Assert.False(perm.ViewChannel);
             Assert.Equal(GuildPermissions.None.RawValue, perm.RawValue);
 
 

--- a/test/Discord.Net.Tests/Tests.Permissions.cs
+++ b/test/Discord.Net.Tests/Tests.Permissions.cs
@@ -280,7 +280,7 @@ namespace Discord
             TestHelper(value, GuildPermission.ManageGuild, false);
             TestHelper(value, GuildPermission.AddReactions, false);
             TestHelper(value, GuildPermission.ViewAuditLog, false);
-            TestHelper(value, GuildPermission.ReadMessages, false);
+            TestHelper(value, GuildPermission.ViewChannel, false);
             TestHelper(value, GuildPermission.SendMessages, false);
             TestHelper(value, GuildPermission.SendTTSMessages, false);
             TestHelper(value, GuildPermission.ManageMessages, false);
@@ -323,7 +323,7 @@ namespace Discord
             TestHelper(value, GuildPermission.ManageGuild, true);
             TestHelper(value, GuildPermission.AddReactions, true);
             TestHelper(value, GuildPermission.ViewAuditLog, true);
-            TestHelper(value, GuildPermission.ReadMessages, true);
+            TestHelper(value, GuildPermission.ViewChannel, true);
             TestHelper(value, GuildPermission.SendMessages, true);
             TestHelper(value, GuildPermission.SendTTSMessages, true);
             TestHelper(value, GuildPermission.ManageMessages, true);
@@ -367,7 +367,7 @@ namespace Discord
             TestHelper(value, GuildPermission.ManageGuild, false);
             TestHelper(value, GuildPermission.AddReactions, false);
             TestHelper(value, GuildPermission.ViewAuditLog, false);
-            TestHelper(value, GuildPermission.ReadMessages, false);
+            TestHelper(value, GuildPermission.ViewChannel, false);
             TestHelper(value, GuildPermission.SendMessages, true);
             TestHelper(value, GuildPermission.SendTTSMessages, true);
             TestHelper(value, GuildPermission.ManageMessages, false);


### PR DESCRIPTION
- Replaces the usages of `ReadMessages` with `ViewChannel`
- Renames the read message parameters of `GuildPermissions#Modify` to be view channel as well

Build errors can be seen in the most recent `dev` build: https://ci.appveyor.com/project/RogueException/discord-net/build/build-948#L208