### PR TITLE
Improve XML docs for commands quotation mark aliases feature

### DIFF
--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -8,6 +8,9 @@ namespace Discord.Commands
         /// <summary> Gets or sets the default RunMode commands should have, if one is not specified on the Command attribute or builder. </summary>
         public RunMode DefaultRunMode { get; set; } = RunMode.Sync;
 
+        /// <summary>
+        /// The delimiter which separates command parameters.
+        /// </summary>
         public char SeparatorChar { get; set; } = ' ';
         
         /// <summary> Determines whether commands should be case-sensitive. </summary>
@@ -19,8 +22,23 @@ namespace Discord.Commands
         /// <summary> Determines whether RunMode.Sync commands should push exceptions up to the caller. </summary>
         public bool ThrowOnError { get; set; } = true;
 
-        /// <summary> Collection of aliases that can wrap strings for command parsing. 
-        /// represents the opening quotation mark and the value is the corresponding closing mark.</summary>
+        /// <summary>
+        /// Collection of aliases for matching pairs of string delimiters.
+        /// The dictionary stores the opening delimiter as a key, and the matching closing delimiter as the value.
+        /// If no value is supplied <see cref="QuotationAliasUtils.GetDefaultAliasMap"/> will be used, which contains
+        /// many regional equivalents.
+        /// If this map is set to null or empty, the default delimiter of " will be used.
+        /// </summary>
+        /// <example>
+        /// <code language="C#">
+        /// QuotationMarkAliasMap = new Dictionary&lt;char, char%gt;()
+        /// {
+        ///     {'\"', '\"' },
+        ///     {'“', '”' },
+        ///     {'「', '」' },
+        /// }
+        /// </code>
+        /// </example>
         public Dictionary<char, char> QuotationMarkAliasMap { get; set; } = QuotationAliasUtils.GetDefaultAliasMap;
 
         /// <summary> Determines whether extra parameters should be ignored. </summary>

--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -27,6 +27,8 @@ namespace Discord.Commands
         /// The dictionary stores the opening delimiter as a key, and the matching closing delimiter as the value.
         /// If no value is supplied <see cref="QuotationAliasUtils.GetDefaultAliasMap"/> will be used, which contains
         /// many regional equivalents.
+        /// Only values that are specified in this map will be used as string delimiters, so if " is removed then
+        /// it won't be used.
         /// If this map is set to null or empty, the default delimiter of " will be used.
         /// </summary>
         /// <example>

--- a/src/Discord.Net.Commands/Utilities/QuotationAliasUtils.cs
+++ b/src/Discord.Net.Commands/Utilities/QuotationAliasUtils.cs
@@ -6,13 +6,13 @@ using System.Globalization;
 namespace Discord.Commands
 {
     /// <summary>
-    /// Utility methods for generating matching pairs of unicode quotation marks for CommandServiceConfig
+    /// Utility class which contains the default matching pairs of quotation marks for CommandServiceConfig
     /// </summary>
     internal static class QuotationAliasUtils
     {
         /// <summary>
-        /// Generates an IEnumerable of characters representing open-close pairs of
-        /// quotation punctuation.
+        /// A default map of open-close pairs of quotation marks.
+        /// Contains many regional and Unicode equivalents.
         /// </summary>
         internal static Dictionary<char, char> GetDefaultAliasMap
         {

--- a/src/Discord.Net.Commands/Utilities/QuotationAliasUtils.cs
+++ b/src/Discord.Net.Commands/Utilities/QuotationAliasUtils.cs
@@ -13,7 +13,9 @@ namespace Discord.Commands
         /// <summary>
         /// A default map of open-close pairs of quotation marks.
         /// Contains many regional and Unicode equivalents.
+        /// Used in the <see cref="CommandServiceConfig"/>.
         /// </summary>
+        /// <seealso cref="CommandServiceConfig.QuotationMarkAliasMap"/>
         internal static Dictionary<char, char> GetDefaultAliasMap
         {
             get


### PR DESCRIPTION
I realized that the XML docs around `QuotationMarkAliasMap` were either incorrect or not up to a level of quality I'm happy with (compared to the recent documentation effort).

This improves the documentation by explaining the default behavior and providing an example.

I'm unsure if this is a big enough topic to warrant it's own guide in the documentation, but I would like to get thoughts on that. If it might be helpful I could write something up.