### PR TITLE
Update Guild and Message Models

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/ExplicitContentFilterLevel.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/ExplicitContentFilterLevel.cs
@@ -1,0 +1,13 @@
+namespace Discord
+{
+    public enum ExplicitContentFilterLevel
+    {
+        /// <summary> No messages will be scanned. </summary>
+        Disabled = 0,
+        /// <summary> Scans messages from all guild members that do not have a role. </summary>
+        /// <remarks> Recommented option for servers that use roles for trusted membership. </remarks>
+        MembersWithoutRoles = 1,
+        /// <summary> Scan messages sent by all guild members. </summary>
+        AllMembers = 2
+    }
+}

--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -66,5 +66,9 @@ namespace Discord
         ///     Gets or sets the ID of the owner of this guild.
         /// </summary>
         public Optional<ulong> OwnerId { get; set; }
+        /// <summary>
+        ///     Gets or sets the explicit content filter level of this guild.
+        /// </summary>
+        public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -20,7 +20,7 @@ namespace Discord
         /// <summary> Gets the level of requirements a user must fulfill before being allowed to post messages in this guild. </summary>
         VerificationLevel VerificationLevel { get; }
         /// <summary> Gets the level of content filtering applied to user's content in a Guild. </summary>
-        ExplicitContentFilterLevel ExplicitContentFilterLevel { get; }
+        ExplicitContentFilterLevel ExplicitContentFilter { get; }
         /// <summary> Returns the id of this guild's icon, or null if one is not set. </summary>
         string IconId { get; }
         /// <summary> Returns the url to this guild's icon, or null if one is not set. </summary>
@@ -40,6 +40,8 @@ namespace Discord
         ulong? EmbedChannelId { get; }
         /// <summary> Gets the id of the channel where randomized welcome messages are sent, or null if not. </summary>
         ulong? SystemChannelId { get; }
+        /// <summary> Gets the application id of the guild creator if it is bot-created. </summary>
+        ulong? ApplicationId { get; }
         /// <summary> Gets the id of the user that created this guild. </summary>
         ulong OwnerId { get; }
         /// <summary> Gets the id of the region hosting this guild's voice channels. </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -52,7 +52,12 @@ namespace Discord
         ///     The level of requirements.
         /// </returns>
         VerificationLevel VerificationLevel { get; }
-        /// <summary> Gets the level of content filtering applied to user's content in a Guild. </summary>
+        /// <summary>
+        ///     Gets the level of content filtering applied to user's content in a Guild.
+        /// </summary>
+        /// <returns>
+        ///     The level of explicit content filtering.
+        /// </returns>
         ExplicitContentFilterLevel ExplicitContentFilter { get; }
         /// <summary>
         ///     Gets the ID of this guild's icon.

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -148,10 +148,10 @@ namespace Discord
         /// </returns>
         ulong OwnerId { get; }
         /// <summary>
