### PR TITLE
Fix swapped parameters in ArgumentException, ArgumentNullException cstrs

### DIFF
--- a/src/Discord.Net.Core/Entities/Emotes/Emote.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/Emote.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace Discord
@@ -58,7 +58,7 @@ namespace Discord
         {
             if (TryParse(text, out Emote result))
                 return result;
-            throw new ArgumentException("Invalid emote format", nameof(text));
+            throw new ArgumentException(message: "Invalid emote format", paramName: nameof(text));
         }
 
         public static bool TryParse(string text, out Emote result)

--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -75,7 +75,7 @@ namespace Discord
             get => _fields;
             set
             {
-                if (value == null) throw new ArgumentNullException("Cannot set an embed builder's fields collection to null", nameof(Fields));
+                if (value == null) throw new ArgumentNullException(nameof(Fields), "Cannot set an embed builder's fields collection to null");
                 if (value.Count > MaxFieldCount) throw new ArgumentException($"Field count must be less than or equal to {MaxFieldCount}.", nameof(Fields));
                 _fields = value;
             }

--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -29,7 +29,7 @@ namespace Discord
             get => _title;
             set
             {
-                if (value?.Length > MaxTitleLength) throw new ArgumentException($"Title length must be less than or equal to {MaxTitleLength}.", nameof(Title));
+                if (value?.Length > MaxTitleLength) throw new ArgumentException(message: $"Title length must be less than or equal to {MaxTitleLength}.", paramName: nameof(Title));
                 _title = value;
             }
         }
@@ -38,7 +38,7 @@ namespace Discord
             get => _description;
             set
             {
-                if (value?.Length > MaxDescriptionLength) throw new ArgumentException($"Description length must be less than or equal to {MaxDescriptionLength}.", nameof(Description));
+                if (value?.Length > MaxDescriptionLength) throw new ArgumentException(message: $"Description length must be less than or equal to {MaxDescriptionLength}.", paramName: nameof(Description));
                 _description = value;
             }
         }
@@ -48,7 +48,7 @@ namespace Discord
             get => _url;
             set
             {
-                if (!value.IsNullOrUri()) throw new ArgumentException("Url must be a well-formed URI", nameof(Url));
+                if (!value.IsNullOrUri()) throw new ArgumentException(message: "Url must be a well-formed URI", paramName: nameof(Url));
                 _url = value;
             }
         }
@@ -57,7 +57,7 @@ namespace Discord
             get => _thumbnail?.Url;
             set
             {
-                if (!value.IsNullOrUri()) throw new ArgumentException("Url must be a well-formed URI", nameof(ThumbnailUrl));
+                if (!value.IsNullOrUri()) throw new ArgumentException(message: "Url must be a well-formed URI", paramName: nameof(ThumbnailUrl));
                 _thumbnail = new EmbedThumbnail(value, null, null, null);
             }
         }
@@ -66,7 +66,7 @@ namespace Discord
             get => _image?.Url;
             set
             {
-                if (!value.IsNullOrUri()) throw new ArgumentException("Url must be a well-formed URI", nameof(ImageUrl));
+                if (!value.IsNullOrUri()) throw new ArgumentException(message: "Url must be a well-formed URI", paramName: nameof(ImageUrl));
                 _image = new EmbedImage(value, null, null, null);
             }
         }
@@ -75,8 +75,8 @@ namespace Discord
             get => _fields;
             set
             {
-                if (value == null) throw new ArgumentNullException(nameof(Fields), "Cannot set an embed builder's fields collection to null");
-                if (value.Count > MaxFieldCount) throw new ArgumentException($"Field count must be less than or equal to {MaxFieldCount}.", nameof(Fields));
+                if (value == null) throw new ArgumentNullException(paramName: nameof(Fields), message: "Cannot set an embed builder's fields collection to null");
+                if (value.Count > MaxFieldCount) throw new ArgumentException(message: $"Field count must be less than or equal to {MaxFieldCount}.", paramName: nameof(Fields));
                 _fields = value;
             }
         }
