### PR TITLE
Remove public setters for MessageApplication, MessageActivity properties

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/MessageActivity.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageActivity.cs
@@ -13,11 +13,11 @@ namespace Discord
         /// <summary>
         ///     Gets the type of activity of this message.
         /// </summary>
-        public MessageActivityType Type { get; set; }
+        public MessageActivityType Type { get; internal set; }
         /// <summary>
         ///     Gets the party ID of this activity, if any.
         /// </summary>
-        public string PartyId { get; set; }
+        public string PartyId { get; internal set; }
 
         private string DebuggerDisplay
             => $"{Type}{(string.IsNullOrWhiteSpace(PartyId) ? "" : $" {PartyId}")}";

--- a/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageApplication.cs
@@ -13,19 +13,19 @@ namespace Discord
         /// <summary>
         ///     Gets the snowflake ID of the application.
         /// </summary>
-        public ulong Id { get; set; }
+        public ulong Id { get; internal set; }
         /// <summary>
         ///     Gets the ID of the embed's image asset.
         /// </summary>
-        public string CoverImage { get; set; }
+        public string CoverImage { get; internal set; }
         /// <summary>
         ///     Gets the application's description.
         /// </summary>
-        public string Description { get; set; }
+        public string Description { get; internal set; }
         /// <summary>
         ///     Gets the ID of the application's icon.
         /// </summary>
-        public string Icon { get; set; }
+        public string Icon { get; internal set; }
         /// <summary>
         ///     Gets the Url of the application's icon.
         /// </summary>
@@ -34,7 +34,7 @@ namespace Discord
         /// <summary>
         ///     Gets the name of the application.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; internal set; }
         private string DebuggerDisplay
             => $"{Name} ({Id}): {Description}";
         public override string ToString()


### PR DESCRIPTION
This fixes an error that was introduced in d30d12246d5173321c2556cf65d3c69da230cb8c (thanks Still for noticing!)

Changes the public property setters of the MessageActivity and MessageApplication entities to be
internal, since they cannot be modified by the user in the API.