### PR TITLE
CDN Rehaul

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -56,10 +56,13 @@ namespace Discord
         /// <returns>
         ///     A URL pointing to the guild's icon in the specified size.
         /// </returns>
-        public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size, ImageFormat format)
+        public static string GetGuildIconUrl(ulong guildId, string iconId, ImageFormat format, ushort size)
         {
             if (string.IsNullOrWhiteSpace(iconId))
                 return null;
+            if (format == ImageFormat.Gif)
+                throw new ArgumentException("Requested image format mustn't be a gif.");
+
             string extension = FormatToExtension(format, iconId);
             return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";
         }

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -12,26 +12,45 @@ namespace Discord
         /// </summary>
         /// <param name="appId">The application identifier.</param>
         /// <param name="iconId">The icon identifier.</param>
+        /// <param name="format">The format to return. Mustn't be a gif.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the application's icon.
         /// </returns>
-        public static string GetApplicationIconUrl(ulong appId, string iconId)
-            => iconId != null ? $"{DiscordConfig.CDNUrl}app-icons/{appId}/{iconId}.jpg" : null;
+        public static string GetApplicationIconUrl(ulong appId, string iconId, ImageFormat format, ushort size)
+        {
+            if (string.IsNullOrWhiteSpace(iconId))
+                return null;
+            if (format == ImageFormat.Gif)
+                throw new ArgumentException("Requested image format mustn't be a gif.");
+            if (!(size >= 16 && size <= 2048))
+                throw new ArgumentOutOfRangeException("Size must be a power of two in a range between 16 and 2048.");
+            if ((size & (size - 1)) != 0)
+                throw new ArgumentException("Size must be a power of two.");
+
+            string extension = FormatToExtension(format, iconId);
+            return $"{DiscordConfig.CDNUrl}app-icons/{appId}/{iconId}.{extension}?size={size}";
+        }
 
         /// <summary>
         ///     Returns a user avatar URL.
         /// </summary>
         /// <param name="userId">The user snowflake identifier.</param>
         /// <param name="avatarId">The avatar identifier.</param>
-        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <param name="format">The format to return.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the user's avatar in the specified size.
         /// </returns>
-        public static string GetUserAvatarUrl(ulong userId, string avatarId, ushort size, ImageFormat format)
+        public static string GetUserAvatarUrl(ulong userId, string avatarId, ImageFormat format, ushort size)
         {
-            if (avatarId == null)
+            if (string.IsNullOrWhiteSpace(avatarId))
                 return null;
+            if (!(size >= 16 && size <= 2048))
+                throw new ArgumentOutOfRangeException("Size must be a power of two in a range between 16 and 2048.");
+            if ((size & (size - 1)) != 0)
+                throw new ArgumentException("Size must be a power of two.");
+
             string extension = FormatToExtension(format, avatarId);
             return $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.{extension}?size={size}";
         }
@@ -51,8 +70,8 @@ namespace Discord
         /// </summary>
         /// <param name="guildId">The guild snowflake identifier.</param>
         /// <param name="iconId">The icon identifier.</param>
+        /// <param name="format">The format to return. Mustn't be a gif.</param>
         /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
-        /// <param name="format">The format to return.</param>
         /// <returns>
         ///     A URL pointing to the guild's icon in the specified size.
         /// </returns>
@@ -62,6 +81,10 @@ namespace Discord
                 return null;
             if (format == ImageFormat.Gif)
                 throw new ArgumentException("Requested image format mustn't be a gif.");
+            if (!(size >= 16 && size <= 2048))
+                throw new ArgumentOutOfRangeException("Size must be a power of two in a range between 16 and 2048.");
+            if ((size & (size - 1)) != 0)
+                throw new ArgumentException("Size must be a power of two.");
 
             string extension = FormatToExtension(format, iconId);
             return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";
@@ -71,44 +94,63 @@ namespace Discord
         /// </summary>
         /// <param name="guildId">The guild snowflake identifier.</param>
         /// <param name="splashId">The splash icon identifier.</param>
+        /// <param name="format">The format to return. Mustn't be a gif.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the guild's icon.
         /// </returns>