@@ -200,7 +200,7 @@ namespace Discord
         {
             if (Fields.Count >= MaxFieldCount)
             {
-                throw new ArgumentException($"Field count must be less than or equal to {MaxFieldCount}.", nameof(field));
+                throw new ArgumentException(message: $"Field count must be less than or equal to {MaxFieldCount}.", paramName: nameof(field));
             }
 
             Fields.Add(field);
@@ -239,8 +239,8 @@ namespace Discord
             get => _name;
             set
             {
-                if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException("Field name must not be null, empty or entirely whitespace.", nameof(Name));
-                if (value.Length > MaxFieldNameLength) throw new ArgumentException($"Field name length must be less than or equal to {MaxFieldNameLength}.", nameof(Name));
+                if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException(message: "Field name must not be null, empty or entirely whitespace.", paramName: nameof(Name));
+                if (value.Length > MaxFieldNameLength) throw new ArgumentException(message: $"Field name length must be less than or equal to {MaxFieldNameLength}.", paramName: nameof(Name));
                 _name = value;
             }
         }
@@ -251,8 +251,8 @@ namespace Discord
             set
             {
                 var stringValue = value?.ToString();
-                if (string.IsNullOrEmpty(stringValue)) throw new ArgumentException("Field value must not be null or empty.", nameof(Value));
-                if (stringValue.Length > MaxFieldValueLength) throw new ArgumentException($"Field value length must be less than or equal to {MaxFieldValueLength}.", nameof(Value));
+                if (string.IsNullOrEmpty(stringValue)) throw new ArgumentException(message: "Field value must not be null or empty.", paramName: nameof(Value));
+                if (stringValue.Length > MaxFieldValueLength) throw new ArgumentException(message: $"Field value length must be less than or equal to {MaxFieldValueLength}.", paramName: nameof(Value));
                 _value = stringValue;
             }
         }
@@ -290,7 +290,7 @@ namespace Discord
             get => _name;
             set
             {
-                if (value?.Length > MaxAuthorNameLength) throw new ArgumentException($"Author name length must be less than or equal to {MaxAuthorNameLength}.", nameof(Name));
+                if (value?.Length > MaxAuthorNameLength) throw new ArgumentException(message: $"Author name length must be less than or equal to {MaxAuthorNameLength}.", paramName: nameof(Name));
                 _name = value;
             }
         }
@@ -299,7 +299,7 @@ namespace Discord
             get => _url;
             set
             {
-                if (!value.IsNullOrUri()) throw new ArgumentException("Url must be a well-formed URI", nameof(Url));
+                if (!value.IsNullOrUri()) throw new ArgumentException(message: "Url must be a well-formed URI", paramName: nameof(Url));
                 _url = value;
             }
         }
@@ -308,7 +308,7 @@ namespace Discord
             get => _iconUrl;
             set
             {
-                if (!value.IsNullOrUri()) throw new ArgumentException("Url must be a well-formed URI", nameof(IconUrl));
+                if (!value.IsNullOrUri()) throw new ArgumentException(message: "Url must be a well-formed URI", paramName: nameof(IconUrl));
                 _iconUrl = value;
             }
         }
@@ -345,7 +345,7 @@ namespace Discord
             get => _text;
             set
             {
-                if (value?.Length > MaxFooterTextLength) throw new ArgumentException($"Footer text length must be less than or equal to {MaxFooterTextLength}.", nameof(Text));
+                if (value?.Length > MaxFooterTextLength) throw new ArgumentException(message: $"Footer text length must be less than or equal to {MaxFooterTextLength}.", paramName: nameof(Text));
                 _text = value;
             }
         }
@@ -354,7 +354,7 @@ namespace Discord
             get => _iconUrl;
             set
             {
-                if (!value.IsNullOrUri()) throw new ArgumentException("Url must be a well-formed URI", nameof(IconUrl));
+                if (!value.IsNullOrUri()) throw new ArgumentException(message: "Url must be a well-formed URI", paramName: nameof(IconUrl));
                 _iconUrl = value;
             }
         }

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -29,7 +29,7 @@ namespace Discord
                 case ICategoryChannel _: return Category;
                 case IDMChannel _: return DM;
                 case IGroupChannel _: return Group;
