### PR TITLE
Update minimum Bot Token length to 58 char

### DIFF
--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -8,6 +8,15 @@ namespace Discord
     public static class TokenUtils
     {
         /// <summary>
+        ///     The minimum length of a Bot token.
+        /// </summary>
+        /// <remarks>
+        ///     This value was determined by comparing against the examples in the Discord
+        ///     documentation, and pre-existing tokens.
+        /// </remarks>
+        internal const int MinBotTokenLength = 58;
+
+        /// <summary>
         ///     Checks the validity of the supplied token of a specific type.
         /// </summary>
         /// <param name="tokenType"> The type of token to validate. </param>
@@ -29,11 +38,11 @@ namespace Discord
                     // no validation is performed on Bearer tokens
                     break;
                 case TokenType.Bot:
-                    // bot tokens are assumed to be at least 59 characters in length
+                    // bot tokens are assumed to be at least 58 characters in length
                     // this value was determined by referencing examples in the discord documentation, and by comparing with
                     // pre-existing tokens
-                    if (token.Length < 59)
-                        throw new ArgumentException(message: "A Bot token must be at least 59 characters in length.", paramName: nameof(token));
+                    if (token.Length < MinBotTokenLength)
+                        throw new ArgumentException(message: $"A Bot token must be at least {MinBotTokenLength} characters in length.", paramName: nameof(token));
                     break;
                 default:
                     // All unrecognized TokenTypes (including User tokens) are considered to be invalid.

--- a/test/Discord.Net.Tests/Tests.TokenUtils.cs
+++ b/test/Discord.Net.Tests/Tests.TokenUtils.cs
@@ -69,9 +69,12 @@ namespace Discord
         /// <summary>
         ///     Tests the behavior of <see cref="TokenUtils.ValidateToken(TokenType, string)"/>
         ///     to see that valid Bot tokens do not throw Exceptions.
-        ///     Valid Bot tokens can be strings of length 59 or above.
+        ///     Valid Bot tokens can be strings of length 58 or above.
         /// </summary>
         [Theory]
+        // missing a single character from the end, 58 char. still should be valid
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKW")]
+        // 59 char token
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
         [InlineData("This appears to be completely invalid, however the current validation rules are not very strict.")]
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWss")]
@@ -90,12 +93,12 @@ namespace Discord
         /// </summary>
         [Theory]
         [InlineData("This is invalid")]
-        // missing a single character from the end
-        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKW")]
         // bearer token
         [InlineData("6qrZcUqja7812RVdnEKjpzOL4CvHBFG")]
         // client secret
         [InlineData("937it3ow87i4ery69876wqire")]
+        // 57 char bot token
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kK")]
         public void TestBotTokenInvalidThrowsArgumentException(string token)
         {
             Assert.Throws<ArgumentException>(() => TokenUtils.ValidateToken(TokenType.Bot, token));
@@ -113,6 +116,7 @@ namespace Discord
         // TokenType.User
         [InlineData(0)]
         // out of range TokenType
+        [InlineData(-1)]
         [InlineData(4)]
         [InlineData(7)]
         public void TestUnrecognizedTokenType(int type)


### PR DESCRIPTION
As found by @moiph , some (older) bot tokens can be 58 characters. This incorrectly warns that the provided token is invalid. [Conversation on DAPI](https://discordapp.com/channels/81384788765712384/381889909113225237/517939266702278659)

This PR updates this value to 58 char from 59, and updates the tests. In addition the length value was moved into a constant value, instead of being a magic number.