### PR TITLE
Pass our json serializer to ToObject calls

### DIFF
--- a/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
@@ -20,7 +20,7 @@ namespace Discord.API
         [JsonProperty("role_name")]
         public string OverwriteRoleName { get; set; }
         [JsonProperty("type")]
-        public string OverwriteType { get; set; }
+        public PermissionTarget OverwriteType { get; set; }
         [JsonProperty("id")]
         public ulong? OverwriteTargetId { get; set; }
     }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -43,9 +43,11 @@ namespace Discord.API
         public TokenType AuthTokenType { get; private set; }
         internal string AuthToken { get; private set; }
         internal IRestClient RestClient { get; private set; }
-        internal ulong? CurrentUserId { get; set;}
+        internal ulong? CurrentUserId { get; set; }
 
-        public DiscordRestApiClient(RestClientProvider restClientProvider, string userAgent, RetryMode defaultRetryMode = RetryMode.AlwaysRetry, 
+        internal JsonSerializer Serializer => _serializer;
+
+        public DiscordRestApiClient(RestClientProvider restClientProvider, string userAgent, RetryMode defaultRetryMode = RetryMode.AlwaysRetry,
             JsonSerializer serializer = null)
         {
             _restClientProvider = restClientProvider;
@@ -235,7 +237,7 @@ namespace Discord.API
         internal Task<TResponse> SendMultipartAsync<TResponse>(string method, Expression<Func<string>> endpointExpr, IReadOnlyDictionary<string, object> multipartArgs, BucketIds ids,
              ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null, [CallerMemberName] string funcName = null)
             => SendMultipartAsync<TResponse>(method, GetEndpoint(endpointExpr), multipartArgs, GetBucketId(ids, endpointExpr, AuthTokenType, funcName), clientBucket, options);
-        public async Task<TResponse> SendMultipartAsync<TResponse>(string method, string endpoint, IReadOnlyDictionary<string, object> multipartArgs, 
+        public async Task<TResponse> SendMultipartAsync<TResponse>(string method, string endpoint, IReadOnlyDictionary<string, object> multipartArgs,
             string bucketId = null, ClientBucketType clientBucket = ClientBucketType.Unbucketed, RequestOptions options = null)
         {
             options = options ?? new RequestOptions();
@@ -414,7 +416,7 @@ namespace Discord.API
             var ids = new BucketIds(guildId: guildId);
             await SendAsync("DELETE", () => $"guilds/{guildId}/members/{userId}/roles/{roleId}", ids, options: options);
         }
-        
+
         //Channel Messages
         public async Task<Message> GetChannelMessageAsync(ulong channelId, ulong messageId, RequestOptions options = null)
         {
@@ -490,7 +492,7 @@ namespace Discord.API
             if (args.Content?.Length > DiscordConfig.MaxMessageSize)
                 throw new ArgumentException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
             options = RequestOptions.CreateOrClone(options);
-            
+
             return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args, new BucketIds(), clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
         public async Task<Message> UploadFileAsync(ulong channelId, UploadFileParams args, RequestOptions options = null)
@@ -737,7 +739,7 @@ namespace Discord.API
             Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
             Preconditions.NotNullOrWhitespace(args.RegionId, nameof(args.RegionId));
             options = RequestOptions.CreateOrClone(options);
-            
+
             return await SendJsonAsync<Guild>("POST", () => "guilds", args, new BucketIds(), options: options).ConfigureAwait(false);
         }
         public async Task<Guild> DeleteGuildAsync(ulong guildId, RequestOptions options = null)
@@ -964,7 +966,7 @@ namespace Discord.API
         {
             Preconditions.NotNullOrEmpty(inviteId, nameof(inviteId));
             options = RequestOptions.CreateOrClone(options);
-            
+
             return await SendAsync<Invite>("DELETE", () => $"invites/{inviteId}", new BucketIds(), options: options).ConfigureAwait(false);
         }
 
@@ -1163,7 +1165,7 @@ namespace Discord.API
 
             int limit = args.Limit.GetValueOrDefault(int.MaxValue);
             ulong afterGuildId = args.AfterGuildId.GetValueOrDefault(0);
-            
+
             return await SendAsync<IReadOnlyCollection<UserGuild>>("GET", () => $"users/@me/guilds?limit={limit}&after={afterGuildId}", new BucketIds(), options: options).ConfigureAwait(false);
         }
         public async Task<Application> GetMyApplicationAsync(RequestOptions options = null)
@@ -1263,7 +1265,7 @@ namespace Discord.API
             Preconditions.NotNull(args, nameof(args));
             Preconditions.NotNullOrEmpty(args.Name, nameof(args.Name));
             options = RequestOptions.CreateOrClone(options);
-            
+
             if (AuthTokenType == TokenType.Webhook)
                 return await SendJsonAsync<Webhook>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}", args, new BucketIds(), options: options).ConfigureAwait(false);
             else
@@ -1393,7 +1395,7 @@ namespace Discord.API
                     int argId = int.Parse(format.Substring(leftIndex + 1, rightIndex - leftIndex - 1));
                     string fieldName = GetFieldName(methodArgs[argId + 1]);
                     int? mappedId;
-                    
+
                     mappedId = BucketIds.GetIndex(fieldName);
                     if(!mappedId.HasValue && rightIndex != endIndex && format.Length > rightIndex + 1 && format[rightIndex + 1] == '/') //Ignore the next slash
                         rightIndex++;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
@@ -26,17 +26,15 @@ namespace Discord.Rest
             var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
 
-            var type = typeModel.NewValue.ToObject<ChannelType>();
-            var name = nameModel.NewValue.ToObject<string>();
+            var type = typeModel.NewValue.ToObject<ChannelType>(discord.ApiClient.Serializer);
+            var name = nameModel.NewValue.ToObject<string>(discord.ApiClient.Serializer);
 
             foreach (var overwrite in overwritesModel.NewValue)
             {
                 var deny = overwrite.Value<ulong>("deny");
-                var _type = overwrite.Value<string>("type");
+                var permType = overwrite.Value<PermissionTarget>("type");
                 var id = overwrite.Value<ulong>("id");
                 var allow = overwrite.Value<ulong>("allow");
-
-                PermissionTarget permType = _type == "member" ? PermissionTarget.User : PermissionTarget.Role;
 
                 overwrites.Add(new Overwrite(id, permType, new OverwritePermissions(allow, deny)));
             }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
@@ -27,11 +27,11 @@ namespace Discord.Rest
             var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
 
-            var overwrites = overwritesModel.OldValue.ToObject<API.Overwrite[]>()
+            var overwrites = overwritesModel.OldValue.ToObject<API.Overwrite[]>(discord.ApiClient.Serializer)
                 .Select(x => new Overwrite(x.TargetId, x.TargetType, new OverwritePermissions(x.Allow, x.Deny)))
                 .ToList();
-            var type = typeModel.OldValue.ToObject<ChannelType>();
-            var name = nameModel.OldValue.ToObject<string>();
+            var type = typeModel.OldValue.ToObject<ChannelType>(discord.ApiClient.Serializer);
+            var name = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
             var id = entry.TargetId.Value;
 
             return new ChannelDeleteAuditLogData(id, name, type, overwrites.ToReadOnlyCollection());

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
@@ -23,14 +23,14 @@ namespace Discord.Rest
             var bitrateModel = changes.FirstOrDefault(x => x.ChangedProperty == "bitrate");
             var userLimitModel = changes.FirstOrDefault(x => x.ChangedProperty == "user_limit");
 
-            string oldName = nameModel?.OldValue?.ToObject<string>(),
-                newName = nameModel?.NewValue?.ToObject<string>();
-            string oldTopic = topicModel?.OldValue?.ToObject<string>(),
-                newTopic = topicModel?.NewValue?.ToObject<string>();
-            int? oldBitrate = bitrateModel?.OldValue?.ToObject<int>(),
-                newBitrate = bitrateModel?.NewValue?.ToObject<int>();
-            int? oldLimit = userLimitModel?.OldValue?.ToObject<int>(),
-                newLimit = userLimitModel?.NewValue?.ToObject<int>();
+            string oldName = nameModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newName = nameModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            string oldTopic = topicModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newTopic = topicModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            int? oldBitrate = bitrateModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
+                newBitrate = bitrateModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
+            int? oldLimit = userLimitModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
+                newLimit = userLimitModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
 
             var before = new ChannelInfo(oldName, oldTopic, oldBitrate, oldLimit);
             var after = new ChannelInfo(newName, newTopic, newBitrate, newLimit);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteCreateAuditLogData.cs
@@ -21,7 +21,7 @@ namespace Discord.Rest
         {
             var change = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
 
-            var emoteName = change.NewValue?.ToObject<string>();
+            var emoteName = change.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
             return new EmoteCreateAuditLogData(entry.TargetId.Value, emoteName);
         }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteDeleteAuditLogData.cs
@@ -17,7 +17,7 @@ namespace Discord.Rest
         {
             var change = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
 
-            var emoteName = change.OldValue?.ToObject<string>();
+            var emoteName = change.OldValue?.ToObject<string>(discord.ApiClient.Serializer);
 
             return new EmoteDeleteAuditLogData(entry.TargetId.Value, emoteName);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/EmoteUpdateAuditLogData.cs
@@ -18,8 +18,8 @@ namespace Discord.Rest
         {
             var change = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
 
-            var newName = change.NewValue?.ToObject<string>();
-            var oldName = change.OldValue?.ToObject<string>();
+            var newName = change.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            var oldName = change.OldValue?.ToObject<string>(discord.ApiClient.Serializer);
 
             return new EmoteUpdateAuditLogData(entry.TargetId.Value, oldName, newName);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
@@ -28,26 +28,26 @@ namespace Discord.Rest
             var mfaLevelModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
             var contentFilterModel = changes.FirstOrDefault(x => x.ChangedProperty == "afk_timeout");
 
-            int? oldAfkTimeout = afkTimeoutModel?.OldValue?.ToObject<int>(),
-                newAfkTimeout = afkTimeoutModel?.NewValue?.ToObject<int>();
-            DefaultMessageNotifications? oldDefaultMessageNotifications = defaultMessageNotificationsModel?.OldValue?.ToObject<DefaultMessageNotifications>(),
-                newDefaultMessageNotifications = defaultMessageNotificationsModel?.NewValue?.ToObject<DefaultMessageNotifications>();
-            ulong? oldAfkChannelId = afkChannelModel?.OldValue?.ToObject<ulong>(),
-                newAfkChannelId = afkChannelModel?.NewValue?.ToObject<ulong>();
-            string oldName = nameModel?.OldValue?.ToObject<string>(),
-                newName = nameModel?.NewValue?.ToObject<string>();
-            string oldRegionId = regionIdModel?.OldValue?.ToObject<string>(),
-                newRegionId = regionIdModel?.NewValue?.ToObject<string>();
-            string oldIconHash = iconHashModel?.OldValue?.ToObject<string>(),
-                newIconHash = iconHashModel?.NewValue?.ToObject<string>();
-            VerificationLevel? oldVerificationLevel = verificationLevelModel?.OldValue?.ToObject<VerificationLevel>(),
-                newVerificationLevel = verificationLevelModel?.NewValue?.ToObject<VerificationLevel>();
-            ulong? oldOwnerId = ownerIdModel?.OldValue?.ToObject<ulong>(),
-                newOwnerId = ownerIdModel?.NewValue?.ToObject<ulong>();
-            MfaLevel? oldMfaLevel = mfaLevelModel?.OldValue?.ToObject<MfaLevel>(),
-                newMfaLevel = mfaLevelModel?.NewValue?.ToObject<MfaLevel>();
-            int? oldContentFilter = contentFilterModel?.OldValue?.ToObject<int>(),
-                newContentFilter = contentFilterModel?.NewValue?.ToObject<int>();
+            int? oldAfkTimeout = afkTimeoutModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
+                newAfkTimeout = afkTimeoutModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
+            DefaultMessageNotifications? oldDefaultMessageNotifications = defaultMessageNotificationsModel?.OldValue?.ToObject<DefaultMessageNotifications>(discord.ApiClient.Serializer),
+                newDefaultMessageNotifications = defaultMessageNotificationsModel?.NewValue?.ToObject<DefaultMessageNotifications>(discord.ApiClient.Serializer);
+            ulong? oldAfkChannelId = afkChannelModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer),
+                newAfkChannelId = afkChannelModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            string oldName = nameModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newName = nameModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            string oldRegionId = regionIdModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newRegionId = regionIdModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            string oldIconHash = iconHashModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newIconHash = iconHashModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            VerificationLevel? oldVerificationLevel = verificationLevelModel?.OldValue?.ToObject<VerificationLevel>(discord.ApiClient.Serializer),
+                newVerificationLevel = verificationLevelModel?.NewValue?.ToObject<VerificationLevel>(discord.ApiClient.Serializer);
+            ulong? oldOwnerId = ownerIdModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer),
+                newOwnerId = ownerIdModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            MfaLevel? oldMfaLevel = mfaLevelModel?.OldValue?.ToObject<MfaLevel>(discord.ApiClient.Serializer),
+                newMfaLevel = mfaLevelModel?.NewValue?.ToObject<MfaLevel>(discord.ApiClient.Serializer);
+            int? oldContentFilter = contentFilterModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
+                newContentFilter = contentFilterModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
 
             IUser oldOwner = null;
             if (oldOwnerId != null)

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
@@ -30,13 +30,13 @@ namespace Discord.Rest
             var usesModel = changes.FirstOrDefault(x => x.ChangedProperty == "uses");
             var maxUsesModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_uses");
 
-            var maxAge = maxAgeModel.NewValue.ToObject<int>();
-            var code = codeModel.NewValue.ToObject<string>();
-            var temporary = temporaryModel.NewValue.ToObject<bool>();
-            var inviterId = inviterIdModel.NewValue.ToObject<ulong>();
-            var channelId = channelIdModel.NewValue.ToObject<ulong>();
-            var uses = usesModel.NewValue.ToObject<int>();
-            var maxUses = maxUsesModel.NewValue.ToObject<int>();
+            var maxAge = maxAgeModel.NewValue.ToObject<int>(discord.ApiClient.Serializer);
+            var code = codeModel.NewValue.ToObject<string>(discord.ApiClient.Serializer);
+            var temporary = temporaryModel.NewValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var inviterId = inviterIdModel.NewValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var channelId = channelIdModel.NewValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var uses = usesModel.NewValue.ToObject<int>(discord.ApiClient.Serializer);
+            var maxUses = maxUsesModel.NewValue.ToObject<int>(discord.ApiClient.Serializer);
 
             var inviterInfo = log.Users.FirstOrDefault(x => x.Id == inviterId);
             var inviter = RestUser.Create(discord, inviterInfo);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
@@ -30,13 +30,13 @@ namespace Discord.Rest
             var usesModel = changes.FirstOrDefault(x => x.ChangedProperty == "uses");
             var maxUsesModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_uses");
 
-            var maxAge = maxAgeModel.OldValue.ToObject<int>();
-            var code = codeModel.OldValue.ToObject<string>();
-            var temporary = temporaryModel.OldValue.ToObject<bool>();
-            var inviterId = inviterIdModel.OldValue.ToObject<ulong>();
-            var channelId = channelIdModel.OldValue.ToObject<ulong>();
-            var uses = usesModel.OldValue.ToObject<int>();
-            var maxUses = maxUsesModel.OldValue.ToObject<int>();
+            var maxAge = maxAgeModel.OldValue.ToObject<int>(discord.ApiClient.Serializer);
+            var code = codeModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
+            var temporary = temporaryModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var inviterId = inviterIdModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var channelId = channelIdModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var uses = usesModel.OldValue.ToObject<int>(discord.ApiClient.Serializer);
+            var maxUses = maxUsesModel.OldValue.ToObject<int>(discord.ApiClient.Serializer);
 
             var inviterInfo = log.Users.FirstOrDefault(x => x.Id == inviterId);
             var inviter = RestUser.Create(discord, inviterInfo);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteUpdateAuditLogData.cs
@@ -23,16 +23,16 @@ namespace Discord.Rest
             var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
             var maxUsesModel = changes.FirstOrDefault(x => x.ChangedProperty == "max_uses");
 
-            int? oldMaxAge = maxAgeModel?.OldValue?.ToObject<int>(),
-                newMaxAge = maxAgeModel?.NewValue?.ToObject<int>();
-            string oldCode = codeModel?.OldValue?.ToObject<string>(),
-                newCode = codeModel?.NewValue?.ToObject<string>();
-            bool? oldTemporary = temporaryModel?.OldValue?.ToObject<bool>(),
-                newTemporary = temporaryModel?.NewValue?.ToObject<bool>();
-            ulong? oldChannelId = channelIdModel?.OldValue?.ToObject<ulong>(),
-                newChannelId = channelIdModel?.NewValue?.ToObject<ulong>();
-            int? oldMaxUses = maxUsesModel?.OldValue?.ToObject<int>(),
-                newMaxUses = maxUsesModel?.NewValue?.ToObject<int>();
+            int? oldMaxAge = maxAgeModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
+                newMaxAge = maxAgeModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
+            string oldCode = codeModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newCode = codeModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            bool? oldTemporary = temporaryModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
+                newTemporary = temporaryModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            ulong? oldChannelId = channelIdModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer),
+                newChannelId = channelIdModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            int? oldMaxUses = maxUsesModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
+                newMaxUses = maxUsesModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
 
             var before = new InviteInfo(oldMaxAge, oldCode, oldTemporary, oldChannelId, oldMaxUses);
             var after = new InviteInfo(newMaxAge, newCode, newTemporary, newChannelId, newMaxUses);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleAuditLogData.cs
