### PR TITLE
Fix #1213, Add GuildEmote Creator Property

### DIFF
--- a/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
@@ -34,7 +34,7 @@ namespace Discord
         ///     Gets the user Id that created this emoji.
         /// </summary>
         /// <returns>
-        ///     A User Id who created this emoji, which may be null.
+        ///     A user Id of the user who created this emoji, which may be null. A null value only indicates that the creator was not supplied as part of the API response.
         /// </returns>
         public ulong? CreatorId { get; }
 

--- a/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
@@ -30,12 +30,20 @@ namespace Discord
         ///     A read-only list containing snowflake identifiers for roles that are allowed to use this emoji.
         /// </returns>
         public IReadOnlyList<ulong> RoleIds { get; }
+        /// <summary>
+        ///     Gets the user Id that created this emoji.
+        /// </summary>
+        /// <returns>
+        ///     A User Id who created this emoji, which may be null.
+        /// </returns>
+        public ulong? CreatorId { get; }
 
-        internal GuildEmote(ulong id, string name, bool animated, bool isManaged, bool requireColons, IReadOnlyList<ulong> roleIds) : base(id, name, animated)
+        internal GuildEmote(ulong id, string name, bool animated, bool isManaged, bool requireColons, IReadOnlyList<ulong> roleIds, ulong? userId) : base(id, name, animated)
         {
             IsManaged = isManaged;
             RequireColons = requireColons;
             RoleIds = roleIds;
+            CreatorId = userId;
         }
 
         private string DebuggerDisplay => $"{Name} ({Id})";

--- a/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
@@ -31,19 +31,19 @@ namespace Discord
         /// </returns>
         public IReadOnlyList<ulong> RoleIds { get; }
         /// <summary>
-        ///     Gets the user Id that created this emoji.
+        ///     Gets the User that created this emoji.
         /// </summary>
         /// <returns>
-        ///     A user Id of the user who created this emoji, which may be null. A null value only indicates that the creator was not supplied as part of the API response.
-        /// </returns>
-        public ulong? CreatorId { get; }
+        ///     An optional <see cref="IUser"/> who created this emoji. An unspecified value only indicates that the creator was not supplied as part of the API response.
+        /// </returns>        
+        public Optional<IUser> Creator { get; }
 
-        internal GuildEmote(ulong id, string name, bool animated, bool isManaged, bool requireColons, IReadOnlyList<ulong> roleIds, ulong? userId) : base(id, name, animated)
+        internal GuildEmote(ulong id, string name, bool animated, bool isManaged, bool requireColons, IReadOnlyList<ulong> roleIds, Optional<IUser> creator) : base(id, name, animated)
         {
             IsManaged = isManaged;
             RequireColons = requireColons;
             RoleIds = roleIds;
-            CreatorId = userId;
+            Creator = creator;
         }
 
         private string DebuggerDisplay => $"{Name} ({Id})";

--- a/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
@@ -31,14 +31,15 @@ namespace Discord
         /// </returns>
         public IReadOnlyList<ulong> RoleIds { get; }
         /// <summary>
-        ///     Gets the User that created this emoji.
+        ///     Gets the cached User that created this emoji.
         /// </summary>
         /// <returns>
-        ///     An optional <see cref="IUser"/> who created this emoji. An unspecified value only indicates that the creator was not supplied as part of the API response.
+        ///     An optional <see cref="Cacheable{TEntity, TId}"/> <see cref="IUser"/> who created this emoji.
+        ///     An unspecified value only indicates that the creator was not supplied as part of the API response.
         /// </returns>        
-        public Optional<IUser> Creator { get; }
+        public Optional<Cacheable<IUser, ulong>> Creator { get; }
 
-        internal GuildEmote(ulong id, string name, bool animated, bool isManaged, bool requireColons, IReadOnlyList<ulong> roleIds, Optional<IUser> creator) : base(id, name, animated)
+        internal GuildEmote(ulong id, string name, bool animated, bool isManaged, bool requireColons, IReadOnlyList<ulong> roleIds, Optional<Cacheable<IUser, ulong>> creator) : base(id, name, animated)
         {
             IsManaged = isManaged;
             RequireColons = requireColons;

--- a/src/Discord.Net.Rest/API/Common/Emoji.cs
+++ b/src/Discord.Net.Rest/API/Common/Emoji.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -17,5 +17,7 @@ namespace Discord.API
         public bool RequireColons { get; set; }
         [JsonProperty("managed")]
         public bool Managed { get; set; }
+        [JsonProperty("user")]
+        public Optional<User> User { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -393,7 +393,7 @@ namespace Discord.Rest
         public static async Task<GuildEmote> GetEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options)
         {
             var emote = await client.ApiClient.GetGuildEmoteAsync(guild.Id, id, options).ConfigureAwait(false);
-            return emote.ToEntity();
+            return emote.ToEntity(guild);
         }
         public static async Task<GuildEmote> CreateEmoteAsync(IGuild guild, BaseDiscordClient client, string name, Image image, Optional<IEnumerable<IRole>> roles, 
             RequestOptions options)
@@ -407,7 +407,7 @@ namespace Discord.Rest
                 apiargs.RoleIds = roles.Value?.Select(xr => xr.Id).ToArray();
 
             var emote = await client.ApiClient.CreateGuildEmoteAsync(guild.Id, apiargs, options).ConfigureAwait(false);
-            return emote.ToEntity();
+            return emote.ToEntity(guild);
         }
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
         public static async Task<GuildEmote> ModifyEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, Action<EmoteProperties> func, 
