### PR TITLE
TimeSpan parser

### DIFF
--- a/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
@@ -34,13 +34,12 @@ namespace Discord.Commands
             //First, try using the built-in TimeSpan.Parse. (Default Implementation)
             if (TimeSpan.TryParseExact(data, _formats, CultureInfo.InvariantCulture, out var timeSpan))
                 return Task.FromResult(TypeReaderResult.FromSuccess(timeSpan));
-            //@ericmck2000 - Try using the regular TimeSpan.TryPrase. Greatly improves success rate.
-            else if (TimeSpan.TryParse(data, out var time))
-                return Task.FromResult(TypeReaderResult.FromSuccess(time));
+            //Try using the regular TimeSpan.TryPrase. Greatly improves success rate.
+            else if (TimeSpan.TryParse(data, out timeSpan))
+                return Task.FromResult(TypeReaderResult.FromSuccess(timeSpan));
+            //Else, return parse failed error.
             else
-            {
                 return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));
-            }
         }
     }
 }

--- a/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
@@ -25,11 +25,22 @@ namespace Discord.Commands
             "%s's'",                //      1s
         };
 
+
         public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
-            return (TimeSpan.TryParseExact(input.ToLowerInvariant(), _formats, CultureInfo.InvariantCulture, out var timeSpan))
-                ? Task.FromResult(TypeReaderResult.FromSuccess(timeSpan))
-                : Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));
+            //Store as variable, to prevent multiple calls to this method.
+            string data = input.ToLowerInvariant();
+
+            //First, try using the built-in TimeSpan.Parse. (Default Implementation)
+            if (TimeSpan.TryParseExact(data, _formats, CultureInfo.InvariantCulture, out TimeSpan timeSpan))
+                return Task.FromResult(TypeReaderResult.FromSuccess(new TimeSpanext(timeSpan)));
+            //@XtremeOwnage - Try using the regular TimeSpan.TryPrase
+            else if (TimeSpan.TryParse(data, out TimeSpan Time))
+                return Task.FromResult(TypeReaderResult.FromSuccess(new TimeSpanext(Time)));
+            else
+            {
+                return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));
+            }
         }
     }
 }

--- a/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
@@ -33,10 +33,10 @@ namespace Discord.Commands
 
             //First, try using the built-in TimeSpan.Parse. (Default Implementation)
             if (TimeSpan.TryParseExact(data, _formats, CultureInfo.InvariantCulture, out TimeSpan timeSpan))
-                return Task.FromResult(TypeReaderResult.FromSuccess(new TimeSpanext(timeSpan)));
-            //@XtremeOwnage - Try using the regular TimeSpan.TryPrase
+                return Task.FromResult(TypeReaderResult.FromSuccess(timeSpan));
+            //@ericmck2000 - Try using the regular TimeSpan.TryPrase. Greatly improves success rate.
             else if (TimeSpan.TryParse(data, out TimeSpan Time))
-                return Task.FromResult(TypeReaderResult.FromSuccess(new TimeSpanext(Time)));
+                return Task.FromResult(TypeReaderResult.FromSuccess(Time));
             else
             {
                 return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));

--- a/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TimeSpanTypeReader.cs
@@ -32,11 +32,11 @@ namespace Discord.Commands
             string data = input.ToLowerInvariant();
 
             //First, try using the built-in TimeSpan.Parse. (Default Implementation)
-            if (TimeSpan.TryParseExact(data, _formats, CultureInfo.InvariantCulture, out TimeSpan timeSpan))
+            if (TimeSpan.TryParseExact(data, _formats, CultureInfo.InvariantCulture, out var timeSpan))
                 return Task.FromResult(TypeReaderResult.FromSuccess(timeSpan));
             //@ericmck2000 - Try using the regular TimeSpan.TryPrase. Greatly improves success rate.
-            else if (TimeSpan.TryParse(data, out TimeSpan Time))
-                return Task.FromResult(TypeReaderResult.FromSuccess(Time));
+            else if (TimeSpan.TryParse(data, out var time))
+                return Task.FromResult(TypeReaderResult.FromSuccess(time));
             else
             {
                 return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));


### PR DESCRIPTION
This change will greatly increase the success rate for the TimeSpan parser to actually work, by leveraging the built-in TimeSpan.Parse, with no additional parameters.
