### PR TITLE
Add AddBlankField to embed + Allow empty name/values.

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -196,6 +196,17 @@ namespace Discord
             AddField(field);
             return this;
         }
+        
+        public EmbedBuilder AddBlankField(bool inline = false)
+        {
+            var field = new EmbedFieldBuilder()
+                .WithIsInline(inline)
+                .WithName(null)
+                .WithValue(null);
+            AddField(field);
+            return this;
+        }
+        
         public EmbedBuilder AddField(EmbedFieldBuilder field)
         {
             if (Fields.Count >= MaxFieldCount)
@@ -231,6 +242,8 @@ namespace Discord
     {
         private string _name;
         private string _value;
+        private const string emptyString = "_ _";
+        
         public const int MaxFieldNameLength = 256;
         public const int MaxFieldValueLength = 1024;
 
@@ -240,7 +253,7 @@ namespace Discord
             set
             {
                 if (string.IsNullOrWhiteSpace(value))
-                    _name = "_ _";
+                    _name = emptyString;
                 else if (value.Length > MaxFieldNameLength)
                     throw new ArgumentException($"Field name length must be less than or equal to {MaxFieldNameLength}.", nameof(Name));
                 else
@@ -255,7 +268,7 @@ namespace Discord
             {
                 var stringValue = value?.ToString();
                 if (string.IsNullOrWhiteSpace(stringValue)) 
-                    _value = "_ _";
+                    _value = emptyString;
                 else if (stringValue.Length > MaxFieldValueLength)
                     throw new ArgumentException($"Field value length must be less than or equal to {MaxFieldValueLength}.", nameof(Value));
                 else 

--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -239,9 +239,12 @@ namespace Discord
             get => _name;
             set
             {
-                if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException($"Field name must not be null, empty or entirely whitespace.", nameof(Name));
-                if (value.Length > MaxFieldNameLength) throw new ArgumentException($"Field name length must be less than or equal to {MaxFieldNameLength}.", nameof(Name));
-                _name = value;
+                if (string.IsNullOrWhiteSpace(value))
+                    _name = "_ _";
+                else if (value.Length > MaxFieldNameLength)
+                    throw new ArgumentException($"Field name length must be less than or equal to {MaxFieldNameLength}.", nameof(Name));
+                else
+                    _name = value;
             }
         }
 
@@ -251,9 +254,12 @@ namespace Discord
             set
             {
                 var stringValue = value?.ToString();
-                if (string.IsNullOrEmpty(stringValue)) throw new ArgumentException($"Field value must not be null or empty.", nameof(Value));
-                if (stringValue.Length > MaxFieldValueLength) throw new ArgumentException($"Field value length must be less than or equal to {MaxFieldValueLength}.", nameof(Value));
-                _value = stringValue;
+                if (string.IsNullOrWhiteSpace(stringValue)) 
+                    _value = "_ _";
+                else if (stringValue.Length > MaxFieldValueLength)
+                    throw new ArgumentException($"Field value length must be less than or equal to {MaxFieldValueLength}.", nameof(Value));
+                else 
+                    _value = stringValue;
             }
         }
         public bool IsInline { get; set; }


### PR DESCRIPTION
Updated Field builder, to allow for "Empty" fields and values.

If you send "_ _" via the API, it will properly display as a blank field. I have tested this locally, and are currently utilizing it in production.

As well,
I Updated the Value setting to use String.IsNullOrWhiteSpace instead of String.IsNullOrEmpty, because passing a string containing nothing but spaces through the API will cause errors as well. However, "_ _" works perfectly.