### PR TITLE
RemarksAttribute name to RemarkAttribute

### DIFF
--- a/src/Discord.Net.Commands/Attributes/RemarkAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/RemarkAttribute.cs
@@ -4,11 +4,11 @@ namespace Discord.Commands
 {
     // Extension of the Cosmetic Summary, for Groups, Commands, and Parameters
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public class RemarksAttribute : Attribute
+    public class RemarkAttribute : Attribute
     {
         public string Text { get; }
 
-        public RemarksAttribute(string text)
+        public RemarkAttribute(string text)
         {
             Text = text;
         }

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -109,7 +109,7 @@ namespace Discord.Commands
                     case SummaryAttribute summary:
                         builder.Summary = summary.Text;
                         break;
-                    case RemarksAttribute remarks:
+                    case RemarkAttribute remarks:
                         builder.Remarks = remarks.Text;
                         break;
                     case AliasAttribute alias:
@@ -169,7 +169,7 @@ namespace Discord.Commands
                     case SummaryAttribute summary:
                         builder.Summary = summary.Text;
                         break;
-                    case RemarksAttribute remarks:
+                    case RemarkAttribute remarks:
                         builder.Remarks = remarks.Text;
                         break;
                     case AliasAttribute alias:


### PR DESCRIPTION
Changed RemarksAttribute to RemarkAttribute because the attribute usage is set to `AllowMultiple = false` so the 's' in 'Remarks' was misleading.