-        ///     Gets the application id of the guild creator if it is bot-created.
+        ///     Gets the application ID of the guild creator if it is bot-created.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the application Id that created this guild, or <c>null</c> if it was not bot-created.
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the application ID that created this guild, or <c>null</c> if it was not bot-created.
         /// </returns>
         ulong? ApplicationId { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -140,19 +140,20 @@ namespace Discord
         ///     welcome messages are sent; <c>null</c> if none is set.
         /// </returns>
         ulong? SystemChannelId { get; }
-<<<<<<< HEAD
         /// <summary>
         ///     Gets the ID of the user that owns this guild.
         /// </summary>
         /// <returns>
         ///     A <see cref="ulong"/> representing the snowflake identifier of the user that owns this guild.
         /// </returns>
-=======
-        /// <summary> Gets the application id of the guild creator if it is bot-created. </summary>
-        ulong? ApplicationId { get; }
-        /// <summary> Gets the id of the user that created this guild. </summary>
->>>>>>> Implement ApplicationId in Guild model
         ulong OwnerId { get; }
+        /// <summary>
+        ///     Gets the application id of the guild creator if it is bot-created.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the application Id that created this guild, or <c>null</c> if it was not bot-created.
+        /// </returns>
+        ulong? ApplicationId { get; }
         /// <summary>
         ///     Gets the ID of the region hosting this guild's voice channels.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -19,6 +19,8 @@ namespace Discord
         MfaLevel MfaLevel { get; }
         /// <summary> Gets the level of requirements a user must fulfill before being allowed to post messages in this guild. </summary>
         VerificationLevel VerificationLevel { get; }
+        /// <summary> Gets the level of content filtering applied to user's content in a Guild. </summary>
+        ExplicitContentFilterLevel ExplicitContentFilterLevel { get; }
         /// <summary> Returns the id of this guild's icon, or null if one is not set. </summary>
         string IconId { get; }
         /// <summary> Returns the url to this guild's icon, or null if one is not set. </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -52,6 +52,8 @@ namespace Discord
         ///     The level of requirements.
         /// </returns>
         VerificationLevel VerificationLevel { get; }
+        /// <summary> Gets the level of content filtering applied to user's content in a Guild. </summary>
+        ExplicitContentFilterLevel ExplicitContentFilter { get; }
         /// <summary>
         ///     Gets the ID of this guild's icon.
         /// </summary>
@@ -133,12 +135,18 @@ namespace Discord
         ///     welcome messages are sent; <c>null</c> if none is set.
         /// </returns>
         ulong? SystemChannelId { get; }
+<<<<<<< HEAD
         /// <summary>
         ///     Gets the ID of the user that owns this guild.
         /// </summary>
         /// <returns>
         ///     A <see cref="ulong"/> representing the snowflake identifier of the user that owns this guild.
         /// </returns>
+=======
+        /// <summary> Gets the application id of the guild creator if it is bot-created. </summary>
+        ulong? ApplicationId { get; }
+        /// <summary> Gets the id of the user that created this guild. </summary>
+>>>>>>> Implement ApplicationId in Guild model
         ulong OwnerId { get; }
         /// <summary>
         ///     Gets the ID of the region hosting this guild's voice channels.

--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -100,5 +100,25 @@ namespace Discord
         ///     A read-only collection of user IDs.
         /// </returns>
         IReadOnlyCollection<ulong> MentionedUserIds { get; }
+        /// <summary>
+        ///     Returns the Activity associated with a message.
+        /// </summary>
+        /// <remarks>
+        ///     Sent with Rich Presence-related chat embeds.
+        /// </remarks>
+        /// <returns>
+        ///     A message's activity, if any is associated.
+        /// </returns>
+        MessageActivity Activity { get; }
+        /// <summary>
+        ///     Returns the Application associated with a messsage.
+        /// </summary>
+        /// <remarks>
+        ///     Sent with Rich-Presence-related chat embeds.
+        /// </remarks>
+        /// <returns>
+        ///     A message's application, if any is associated.
+        /// </returns>
+        MessageApplication Application { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Messages/MessageActivity.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageActivity.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class MessageActivity
+    {
+        /// <summary>
+        ///     Gets the type of activity of this message.
+        /// </summary>
+        public MessageActivityType Type { get; set; }
+        /// <summary>
+        ///     Gets the party ID of this activity, if any.
+        /// </summary>
+        public string PartyId { get; set; }
+
+        private string DebuggerDisplay
+            => $"{Type}{(string.IsNullOrWhiteSpace(PartyId) ? "" : $" {PartyId}")}";
+
+        public override string ToString() => DebuggerDisplay;
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/MessageActivityType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageActivityType.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    public enum MessageActivityType
+    {
+        Join = 1,
+        Spectate = 2,
+        Listen = 3,
+        JoinRequest = 5
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
@@ -26,21 +26,17 @@ namespace Discord
         ///     Gets the ID of the application's icon.
         /// </summary>
         public string Icon { get; set; }
-
         /// <summary>
         ///     Gets the Url of the application's icon.
         /// </summary>
         public string IconUrl
             => $"https://cdn.discordapp.com/app-icons/{Id}/{Icon}";
-
         /// <summary>
         ///     Gets the name of the application.
         /// </summary>
         public string Name { get; set; }
-
         private string DebuggerDisplay
             => $"{Name} ({Id}): {Description}";
-
         public override string ToString()
             => DebuggerDisplay;
     }

--- a/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class MessageApplication
+    {
+        /// <summary>
+        ///     Gets the snowflake ID of the application.
+        /// </summary>
+        public ulong Id { get; set; }
+        /// <summary>
+        ///     Gets the ID of the embed's image asset.
+        /// </summary>
+        public string CoverImage { get; set; }
+        /// <summary>
+        ///     Gets the application's description.
+        /// </summary>
+        public string Description { get; set; }
+        /// <summary>
+        ///     Gets the ID of the application's icon.
+        /// </summary>
+        public string Icon { get; set; }
+        /// <summary>
+        ///     Gets the name of the application.
+        /// </summary>
+        public string Name { get; set; }
+
+        private string DebuggerDisplay
+            => $"{Name} ({Id}): {Description}";
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
@@ -26,6 +26,13 @@ namespace Discord
         ///     Gets the ID of the application's icon.
         /// </summary>
         public string Icon { get; set; }
+
+        /// <summary>
+        ///     Gets the Url of the application's icon.
+        /// </summary>
+        public string IconUrl
+            => $"https://cdn.discordapp.com/app-icons/{Id}/{Icon}";
+
         /// <summary>
         ///     Gets the name of the application.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
@@ -33,5 +33,8 @@ namespace Discord
 
         private string DebuggerDisplay
             => $"{Name} ({Id}): {Description}";
+
+        public override string ToString()
+            => DebuggerDisplay;
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -29,6 +29,10 @@ namespace Discord.API
         public ulong? SystemChannelId { get; set; }
         [JsonProperty("verification_level")]
         public VerificationLevel VerificationLevel { get; set; }
+        [JsonProperty("default_message_notifications")]
+        public DefaultMessageNotifications DefaultMessageNotifications { get; set; }
+        [JsonProperty("explicit_content_filter")]
+        public ExplicitContentFilterLevel ExplicitContentFilter { get; set; }
         [JsonProperty("voice_states")]
         public VoiceState[] VoiceStates { get; set; }
         [JsonProperty("roles")]
@@ -39,9 +43,5 @@ namespace Discord.API
         public string[] Features { get; set; }
         [JsonProperty("mfa_level")]
         public MfaLevel MfaLevel { get; set; }
-        [JsonProperty("default_message_notifications")]
-        public DefaultMessageNotifications DefaultMessageNotifications { get; set; }
-        [JsonProperty("explicit_content_filter")]
-        public ExplicitContentFilterLevel ExplicitContentFilter { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -41,5 +41,7 @@ namespace Discord.API
         public MfaLevel MfaLevel { get; set; }
         [JsonProperty("default_message_notifications")]
         public DefaultMessageNotifications DefaultMessageNotifications { get; set; }
+        [JsonProperty("explicit_content_filter")]
+        public ExplicitContentFilterLevel ExplicitContentFilter { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -41,6 +41,8 @@ namespace Discord.API
         public string[] Features { get; set; }
         [JsonProperty("mfa_level")]
         public MfaLevel MfaLevel { get; set; }
+        [JsonProperty("application_id")]
+        public ulong? ApplicationId { get; set; }
         [JsonProperty("system_channel_id")]
         public ulong? SystemChannelId { get; set; }
     }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -25,8 +25,6 @@ namespace Discord.API
         public bool EmbedEnabled { get; set; }
         [JsonProperty("embed_channel_id")]
         public ulong? EmbedChannelId { get; set; }
-        [JsonProperty("system_channel_id")]
-        public ulong? SystemChannelId { get; set; }
         [JsonProperty("verification_level")]
         public VerificationLevel VerificationLevel { get; set; }
         [JsonProperty("default_message_notifications")]
@@ -43,5 +41,7 @@ namespace Discord.API
         public string[] Features { get; set; }
         [JsonProperty("mfa_level")]
         public MfaLevel MfaLevel { get; set; }
+        [JsonProperty("system_channel_id")]
+        public ulong? SystemChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Message.cs
+++ b/src/Discord.Net.Rest/API/Common/Message.cs
@@ -44,5 +44,11 @@ namespace Discord.API
         public Optional<bool> Pinned { get; set; }
         [JsonProperty("reactions")]
         public Optional<Reaction[]> Reactions { get; set; }
+        // sent with Rich Presence-related chat embeds
+        [JsonProperty("activity")]
+        public Optional<MessageActivity> Activity { get; set; }
+        // sent with Rich Presence-related chat embeds
+        [JsonProperty("application")]
+        public Optional<MessageApplication> Application { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/MessageActivity.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageActivity.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.API
+{
+    public class MessageActivity
+    {
+        [JsonProperty("type")]
+        public Optional<MessageActivityType> Type { get; set; }
+        [JsonProperty("party_id")]
+        public Optional<string> PartyId { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/MessageApplication.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageApplication.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.API
+{
+    public class MessageApplication
+    {
+        /// <summary>
+        ///     Gets the snowflake ID of the application.
+        /// </summary>
+        [JsonProperty("id")]
+        public ulong Id { get; set; }
+        /// <summary>
+        ///     Gets the ID of the embed's image asset.
+        /// </summary>
+        [JsonProperty("cover_image")]
+        public string CoverImage { get; set; }
+        /// <summary>
+        ///     Gets the application's description.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+        /// <summary>
+        ///     Gets the ID of the application's icon.
+        /// </summary>
+        [JsonProperty("icon")]
+        public string Icon { get; set; }
+        /// <summary>
+        ///     Gets the name of the application.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest
@@ -28,5 +28,7 @@ namespace Discord.API.Rest
         public Optional<ulong?> AfkChannelId { get; set; }
         [JsonProperty("owner_id")]
         public Optional<ulong> OwnerId { get; set; }
+        [JsonProperty("explicit_content_filter")]
+        public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -32,7 +32,8 @@ namespace Discord.Rest
                 Icon = args.Icon.IsSpecified ? args.Icon.Value?.ToModel() : Optional.Create<ImageModel?>(),
                 Name = args.Name,
                 Splash = args.Splash.IsSpecified ? args.Splash.Value?.ToModel() : Optional.Create<ImageModel?>(),
-                VerificationLevel = args.VerificationLevel
+                VerificationLevel = args.VerificationLevel,
+                ExplicitContentFilter = args.ExplicitContentFilter
             };
 
             if (args.AfkChannel.IsSpecified)
@@ -59,6 +60,9 @@ namespace Discord.Rest
                 apiArgs.Splash = new ImageModel(guild.SplashId);
             if (!apiArgs.Icon.IsSpecified && guild.IconId != null)
                 apiArgs.Icon = new ImageModel(guild.IconId);
+
+            if (args.ExplicitContentFilter.IsSpecified)
+                apiArgs.ExplicitContentFilter = args.ExplicitContentFilter.Value;
 
             return await client.ApiClient.ModifyGuildAsync(guild.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -32,6 +32,7 @@ namespace Discord.Rest
         public MfaLevel MfaLevel { get; private set; }
         /// <inheritdoc />
         public DefaultMessageNotifications DefaultMessageNotifications { get; private set; }
+        public ExplicitContentFilterLevel ExplicitContentFilter { get; private set; }
 
         /// <inheritdoc />
         public ulong? AFKChannelId { get; private set; }
@@ -98,6 +99,7 @@ namespace Discord.Rest
             VerificationLevel = model.VerificationLevel;
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
+            ExplicitContentFilter = model.ExplicitContentFilter;            
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -49,6 +49,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string SplashId { get; private set; }
         internal bool Available { get; private set; }
+        public ulong? ApplicationId { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -99,7 +100,8 @@ namespace Discord.Rest
             VerificationLevel = model.VerificationLevel;
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
-            ExplicitContentFilter = model.ExplicitContentFilter;            
+            ExplicitContentFilter = model.ExplicitContentFilter;
+            ApplicationId = model.ApplicationId;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -32,6 +32,7 @@ namespace Discord.Rest
         public MfaLevel MfaLevel { get; private set; }
         /// <inheritdoc />
         public DefaultMessageNotifications DefaultMessageNotifications { get; private set; }
+        /// <inheritdoc />
         public ExplicitContentFilterLevel ExplicitContentFilter { get; private set; }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -23,6 +23,7 @@ namespace Discord.Rest
         public VerificationLevel VerificationLevel { get; private set; }
         public MfaLevel MfaLevel { get; private set; }
         public DefaultMessageNotifications DefaultMessageNotifications { get; private set; }
+        public ExplicitContentFilterLevel ExplicitContentFilter { get; private set; }
 
         public ulong? AFKChannelId { get; private set; }
         public ulong? EmbedChannelId { get; private set; }
@@ -70,6 +71,7 @@ namespace Discord.Rest
             VerificationLevel = model.VerificationLevel;
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
+            ExplicitContentFilter = model.ExplicitContentFilter;            
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -50,6 +50,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string SplashId { get; private set; }
         internal bool Available { get; private set; }
+        /// <inheritdoc />
         public ulong? ApplicationId { get; private set; }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -33,6 +33,7 @@ namespace Discord.Rest
         public string IconId { get; private set; }
         public string SplashId { get; private set; }
         internal bool Available { get; private set; }
+        public ulong? ApplicationId { get; private set; }
 
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
 
@@ -71,7 +72,8 @@ namespace Discord.Rest
             VerificationLevel = model.VerificationLevel;
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
-            ExplicitContentFilter = model.ExplicitContentFilter;            
+            ExplicitContentFilter = model.ExplicitContentFilter;
+            ApplicationId = model.ApplicationId;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -55,6 +55,9 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         public DateTimeOffset Timestamp => DateTimeUtils.FromTicks(_timestampTicks);
+        //todo Rest impl
+        public MessageActivity Activity => null;
+        public MessageApplication Application => null;
 
         internal RestMessage(BaseDiscordClient discord, ulong id, IMessageChannel channel, IUser author, MessageSource source)
             : base(discord, id)

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -55,9 +55,10 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         public DateTimeOffset Timestamp => DateTimeUtils.FromTicks(_timestampTicks);
-        //todo Rest impl
-        public MessageActivity Activity => null;
-        public MessageApplication Application => null;
+        /// <inheritdoc />
+        public MessageActivity Activity { get; private set; }
+        /// <inheritdoc />
+        public MessageApplication Application { get; private set; }
 
         internal RestMessage(BaseDiscordClient discord, ulong id, IMessageChannel channel, IUser author, MessageSource source)
             : base(discord, id)
@@ -80,6 +81,29 @@ namespace Discord.Rest
 
             if (model.Content.IsSpecified)
                 Content = model.Content.Value;
+
+            if (model.Application.IsSpecified)
+            {
+                // create a new Application from the API model
+                Application = new MessageApplication()
+                {
+                    Id = model.Application.Value.Id,
+                    CoverImage = model.Application.Value.CoverImage,
+                    Description = model.Application.Value.Description,
+                    Icon = model.Application.Value.Icon,
+                    Name = model.Application.Value.Name
+                };
+            }
+
+            if (model.Activity.IsSpecified)
+            {
+                // create a new Activity from the API model
+                Activity = new MessageActivity()
+                {
+                    Type = model.Activity.Value.Type.Value,
+                    PartyId = model.Activity.Value.PartyId.Value
+                };
+            }
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -50,6 +50,8 @@ namespace Discord.WebSocket
         public MfaLevel MfaLevel { get; private set; }
         /// <inheritdoc />
         public DefaultMessageNotifications DefaultMessageNotifications { get; private set; }
+        /// <inheritdoc />
+        public ExplicitContentFilterLevel ExplicitContentFilter { get; private set; }
         /// <summary>
         ///     Gets the number of members.
         /// </summary>
@@ -346,6 +348,7 @@ namespace Discord.WebSocket
             VerificationLevel = model.VerificationLevel;
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
+            ExplicitContentFilter = model.ExplicitContentFilter;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -40,6 +40,7 @@ namespace Discord.WebSocket
         public VerificationLevel VerificationLevel { get; private set; }
         public MfaLevel MfaLevel { get; private set; }
         public DefaultMessageNotifications DefaultMessageNotifications { get; private set; }
+        public ExplicitContentFilterLevel ExplicitContentFilter { get; private set; }
         public int MemberCount { get; internal set; }
         public int DownloadedMemberCount { get; private set; }
         internal bool IsAvailable { get; private set; }
@@ -210,6 +211,7 @@ namespace Discord.WebSocket
             VerificationLevel = model.VerificationLevel;
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
+            ExplicitContentFilter = model.ExplicitContentFilter;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -75,6 +75,7 @@ namespace Discord.WebSocket
         internal bool IsAvailable { get; private set; }
         /// <summary> Indicates whether the client is connected to this guild. </summary>
         public bool IsConnected { get; internal set; }
+        /// <inheritdoc />
         public ulong? ApplicationId { get; internal set; }
 
         internal ulong? AFKChannelId { get; private set; }

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -45,6 +45,7 @@ namespace Discord.WebSocket
         public int DownloadedMemberCount { get; private set; }
         internal bool IsAvailable { get; private set; }
         public bool IsConnected { get; internal set; }
+        public ulong? ApplicationId { get; internal set; }
 
         internal ulong? AFKChannelId { get; private set; }
         internal ulong? EmbedChannelId { get; private set; }
@@ -212,6 +213,7 @@ namespace Discord.WebSocket
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
             ExplicitContentFilter = model.ExplicitContentFilter;
+            ApplicationId = model.ApplicationId;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -75,6 +75,7 @@ namespace Discord.WebSocket
         internal bool IsAvailable { get; private set; }
         /// <summary> Indicates whether the client is connected to this guild. </summary>
         public bool IsConnected { get; internal set; }
+        public ulong? ApplicationId { get; internal set; }
 
         internal ulong? AFKChannelId { get; private set; }
         internal ulong? EmbedChannelId { get; private set; }
@@ -349,6 +350,7 @@ namespace Discord.WebSocket
             MfaLevel = model.MfaLevel;
             DefaultMessageNotifications = model.DefaultMessageNotifications;
             ExplicitContentFilter = model.ExplicitContentFilter;
+            ApplicationId = model.ApplicationId;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -50,7 +50,6 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public MessageApplication Application { get; private set; }
 
-
         /// <summary>
         ///     Returns all attachments included in this message.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -43,6 +43,14 @@ namespace Discord.WebSocket
         public virtual bool IsPinned => false;
         /// <inheritdoc />
         public virtual DateTimeOffset? EditedTimestamp => null;
+
+        /// <inheritdoc />
+        public MessageActivity Activity { get; private set; }
+
+        /// <inheritdoc />
+        public MessageApplication Application { get; private set; }
+
+
         /// <summary>
         ///     Returns all attachments included in this message.
         /// </summary>
@@ -105,6 +113,29 @@ namespace Discord.WebSocket
 
             if (model.Content.IsSpecified)
                 Content = model.Content.Value;
+
+            if (model.Application.IsSpecified)
+            {
+                // create a new Application from the API model
+                Application = new MessageApplication()
+                {
+                    Id = model.Application.Value.Id,
+                    CoverImage = model.Application.Value.CoverImage,
+                    Description = model.Application.Value.Description,
+                    Icon = model.Application.Value.Icon,
+                    Name = model.Application.Value.Name
+                };
+            }
+
+            if (model.Activity.IsSpecified)
+            {
+                // create a new Activity from the API model
+                Activity = new MessageActivity()
+                {
+                    Type = model.Activity.Value.Type.Value,
+                    PartyId = model.Activity.Value.PartyId.Value
+                };
+            }
         }
 
         /// <inheritdoc />

--- a/test/Discord.Net.Tests/Tests.Guilds.cs
+++ b/test/Discord.Net.Tests/Tests.Guilds.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Discord
 {
-    public class GuidPermissionsTests
+    public class GuildTests
     {
         [Fact]
         public Task TestGuildPermission()

--- a/test/Discord.Net.Tests/Tests.Guilds.cs
+++ b/test/Discord.Net.Tests/Tests.Guilds.cs
@@ -5,8 +5,27 @@ using Xunit;
 
 namespace Discord
 {
-    public class GuildTests
+    public partial class Tests
     {
+        /// <summary>
+        ///     Tests the behavior of modifying the ExplicitContentFilter property of a Guild.
+        /// </summary>
+        [Fact]
+        public async Task TestExplicitContentFilter()
+        {
+            async Task ModifyAndAssert(ExplicitContentFilterLevel level)
+            {
+                await _guild.ModifyAsync(x => x.ExplicitContentFilter = level);
+                Assert.Equal(level, _guild.ExplicitContentFilter);
+            }
+
+            foreach (var level in Enum.GetValues(typeof(ExplicitContentFilterLevel)))
+                await ModifyAndAssert((ExplicitContentFilterLevel)level);
+        }
+
+        /// <summary>
+        ///     Tests the behavior of the GuildPermissions class.
+        /// </summary>
         [Fact]
         public Task TestGuildPermission()
         {

--- a/test/Discord.Net.Tests/Tests.Guilds.cs
+++ b/test/Discord.Net.Tests/Tests.Guilds.cs
@@ -13,14 +13,12 @@ namespace Discord
         [Fact]
         public async Task TestExplicitContentFilter()
         {
-            async Task ModifyAndAssert(ExplicitContentFilterLevel level)
+            foreach (var level in Enum.GetValues(typeof(ExplicitContentFilterLevel)))
             {
-                await _guild.ModifyAsync(x => x.ExplicitContentFilter = level);
+                await _guild.ModifyAsync(x => x.ExplicitContentFilter = (ExplicitContentFilterLevel)level);
+                await _guild.UpdateAsync();
                 Assert.Equal(level, _guild.ExplicitContentFilter);
             }
-
-            foreach (var level in Enum.GetValues(typeof(ExplicitContentFilterLevel)))
-                await ModifyAndAssert((ExplicitContentFilterLevel)level);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR includes many updates to the Guild and Message API models and their related classes.
Fixes #1113 .

Guild:
- Adds the `ExplicitContentFilter` property and `ExplicitContentFilterLevel` type
    - Add a test for this property's `ModifyAsync` behavior
- Adds the `ApplicationID` property.
    - Can test this by having a bot create a new guild, then checking that the `ApplicationId` property is not null. This is not viable to include as part of the bot's integration tests in CI, as bots can only create up to 10 guilds iirc.

Message:
- Adds the `Activity` property and `MessageActivity`, `MessageActivityType` types
    - Can test this by inviting a channel w/ bot to listen along on Spotify
- Adds the `Application` property and the `MessageApplication` type
    - Can test this (and `Activity`) by inviting a channel w/ bot to a Fortnite lobby (I actually had to install the game to test this behavior)
![image](https://user-images.githubusercontent.com/16418643/46518973-8d071280-c82b-11e8-9aac-917ffe1df58b.png)

This commit log may look a bit strange because of an issue when resolving merge conflicts.