### PR TITLE
Allow the user to define guild icon's format and size

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -56,10 +56,13 @@ namespace Discord
         /// <returns>
         ///     A URL pointing to the guild's icon in the specified size.
         /// </returns>
-        public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size, ImageFormat format)
+        public static string GetGuildIconUrl(ulong guildId, string iconId, ImageFormat format, ushort size)
         {
             if (string.IsNullOrWhiteSpace(iconId))
                 return null;
+            if (format == ImageFormat.Gif)
+                throw new ArgumentException("Requested image format mustn't be a gif.");
+
             string extension = FormatToExtension(format, iconId);
             return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";
         }

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -58,7 +58,7 @@ namespace Discord
         /// </returns>
         public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size, ImageFormat format)
         {
-            if (iconId == null)
+            if (string.IsNullOrWhiteSpace(iconId))
                 return null;
             string extension = FormatToExtension(format, iconId);
             return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -51,11 +51,18 @@ namespace Discord
         /// </summary>
         /// <param name="guildId">The guild snowflake identifier.</param>
         /// <param name="iconId">The icon identifier.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
+        /// <param name="format">The format to return.</param>
         /// <returns>
-        ///     A URL pointing to the guild's icon.
+        ///     A URL pointing to the guild's icon in the specified size.
         /// </returns>
-        public static string GetGuildIconUrl(ulong guildId, string iconId)
-            => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
+        public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size, ImageFormat format)
+        {
+            if (iconId == null)
+                return null;
+            string extension = FormatToExtension(format, iconId);
+            return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";
+        }
         /// <summary>
         ///     Returns a guild splash URL.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -72,7 +72,7 @@ namespace Discord
         /// <returns>
         ///     A URL pointing to the guild's icon; <c>null</c> if none is set.
         /// </returns>
-        string IconUrl { get; }
+        string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary>
         ///     Gets the ID of this guild's splash image.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IUserGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IUserGuild.cs
@@ -9,7 +9,7 @@ namespace Discord
         /// <summary>
         ///     Gets the icon URL associated with this guild, or <c>null</c> if one is not set.
         /// </summary>
-        string IconUrl { get; }
+        string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary>
         ///     Returns <c>true</c> if the current user owns this guild.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -59,7 +59,8 @@ namespace Discord.Rest
         [Obsolete("DefaultChannelId is deprecated, use GetDefaultChannelAsync")]
         public ulong DefaultChannelId => Id;
         /// <inheritdoc />
-        public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
+        public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetGuildIconUrl(Id, IconId, size, format);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
 

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -60,7 +60,7 @@ namespace Discord.Rest
         public ulong DefaultChannelId => Id;
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, IconId, size, format);
+            => CDN.GetGuildIconUrl(Id, IconId, format, size);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
 

--- a/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
@@ -20,7 +20,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
-        public string IconUrl => CDN.GetGuildIconUrl(Id, _iconId);
+        public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetGuildIconUrl(Id, IconId, size, format);
 
         internal RestUserGuild(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
@@ -21,7 +21,7 @@ namespace Discord.Rest
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, _iconId, size, format);
+            => CDN.GetGuildIconUrl(Id, _iconId, format, size);
 
         internal RestUserGuild(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
@@ -21,7 +21,7 @@ namespace Discord.Rest
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, IconId, size, format);
+            => CDN.GetGuildIconUrl(Id, _iconId, size, format);
 
         internal RestUserGuild(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -98,7 +98,7 @@ namespace Discord.WebSocket
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, IconId, size, format);
+            => CDN.GetGuildIconUrl(Id, IconId, format, size);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -97,7 +97,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
-        public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
+        public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetGuildIconUrl(Id, IconId, size, format);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>


### PR DESCRIPTION
The default ``IconUrl`` property returns the image in a jpg format with no ability to define the size. This PR is a simple change following ``IUser``'s ``GetAvatarUrl`` method, adding the ability to define both the format and the size.