### PR TITLE
Changed Command execution to use a scoped ServiceProvider

### DIFF
--- a/src/Discord.Net.Core/Commands/CommandContextAccessor.cs
+++ b/src/Discord.Net.Core/Commands/CommandContextAccessor.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+
+namespace Discord.Commands
+{
+    public class CommandContextAccessor : ICommandContextAccessor
+    {
+        private static AsyncLocal<ICommandContext> _commandContextCurrent = new AsyncLocal<ICommandContext>();
+
+        public ICommandContext CommandContext
+        {
+            get => _commandContextCurrent.Value;
+            set => _commandContextCurrent.Value = value;
+        }
+
+    }
+}

--- a/src/Discord.Net.Core/Commands/ICommandContextAccessor.cs
+++ b/src/Discord.Net.Core/Commands/ICommandContextAccessor.cs
@@ -1,0 +1,7 @@
+namespace Discord.Commands
+{
+    public interface ICommandContextAccessor
+    {
+        ICommandContext CommandContext { get; set; }
+    }
+}


### PR DESCRIPTION
In Asp.Net Core, services can be scoped to the lifetime of an http request.

If the modules are analogous to controllers, and the CommandContext is analogous to the HttpContext, the lifetime of each module should be scoped to the command request.

Further, services injected into modules may need access to the current request's ICommandContext. Asp.Net Core provides this via an HttpContextAccessor. I've included a CommandContextAccessor which mirrors this same functionality.

The end result is users will be able to create scoped services in their DI container, and provide the ICommandContext to these scoped services. 