-                default: throw new ArgumentException("Unknown channel type", nameof(channel));
+                default: throw new ArgumentException(message: "Unknown channel type", paramName: nameof(channel));
             }
         }
 

--- a/src/Discord.Net.Core/Utils/ConcurrentHashSet.cs
+++ b/src/Discord.Net.Core/Utils/ConcurrentHashSet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -160,23 +160,23 @@ namespace Discord
         public ConcurrentHashSet(IEnumerable<T> collection, IEqualityComparer<T> comparer) 
             : this(comparer)
         {
-            if (collection == null) throw new ArgumentNullException(nameof(collection));
+            if (collection == null) throw new ArgumentNullException(paramName: nameof(collection));
             InitializeFromCollection(collection);
         }
         public ConcurrentHashSet(int concurrencyLevel, IEnumerable<T> collection, IEqualityComparer<T> comparer)
             : this(concurrencyLevel, DefaultCapacity, false, comparer)
         {
-            if (collection == null) throw new ArgumentNullException(nameof(collection));
-            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+            if (collection == null) throw new ArgumentNullException(paramName: nameof(collection));
+            if (comparer == null) throw new ArgumentNullException(paramName: nameof(comparer));
             InitializeFromCollection(collection);
         }        
         public ConcurrentHashSet(int concurrencyLevel, int capacity, IEqualityComparer<T> comparer)
             : this(concurrencyLevel, capacity, false, comparer) { }
         internal ConcurrentHashSet(int concurrencyLevel, int capacity, bool growLockArray, IEqualityComparer<T> comparer)
         {
-            if (concurrencyLevel < 1) throw new ArgumentOutOfRangeException(nameof(concurrencyLevel));
-            if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity));
-            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+            if (concurrencyLevel < 1) throw new ArgumentOutOfRangeException(paramName: nameof(concurrencyLevel));
+            if (capacity < 0) throw new ArgumentOutOfRangeException(paramName: nameof(capacity));
+            if (comparer == null) throw new ArgumentNullException(paramName: nameof(comparer));
                         
             if (capacity < concurrencyLevel)
                 capacity = concurrencyLevel;
