### PR TITLE
Fixes lazily-loaded default type reader bug

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -262,7 +262,7 @@ namespace Discord.Commands
         /// <param name="replaceDefault">If <paramref name="reader"/> should replace the default <see cref="TypeReader"/> for <paramref name="type"/> if one exists.</param>
         public void AddTypeReader(Type type, TypeReader reader, bool replaceDefault)
         {
-            if (replaceDefault && _defaultTypeReaders.ContainsKey(type))
+            if (replaceDefault && HasDefaultTypeReader(type))
             {
                 _defaultTypeReaders.AddOrUpdate(type, reader, (k, v) => reader);
                 if (type.GetTypeInfo().IsValueType)
@@ -280,6 +280,16 @@ namespace Discord.Commands
                 if (type.GetTypeInfo().IsValueType)
                     AddNullableTypeReader(type, reader);
             }
+        }
+        internal bool HasDefaultTypeReader(Type type)
+        {
+            if (_defaultTypeReaders.ContainsKey(type))
+                return true;
+
+            var typeInfo = type.GetTypeInfo();
+            if (typeInfo.IsEnum)
+                return true;
+            return _entityTypeReaders.Any(x => type == x.Item1 || typeInfo.ImplementedInterfaces.Contains(x.Item2));
         }
         internal void AddNullableTypeReader(Type valueType, TypeReader valueTypeReader)
         {


### PR DESCRIPTION
This push request fixes the bugs (#1076 and #1014) where the lazily-loaded default type readers, i.e. entities and enums, could not be replaced with `CommandService#AddTypeReader`. This shouldn't be a breaking change.