@@ -19,7 +19,7 @@ namespace Discord.Rest
         {
             var changes = entry.Changes;
 
-            var roleInfos = changes.SelectMany(x => x.NewValue.ToObject<API.Role[]>(),
+            var roleInfos = changes.SelectMany(x => x.NewValue.ToObject<API.Role[]>(discord.ApiClient.Serializer),
                 (model, role) => new { model.ChangedProperty, Role = role })
                 .Select(x => new MemberRoleEditInfo(x.Role.Name, x.Role.Id, x.ChangedProperty == "$add"))
                 .ToList();

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
@@ -24,14 +24,14 @@ namespace Discord.Rest
             var muteModel = changes.FirstOrDefault(x => x.ChangedProperty == "mute");
             var avatarModel = changes.FirstOrDefault(x => x.ChangedProperty == "avatar_hash");
 
-            string oldNick = nickModel?.OldValue?.ToObject<string>(),
-                newNick = nickModel?.NewValue?.ToObject<string>();
-            bool? oldDeaf = deafModel?.OldValue?.ToObject<bool>(),
-                newDeaf = deafModel?.NewValue?.ToObject<bool>();
-            bool? oldMute = muteModel?.OldValue?.ToObject<bool>(),
-                newMute = muteModel?.NewValue?.ToObject<bool>();
-            string oldAvatar = avatarModel?.OldValue?.ToObject<string>(),
-                newAvatar = avatarModel?.NewValue?.ToObject<string>();
+            string oldNick = nickModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newNick = nickModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            bool? oldDeaf = deafModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
+                newDeaf = deafModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            bool? oldMute = muteModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
+                newMute = muteModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            string oldAvatar = avatarModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newAvatar = avatarModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
 
             var targetInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
             var user = RestUser.Create(discord, targetInfo);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteCreateAuditLogData.cs
@@ -19,17 +19,15 @@ namespace Discord.Rest
             var denyModel = changes.FirstOrDefault(x => x.ChangedProperty == "deny");
             var allowModel = changes.FirstOrDefault(x => x.ChangedProperty == "allow");
 
-            var deny = denyModel.NewValue.ToObject<ulong>();
-            var allow = allowModel.NewValue.ToObject<ulong>();
+            var deny = denyModel.NewValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var allow = allowModel.NewValue.ToObject<ulong>(discord.ApiClient.Serializer);
 
             var permissions = new OverwritePermissions(allow, deny);
 
             var id = entry.Options.OverwriteTargetId.Value;
             var type = entry.Options.OverwriteType;
 
-            PermissionTarget target = type == "member" ? PermissionTarget.User : PermissionTarget.Role;
-
-            return new OverwriteCreateAuditLogData(new Overwrite(id, target, permissions));
+            return new OverwriteCreateAuditLogData(new Overwrite(id, type, permissions));
         }
 
         public Overwrite Overwrite { get; }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteDeleteAuditLogData.cs
@@ -27,14 +27,12 @@ namespace Discord.Rest
             var idModel = changes.FirstOrDefault(x => x.ChangedProperty == "id");
             var allowModel = changes.FirstOrDefault(x => x.ChangedProperty == "allow");
 
-            var deny = denyModel.OldValue.ToObject<ulong>();
-            var type = typeModel.OldValue.ToObject<string>();
-            var id = idModel.OldValue.ToObject<ulong>();
-            var allow = allowModel.OldValue.ToObject<ulong>();
+            var deny = denyModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var type = typeModel.OldValue.ToObject<PermissionTarget>(discord.ApiClient.Serializer);
+            var id = idModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var allow = allowModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
 
-            PermissionTarget target = type == "member" ? PermissionTarget.User : PermissionTarget.Role;
-
-            return new OverwriteDeleteAuditLogData(new Overwrite(id, target, new OverwritePermissions(allow, deny)));
+            return new OverwriteDeleteAuditLogData(new Overwrite(id, type, new OverwritePermissions(allow, deny)));
         }
 
         public Overwrite Overwrite { get; }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