@@ -197,7 +197,7 @@ namespace Discord
         {
             foreach (var value in collection)
             {
-                if (value == null) throw new ArgumentNullException("key");
+                if (value == null) throw new ArgumentNullException(paramName: "key");
 
                 if (!TryAddInternal(value, _comparer.GetHashCode(value), false))
                     throw new ArgumentException();
@@ -209,7 +209,7 @@ namespace Discord
         
         public bool ContainsKey(T value)
         {
-            if (value == null) throw new ArgumentNullException("key");
+            if (value == null) throw new ArgumentNullException(paramName: "key");
             return ContainsKeyInternal(value, _comparer.GetHashCode(value));
         }
         private bool ContainsKeyInternal(T value, int hashcode)
@@ -232,7 +232,7 @@ namespace Discord
 
         public bool TryAdd(T value)
         {
-            if (value == null)  throw new ArgumentNullException("key");
+            if (value == null) throw new ArgumentNullException(paramName: "key");
             return TryAddInternal(value, _comparer.GetHashCode(value), true);
         }
         private bool TryAddInternal(T value, int hashcode, bool acquireLock)
@@ -281,7 +281,7 @@ namespace Discord
 
         public bool TryRemove(T value)
         {
-            if (value == null) throw new ArgumentNullException("key");
+            if (value == null) throw new ArgumentNullException(paramName: "key");
             return TryRemoveInternal(value);
         }        
         private bool TryRemoveInternal(T value)

--- a/src/Discord.Net.Core/Utils/MentionUtils.cs
+++ b/src/Discord.Net.Core/Utils/MentionUtils.cs
@@ -21,7 +21,7 @@ namespace Discord
         {
             if (TryParseUser(text, out ulong id))
                 return id;
-            throw new ArgumentException("Invalid mention format", nameof(text));
+            throw new ArgumentException(message: "Invalid mention format", paramName: nameof(text));
         }
         /// <summary> Tries to parse a provided user mention string. </summary>
         public static bool TryParseUser(string text, out ulong userId)
@@ -45,7 +45,7 @@ namespace Discord
         {
             if (TryParseChannel(text, out ulong id))
                 return id;
-            throw new ArgumentException("Invalid mention format", nameof(text));
+            throw new ArgumentException(message: "Invalid mention format", paramName: nameof(text));
         }
         /// <summary>Tries to parse a provided channel mention string. </summary>
         public static bool TryParseChannel(string text, out ulong channelId)
@@ -66,7 +66,7 @@ namespace Discord
         {
             if (TryParseRole(text, out ulong id))
                 return id;
-            throw new ArgumentException("Invalid mention format", nameof(text));
+            throw new ArgumentException(message: "Invalid mention format", paramName: nameof(text));
         }
         /// <summary>Tries to parse a provided role mention string. </summary>
         public static bool TryParseRole(string text, out ulong roleId)

--- a/src/Discord.Net.Core/Utils/Preconditions.cs
+++ b/src/Discord.Net.Core/Utils/Preconditions.cs
@@ -10,8 +10,8 @@ namespace Discord
 
         private static ArgumentNullException CreateNotNullException(string name, string msg)
         {
-            if (msg == null) return new ArgumentNullException(name);
-            else return new ArgumentNullException(name, msg);
+            if (msg == null) return new ArgumentNullException(paramName: name);
+            else return new ArgumentNullException(paramName: name, message: msg);
         }
 
         //Strings
@@ -45,7 +45,7 @@ namespace Discord
         }        
 
         private static ArgumentException CreateNotEmptyException(string name, string msg)
-            => new ArgumentException(msg ?? "Argument cannot be blank.", name);
+            => new ArgumentException(message: msg ?? "Argument cannot be blank.", paramName: name);
 
         //Numerics
         public static void NotEqual(sbyte obj, sbyte value, string name, string msg = null) { if (obj == value) throw CreateNotEqualException(name, msg, value); }
@@ -82,11 +82,8 @@ namespace Discord
         public static void NotEqual(Optional<ulong?> obj, ulong value, string name, string msg = null) { if (obj.IsSpecified && obj.Value == value) throw CreateNotEqualException(name, msg, value); }
 
         private static ArgumentException CreateNotEqualException<T>(string name, string msg, T value)
-        {
-            if (msg == null) return new ArgumentException($"Value may not be equal to {value}", name);
-            else return new ArgumentException(msg, name);
-        }
-
+            => new ArgumentException(message: msg ?? $"Value may not be equal to {value}", paramName: name);
+        
         public static void AtLeast(sbyte obj, sbyte value, string name, string msg = null) { if (obj < value) throw CreateAtLeastException(name, msg, value); }
         public static void AtLeast(byte obj, byte value, string name, string msg = null) { if (obj < value) throw CreateAtLeastException(name, msg, value); }
         public static void AtLeast(short obj, short value, string name, string msg = null) { if (obj < value) throw CreateAtLeastException(name, msg, value); }
@@ -105,10 +102,7 @@ namespace Discord
         public static void AtLeast(Optional<ulong> obj, ulong value, string name, string msg = null) { if (obj.IsSpecified && obj.Value < value) throw CreateAtLeastException(name, msg, value); }
 
         private static ArgumentException CreateAtLeastException<T>(string name, string msg, T value)
-        {
-            if (msg == null) return new ArgumentException($"Value must be at least {value}", name);
-            else return new ArgumentException(msg, name);
-        }
+            => new ArgumentException(message: msg ?? $"Value must be at least {value}", paramName: name);
 
         public static void GreaterThan(sbyte obj, sbyte value, string name, string msg = null) { if (obj <= value) throw CreateGreaterThanException(name, msg, value); }
         public static void GreaterThan(byte obj, byte value, string name, string msg = null) { if (obj <= value) throw CreateGreaterThanException(name, msg, value); }
@@ -128,10 +122,7 @@ namespace Discord
         public static void GreaterThan(Optional<ulong> obj, ulong value, string name, string msg = null) { if (obj.IsSpecified && obj.Value <= value) throw CreateGreaterThanException(name, msg, value); }
 
         private static ArgumentException CreateGreaterThanException<T>(string name, string msg, T value)
-        {
-            if (msg == null) return new ArgumentException($"Value must be greater than {value}", name);
-            else return new ArgumentException(msg, name);
-        }
+            => new ArgumentException(message: msg ?? $"Value must be greater than {value}", paramName: name);
 
         public static void AtMost(sbyte obj, sbyte value, string name, string msg = null) { if (obj > value) throw CreateAtMostException(name, msg, value); }
         public static void AtMost(byte obj, byte value, string name, string msg = null) { if (obj > value) throw CreateAtMostException(name, msg, value); }
@@ -151,10 +142,7 @@ namespace Discord
         public static void AtMost(Optional<ulong> obj, ulong value, string name, string msg = null) { if (obj.IsSpecified && obj.Value > value) throw CreateAtMostException(name, msg, value); }
 
         private static ArgumentException CreateAtMostException<T>(string name, string msg, T value)
-        {
-            if (msg == null) return new ArgumentException($"Value must be at most {value}", name);
-            else return new ArgumentException(msg, name);
-        }
+            => new ArgumentException(message: msg ?? $"Value must be at most {value}", paramName: name);
 
         public static void LessThan(sbyte obj, sbyte value, string name, string msg = null) { if (obj >= value) throw CreateLessThanException(name, msg, value); }
         public static void LessThan(byte obj, byte value, string name, string msg = null) { if (obj >= value) throw CreateLessThanException(name, msg, value); }
@@ -174,10 +162,7 @@ namespace Discord
         public static void LessThan(Optional<ulong> obj, ulong value, string name, string msg = null) { if (obj.IsSpecified && obj.Value >= value) throw CreateLessThanException(name, msg, value); }
 
         private static ArgumentException CreateLessThanException<T>(string name, string msg, T value)
-        {
-            if (msg == null) return new ArgumentException($"Value must be less than {value}", name);
-            else return new ArgumentException(msg, name);
-        }
+            => new ArgumentException(message: msg ?? $"Value must be less than {value}", paramName: name);
 
         // Bulk Delete
         public static void YoungerThanTwoWeeks(ulong[] collection, string name)
@@ -195,7 +180,7 @@ namespace Discord
             for (var i = 0; i < roles.Length; i++)
             {
                 if (roles[i] == guildId)
-                    throw new ArgumentException("The everyone role cannot be assigned to a user", name);
+                    throw new ArgumentException(message: "The everyone role cannot be assigned to a user", paramName: name);
             }
         }
     }

