### PR TITLE
feature: Add OffloadAllHandlers to config

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -58,6 +58,7 @@ namespace Discord.WebSocket
         internal WebSocketProvider WebSocketProvider { get; private set; }
         internal bool AlwaysDownloadUsers { get; private set; }
         internal int? HandlerTimeout { get; private set; }
+        internal bool OffloadAllHandlers { get; private set; }
 
         internal new DiscordSocketApiClient ApiClient => base.ApiClient as DiscordSocketApiClient;
         public override IReadOnlyCollection<SocketGuild> Guilds => State.Guilds;
@@ -84,8 +85,12 @@ namespace Discord.WebSocket
             WebSocketProvider = config.WebSocketProvider;
             AlwaysDownloadUsers = config.AlwaysDownloadUsers;
             HandlerTimeout = config.HandlerTimeout;
+            OffloadAllHandlers = config.OffloadAllHandlers;
             State = new ClientState(0, 0);
             _heartbeatTimes = new ConcurrentQueue<long>();
+
+            if (OffloadAllHandlers && !HandlerTimeout.HasValue)
+                throw new InvalidOperationException("If OffloadAllHandlers is set, the HandlerTimeout must also be set. To suppress this message, unset OffloadAllHandlers");
 
             _stateLock = new SemaphoreSlim(1, 1);
             _gatewayLogger = LogManager.CreateLogger(ShardId == 0 && TotalShards == 1 ? "Gateway" : $"Shard #{ShardId}");
@@ -1733,8 +1738,10 @@ namespace Discord.WebSocket
         {
             try
             {
-                var timeoutTask = Task.Delay(HandlerTimeout.Value);
                 var handlersTask = action();
+                if (OffloadAllHandlers)
+                    return;
+                var timeoutTask = Task.Delay(HandlerTimeout.Value);
                 if (await Task.WhenAny(timeoutTask, handlersTask).ConfigureAwait(false) == timeoutTask)
                 {
                     await _gatewayLogger.WarningAsync($"A {name} handler is blocking the gateway task.").ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Net.Udp;
+using Discord.Net.Udp;
 using Discord.Net.WebSockets;
 using Discord.Rest;
 
@@ -35,6 +35,8 @@ namespace Discord.WebSocket
         public bool AlwaysDownloadUsers { get; set; } = false;
         /// <summary> Gets or sets the timeout for event handlers, in milliseconds, after which a warning will be logged. Null disables this check. </summary>
         public int? HandlerTimeout { get; set; } = 3000;
+        /// <summary> Gets or sets whether or not offload all event handlers from the gateway task. This can have dangerous consequences. </summary>
+        public bool OffloadAllHandlers { get; set; } = false;
 
         public DiscordSocketConfig()
         {


### PR DESCRIPTION
## Summary

This change allows users to request that all event handlers be invoked off of the gateway thread.

### Additions

- Added `OffloadAllHandlers` to `DiscordSocketConfig`.

## Possible Caveats

Setting this flag to true may lead to data races, users may ignorantly set this flag without being aware of the potential consequences.