### PR TITLE
Creates full guild user object, resolves #1047

### DIFF
--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -142,9 +142,14 @@ namespace Discord.Rest
         public static async Task<RestGuildUser> GetGuildUserAsync(BaseDiscordClient client,
             ulong guildId, ulong id, RequestOptions options)
         {
+            var guild = await GetGuildAsync(client, guildId, options).ConfigureAwait(false);
+            if (guild == null)
+                return null;
+
             var model = await client.ApiClient.GetGuildMemberAsync(guildId, id, options).ConfigureAwait(false);
             if (model != null)
-                return RestGuildUser.Create(client, new RestGuild(client, guildId), model);
+                return RestGuildUser.Create(client, guild, model);
+
             return null;
         }
 


### PR DESCRIPTION
With this PR, `ClientHelper.GetGuildUserAsync` now creates a full `RestGuildUser` object by calling `ClientHelper.GetGuildAsync` additionally, thereby resolving #1047, Non-breaking change