### PR TITLE
Add Ubuntu target to AppVeyor CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,20 +51,23 @@ build_script:
     }
 - ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
 after_build:
-- ps: dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-- ps: dotnet pack "src\Discord.Net.Analyzers\Discord.Net.Analyzers.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: if ($isWindows) { dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG" }
+- ps: if ($isWindows) { dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG" }
+- ps: if ($isWindows) { dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG" }
+- ps: if ($isWindows) { dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG" }
+- ps: if ($isWindows) { dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG" }
+- ps: if ($isWindows) { dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG" }
+- ps: if ($isWindows) { dotnet pack "src\Discord.Net.Analyzers\Discord.Net.Analyzers.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG" }
 - ps: >-
-    if ($Env:APPVEYOR_REPO_TAG -eq "true") {
-      nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
-    } else {
-      nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-$Env:BUILD"
+    if ($isWindows)
+    {
+      if ($Env:APPVEYOR_REPO_TAG -eq "true") {
+        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
+      } else {
+        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-$Env:BUILD"
+      }
     }
-- ps: Get-ChildItem artifacts/*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+- ps: if ($isWindows) { Get-ChildItem artifacts/*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } }
 
 test_script:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,15 @@ init:
 - ps: $Env:BUILD = "$($Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))"
 
 build_script:
-- ps: appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+- ps: |
+  if ($isLinux)
+  {
+    ./appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+  }
+  else
+  {
+    appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+  }
 - ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
 after_build:
 - ps: dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ init:
 build_script:
 - ps: >-
     if ($isLinux) {
-      ./appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+      dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
     } else {
       appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,9 @@ init:
 
 build_script:
 - ps: |
-  if ($isLinux)
-  {
+  if ($isLinux) {
     ./appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-  }
-  else
-  {
+  } else {
     appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
   }
 - ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,23 @@ init:
 build_script:
 - ps: >-
     if ($isLinux) {
-      dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+      # AppVeyor Linux images do not have appveyor-retry, which retries the commands a few times
+      # until the command exits with code 0.
+      # So, this is done with a short script.
+      $code = 0
+      $counter = 0
+      do {
+        dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+        $code = $LASTEXITCODE
+        $counter++
+
+        if ($code -ne 0)
+        {
+          # Wait 5s before attempting to run again
+          Start-sleep -Seconds 5
+        }
+
+      } until ($counter -eq 5 -or $code -eq 0)
     } else {
       appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,25 +25,28 @@ init:
 
 build_script:
 - ps: >-
-    if ($isLinux) {
+    if ($isLinux)
+    {
       # AppVeyor Linux images do not have appveyor-retry, which retries the commands a few times
       # until the command exits with code 0.
       # So, this is done with a short script.
       $code = 0
       $counter = 0
-      do {
+      do
+      {
         dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
         $code = $LASTEXITCODE
         $counter++
-
         if ($code -ne 0)
         {
           # Wait 5s before attempting to run again
           Start-sleep -Seconds 5
         }
-
-      } until ($counter -eq 5 -or $code -eq 0)
-    } else {
+      }
+      until ($counter -eq 5 -or $code -eq 0)
+    }
+    else
+    {
       appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
     }
 - ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,11 +41,11 @@ after_build:
 - ps: dotnet pack "src\Discord.Net.Analyzers\Discord.Net.Analyzers.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
 - ps: >-
     if ($Env:APPVEYOR_REPO_TAG -eq "true") {
-      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
+      nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
     } else {
-      nuget pack src\Discord.Net\Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-$Env:BUILD"
+      nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-$Env:BUILD"
     }
-- ps: Get-ChildItem artifacts\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+- ps: Get-ChildItem artifacts/*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
 test_script:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,9 @@ version: build-{build}
 branches:
   only:
   - dev
-image: Visual Studio 2017
+image:
+- Visual Studio 2017
+- Ubuntu
 
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ nuget:
   disable_publish_on_pr: true
 pull_requests:
   do_not_increment_build_number: true
-# This is the default on Windows
-# For Ubuntu, it's /home/appveyor/projects/
-# clone_folder: C:\Projects\Discord.Net
+# Use the default clone_folder
+# Windows: C:\Projects\discord-net
+# Ubuntu: /home/appveyor/projects/discord-net
 cache: test/Discord.Net.Tests/cache.db
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,9 @@ nuget:
   disable_publish_on_pr: true
 pull_requests:
   do_not_increment_build_number: true
-clone_folder: C:\Projects\Discord.Net
+# This is the default on Windows
+# For Ubuntu, it's /home/appveyor/projects/
+# clone_folder: C:\Projects\Discord.Net
 cache: test/Discord.Net.Tests/cache.db
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,12 +24,12 @@ init:
 - ps: $Env:BUILD = "$($Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))"
 
 build_script:
-- ps: |
-  if ($isLinux) {
-    ./appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-  } else {
-    appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
-  }
+- ps: >-
+    if ($isLinux) {
+      ./appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+    } else {
+      appveyor-retry dotnet restore Discord.Net.sln -v Minimal /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
+    }
 - ps: dotnet build Discord.Net.sln -c "Release" /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"
 after_build:
 - ps: dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" -c "Release" -o "../../artifacts" --no-build /p:BuildNumber="$Env:BUILD" /p:IsTagBuild="$Env:APPVEYOR_REPO_TAG"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,6 +83,7 @@ deploy:
   symbol_server: https://www.myget.org/F/discord-net/symbols/api/v2/package
   on:
     branch: dev
+    isWindows: True
 - provider: NuGet
   server: https://www.myget.org/F/rogueexception/api/v2/package
   api_key:
@@ -90,3 +91,4 @@ deploy:
   symbol_server: https://www.myget.org/F/rogueexception/symbols/api/v2/package
   on:
     branch: dev
+    isWindows: True


### PR DESCRIPTION
This adds Ubuntu as another build target in the CI process. Some minor changes have been made to the `appveyor.yml` file to ensure that the build process works in both environments (paths, `appveyor-retry`).

Building and testing with the Ubuntu build target will help ensure that OS-specific issues are not introduced.

In my experience, builds on Ubuntu are slightly faster, but may take longer to queue up in AppVeyor.