### PR TITLE
Added GetJumpUrl() to IMessage, RestMessage, SocketMessage, and MessageHelper

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Discord
@@ -15,6 +15,8 @@ namespace Discord
         bool IsPinned { get; }
         /// <summary> Returns the content for this message. </summary>
         string Content { get; }
+        /// <summary> Returns a jump url for this message. </summary>
+        string GetJumpUrl();
         /// <summary> Gets the time this message was sent. </summary>
         DateTimeOffset Timestamp { get; }
         /// <summary> Gets the time of this message's last edit, if any. </summary>

--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -15,8 +15,6 @@ namespace Discord
         bool IsPinned { get; }
         /// <summary> Returns the content for this message. </summary>
         string Content { get; }
-        /// <summary> Returns a jump url for this message. </summary>
-        string GetJumpUrl();
         /// <summary> Gets the time this message was sent. </summary>
         DateTimeOffset Timestamp { get; }
         /// <summary> Gets the time of this message's last edit, if any. </summary>

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -93,6 +93,12 @@ namespace Discord.Rest
             await client.ApiClient.RemovePinAsync(msg.Channel.Id, msg.Id, options).ConfigureAwait(false);
         }
 
+        public static string GetJumpUrl(IMessage msg)
+        {
+            var channel = msg.Channel;
+            return $"https://discordapp.com/channels/{(channel is IDMChannel ? "@me" : $"{(channel as IGuildChannel).GuildId}")}/{channel.Id}/{msg.Id}";
+        }
+
         public static ImmutableArray<ITag> ParseTags(string text, IMessageChannel channel, IGuild guild, IReadOnlyCollection<IUser> userMentions)
         {
             var tags = ImmutableArray.CreateBuilder<ITag>();

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -63,7 +63,8 @@ namespace Discord.Rest
 
         public override string ToString() => Content;
 
-        public string GetJumpUrl() => MessageHelper.GetJumpUrl(this);
+        public string GetJumpUrl() 
+            => MessageHelper.GetJumpUrl(this);
 
         MessageType IMessage.Type => MessageType.Default;
         IUser IMessage.Author => Author;

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -62,6 +62,8 @@ namespace Discord.Rest
             => MessageHelper.DeleteAsync(this, Discord, options);
 
         public override string ToString() => Content;
+
+        public string GetJumpUrl() => MessageHelper.GetJumpUrl(this);
 
         MessageType IMessage.Type => MessageType.Default;
         IUser IMessage.Author => Author;

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -1,4 +1,4 @@
-﻿using Discord.Rest;
+using Discord.Rest;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -58,6 +58,9 @@ namespace Discord.WebSocket
             => MessageHelper.DeleteAsync(this, Discord, options);
 
         public override string ToString() => Content;
+
+        public string GetJumpUrl() => MessageHelper.GetJumpUrl(this);
+
         internal SocketMessage Clone() => MemberwiseClone() as SocketMessage;
 
         //IMessage

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -59,7 +59,8 @@ namespace Discord.WebSocket
 
         public override string ToString() => Content;
 
-        public string GetJumpUrl() => MessageHelper.GetJumpUrl(this);
+        public string GetJumpUrl() 
+            => MessageHelper.GetJumpUrl(this);
 
         internal SocketMessage Clone() => MemberwiseClone() as SocketMessage;
 


### PR DESCRIPTION
Used a Get method instead of a property to be consistent with GetAvatarUrl and other GetUrl methods. The `"https://discordapp.com/"` can be exchanged with `DiscordConfig.CDNUrl` and the links work fine still. Except this removes the embed preview from the links. This has been tested in both dms and guilds by checking the value of `GetJumpUrl()` on received and sent messages. I think I got all occurrences of where this should be implemented.