### PR TITLE
Move Invites-related Methods from IGuildChannel to INestedChannel

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
@@ -45,45 +45,6 @@ namespace Discord
         IReadOnlyCollection<Overwrite> PermissionOverwrites { get; }
 
         /// <summary>
-        ///     Creates a new invite to this channel.
-        /// </summary>
-        /// <example>
-        ///     The following example creates a new invite to this channel; the invite lasts for 12 hours and can only
-        ///     be used 3 times throughout its lifespan.
-        ///     <code language="cs">
-        ///     await guildChannel.CreateInviteAsync(maxAge: 43200, maxUses: 3);
-        ///     </code>
-        /// </example>
-        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
-        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
-        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
-        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous invite creation operation. The task result contains an invite
-        ///     metadata object containing information for the created invite.
-        /// </returns>
-        Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null);
-        /// <summary>
-        ///     Gets a collection of all invites to this channel.
-        /// </summary>
-        /// <example>
-        ///     The following example gets all of the invites that have been created in this channel and selects the
-        ///     most used invite.
-        ///     <code language="cs">
-        ///     var invites = await channel.GetInvitesAsync();
-        ///     if (invites.Count == 0) return;
-        ///     var invite = invites.OrderByDescending(x => x.Uses).FirstOrDefault();
-        ///     </code>
-        /// </example>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
-        ///     of invite metadata that are created for this channel.
-        /// </returns>
-        Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null);
-
-        /// <summary>
         ///     Modifies this guild channel.
         /// </summary>
         /// <param name="func">The delegate containing the properties to modify the channel with.</param>

--- a/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -25,5 +26,44 @@ namespace Discord
         ///     representing the parent of this channel; <c>null</c> if none is set.
         /// </returns>
         Task<ICategoryChannel> GetCategoryAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
+        /// <summary>
+        ///     Creates a new invite to this channel.
+        /// </summary>
+        /// <example>
+        ///     The following example creates a new invite to this channel; the invite lasts for 12 hours and can only
+        ///     be used 3 times throughout its lifespan.
+        ///     <code language="cs">
+        ///     await guildChannel.CreateInviteAsync(maxAge: 43200, maxUses: 3);
+        ///     </code>
+        /// </example>
+        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
+        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
+        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
+        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous invite creation operation. The task result contains an invite
+        ///     metadata object containing information for the created invite.
+        /// </returns>
+        Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null);
+        /// <summary>
+        ///     Gets a collection of all invites to this channel.
+        /// </summary>B
+        /// <example>
+        ///     The following example gets all of the invites that have been created in this channel and selects the
+        ///     most used invite.
+        ///     <code language="cs">
+        ///     var invites = await channel.GetInvitesAsync();
+        ///     if (invites.Count == 0) return;
+        ///     var invite = invites.OrderByDescending(x => x.Uses).FirstOrDefault();
+        ///     </code>
+        /// </example>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
+        ///     of invite metadata that are created for this channel.
+        /// </returns>
+        Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
@@ -25,16 +25,6 @@ namespace Discord.Rest
 
         private string DebuggerDisplay => $"{Name} ({Id}, Category)";
 
-        // IGuildChannel
-        /// <inheritdoc />
-        /// <exception cref="NotSupportedException">This method is not supported with category channels.</exception>
-        Task<IInviteMetadata> IGuildChannel.CreateInviteAsync(int? maxAge, int? maxUses, bool isTemporary, bool isUnique, RequestOptions options)
-            => throw new NotSupportedException();
-        /// <inheritdoc />
-        /// <exception cref="NotSupportedException">This method is not supported with category channels.</exception>
-        Task<IReadOnlyCollection<IInviteMetadata>> IGuildChannel.GetInvitesAsync(RequestOptions options)
-            => throw new NotSupportedException();
-
         //IChannel
         /// <inheritdoc />
         /// <exception cref="NotSupportedException">This method is not supported with category channels.</exception>

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -179,32 +179,6 @@ namespace Discord.Rest
         }
 
         /// <summary>
-        ///     Gets a collection of all invites to this channel.
-        /// </summary>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
-        ///     of invite metadata that are created for this channel.
-        /// </returns>
-        public async Task<IReadOnlyCollection<RestInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
-            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
-
-        /// <summary>
-        ///     Creates a new invite to this channel.
-        /// </summary>
-        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
-        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
-        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
-        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous invite creation operation. The task result contains an invite
-        ///     metadata object containing information for the created invite.
-        /// </returns>
-        public async Task<RestInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
-
-        /// <summary>
         ///     Gets the name of this channel.
         /// </summary>
         /// <returns>
@@ -223,13 +197,6 @@ namespace Discord.Rest
                 throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
             }
         }
