### PR TITLE
Added AudioLock & Modified Throw

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -549,10 +549,13 @@ namespace Discord.WebSocket
 
                 await Discord.ApiClient.SendVoiceStateUpdateAsync(Id, channelId, selfDeaf, selfMute).ConfigureAwait(false);
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 await DisconnectAudioInternalAsync().ConfigureAwait(false);
-                throw;
+
+                // Since we're throwing an exception, we must release the audiolock to prevent future lockups/hanging.
+                _audioLock.Release();
+                throw e;
             }
             finally
             {
@@ -566,10 +569,10 @@ namespace Discord.WebSocket
                     throw new TimeoutException();
                 return await promise.Task.ConfigureAwait(false);
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 await DisconnectAudioAsync().ConfigureAwait(false);
-                throw;
+                throw e;
             }
         }
 


### PR DESCRIPTION
AudioLock << Copied to catch block to release before throwing an exception. Previously, this was known to lockup & prevent new audio clients from spawning.

Modified Throw << Now throws the caught exception. This previously wasn't producing a stacktrace.