@@ -22,17 +22,17 @@ namespace Discord.Rest
             var denyModel = changes.FirstOrDefault(x => x.ChangedProperty == "deny");
             var allowModel = changes.FirstOrDefault(x => x.ChangedProperty == "allow");
 
-            var beforeAllow = allowModel?.OldValue?.ToObject<ulong>();
-            var afterAllow = allowModel?.NewValue?.ToObject<ulong>();
-            var beforeDeny = denyModel?.OldValue?.ToObject<ulong>();
-            var afterDeny = denyModel?.OldValue?.ToObject<ulong>();
+            var beforeAllow = allowModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            var afterAllow = allowModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            var beforeDeny = denyModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            var afterDeny = denyModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
 
             var beforePermissions = new OverwritePermissions(beforeAllow ?? 0, beforeDeny ?? 0);
             var afterPermissions = new OverwritePermissions(afterAllow ?? 0, afterDeny ?? 0);
 
-            PermissionTarget target = entry.Options.OverwriteType == "member" ? PermissionTarget.User : PermissionTarget.Role;
+            var type = entry.Options.OverwriteType;
 
-            return new OverwriteUpdateAuditLogData(beforePermissions, afterPermissions, entry.Options.OverwriteTargetId.Value, target);
+            return new OverwriteUpdateAuditLogData(beforePermissions, afterPermissions, entry.Options.OverwriteTargetId.Value, type);
         }
 
         public OverwritePermissions OldPermissions { get; }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleCreateAuditLogData.cs