--- a/src/Discord.Net.Core/Utils/Preconditions.cs
+++ b/src/Discord.Net.Core/Utils/Preconditions.cs
@@ -45,10 +45,7 @@ namespace Discord
         }        
 
         private static ArgumentException CreateNotEmptyException(string name, string msg)
-        {
-            if (msg == null) return new ArgumentException("Argument cannot be blank", name);
-            else return new ArgumentException(name, msg);
-        }
+            => new ArgumentException(msg ?? "Argument cannot be blank.", name);
 
         //Numerics
         public static void NotEqual(sbyte obj, sbyte value, string name, string msg = null) { if (obj == value) throw CreateNotEqualException(name, msg, value); }

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -19,7 +19,7 @@ namespace Discord
         {
             // A Null or WhiteSpace token of any type is invalid.
             if (string.IsNullOrWhiteSpace(token))
-                throw new ArgumentNullException(nameof(token), "A token cannot be null, empty, or contain only whitespace.");
+                throw new ArgumentNullException(paramName: nameof(token), message: "A token cannot be null, empty, or contain only whitespace.");
 
             switch (tokenType)
             {
@@ -34,11 +34,11 @@ namespace Discord
                     // this value was determined by referencing examples in the discord documentation, and by comparing with
                     // pre-existing tokens
                     if (token.Length < 59)
-                        throw new ArgumentException("A Bot token must be at least 59 characters in length.", nameof(token));
+                        throw new ArgumentException(message: "A Bot token must be at least 59 characters in length.", paramName: nameof(token));
                     break;
                 default:
                     // All unrecognized TokenTypes (including User tokens) are considered to be invalid.
-                    throw new ArgumentException("Unrecognized TokenType.", nameof(token));
+                    throw new ArgumentException(message: "Unrecognized TokenType.", paramName: nameof(token));
             }
         }
 

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -19,7 +19,7 @@ namespace Discord
         {
             // A Null or WhiteSpace token of any type is invalid.
             if (string.IsNullOrWhiteSpace(token))
-                throw new ArgumentNullException("A token cannot be null, empty, or contain only whitespace.", nameof(token));
+                throw new ArgumentNullException(nameof(token), "A token cannot be null, empty, or contain only whitespace.");
 
             switch (tokenType)
             {

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -78,7 +78,7 @@ namespace Discord.API
                 case TokenType.Bearer:
                     return $"Bearer {token}";
                 default:
-                    throw new ArgumentException("Unknown OAuth token type", nameof(tokenType));
+                    throw new ArgumentException(message: "Unknown OAuth token type", paramName: nameof(tokenType));
             }
         }
         internal virtual void Dispose(bool disposing)
