### PR TITLE
Improve validation of Bot Tokens

### DIFF
--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -28,6 +28,9 @@ namespace Discord
         /// </returns>
         internal static bool CheckBotTokenValidity(string message)
         {
+            if (string.IsNullOrWhiteSpace(message))
+                return false;
+
             // split each component of the JWT
             var segments = message.Split('.');
 

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -85,10 +85,12 @@ namespace Discord
                     // this value was determined by referencing examples in the discord documentation, and by comparing with
                     // pre-existing tokens
                     if (token.Length < MinBotTokenLength)
-                        throw new ArgumentException(message: $"A Bot token must be at least {MinBotTokenLength} characters in length.", paramName: nameof(token));
+                        throw new ArgumentException(message: $"A Bot token must be at least {MinBotTokenLength} characters in length. " +
+                            "Ensure that the Bot Token provided is not an OAuth client secret.", paramName: nameof(token));
                     // check the validity of the bot token by decoding the ulong userid from the jwt
                     if (!CheckBotTokenValidity(token))
-                        throw new ArgumentException(message: "The Bot token was invalid.", paramName: nameof(token));
+                        throw new ArgumentException(message: "The Bot token was invalid. " +
+                            "Ensure that the Bot Token provided is not an OAuth client secret.", paramName: nameof(token));
                     break;
                 default:
                     // All unrecognized TokenTypes (including User tokens) are considered to be invalid.

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -47,6 +47,11 @@ namespace Discord
                 // discard id
                 return ulong.TryParse(idStr, out var id);
             }
+            catch (DecoderFallbackException)
+            {
+                // can be thrown by GetString
+                return false;
+            }
             catch (FormatException)
             {
                 // ignore exception, if contains invalid base64 characters return false

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -28,6 +28,9 @@ namespace Discord
         /// </returns>
         internal static bool CheckBotTokenValidity(string message)
         {
+            if (string.IsNullOrWhiteSpace(message))
+                return false;
+
             // split each component of the JWT
             var segments = message.Split('.');
 
@@ -91,6 +94,5 @@ namespace Discord
                     throw new ArgumentException(message: "Unrecognized TokenType.", paramName: nameof(token));
             }
         }
-
     }
 }

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 namespace Discord
 {
@@ -41,10 +42,10 @@ namespace Discord
             try
             {
                 // decode the first segment as base64
-                var v = Convert.FromBase64String(segments[0]);
-                BitConverter.ToUInt64(v, 0);
-                // if no exception thrown, token is valid
-                return true;
+                var bytes = Convert.FromBase64String(segments[0]);
+                var idStr = Encoding.UTF8.GetString(bytes);
+                // discard id
+                return ulong.TryParse(idStr, out var id);
             }
             catch (FormatException)
             {

--- a/test/Discord.Net.Tests/Tests.TokenUtils.cs
+++ b/test/Discord.Net.Tests/Tests.TokenUtils.cs
@@ -138,6 +138,7 @@ namespace Discord
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4. this part is invalid. this part is also invalid", true)]
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.", false)]
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4", false)]
+        [InlineData("NDI4NDc3OTQ0MDA5MTk1NTIw.xxxx.xxxxx", true)]
         // should not throw an unexpected exception
         [InlineData("", false)]
         [InlineData(null, false)]

--- a/test/Discord.Net.Tests/Tests.TokenUtils.cs
+++ b/test/Discord.Net.Tests/Tests.TokenUtils.cs
@@ -146,5 +146,23 @@ namespace Discord
         {
             Assert.Equal(expected, TokenUtils.CheckBotTokenValidity(token));
         }
+
+        [Theory]
+        // cannot pass a ulong? as a param in InlineData, so have to have a separate param
+        // indicating if a value is null
+        [InlineData("NDI4NDc3OTQ0MDA5MTk1NTIw", false, 428477944009195520)]
+        // should return null w/o throwing other exceptions
+        [InlineData("", true, 0)]
+        [InlineData(" ", true, 0)]
+        [InlineData(null, true, 0)]
+        [InlineData("these chars aren't allowed @U#)*@#!)*", true, 0)]
+        public void TestDecodeBase64UserId(string encodedUserId, bool isNull, ulong expectedUserId)
+        {
+            var result = TokenUtils.DecodeBase64UserId(encodedUserId);
+            if (isNull)
+                Assert.Null(result);
+            else
+                Assert.Equal(expectedUserId, result);
+        }
     }
 }

--- a/test/Discord.Net.Tests/Tests.TokenUtils.cs
+++ b/test/Discord.Net.Tests/Tests.TokenUtils.cs
@@ -76,9 +76,7 @@ namespace Discord
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKW")]
         // 59 char token
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
-        [InlineData("This appears to be completely invalid, however the current validation rules are not very strict.")]
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWss")]
-        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWsMTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
         public void TestBotTokenDoesNotThrowExceptions(string token)
         {
             // This example token is pulled from the Discord Docs
@@ -99,6 +97,9 @@ namespace Discord
         [InlineData("937it3ow87i4ery69876wqire")]
         // 57 char bot token
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kK")]
+        [InlineData("This is an invalid token, but it passes the check for string length.")]
+        // valid token, but passed in twice
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWsMTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]
         public void TestBotTokenInvalidThrowsArgumentException(string token)
         {
             Assert.Throws<ArgumentException>(() => TokenUtils.ValidateToken(TokenType.Bot, token));

--- a/test/Discord.Net.Tests/Tests.TokenUtils.cs
+++ b/test/Discord.Net.Tests/Tests.TokenUtils.cs
@@ -125,5 +125,25 @@ namespace Discord
             Assert.Throws<ArgumentException>(() =>
                 TokenUtils.ValidateToken((TokenType)type, "MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs"));
         }
+
+        /// <summary>
+        ///     Checks the <see cref="TokenUtils.CheckBotTokenValidity(string)"/> method for expected output.
+        /// </summary>
+        /// <param name="token"> The Bot Token to test.</param>
+        /// <param name="expected"> The expected result. </param>
+        [Theory]
+        // this method only checks the first part of the JWT
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4..", true)]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kK", true)]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4. this part is invalid. this part is also invalid", true)]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.", false)]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4", false)]
+        // should not throw an unexpected exception
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void TestCheckBotTokenValidity(string token, bool expected)
+        {
+            Assert.Equal(expected, TokenUtils.CheckBotTokenValidity(token));
+        }
     }
 }


### PR DESCRIPTION
Per feedback from @Emzi0767 received right before #1204 was merged, this PR improves the methods used to validate Bot Tokens.

In addition to checking that tokens satisfy a minimum length requirement, this method will also try to decode the user id from the first part of the Bot Token. Test cases have been updated as well.

Exception messages have been updated to include a hint to check if the supplied Bot Token is an OAuth client secret.