### PR TITLE
UploadWebhookFileParams: Move most things into a json_payload

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
@@ -1,12 +1,17 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
+using Discord.Net.Converters;
 using Discord.Net.Rest;
+using Newtonsoft.Json;
 
 namespace Discord.API.Rest
 {
     internal class UploadWebhookFileParams
     {
+        private static JsonSerializer _serializer = new JsonSerializer { ContractResolver = new DiscordContractResolver() };
+
         public Stream File { get; }
 
         public Optional<string> Filename { get; set; }
@@ -27,18 +32,27 @@ namespace Discord.API.Rest
             var d = new Dictionary<string, object>();
             d["file"] = new MultipartFile(File, Filename.GetValueOrDefault("unknown.dat"));
 
+            var payload = new Dictionary<string, object>();
             if (Content.IsSpecified)
-                d["content"] = Content.Value;
+                payload["content"] = Content.Value;
             if (IsTTS.IsSpecified)
-                d["tts"] = IsTTS.Value.ToString();
+                payload["tts"] = IsTTS.Value.ToString();
             if (Nonce.IsSpecified)
-                d["nonce"] = Nonce.Value;
+                payload["nonce"] = Nonce.Value;
             if (Username.IsSpecified)
-                d["username"] = Username.Value;
+                payload["username"] = Username.Value;
             if (AvatarUrl.IsSpecified)
-                d["avatar_url"] = AvatarUrl.Value;
+                payload["avatar_url"] = AvatarUrl.Value;
             if (Embeds.IsSpecified)
-                d["embeds"] = Embeds.Value;
+                payload["embeds"] = Embeds.Value;
+
+            var json = new StringBuilder();
+            using (var text = new StringWriter(json))
+            using (var writer = new JsonTextWriter(text))
+                _serializer.Serialize(writer, payload);
+
+            d["payload_json"] = json.ToString();
+
             return d;
         }
     }


### PR DESCRIPTION
This fixes ``DiscordWebhookClient.SendFileAsync()`` with embeds by making ``UploadWebhookFileParams`` act more like ``UploadFileParams``.