@@ -473,7 +473,7 @@ namespace Discord.API
                 Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
 
             if (args.Content?.Length > DiscordConfig.MaxMessageSize)
-                throw new ArgumentException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
+                throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(channelId: channelId);
@@ -490,7 +490,7 @@ namespace Discord.API
                 Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
 
             if (args.Content?.Length > DiscordConfig.MaxMessageSize)
-                throw new ArgumentException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
+                throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
             options = RequestOptions.CreateOrClone(options);
 
             return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args, new BucketIds(), clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -147,7 +147,7 @@ namespace Discord.Rest
         public static async Task<RestTextChannel> CreateTextChannelAsync(IGuild guild, BaseDiscordClient client,
             string name, RequestOptions options, Action<TextChannelProperties> func = null)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (name == null) throw new ArgumentNullException(paramName: nameof(name));
 
             var props = new TextChannelProperties();
             func?.Invoke(props);
@@ -164,7 +164,7 @@ namespace Discord.Rest
         public static async Task<RestVoiceChannel> CreateVoiceChannelAsync(IGuild guild, BaseDiscordClient client,
             string name, RequestOptions options, Action<VoiceChannelProperties> func = null)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (name == null) throw new ArgumentNullException(paramName: nameof(name));
 
             var props = new VoiceChannelProperties();
             func?.Invoke(props);
@@ -181,7 +181,7 @@ namespace Discord.Rest
         public static async Task<RestCategoryChannel> CreateCategoryChannelAsync(IGuild guild, BaseDiscordClient client,
             string name, RequestOptions options)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (name == null) throw new ArgumentNullException(paramName: nameof(name));
 
             var args = new CreateGuildChannelParams(name, ChannelType.Category);
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
@@ -221,7 +221,7 @@ namespace Discord.Rest
         public static async Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
             string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (name == null) throw new ArgumentNullException(paramName: nameof(name));
 
             var model = await client.ApiClient.CreateGuildRoleAsync(guild.Id, options).ConfigureAwait(false);
             var role = RestRole.Create(client, guild, model);
@@ -356,7 +356,7 @@ namespace Discord.Rest
         public static async Task<GuildEmote> ModifyEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, Action<EmoteProperties> func, 
             RequestOptions options)
         {
-            if (func == null) throw new ArgumentNullException(nameof(func));
+            if (func == null) throw new ArgumentNullException(paramName: nameof(func));
 
             var props = new EmoteProperties();
             func(props);


### PR DESCRIPTION
The constructors of `ArgumentException` and `ArgumentNullException` are inconsistent with each other, which sometimes results in their parameters being swapped. I've looked for all occurrences of this and fixed their constructors. Named parameters would have worked too.

For reference, here's the constructor definitions I'm referring to:
```csharp
public ArgumentNullException(string paramName, string message);
public ArgumentException(string message, string paramName);
```