### PR TITLE
Implement messages bulk deleted event (from previous PR #1120)

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -110,9 +110,12 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>>();
         /// <summary> Fired when multiple messages are bulk deleted. </summary>
         /// <remarks>
+        ///     <note>
+        ///         The <see cref="MessageDeleted"/> event will not be fired for individual messages contained in this event.
+        ///     </note>
         ///     <para>
         ///         This event is fired when multiple messages are bulk deleted. The event handler must return a
-        ///         <see cref="Task"/> and accept a <see cref="IReadOnlyCollection{Cacheable{TEntity,TId}}"/> and 
+        ///         <see cref="Task"/> and accept an <see cref="IReadOnlyCollection{Cacheable{TEntity,TId}}"/> and 
         ///         <see cref="ISocketMessageChannel"/> as its parameters.
         ///     </para>
         ///     <para>

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Discord.WebSocket
@@ -107,6 +108,35 @@ namespace Discord.WebSocket
             remove { _messageDeletedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>>();
+        /// <summary> Fired when multiple messages are bulk deleted. </summary>
+        /// <remarks>
+        ///     <para>
+        ///         This event is fired when multiple messages are bulk deleted. The event handler must return a
+        ///         <see cref="Task"/> and accept a <see cref="IReadOnlyCollection{Cacheable{TEntity,TId}}"/> and 
+        ///         <see cref="ISocketMessageChannel"/> as its parameters.
+        ///     </para>
+        ///     <para>
+        ///         <note type="important">
+        ///             It is not possible to retrieve the message via
+        ///             <see cref="Cacheable{TEntity,TId}.DownloadAsync"/>; the message cannot be retrieved by Discord
+        ///             after the message has been deleted.
+        ///         </note>
+        ///         If caching is enabled via <see cref="DiscordSocketConfig"/>, the
+        ///         <see cref="Cacheable{TEntity,TId}"/> entity will contain the deleted message; otherwise, in event
+        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the 
+        ///         <see cref="ulong"/>.
+        ///     </para>
+        ///     <para>
+        ///         The source channel of the removed message will be passed into the 
+        ///         <see cref="ISocketMessageChannel"/> parameter.
+        ///     </para>
+        /// </remarks>
+        public event Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, ISocketMessageChannel, Task> MessagesBulkDeleted
+        {
+            add { _messagesBulkDeletedEvent.Add(value); }
+            remove { _messagesBulkDeletedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, ISocketMessageChannel, Task>> _messagesBulkDeletedEvent = new AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, ISocketMessageChannel, Task>>();
         /// <summary> Fired when a message is updated. </summary>
         /// <remarks>
         ///     <para>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -302,6 +302,7 @@ namespace Discord.WebSocket
 
             client.MessageReceived += (msg) => _messageReceivedEvent.InvokeAsync(msg);
             client.MessageDeleted += (cache, channel) => _messageDeletedEvent.InvokeAsync(cache, channel);
+            client.MessagesBulkDeleted += (cache, channel) => _messagesBulkDeletedEvent.InvokeAsync(cache, channel);
             client.MessageUpdated += (oldMsg, newMsg, channel) => _messageUpdatedEvent.InvokeAsync(oldMsg, newMsg, channel);
             client.ReactionAdded += (cache, channel, reaction) => _reactionAddedEvent.InvokeAsync(cache, channel, reaction);
             client.ReactionRemoved += (cache, channel, reaction) => _reactionRemovedEvent.InvokeAsync(cache, channel, reaction);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -66,6 +66,7 @@ namespace Discord.WebSocket
         internal WebSocketProvider WebSocketProvider { get; private set; }
         internal bool AlwaysDownloadUsers { get; private set; }
         internal int? HandlerTimeout { get; private set; }
+        internal bool UseMessagesBulkDeletedOnly { get; private set; }
 
         internal new DiscordSocketApiClient ApiClient => base.ApiClient as DiscordSocketApiClient;
         /// <inheritdoc />
@@ -128,6 +129,7 @@ namespace Discord.WebSocket
             WebSocketProvider = config.WebSocketProvider;
             AlwaysDownloadUsers = config.AlwaysDownloadUsers;
             HandlerTimeout = config.HandlerTimeout;
+            UseMessagesBulkDeletedOnly = config.UseMessagesBulkDeletedOnly;
             State = new ClientState(0, 0);
             Rest = new DiscordSocketRestClient(config, ApiClient);
             _heartbeatTimes = new ConcurrentQueue<long>();
@@ -1366,7 +1368,11 @@ namespace Discord.WebSocket
                                         {
                                             var msg = SocketChannelHelper.RemoveMessage(channel, this, id);
                                             bool isCached = msg != null;
-                                            cacheableList = cacheableList.Add(new Cacheable<IMessage, ulong>(msg, id, isCached, async () => await channel.GetMessageAsync(id).ConfigureAwait(false)));
+                                            var cacheable = new Cacheable<IMessage, ulong>(msg, id, isCached, async () => await channel.GetMessageAsync(id).ConfigureAwait(false));
+                                            cacheableList = cacheableList.Add(cacheable);
+
+                                            if (!UseMessagesBulkDeletedOnly)
+                                                await TimedInvokeAsync(_messageDeletedEvent, nameof(MessageDeleted), cacheable, channel).ConfigureAwait(false);
                                         }
 
                                         await TimedInvokeAsync(_messagesBulkDeletedEvent, nameof(MessagesBulkDeleted), cacheableList, channel).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1361,13 +1361,15 @@ namespace Discord.WebSocket
                                             return;
                                         }
 
+                                        var cacheableList = ImmutableArray<Cacheable<IMessage, ulong>>.Empty;
                                         foreach (ulong id in data.Ids)
                                         {
                                             var msg = SocketChannelHelper.RemoveMessage(channel, this, id);
                                             bool isCached = msg != null;
-                                            var cacheable = new Cacheable<IMessage, ulong>(msg, id, isCached, async () => await channel.GetMessageAsync(id).ConfigureAwait(false));
-                                            await TimedInvokeAsync(_messageDeletedEvent, nameof(MessageDeleted), cacheable, channel).ConfigureAwait(false);
+                                            cacheableList = cacheableList.Add(new Cacheable<IMessage, ulong>(msg, id, isCached, async () => await channel.GetMessageAsync(id).ConfigureAwait(false)));
                                         }
+
+                                        await TimedInvokeAsync(_messagesBulkDeletedEvent, nameof(MessagesBulkDeleted), cacheableList, channel).ConfigureAwait(false);
                                     }
                                     else
                                     {

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -105,6 +105,11 @@ namespace Discord.WebSocket
         public int? HandlerTimeout { get; set; } = 3000;
 
         /// <summary>
+        ///     Gets or sets whether or not <see cref="Discord.WebSocket.BaseSocketClient.MessageDeleted"/> is fired for each message on bulk delete.
+        /// </summary>
+        public bool UseMessagesBulkDeletedOnly { get; set; } = false;
+
+        /// <summary>
         ///     Initializes a default configuration.
         /// </summary>
         public DiscordSocketConfig()


### PR DESCRIPTION
## About
This re-implemented MessagesBulkDeleted event from an old PR that was closed by the author and forgotten about.

I give credit to the original author of the code in #1120 as I referenced them to rewrite it in.

This event would tremendously help with logging bots so as to possibly ignore bulk deletes as they get quite spammy or to perform a different action, though this isn't limited to that scope and is just useful to know that a set of messages were bulk deleted.

## Changes
- A new BaseSocketClient#MessagesBulkDeleted event
- MESSAGE_DELETE_BULK gateway event no longer fires individual BaseSocketClient#MessageDeleted events