-        public static string GetGuildSplashUrl(ulong guildId, string splashId)
-            => splashId != null ? $"{DiscordConfig.CDNUrl}splashes/{guildId}/{splashId}.jpg" : null;
-        /// <summary>
-        ///     Returns a channel icon URL.
-        /// </summary>
-        /// <param name="channelId">The channel snowflake identifier.</param>
-        /// <param name="iconId">The icon identifier.</param>
-        /// <returns>
-        ///     A URL pointing to the channel's icon.
-        /// </returns>
-        public static string GetChannelIconUrl(ulong channelId, string iconId)
-            => iconId != null ? $"{DiscordConfig.CDNUrl}channel-icons/{channelId}/{iconId}.jpg" : null;
+        public static string GetGuildSplashUrl(ulong guildId, string splashId, ImageFormat format, ushort size)
+        {
+            if (string.IsNullOrWhiteSpace(splashId))
+                return null;
+            if (format == ImageFormat.Gif)
+                throw new ArgumentException("Requested image format mustn't be a gif.");
+            if (!(size >= 16 && size <= 2048))
+                throw new ArgumentOutOfRangeException("Size must be a power of two in a range between 16 and 2048.");
+            if ((size & (size - 1)) != 0)
+                throw new ArgumentException("Size must be a power of two.");
+
+            string extension = FormatToExtension(format, splashId);
+            return $"{DiscordConfig.CDNUrl}splashes/{guildId}/{splashId}.{ extension}?size={size}";
+        }
         /// <summary>
         ///     Returns an emoji URL.
         /// </summary>
         /// <param name="emojiId">The emoji snowflake identifier.</param>
         /// <param name="animated">Whether this emoji is animated.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the custom emote.
         /// </returns>
-        public static string GetEmojiUrl(ulong emojiId, bool animated)
-            => $"{DiscordConfig.CDNUrl}emojis/{emojiId}.{(animated ? "gif" : "png")}";
+        public static string GetEmojiUrl(ulong emojiId, bool animated, ushort size)
+        {
+            if (!(size >= 16 && size <= 2048))
+                throw new ArgumentOutOfRangeException("Size must be a power of two in a range between 16 and 2048.");
+            if ((size & (size - 1)) != 0)
+                throw new ArgumentException("Size must be a power of two.");
+
+            return $"{DiscordConfig.CDNUrl}emojis/{emojiId}.{(animated ? "gif" : "png")}?size={size}";
+        }
 
         /// <summary>
         ///     Returns a Rich Presence asset URL.
         /// </summary>
         /// <param name="appId">The application identifier.</param>
         /// <param name="assetId">The asset identifier.</param>
-        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <param name="format">The format to return.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the asset image in the specified size.
         /// </returns>
-        public static string GetRichAssetUrl(ulong appId, string assetId, ushort size, ImageFormat format)
+        public static string GetRichAssetUrl(ulong appId, string assetId, ImageFormat format, ushort size)
         {
+            if (string.IsNullOrWhiteSpace(assetId))
+                return null;
+            if (!(size >= 16 && size <= 2048))
+                throw new ArgumentOutOfRangeException("Size must be a power of two in a range between 16 and 2048.");
+            if ((size & (size - 1)) != 0)
+                throw new ArgumentException("Size must be a power of two.");
+
             string extension = FormatToExtension(format, "");
             return $"{DiscordConfig.CDNUrl}app-assets/{appId}/{assetId}.{extension}?size={size}";
         }

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -58,7 +58,7 @@ namespace Discord
         /// </returns>
         public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size, ImageFormat format)
         {
-            if (iconId == null)
+            if (string.IsNullOrWhiteSpace(iconId))
                 return null;
             string extension = FormatToExtension(format, iconId);
             return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -51,11 +51,18 @@ namespace Discord
         /// </summary>
         /// <param name="guildId">The guild snowflake identifier.</param>
         /// <param name="iconId">The icon identifier.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
+        /// <param name="format">The format to return.</param>
         /// <returns>
-        ///     A URL pointing to the guild's icon.
+        ///     A URL pointing to the guild's icon in the specified size.
         /// </returns>
-        public static string GetGuildIconUrl(ulong guildId, string iconId)
-            => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
+        public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size, ImageFormat format)
+        {
+            if (iconId == null)
+                return null;
+            string extension = FormatToExtension(format, iconId);
+            return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";
+        }
         /// <summary>
         ///     Returns a guild splash URL.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Activities/GameAsset.cs