-
-        /// <inheritdoc />
-        async Task<IReadOnlyCollection<IInviteMetadata>> IGuildChannel.GetInvitesAsync(RequestOptions options)
-            => await GetInvitesAsync(options).ConfigureAwait(false);
-        /// <inheritdoc />
-        async Task<IInviteMetadata> IGuildChannel.CreateInviteAsync(int? maxAge, int? maxUses, bool isTemporary, bool isUnique, RequestOptions options)
-            => await CreateInviteAsync(maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         OverwritePermissions? IGuildChannel.GetPermissionOverwrite(IRole role)

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -202,6 +202,14 @@ namespace Discord.Rest
         public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
             => ChannelHelper.GetCategoryAsync(this, Discord, options);
 
+        //Invites
+        /// <inheritdoc />
+        public async Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
+            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
+
         private string DebuggerDisplay => $"{Name} ({Id}, Text)";
 
         //ITextChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -57,6 +57,14 @@ namespace Discord.Rest
         /// </returns>
         public Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
             => ChannelHelper.GetCategoryAsync(this, Discord, options);
+         
+        //Invites
+        /// <inheritdoc />
+        public async Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
+            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
 
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
 
@@ -75,6 +83,7 @@ namespace Discord.Rest
             => AsyncEnumerable.Empty<IReadOnlyCollection<IGuildUser>>();
 
         // INestedChannel
+        /// <inheritdoc />
         async Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
         {
             if (CategoryId.HasValue && mode == CacheMode.AllowDownload)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
@@ -67,14 +67,6 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuildUser>(GetUser(id));
-        /// <inheritdoc />
-        /// <exception cref="NotSupportedException">This method is not supported with category channels.</exception>
-        Task<IInviteMetadata> IGuildChannel.CreateInviteAsync(int? maxAge, int? maxUses, bool isTemporary, bool isUnique, RequestOptions options)
-            => throw new NotSupportedException();
-        /// <inheritdoc />
-        /// <exception cref="NotSupportedException">This method is not supported with category channels.</exception>
-        Task<IReadOnlyCollection<IInviteMetadata>> IGuildChannel.GetInvitesAsync(RequestOptions options)
-            => throw new NotSupportedException();
 
         //IChannel
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -184,31 +184,6 @@ namespace Discord.WebSocket
             }
         }
 
-        /// <summary>
-        ///     Returns a collection of all invites to this channel.
-        /// </summary>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
-        ///     of invite metadata that are created for this channel.
-        /// </returns>
-        public async Task<IReadOnlyCollection<RestInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
-            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
-        /// <summary>
-        ///     Creates a new invite to this channel.
-        /// </summary>
-        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
-        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
-        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
-        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous invite creation operation. The task result contains an invite
-        ///     metadata object containing information for the created invite.
-        /// </returns>
-        public async Task<RestInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
-
         public new virtual SocketGuildUser GetUser(ulong id) => null;
 
         /// <summary>
@@ -232,13 +207,6 @@ namespace Discord.WebSocket
         IGuild IGuildChannel.Guild => Guild;
         /// <inheritdoc />
         ulong IGuildChannel.GuildId => Guild.Id;
-
-        /// <inheritdoc />
-        async Task<IReadOnlyCollection<IInviteMetadata>> IGuildChannel.GetInvitesAsync(RequestOptions options)
-            => await GetInvitesAsync(options).ConfigureAwait(false);
-        /// <inheritdoc />
-        async Task<IInviteMetadata> IGuildChannel.CreateInviteAsync(int? maxAge, int? maxUses, bool isTemporary, bool isUnique, RequestOptions options)
-            => await CreateInviteAsync(maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         OverwritePermissions? IGuildChannel.GetPermissionOverwrite(IRole role)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -124,7 +124,6 @@ namespace Discord.WebSocket
         /// <returns>
         ///     Paged collection of messages.
         /// </returns>
-
         public IAsyncEnumerable<IReadOnlyCollection<IMessage>> GetMessagesAsync(int limit = DiscordConfig.MaxMessagesPerBatch, RequestOptions options = null)
             => SocketChannelHelper.GetMessagesAsync(this, Discord, _messages, null, Direction.Before, limit, CacheMode.AllowDownload, options);
         /// <summary>
@@ -301,6 +300,14 @@ namespace Discord.WebSocket
         /// </returns>
         public Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
             => ChannelHelper.GetWebhooksAsync(this, Discord, options);
+
+        //Invites
+        /// <inheritdoc />
+        public async Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
+            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
 
         private string DebuggerDisplay => $"{Name} ({Id}, Text)";
         internal new SocketTextChannel Clone() => MemberwiseClone() as SocketTextChannel;

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -77,6 +77,14 @@ namespace Discord.WebSocket
             return null;
         }
 
+        //Invites
+        /// <inheritdoc />
+        public async Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
+            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
+
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";
         internal new SocketVoiceChannel Clone() => MemberwiseClone() as SocketVoiceChannel;
 


### PR DESCRIPTION
# Summary

This PR moves Invite-related methods from `IGuildChannel` to `INestedChannel` to prevent "Unknown channel" errors from being thrown since creating and getting invites from category channel is invalid.