### PR TITLE
Fixed CommandExecuted firing twice for failed RuntimeResults

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -603,6 +603,8 @@ namespace Discord.Commands
             //If we get this far, at least one parse was successful. Execute the most likely overload.
             var chosenOverload = successfulParses[0];
             var result = await chosenOverload.Key.ExecuteAsync(context, chosenOverload.Value, services).ConfigureAwait(false);
+            if (!result.IsSuccess && result is ExecuteResult)
+                await _commandExecutedEvent.InvokeAsync(chosenOverload.Key.Command, context, result);
             return result;
         }
     }

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -603,8 +603,6 @@ namespace Discord.Commands
             //If we get this far, at least one parse was successful. Execute the most likely overload.
             var chosenOverload = successfulParses[0];
             var result = await chosenOverload.Key.ExecuteAsync(context, chosenOverload.Value, services).ConfigureAwait(false);
-            if (!result.IsSuccess) // succesful results raise the event in CommandInfo#ExecuteInternalAsync (have to raise it there b/c deffered execution)
-                await _commandExecutedEvent.InvokeAsync(chosenOverload.Key.Command, context, result);
             return result;
         }
     }

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -603,7 +603,7 @@ namespace Discord.Commands
             //If we get this far, at least one parse was successful. Execute the most likely overload.
             var chosenOverload = successfulParses[0];
             var result = await chosenOverload.Key.ExecuteAsync(context, chosenOverload.Value, services).ConfigureAwait(false);
-            if (!result.IsSuccess && result is ExecuteResult)
+            if (!result.IsSuccess && !(result is RuntimeResult)) // succesful results raise the event in CommandInfo#ExecuteInternalAsync (have to raise it there b/c deffered execution)
                 await _commandExecutedEvent.InvokeAsync(chosenOverload.Key.Command, context, result);
             return result;
         }


### PR DESCRIPTION
The issue was because of [line 247](https://github.com/RogueException/Discord.Net/blob/dev/src/Discord.Net.Commands/Info/CommandInfo.cs#L247) of CommandInfo also triggering the event.
As far as I can tell this fixes the specific issue. Not too sure of any unintended consequences of removing these two lines, but from my testing, I don't see any but would appreciate others testing.