### PR TITLE
(Part 1 of 4) Added Msg.Content Null Check For Prefixes

### DIFF
--- a/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
@@ -19,7 +19,7 @@ namespace Discord.Commands
         public static bool HasCharPrefix(this IUserMessage msg, char c, ref int argPos)
         {
             var text = msg.Content;
-            if (!string.IsNullOrEmpty(text) && text.Length > 0 && text[0] == c)
+            if (!string.IsNullOrEmpty(text) && text[0] == c)
             {
                 argPos = 1;
                 return true;
@@ -45,7 +45,7 @@ namespace Discord.Commands
         public static bool HasMentionPrefix(this IUserMessage msg, IUser user, ref int argPos)
         {
             var text = msg.Content;
-            if (!string.IsNullOrEmpty(text) && text.Length <= 3 || text[0] != '<' || text[1] != '@') return false;
+            if ((!string.IsNullOrEmpty(text) && text.Length <= 3) || text[0] != '<' || text[1] != '@') return false;
 
             int endPos = text.IndexOf('>');
             if (endPos == -1) return false;

--- a/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
@@ -19,7 +19,7 @@ namespace Discord.Commands
         public static bool HasCharPrefix(this IUserMessage msg, char c, ref int argPos)
         {
             var text = msg.Content;
-            if (text.Length > 0 && text[0] == c)
+            if (!string.IsNullOrEmpty(text) && text.Length > 0 && text[0] == c)
             {
                 argPos = 1;
                 return true;
@@ -32,7 +32,7 @@ namespace Discord.Commands
         public static bool HasStringPrefix(this IUserMessage msg, string str, ref int argPos, StringComparison comparisonType = StringComparison.Ordinal)
         {
             var text = msg.Content;
-            if (text.StartsWith(str, comparisonType))
+            if (!string.IsNullOrEmpty(text) && text.StartsWith(str, comparisonType))
             {
                 argPos = str.Length;
                 return true;
@@ -45,7 +45,7 @@ namespace Discord.Commands
         public static bool HasMentionPrefix(this IUserMessage msg, IUser user, ref int argPos)
         {
             var text = msg.Content;
-            if (text.Length <= 3 || text[0] != '<' || text[1] != '@') return false;
+            if (!string.IsNullOrEmpty(text) && text.Length <= 3 || text[0] != '<' || text[1] != '@') return false;
 
             int endPos = text.IndexOf('>');
             if (endPos == -1) return false;

--- a/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
@@ -45,7 +45,7 @@ namespace Discord.Commands
         public static bool HasMentionPrefix(this IUserMessage msg, IUser user, ref int argPos)
         {
             var text = msg.Content;
-            if (!string.IsNullOrEmpty(text) && (text.Length <= 3 || text[0] != '<' || text[1] != '@')) return false;
+            if (string.IsNullOrEmpty(text) || text.Length <= 3 || text[0] != '<' || text[1] != '@') return false;
 
             int endPos = text.IndexOf('>');
             if (endPos == -1) return false;

--- a/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
@@ -45,7 +45,7 @@ namespace Discord.Commands
         public static bool HasMentionPrefix(this IUserMessage msg, IUser user, ref int argPos)
         {
             var text = msg.Content;
-            if ((!string.IsNullOrEmpty(text) && text.Length <= 3) || text[0] != '<' || text[1] != '@') return false;
+            if (!string.IsNullOrEmpty(text) && (text.Length <= 3 || text[0] != '<' || text[1] != '@')) return false;
 
             int endPos = text.IndexOf('>');
             if (endPos == -1) return false;


### PR DESCRIPTION
Hi There,

This PR solves a NullRef. exception when checking for prefixes as some messages may only contain an embed.

Tested & Non-Breaking Change.

Regards,

CM1