@@ -23,11 +23,11 @@ namespace Discord.Rest
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
             var permissionsModel = changes.FirstOrDefault(x => x.ChangedProperty == "permissions");
 
-            uint? colorRaw = colorModel?.NewValue?.ToObject<uint>();
-            bool? mentionable = mentionableModel?.NewValue?.ToObject<bool>();
-            bool? hoist = hoistModel?.NewValue?.ToObject<bool>();
-            string name = nameModel?.NewValue?.ToObject<string>();
-            ulong? permissionsRaw = permissionsModel?.NewValue?.ToObject<ulong>();
+            uint? colorRaw = colorModel?.NewValue?.ToObject<uint>(discord.ApiClient.Serializer);
+            bool? mentionable = mentionableModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            bool? hoist = hoistModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            string name = nameModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            ulong? permissionsRaw = permissionsModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
 
             Color? color = null;
             GuildPermissions? permissions = null;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleDeleteAuditLogData.cs
@@ -23,11 +23,11 @@ namespace Discord.Rest
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
             var permissionsModel = changes.FirstOrDefault(x => x.ChangedProperty == "permissions");
 
-            uint? colorRaw = colorModel?.OldValue?.ToObject<uint>();
-            bool? mentionable = mentionableModel?.OldValue?.ToObject<bool>();
-            bool? hoist = hoistModel?.OldValue?.ToObject<bool>();
-            string name = nameModel?.OldValue?.ToObject<string>();
-            ulong? permissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>();
+            uint? colorRaw = colorModel?.OldValue?.ToObject<uint>(discord.ApiClient.Serializer);
+            bool? mentionable = mentionableModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            bool? hoist = hoistModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            string name = nameModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer);
+            ulong? permissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
 
             Color? color = null;
             GuildPermissions? permissions = null;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
