### PR TITLE
Solved 4003 Authentication Error (Race Condition)

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -45,7 +45,6 @@ namespace Discord.Audio
         private ulong _userId;
         private uint _ssrc;
         private bool _isSpeaking;
-        private int _heartbeatInterval = 0;
 
         public SocketGuild Guild { get; }
         public DiscordVoiceAPIClient ApiClient { get; private set; }
@@ -217,14 +216,6 @@ namespace Discord.Audio
             {
                 switch (opCode)
                 {
-                    case VoiceOpCode.Hello:
-                        {
-                            await _audioLogger.DebugAsync("Received Hello").ConfigureAwait(false);
-                            var data = (payload as JToken).ToObject<HelloEvent>(_serializer);
-
-                            _heartbeatInterval = (data.HeartbeatInterval / 4) * 3;
-                        }
-                        break;
                     case VoiceOpCode.Ready:
                         {
                             await _audioLogger.DebugAsync("Received Ready").ConfigureAwait(false);
@@ -239,7 +230,7 @@ namespace Discord.Audio
                             await ApiClient.SendDiscoveryAsync(_ssrc).ConfigureAwait(false);
 
                             
-                            _heartbeatTask = RunHeartbeatAsync(_heartbeatInterval, _connection.CancelToken);
+                            _heartbeatTask = RunHeartbeatAsync(41250, _connection.CancelToken);
                         }
                         break;
                     case VoiceOpCode.SessionDescription:


### PR DESCRIPTION
Hi There,

The current build (00969) with the change to VoiceAPI is producing a 4003 Authentication Error. This was caused by a possible race condition created by sending the heartbeat before the identity payload.

This commit solves this by having the heartbeat start after receiving the ready payload. The discord developer documents also shows the identity payload being sent before performing heartbeat payloads. I've added a local variable to store the interval being received by the hello payload.

This change has been tested with NETCore 2.1. It is unknown if this works with 2.0, although there shouldn't be a problem.

**NOTE :** (Please refer to discord dev docs) There is a bug with the hello payload which is sending the incorrect heartbeat interval. This should be changed in the future or you can make the interval a static integer value of 41250.

Regards,

CM1