### PR TITLE
Change NuGet build version suffix for non-tagged commits

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ after_build:
       if ($Env:APPVEYOR_REPO_TAG -eq "true") {
         nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
       } else {
-        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-build$Env:BUILD"
+        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-build-$Env:BUILD"
       }
     }
 - ps: if ($isWindows) { Get-ChildItem artifacts/*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ after_build:
       if ($Env:APPVEYOR_REPO_TAG -eq "true") {
         nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
       } else {
-        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-$Env:BUILD"
+        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-pr$Env:BUILD"
       }
     }
 - ps: if ($isWindows) { Get-ChildItem artifacts/*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ after_build:
       if ($Env:APPVEYOR_REPO_TAG -eq "true") {
         nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
       } else {
-        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-pr$Env:BUILD"
+        nuget pack src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-build$Env:BUILD"
       }
     }
 - ps: if ($isWindows) { Get-ChildItem artifacts/*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name } }


### PR DESCRIPTION
This issue can be seen affecting #1234 , as the build is currently breaking (only on Windows, where it attempts to publish artifacts).
`nuget : '2.0.1-01059' is not a valid version string.`
https://ci.appveyor.com/project/RogueException/discord-net/builds/21502549/job/sb6a85pfe16xr0xf#L264

This PR changes the build suffix to start with `-build`, instead of only `-`. It seems to have fixed things in my testing. This only affects non-tagged commits.

From what I've seen [this appears to be in-line with semantic versioning patterns.](https://semver.org/#spec-item-10)

Per the docs:
https://docs.microsoft.com/en-us/nuget/tools/cli-ref-pack
`Suffixes must start with a letter to avoid warnings, errors, and potential incompatibilities with different versions of NuGet and the NuGet Package Manager.`