### PR TITLE
Add SyncPermissionsAsync to Sync Child Channels with its Parent

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
@@ -12,5 +12,10 @@ namespace Discord
         ulong? CategoryId { get; }
         /// <summary> Gets the parent channel (category) of this channel, if it is set. If unset, returns null.</summary>
         Task<ICategoryChannel> GetCategoryAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
+        /// <summary>
+        ///     Syncs the permissions of this nested channel with its parent's.
+        /// </summary>
+        Task SyncPermissionsAsync(RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Overwrite.cs
+++ b/src/Discord.Net.Rest/API/Common/Overwrite.cs
@@ -13,13 +13,5 @@ namespace Discord.API
         public ulong Deny { get; set; }
         [JsonProperty("allow"), Int53]
         public ulong Allow { get; set; }
-
-        public Overwrite(ulong targetId, PermissionTarget targetType, ulong allowValue, ulong denyValue)
-        {
-            TargetId = targetId;
-            TargetType = targetType;
-            Allow = allowValue;
-            Deny = denyValue;
-        }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Overwrite.cs
+++ b/src/Discord.Net.Rest/API/Common/Overwrite.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -13,5 +13,13 @@ namespace Discord.API
         public ulong Deny { get; set; }
         [JsonProperty("allow"), Int53]
         public ulong Allow { get; set; }
+
+        public Overwrite(ulong targetId, PermissionTarget targetType, ulong allowValue, ulong denyValue)
+        {
+            TargetId = targetId;
+            TargetType = targetType;
+            Allow = allowValue;
+            Deny = denyValue;
+        }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest
@@ -12,5 +12,7 @@ namespace Discord.API.Rest
         public Optional<int> Position { get; set; }
         [JsonProperty("parent_id")]
         public Optional<ulong?> CategoryId { get; set; }
+        [JsonProperty("permission_overwrites")]
+        public Optional<Overwrite[]> Overwrites { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -329,14 +329,17 @@ namespace Discord.Rest
         public static async Task SyncPermissionsAsync(INestedChannel channel, BaseDiscordClient client, RequestOptions options)
         {
             var category = await GetCategoryAsync(channel, client, options).ConfigureAwait(false);
-            if (category == null) return;
+            if (category == null) throw new InvalidOperationException("This channel does not have a parent channel.");
 
             var apiArgs = new ModifyGuildChannelParams
             {
                 Overwrites = category.PermissionOverwrites
-                    .Select(overwrite => new API.Overwrite(overwrite.TargetId, overwrite.TargetType,
-                        overwrite.Permissions.AllowValue, overwrite.Permissions.DenyValue))
-                    .ToArray()
+                    .Select(overwrite => new API.Overwrite{
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue,
+                        Deny = overwrite.Permissions.DenyValue
+                    }).ToArray()
             };
             await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -326,6 +326,20 @@ namespace Discord.Rest
             var model = await client.ApiClient.GetChannelAsync(channel.CategoryId.Value, options).ConfigureAwait(false);
             return RestCategoryChannel.Create(client, model) as ICategoryChannel;
         }
+        public static async Task SyncPermissionsAsync(INestedChannel channel, BaseDiscordClient client, RequestOptions options)
+        {
+            var category = await GetCategoryAsync(channel, client, options).ConfigureAwait(false);
+            if (category == null) return;
+
+            var apiArgs = new ModifyGuildChannelParams
+            {
+                Overwrites = category.PermissionOverwrites
+                    .Select(overwrite => new API.Overwrite(overwrite.TargetId, overwrite.TargetType,
+                        overwrite.Permissions.AllowValue, overwrite.Permissions.DenyValue))
+                    .ToArray()
+            };
+            await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
+        }
 
         //Helpers
         private static IUser GetAuthor(BaseDiscordClient client, IGuild guild, UserModel model, ulong? webhookId)

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -92,6 +92,8 @@ namespace Discord.Rest
 
         public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
             => ChannelHelper.GetCategoryAsync(this, Discord, options);
+        public Task SyncPermissionsAsync(RequestOptions options = null)
+            => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
 
         private string DebuggerDisplay => $"{Name} ({Id}, Text)";
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -41,6 +41,8 @@ namespace Discord.Rest
 
         public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
             => ChannelHelper.GetCategoryAsync(this, Discord, options);
+        public Task SyncPermissionsAsync(RequestOptions options = null)
+            => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
 
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -19,6 +19,8 @@ namespace Discord.WebSocket
         public ulong? CategoryId { get; private set; }
         public ICategoryChannel Category
             => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
+        public Task SyncPermissionsAsync(RequestOptions options = null)
+            => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
 
         private bool _nsfw;
         public bool IsNsfw => _nsfw;

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -18,6 +18,8 @@ namespace Discord.WebSocket
         public ulong? CategoryId { get; private set; }
         public ICategoryChannel Category
             => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
+        public Task SyncPermissionsAsync(RequestOptions options = null)
+            => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
 
         public override IReadOnlyCollection<SocketGuildUser> Users
             => Guild.Users.Where(x => x.VoiceChannel?.Id == Id).ToImmutableArray();


### PR DESCRIPTION
# Summary

This resolves #1144 and attempts to improve from the previous attempt of #1016. Instead of forcefully implementing a property that does not exist on the API, this creates a new method called `SyncPermissionsAsync` under all `INestedChannel`.