+++ b/src/Discord.Net.Core/Entities/Activities/GameAsset.cs
@@ -33,6 +33,6 @@ namespace Discord
         ///     A string pointing to the image URL of the asset; <c>null</c> when the application ID does not exist.
         /// </returns>
         public string GetImageUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => ApplicationId.HasValue ? CDN.GetRichAssetUrl(ApplicationId.Value, ImageId, size, format) : null;
+            => ApplicationId.HasValue ? CDN.GetRichAssetUrl(ApplicationId.Value, ImageId, format, size) : null;
     }
 }

--- a/src/Discord.Net.Core/Entities/Emotes/Emote.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/Emote.cs
@@ -26,10 +26,11 @@ namespace Discord
         /// <summary>
         ///     Gets the image URL of this emote.
         /// </summary>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A string that points to the URL of this emote.
         /// </returns>
-        public string Url => CDN.GetEmojiUrl(Id, Animated);
+        public string GetUrl(ushort size = 128) => CDN.GetEmojiUrl(Id, Animated, size);
 
         internal Emote(ulong id, string name, bool animated)
         {

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -72,7 +72,7 @@ namespace Discord
         /// <returns>
         ///     A URL pointing to the guild's icon; <c>null</c> if none is set.
         /// </returns>
-        string IconUrl { get; }
+        string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary>
         ///     Gets the ID of this guild's splash image.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -69,6 +69,8 @@ namespace Discord
         /// <summary>
         ///     Gets the URL of this guild's icon.
         /// </summary>
+        /// <param name="format">The format to return. Mustn't be a gif.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the guild's icon; <c>null</c> if none is set.
         /// </returns>
@@ -83,10 +85,12 @@ namespace Discord
         /// <summary>
         ///     Gets the URL of this guild's splash image.
         /// </summary>
+        /// <param name="format">The format to return. Mustn't be a gif.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the guild's splash image; <c>null</c> if none is set.
         /// </returns>
-        string SplashUrl { get; }
+        string GetSplashUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary>
         ///     Determines if this guild is currently connected and ready to be used.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IUserGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IUserGuild.cs
@@ -9,7 +9,7 @@ namespace Discord
         /// <summary>
         ///     Gets the icon URL associated with this guild, or <c>null</c> if one is not set.
         /// </summary>
-        string IconUrl { get; }
+        string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary>
         ///     Returns <c>true</c> if the current user owns this guild.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/IApplication.cs
@@ -21,7 +21,9 @@ namespace Discord
         /// <summary>
         ///     Gets the icon URL of the application.
         /// </summary>
-        string IconUrl  { get; }
+        /// <param name="format">The format to return. Mustn't be a gif.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
+        string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
 
         /// <summary>
         ///     Gets the partial user object containing info on the owner of the application.

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -59,7 +59,8 @@ namespace Discord.Rest
         [Obsolete("DefaultChannelId is deprecated, use GetDefaultChannelAsync")]
         public ulong DefaultChannelId => Id;
         /// <inheritdoc />
-        public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
+        public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetGuildIconUrl(Id, IconId, size, format);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
 

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -62,7 +62,8 @@ namespace Discord.Rest
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetGuildIconUrl(Id, IconId, format, size);
         /// <inheritdoc />
-        public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
+        public string GetSplashUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetGuildSplashUrl(Id, SplashId, format, size);
 
         /// <summary>
         ///     Gets the built-in role containing all users in this guild.

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -60,7 +60,7 @@ namespace Discord.Rest
         public ulong DefaultChannelId => Id;
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, IconId, size, format);
+            => CDN.GetGuildIconUrl(Id, IconId, format, size);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
 

