### PR TITLE
Only escape the closing quotation mark of non-remainder strings

### DIFF
--- a/src/Discord.Net.Commands/CommandParser.cs
+++ b/src/Discord.Net.Commands/CommandParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
@@ -58,6 +58,15 @@ namespace Discord.Commands
                 {
                     if (curPos != endPos)
                     {
+                        // if this character matches the quotation mark of the end of the string
+                        // means that it should be escaped
+                        // but if is not, then there is no reason to escape it then
+                        if (c != matchQuote)
+                        {
+                            // if no reason to escape the next character, then re-add \ to the arg
+                            argBuilder.Append('\\');
+                        }
+
                         argBuilder.Append(c);
                         isEscaping = false;
                         continue;


### PR DESCRIPTION
Before this change, non-remainder string arguments like `@"test \n"` would escape the character `'n'`, even though there is no reason to.

For the purposes of the command parser, the only character that can be escaped is the closing quotation mark (typically `"`).

This change only removes the backslash character from the resulting argument if it matches the closing quotation mark. This change does not affect remainder parameters.

For example (code block for formatting):
```
@"`\\test`" now results in @"`\\test`", not @"`\test`"
@"test \n" results in @"test \n", not "test n"
```

Conversation when issue was discussed: https://discordapp.com/channels/81384788765712384/381889909113225237/529627275810045962