### PR TITLE
fix: strip trailing slash from ratelimit bucket IDs

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1415,6 +1415,9 @@ namespace Discord.API
                 }
 
                 format = builder.ToString();
+                if (format.LastIndexOf('/') == format.Length-1)
+                    format = format.Substring(0, format.Length - 1); // perf: change the code above so this isn't necessary
+
                 return x => string.Format(format, x.ToArray());
             }
             catch (Exception ex)

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1,3 +1,4 @@
+
 #pragma warning disable CS1591
 using Discord.API.Rest;
 using Discord.Net;
@@ -1413,10 +1414,10 @@ namespace Discord.API
 
                     lastIndex = rightIndex + 1;
                 }
+                if (builder[builder.Length - 1] == '/')
+                    builder.Remove(builder.Length - 1, 1);
 
                 format = builder.ToString();
-                if (format.LastIndexOf('/') == format.Length-1)
-                    format = format.Substring(0, format.Length - 1); // perf: change the code above so this isn't necessary
 
                 return x => string.Format(format, x.ToArray());
             }


### PR DESCRIPTION
This resolves #1125.

fixes a bug where some ratelimit buckets would include a trailing slash,
while others wouldn't; this would cause them to be treated as separate
ratelimits, even though they are the same

ideally this fix should change the ratelimit generator, but that code is
pretty complicated and this was an easier fix that seems less likely to
break things in the future.

tested against normal bot function, all routes are assigned the proper
buckets from my testing, so this should be good to go.