--- a/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
@@ -20,7 +20,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
-        public string IconUrl => CDN.GetGuildIconUrl(Id, _iconId);
+        public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetGuildIconUrl(Id, IconId, size, format);
 
         internal RestUserGuild(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
@@ -21,7 +21,7 @@ namespace Discord.Rest
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, _iconId, size, format);
+            => CDN.GetGuildIconUrl(Id, _iconId, format, size);
 
         internal RestUserGuild(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestUserGuild.cs
@@ -21,7 +21,7 @@ namespace Discord.Rest
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, IconId, size, format);
+            => CDN.GetGuildIconUrl(Id, _iconId, size, format);
 
         internal RestUserGuild(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rest/Entities/RestApplication.cs
+++ b/src/Discord.Net.Rest/Entities/RestApplication.cs
@@ -28,7 +28,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
-        public string IconUrl => CDN.GetApplicationIconUrl(Id, _iconId);
+        public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetApplicationIconUrl(Id, _iconId, format, size);
 
         internal RestApplication(BaseDiscordClient discord, ulong id)
             : base(discord, id)

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -80,7 +80,7 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+            => CDN.GetUserAvatarUrl(Id, AvatarId, format, size);
 
         /// <inheritdoc />
         public string GetDefaultAvatarUrl()

--- a/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
+++ b/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
@@ -75,7 +75,7 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-           => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+           => CDN.GetUserAvatarUrl(Id, AvatarId, format, size);
 
         public async Task ModifyAsync(Action<WebhookProperties> func, RequestOptions options = null)
         {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -98,7 +98,7 @@ namespace Discord.WebSocket
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetGuildIconUrl(Id, IconId, size, format);
+            => CDN.GetGuildIconUrl(Id, IconId, format, size);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -97,7 +97,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
-        public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
+        public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+            => CDN.GetGuildIconUrl(Id, IconId, size, format);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -100,7 +100,8 @@ namespace Discord.WebSocket
         public string GetIconUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetGuildIconUrl(Id, IconId, format, size);
         /// <inheritdoc />
-        public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
+        public string GetSplashUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128) =>
+            CDN.GetGuildSplashUrl(Id, SplashId, format, size);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>
         public bool HasAllMembers => MemberCount == DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
         /// <summary> Indicates whether the guild cache is synced to this guild. </summary>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -84,7 +84,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-            => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+            => CDN.GetUserAvatarUrl(Id, AvatarId, format, size);
 
         /// <inheritdoc />
         public string GetDefaultAvatarUrl()

--- a/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
+++ b/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Model = Discord.API.Webhook;
@@ -45,7 +45,7 @@ namespace Discord.Webhook
         }
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
-           => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
+           => CDN.GetUserAvatarUrl(Id, AvatarId, format, size);
 
         public async Task ModifyAsync(Action<WebhookProperties> func, RequestOptions options = null)
         {

--- a/test/Discord.Net.Tests/Tests.Emotes.cs
+++ b/test/Discord.Net.Tests/Tests.Emotes.cs
@@ -14,7 +14,7 @@ namespace Discord
             Assert.Equal(394207658351263745UL, emote.Id);
             Assert.False(emote.Animated);
             Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1514056829775), emote.CreatedAt);
-            Assert.EndsWith("png", emote.Url);
+            Assert.EndsWith("png", emote.GetUrl());
         }
         [Fact]
         public void Test_Invalid_Emote_Parse()
@@ -32,7 +32,7 @@ namespace Discord
             Assert.Equal(394207658351263745UL, emote.Id);
             Assert.True(emote.Animated);
             Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1514056829775), emote.CreatedAt);
-            Assert.EndsWith("gif", emote.Url);
+            Assert.EndsWith("gif", emote.GetUrl());
         }
         [Fact]
         public void Test_Invalid_Amimated_Emote_Parse()


### PR DESCRIPTION
This PR rehauls the CDN class. Contains changes from #1231 
Current changes:

 - All CDN methods have been updated to take a format and a size argument for endpoints which allow to  do so.
 - Methods for endpoints which do not support a certain format now throw an ``ArgumentException``  (tested).
 - Every method that takes a size argument now enforces a range between 16 and 2048 and for it to be a power of 2.
 - Arguments have been changed from ``uint, ImageFormat`` to ``ImageFormat, uint`` for fluid consistency.
 - Every entity using a method from the CDN is now prefixed with ``Get`` and takes an ``ImageFormat`` and ``uint`` to suit CDN's changes.

Note: The build may be breaking due to versioning, I have no effect on it.