### PR TITLE
Add AddGuildUserAsync guild ID extension method.

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -294,6 +294,34 @@ namespace Discord.Rest
 
             return model is null ? null : RestGuildUser.Create(client, guild, model);
         }
+
+        public static async Task AddGuildUserAsync(ulong guildId, BaseDiscordClient client, ulong userId, string accessToken,
+            Action<AddGuildUserProperties> func, RequestOptions options)
+        {
+            var args = new AddGuildUserProperties();
+            func?.Invoke(args);
+
+            if (args.Roles.IsSpecified)
+            {
+                var ids = args.Roles.Value.Select(r => r.Id);
+
+                if (args.RoleIds.IsSpecified)
+                    args.RoleIds.Value.Concat(ids);
+                else
+                    args.RoleIds = Optional.Create(ids);
+            }
+            var apiArgs = new AddGuildMemberParams
+            {
+                AccessToken = accessToken,
+                Nickname = args.Nickname,
+                IsDeafened = args.Deaf,
+                IsMuted = args.Mute,
+                RoleIds = args.RoleIds.IsSpecified ? args.RoleIds.Value.Distinct().ToArray() : Optional.Create<ulong[]>()
+            };
+
+            await client.ApiClient.AddGuildMemberAsync(guildId, userId, apiArgs, options);
+        }
+
         public static async Task<RestGuildUser> GetUserAsync(IGuild guild, BaseDiscordClient client,
             ulong id, RequestOptions options)
         {

--- a/src/Discord.Net.Rest/Extensions/ClientExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/ClientExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.Extensions
+{
+    public static class ClientExtensions
+    {
+        /// <summary>
+        ///     Adds a user to the specified guild.
+        /// </summary>
+        /// <remarks>
+        ///     This method requires you have an OAuth2 access token for the user, requested with the guilds.join scope, and that the bot have the MANAGE_INVITES permission in the guild.
+        /// </remarks>
+        /// <param name="client">The Discord client object.</param>
+        /// <param name="guildId">The snowflake identifier of the guild.</param>
+        /// <param name="userId">The snowflake identifier of the user.</param>
+        /// <param name="accessToken">The OAuth2 access token for the user, requested with the guilds.join scope.</param>
+        /// <param name="func">The delegate containing the properties to be applied to the user upon being added to the guild.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        public static Task AddGuildUserAsync(this BaseDiscordClient client, ulong guildId, ulong userId, string accessToken, Action<AddGuildUserProperties> func = null, RequestOptions options = null)
+            => GuildHelper.AddGuildUserAsync(guildId, client, userId, accessToken, func, options);
+    }
+}


### PR DESCRIPTION
Ext. method forgoes returning a guild user as a full guild object won't available to create a RestGuildUser for.