### PR TITLE
Add validation to bot tokens based on string length

### DIFF
--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    public static class TokenUtils
+    {
+        /// <summary>
+        ///     Checks the validity of the supplied token of a specific type.
+        /// </summary>
+        /// <param name="tokenType"> The type of token to validate. </param>
+        /// <param name="token"> The token value to validate. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when the supplied token string is null, empty, or contains only whitespace.</exception>
+        /// <exception cref="ArgumentException"> Thrown when the supplied TokenType or token value is invalid. </exception>
+        public static void ValidateToken(TokenType tokenType, string token)
+        {
+            // A Null or WhiteSpace token of any type is invalid.
+            if (!string.IsNullOrWhiteSpace(token))
+                throw new ArgumentNullException("A token cannot be null, empty, or contain only whitespace.", nameof(token));
+
+            switch (tokenType)
+            {
+                case TokenType.Webhook:
+                    // no validation is performed on Webhook tokens
+                    break;
+                case TokenType.Bearer:
+                    // no validation is performed on Bearer tokens
+                    break;
+                case TokenType.Bot:
+                    // bot tokens are assumed to be at least 59 characters in length
+                    // this value was determined by referencing examples in the discord documentation, and by comparing with
+                    // pre-existing tokens
+                    if (token.Length < 59)
+                        throw new ArgumentException("A Bot token must be at least 59 characters in length.", nameof(token));
+                    break;
+                default:
+                    // All unrecognized TokenTypes (including User tokens) are considered to be invalid.
+                    throw new ArgumentException("Unrecognized TokenType.", nameof(token));
+            }
+        }
+
+    }
+}

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -18,7 +18,7 @@ namespace Discord
         public static void ValidateToken(TokenType tokenType, string token)
         {
             // A Null or WhiteSpace token of any type is invalid.
-            if (!string.IsNullOrWhiteSpace(token))
+            if (string.IsNullOrWhiteSpace(token))
                 throw new ArgumentNullException("A token cannot be null, empty, or contain only whitespace.", nameof(token));
 
             switch (tokenType)

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -52,19 +52,14 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task LoginAsync(TokenType tokenType, string token, bool validateToken = true)
         {
-            // If token validation is enabled, validate the token and let it throw any ArgumentExceptions
-            // that result from invalid parameters
-            if (validateToken)
-                TokenUtils.ValidateToken(tokenType, token);
-
             await _stateLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                await LoginInternalAsync(tokenType, token).ConfigureAwait(false);
+                await LoginInternalAsync(tokenType, token, validateToken).ConfigureAwait(false);
             }
             finally { _stateLock.Release(); }
         }
