### PR TITLE
Fix DM permissions: AddReactions is missing.

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -17,7 +17,7 @@ namespace Discord
         /// <summary> Gets a <see cref="ChannelPermissions"/> that grants all permissions for category channels. </summary>
         public static readonly ChannelPermissions Category = new ChannelPermissions(0b01100_1111110_1111111110001_010001);
         /// <summary> Gets a <see cref="ChannelPermissions"/> that grants all permissions for direct message channels. </summary>
-        public static readonly ChannelPermissions DM = new ChannelPermissions(0b00000_1000110_1011100110000_000000);
+        public static readonly ChannelPermissions DM = new ChannelPermissions(0b00000_1000110_1011100110001_000000);
         /// <summary> Gets a <see cref="ChannelPermissions"/> that grants all permissions for group channels. </summary>
         public static readonly ChannelPermissions Group = new ChannelPermissions(0b00000_1000110_0001101100000_000000);
         /// <summary> Gets a <see cref="ChannelPermissions"/> that grants all permissions for a given channel type. </summary>


### PR DESCRIPTION
AddReactions is missing from the library's DM permissions. I noticed this months ago and brought it up in the Discord API channel, but I thought it was so obvious that someone else would PR it. I'm sorry about the bystander effect.

This aligns with the actual behavior in Discord DM channels.

Changes:
-Switched one bit from 0 to 1 (0x40)