@@ -24,16 +24,16 @@ namespace Discord.Rest
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
             var permissionsModel = changes.FirstOrDefault(x => x.ChangedProperty == "permissions");
 
-            uint? oldColorRaw = colorModel?.OldValue?.ToObject<uint>(),
-                newColorRaw = colorModel?.NewValue?.ToObject<uint>();
-            bool? oldMentionable = mentionableModel?.OldValue?.ToObject<bool>(),
-                newMentionable = mentionableModel?.NewValue?.ToObject<bool>();
-            bool? oldHoist = hoistModel?.OldValue?.ToObject<bool>(),
-                newHoist = hoistModel?.NewValue?.ToObject<bool>();
-            string oldName = nameModel?.OldValue?.ToObject<string>(),
-                newName = nameModel?.NewValue?.ToObject<string>();
-            ulong? oldPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>(),
-                newPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>();
+            uint? oldColorRaw = colorModel?.OldValue?.ToObject<uint>(discord.ApiClient.Serializer),
+                newColorRaw = colorModel?.NewValue?.ToObject<uint>(discord.ApiClient.Serializer);
+            bool? oldMentionable = mentionableModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
+                newMentionable = mentionableModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            bool? oldHoist = hoistModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
+                newHoist = hoistModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            string oldName = nameModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
+                newName = nameModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            ulong? oldPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer),
+                newPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
 
             Color? oldColor = null,
                 newColor = null;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