@@ -426,7 +426,7 @@ namespace Discord.Rest
                 apiargs.RoleIds = props.Roles.Value?.Select(xr => xr.Id).ToArray();
 
             var emote = await client.ApiClient.ModifyGuildEmoteAsync(guild.Id, id, apiargs, options).ConfigureAwait(false);
-            return emote.ToEntity();
+            return emote.ToEntity(guild);
         }
         public static Task DeleteEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options) 
             => client.ApiClient.DeleteGuildEmoteAsync(guild.Id, id, options);

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -109,7 +109,7 @@ namespace Discord.Rest
             {
                 var emotes = ImmutableArray.CreateBuilder<GuildEmote>(model.Emojis.Length);
                 for (int i = 0; i < model.Emojis.Length; i++)
-                    emotes.Add(model.Emojis[i].ToEntity());
+                    emotes.Add(model.Emojis[i].ToEntity(this));
                 _emotes = emotes.ToImmutableArray();
             }
             else

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -5,9 +5,16 @@ namespace Discord.Rest
 {
     internal static class EntityExtensions
     {
-        public static GuildEmote ToEntity(this API.Emoji model)
+        public static GuildEmote ToEntity(this API.Emoji model, IGuild guild)
         {
-            return new GuildEmote(model.Id.Value, model.Name, model.Animated.GetValueOrDefault(), model.Managed, model.RequireColons, ImmutableArray.Create(model.Roles), model.User.IsSpecified ? model.User.Value.Id : (ulong?)null);
+            return new GuildEmote(model.Id.Value, model.Name, model.Animated.GetValueOrDefault(), model.Managed, model.RequireColons, ImmutableArray.Create(model.Roles), GetEmoteAuthor(model, guild));
+        }
+
+        internal static Optional<IUser> GetEmoteAuthor(API.Emoji model, IGuild guild)
+        {
+            if (!model.User.IsSpecified || guild == null)
+                return new Optional<IUser>();
+            return new Optional<IUser>(guild.GetUserAsync(model.User.Value.Id).Result);
         }
 
         public static Embed ToEntity(this API.Embed model)

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Discord.Rest
@@ -7,7 +7,7 @@ namespace Discord.Rest
     {
         public static GuildEmote ToEntity(this API.Emoji model)
         {
-            return new GuildEmote(model.Id.Value, model.Name, model.Animated.GetValueOrDefault(), model.Managed, model.RequireColons, ImmutableArray.Create(model.Roles));
+            return new GuildEmote(model.Id.Value, model.Name, model.Animated.GetValueOrDefault(), model.Managed, model.RequireColons, ImmutableArray.Create(model.Roles), model.User.IsSpecified ? model.User.Value.Id : (ulong?)null);
         }
 
         public static Embed ToEntity(this API.Embed model)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -359,7 +359,7 @@ namespace Discord.WebSocket
             {
                 var emojis = ImmutableArray.CreateBuilder<GuildEmote>(model.Emojis.Length);
                 for (int i = 0; i < model.Emojis.Length; i++)
-                    emojis.Add(model.Emojis[i].ToEntity());
+                    emojis.Add(model.Emojis[i].ToEntity(this));
                 _emotes = emojis.ToImmutable();
             }
             else
@@ -409,7 +409,7 @@ namespace Discord.WebSocket
         {
             var emotes = ImmutableArray.CreateBuilder<GuildEmote>(model.Emojis.Length);
             for (int i = 0; i < model.Emojis.Length; i++)
-                emotes.Add(model.Emojis[i].ToEntity());
+                emotes.Add(model.Emojis[i].ToEntity(this));
             _emotes = emotes.ToImmutable();
         }
 


### PR DESCRIPTION
Fix #1213 . 

Updates the API Model for Emoji to include a User, [from the API specifications](https://discordapp.com/developers/docs/resources/emoji#emoji-object).

Adds the Creator property to GuildEmote, which is optional. This property is not guaranteed to be set by the API whenever Emotes are used. For example, the Guild Create event does not supply the creators of emotes, but explicitly `GET`ting the Emote does.

```cs
private async Task Client_GuildAvailable(SocketGuild arg)
{
    foreach (var e in arg.Emotes)
    {
        // e is supplied as part of the Guild Create payload, Creator will typically **not** be supplied
        // <:lgtm:523410039948443649> by
        Console.WriteLine($"{e} by {e.Creator}");
        // when explicitly GETting the emote, the Creator is supplied
        var x = await arg.GetEmoteAsync(e.Id);
        // 01:14:05 Rest        GET guilds/428476681519497218/emojis/523410039948443649: 511.47 ms
        // <:lgtm:523410039948443649> by ChrisJ#8703
        var c = x.Creator.IsSpecified ? await x.Creator.Value.GetOrDownloadAsync() : null;
        Console.WriteLine($"{x} by {(object)c ?? "null"}");
    }
}
```

Because an IUser entity is used as part of this model and not a User Id, modifications to the `ToEntity` extension method were made, and all references of this method were updated.