-        private async Task LoginInternalAsync(TokenType tokenType, string token)
+        private async Task LoginInternalAsync(TokenType tokenType, string token, bool validateToken)
         {
             if (_isFirstLogin)
             {
@@ -78,6 +73,21 @@ namespace Discord.Rest
 
             try
             {
+                // If token validation is enabled, validate the token and let it throw any ArgumentExceptions
+                // that result from invalid parameters
+                if (validateToken)
+                {
+                    try
+                    {
+                        TokenUtils.ValidateToken(tokenType, token);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        // log these ArgumentExceptions and allow for the client to attempt to log in anyways
+                        await LogManager.WarningAsync("Discord", "A supplied token was invalid", ex).ConfigureAwait(false);
+                    }
+                }
+
                 await ApiClient.LoginAsync(tokenType, token).ConfigureAwait(false);
                 await OnLoginAsync(tokenType, token).ConfigureAwait(false);
                 LoginState = LoginState.LoggedIn;

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -52,6 +52,11 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task LoginAsync(TokenType tokenType, string token, bool validateToken = true)
         {
+            // If token validation is enabled, validate the token and let it throw any ArgumentExceptions
+            // that result from invalid parameters
+            if (validateToken)
+                TokenUtils.ValidateToken(tokenType, token);
+
             await _stateLock.WaitAsync().ConfigureAwait(false);
             try
             {

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -72,6 +72,16 @@ namespace Discord.API
                 case default(TokenType):
                     return token;
                 case TokenType.Bot:
+                    // Validate that the supplied bot token is at least 50 characters long.
+                    // Using other tokens and the ones in the discord docs as an example,
+                    // bot tokens typically appear to be 59 characters long, but it is unknown
+                    // if this is a constant.
+                    // This validation helps catch users who input the wrong type of token (bearer, client secret)
+                    // instead of a Bot token.
+                    if (token.Length <= 50)
+                    {
+                        throw new ArgumentException("Invalid Bot token length.", nameof(token));
+                    }
                     return $"Bot {token}";
                 case TokenType.Bearer:
                     return $"Bearer {token}";

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -72,16 +72,6 @@ namespace Discord.API
                 case default(TokenType):
                     return token;
                 case TokenType.Bot:
-                    // Validate that the supplied bot token is at least 50 characters long.
-                    // Using other tokens and the ones in the discord docs as an example,
-                    // bot tokens typically appear to be 59 characters long, but it is unknown
-                    // if this is a constant.
-                    // This validation helps catch users who input the wrong type of token (bearer, client secret)
-                    // instead of a Bot token.
-                    if (token.Length <= 50)
-                    {
-                        throw new ArgumentException("Invalid Bot token length.", nameof(token));
-                    }
                     return $"Bot {token}";
                 case TokenType.Bearer:
                     return $"Bearer {token}";

--- a/test/Discord.Net.Tests/Tests.TokenUtils.cs
+++ b/test/Discord.Net.Tests/Tests.TokenUtils.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Discord
+{
+    public class TokenUtilsTests
+    {
+        /// <summary>
+        ///     Tests the usage of <see cref="TokenUtils.ValidateToken(TokenType, string)"/>
+        ///     to see that when a null, empty or whitespace-only string is passed as the token,
+        ///     it will throw an ArgumentNullException.
+        /// </summary>
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")] // string.Empty isn't a constant type
+        [InlineData(" ")]
+        [InlineData("    ")]
+        [InlineData("\t")]
+        public void TestNullOrWhitespaceToken(string token)
+        {
+            // an ArgumentNullException should be thrown, regardless of the TokenType
+            Assert.Throws<ArgumentNullException>(() => TokenUtils.ValidateToken(TokenType.Bearer, token));
+            Assert.Throws<ArgumentNullException>(() => TokenUtils.ValidateToken(TokenType.Bot, token));
+            Assert.Throws<ArgumentNullException>(() => TokenUtils.ValidateToken(TokenType.Webhook, token));
+        }
+        
+        /// <summary>
+        ///     Tests the behavior of <see cref="TokenUtils.ValidateToken(TokenType, string)"/>
+        ///     to see that valid Webhook tokens do not throw Exceptions.
+        /// </summary>
+        /// <param name="token"></param>
+        [Theory]
+        [InlineData("123123123")]
+        // bot token
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
+        // bearer token taken from discord docs
+        [InlineData("6qrZcUqja7812RVdnEKjpzOL4CvHBFG")]
+        // client secret
+        [InlineData("937it3ow87i4ery69876wqire")]
+        public void TestWebhookTokenDoesNotThrowExceptions(string token)
+        {
+            TokenUtils.ValidateToken(TokenType.Webhook, token);
+        }
+
+        // No tests for invalid webhook token behavior, because there is nothing there yet.
+
+        /// <summary>
+        ///     Tests the behavior of <see cref="TokenUtils.ValidateToken(TokenType, string)"/>
+        ///     to see that valid Webhook tokens do not throw Exceptions.
+        /// </summary>
+        /// <param name="token"></param>
+        [Theory]
+        [InlineData("123123123")]
+        // bot token
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
+        // bearer token taken from discord docs
+        [InlineData("6qrZcUqja7812RVdnEKjpzOL4CvHBFG")]
+        // client secret
+        [InlineData("937it3ow87i4ery69876wqire")]
+        public void TestBearerTokenDoesNotThrowExceptions(string token)
+        {
+            TokenUtils.ValidateToken(TokenType.Bearer, token);
+        }
+
+        // No tests for invalid bearer token behavior, because there is nothing there yet.
+
+        /// <summary>
+        ///     Tests the behavior of <see cref="TokenUtils.ValidateToken(TokenType, string)"/>
+        ///     to see that valid Bot tokens do not throw Exceptions.
+        ///     Valid Bot tokens can be strings of length 59 or above.
+        /// </summary>
+        [Theory]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
+        [InlineData("This appears to be completely invalid, however the current validation rules are not very strict.")]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWss")]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWsMTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
+        public void TestBotTokenDoesNotThrowExceptions(string token)
+        {
+            // This example token is pulled from the Discord Docs
+            // https://discordapp.com/developers/docs/reference#authentication-example-bot-token-authorization-header
+            // should not throw any exception
+            TokenUtils.ValidateToken(TokenType.Bot, token);
+        }
+
+        /// <summary>
+        ///     Tests the usage of <see cref="TokenUtils.ValidateToken(TokenType, string)"/> with
+        ///     a Bot token that is invalid.
+        /// </summary>
+        [Theory]
+        [InlineData("This is invalid")]
+        // missing a single character from the end
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKW")]
+        // bearer token
+        [InlineData("6qrZcUqja7812RVdnEKjpzOL4CvHBFG")]
+        // client secret
+        [InlineData("937it3ow87i4ery69876wqire")]
+        public void TestBotTokenInvalidThrowsArgumentException(string token)
+        {
+            Assert.Throws<ArgumentException>(() => TokenUtils.ValidateToken(TokenType.Bot, token));
+        }
+
+        /// <summary>
+        ///     Tests the behavior of <see cref="TokenUtils.ValidateToken(TokenType, string)"/>
+        ///     to see that an <see cref="ArgumentException"/> is thrown when an invalid
+        ///     <see cref="TokenType"/> is supplied as a parameter.
+        /// </summary>
+        /// <remarks>
+        ///     The <see cref="TokenType.User"/> type is treated as an invalid <see cref="TokenType"/>.
+        /// </remarks>
+        [Theory]
+        // TokenType.User
+        [InlineData(0)]
+        // out of range TokenType
+        [InlineData(4)]
+        [InlineData(7)]
+        public void TestUnrecognizedTokenType(int type)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                TokenUtils.ValidateToken((TokenType)type, "MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs"));
+        }
+    }
+}


### PR DESCRIPTION
Before generating the authorization header to the prefixed token, this change will check the length of bot tokens to see if they are at least 50 characters long. This is longer than the length of a bearer token or oauth client secret, so it throws an exception if the user tries to use the wrong token here.

I've checked against several of my tokens of various ages, and they all appear to be 59 characters long. [Even this example on the Discord api docs is 59 characters long.](https://discordapp.com/developers/docs/reference#authentication-example-bot-token-authorization-header) But, because this value isn't explicitly stated to always be of this length, I don't think that's a safe assumption to make.

Would it make sense to add this validation for all of the token types?