@@ -23,9 +23,9 @@ namespace Discord.Rest
             var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
 
-            var channelId = channelIdModel.NewValue.ToObject<ulong>();
-            var type = typeModel.NewValue.ToObject<WebhookType>();
-            var name = nameModel.NewValue.ToObject<string>();
+            var channelId = channelIdModel.NewValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var type = typeModel.NewValue.ToObject<WebhookType>(discord.ApiClient.Serializer);
+            var name = nameModel.NewValue.ToObject<string>(discord.ApiClient.Serializer);
 
             var webhookInfo = log.Webhooks?.FirstOrDefault(x => x.Id == entry.TargetId);
             var webhook = RestWebhook.Create(discord, (IGuild)null, webhookInfo);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookDeleteAuditLogData.cs
@@ -29,10 +29,10 @@ namespace Discord.Rest
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
             var avatarHashModel = changes.FirstOrDefault(x => x.ChangedProperty == "avatar_hash");
 
-            var channelId = channelIdModel.OldValue.ToObject<ulong>();
-            var type = typeModel.OldValue.ToObject<WebhookType>();
-            var name = nameModel.OldValue.ToObject<string>();
-            var avatarHash = avatarHashModel?.OldValue?.ToObject<string>();
+            var channelId = channelIdModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var type = typeModel.OldValue.ToObject<WebhookType>(discord.ApiClient.Serializer);
+            var name = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
+            var avatarHash = avatarHashModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer);
 
             return new WebhookDeleteAuditLogData(entry.TargetId.Value, channelId, type, name, avatarHash);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookUpdateAuditLogData.cs
