### PR TITLE
Cleanup #1037

### DIFF
--- a/src/Discord.Net.Commands/Extensions/CommandServiceExtensions.cs
+++ b/src/Discord.Net.Commands/Extensions/CommandServiceExtensions.cs
@@ -11,9 +11,13 @@ namespace Discord.Commands
         {
             var executableCommands = new List<CommandInfo>();
 
-            var tasks = commands.Select(async c => { var result = await c.CheckPreconditionsAsync(context, provider).ConfigureAwait(false); return new { Command = c, PreconditionResult = result }; });
+            var tasks = commands.Select(async c =>
+            {
+                var result = await c.CheckPreconditionsAsync(context, provider).ConfigureAwait(false);
+                return new { Command = c, PreconditionResult = result };
+            });
 
-            var results = await Task.WhenAll(tasks);
+            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
 
             foreach (var result in results)
             {
@@ -32,7 +36,7 @@ namespace Discord.Commands
             executableCommands.AddRange(await module.Commands.ToArray().GetExecutableCommandsAsync(context, provider).ConfigureAwait(false));
 
             var tasks = module.Submodules.Select(async s => await s.GetExecutableCommandsAsync(context, provider).ConfigureAwait(false));
-            var results = await Task.WhenAll(tasks);
+            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
 
             executableCommands.AddRange(results.SelectMany(c => c));
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -37,8 +38,8 @@ namespace Discord.WebSocket
         public IActivity Activity => Presence.Activity;
         /// <inheritdoc />
         public UserStatus Status => Presence.Status;
-        public IEnumerable<SocketGuild> MutualGuilds
-            => Discord.Guilds.Where(g => g.Users.Any(u => u.Id == Id));
+        public IReadOnlyCollection<SocketGuild> MutualGuilds
+            => Discord.Guilds.Where(g => g.Users.Any(u => u.Id == Id)).ToImmutableArray();
 
         internal SocketUser(DiscordSocketClient discord, ulong id)
             : base(discord, id)


### PR DESCRIPTION
# Summary

This PR cleans up changes made in #1037 that did not go through proper review. Main changes are

* Return `IReadOnlyCollection<T>` instead of `IEnumerable<T>` for the newly added `MutualGuilds` property for consistency.
* Stylistic changes and adding `ConfigureAwait(false)` for the `CommandServiceExtensions` methods.