### PR TITLE
(Part 4 of 4) Solves AudioClient Lockup On Disconnect

### DIFF
--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -157,9 +157,9 @@ namespace Discord
 
             await _onDisconnecting(ex).ConfigureAwait(false);
 
-            await _logger.InfoAsync("Disconnected").ConfigureAwait(false);
-            State = ConnectionState.Disconnected;
             await _disconnectedEvent.InvokeAsync(ex, isReconnecting).ConfigureAwait(false);
+            State = ConnectionState.Disconnected;
+            await _logger.InfoAsync("Disconnected").ConfigureAwait(false);
         }
 
         public async Task CompleteAsync()

--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -103,12 +103,10 @@ namespace Discord
                 finally { _stateLock.Release(); }
             });
         }
-        public virtual async Task StopAsync()
+        public virtual Task StopAsync()
         {
             Cancel();
-            var task = _task;
-            if (task != null)
-                await task.ConfigureAwait(false);
+            return Task.CompletedTask;
         }
 
         private async Task ConnectAsync(CancellationTokenSource reconnectCancelToken)


### PR DESCRIPTION
Hi There,

This PR solves the AudioClient disconnect lockup. This issue caused the audio client to not always disconnect properly and indirectly led to memory leaks (objects not being disposed correctly). In other words, the "_task" variable was waiting on itself to complete which caused the lockup.

The "disconnected" event was moved up as it made logical sense to do so. That way, any further faults could be found a little bit better (in my mind at least).

Tested & Non-Breaking.

Regards,

CM1