@@ -37,7 +37,7 @@ namespace Discord.Rest
             var after = new WebhookInfo(newName, newChannelId, newAvatar);
 
             var webhookInfo = log.Webhooks?.FirstOrDefault(x => x.Id == entry.TargetId);
-            var webhook = RestWebhook.Create(discord, (IGuild)null, webhookInfo);
+            var webhook = webhookInfo != null ? RestWebhook.Create(discord, (IGuild)null, webhookInfo) : null;
 
             return new WebhookUpdateAuditLogData(webhook, before, after);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookUpdateAuditLogData.cs
@@ -26,14 +26,14 @@ namespace Discord.Rest
             var channelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
             var avatarHashModel = changes.FirstOrDefault(x => x.ChangedProperty == "avatar_hash");
 
-            var oldName = nameModel?.OldValue?.ToObject<string>();
-            var oldChannelId = channelIdModel?.OldValue?.ToObject<ulong>();
-            var oldAvatar = avatarHashModel?.OldValue?.ToObject<string>();
+            var oldName = nameModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer);
+            var oldChannelId = channelIdModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            var oldAvatar = avatarHashModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer);
             var before = new WebhookInfo(oldName, oldChannelId, oldAvatar);
 
-            var newName = nameModel?.NewValue?.ToObject<string>();
-            var newChannelId = channelIdModel?.NewValue?.ToObject<ulong>();
-            var newAvatar = avatarHashModel?.NewValue?.ToObject<string>();
+            var newName = nameModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            var newChannelId = channelIdModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            var newAvatar = avatarHashModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
             var after = new WebhookInfo(newName, newChannelId, newAvatar);
 
             var webhookInfo = log.Webhooks?.FirstOrDefault(x => x.Id == entry.TargetId);


### PR DESCRIPTION
Should fix issues in audit logs when deserializing overwrites and similar types which we use a custom contract resolver for.

I don't have a test case for this yet, but it *should* work as it compiles successfully as there are almost no changes in logic.