### PR TITLE
Fix the docs index page logo size

### DIFF
--- a/docs/_template/light-dark-theme/styles/master.css
+++ b/docs/_template/light-dark-theme/styles/master.css
@@ -39,6 +39,7 @@ img {
     width: 951pt;
     /* Height was arbitrarily determined */
     min-height: 100pt;
+    max-width: 90%;
 }
 
 article.content p{


### PR DESCRIPTION
Fixes the size of the logo on the index page of the documentation.
On mobile or small windows, this logo would be too large.

This adds a rule to the CSS for that logo that constrains it's size to not be larger than the element it's contained in.

This appears to look correct in the Firefox responsive display tool.

![image](https://user-images.githubusercontent.com/16418643/50573914-dd8dfd80-0d91-11e9-9996-082e1b2e0e08.png)

![image](https://user-images.githubusercontent.com/16418643/50573917-e54da200-0d91-11e9-95df-437d5d08f935.png)

Issue originally reported by @TheCasino https://discordapp.com/channels/81384788765712384/381889909113225237/529292210878021633
