### PR TITLE
Implement Client Status Support

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/ClientType.cs
+++ b/src/Discord.Net.Core/Entities/Users/ClientType.cs
@@ -1,0 +1,21 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Defines the types of clients a user can be active on.
+    /// </summary>
+    public enum ClientType
+    {
+        /// <summary>
+        ///     The user is active using the mobile application.
+        /// </summary>
+        Mobile,
+        /// <summary>
+        ///     The user is active using the desktop application.
+        /// </summary>
+        Desktop,
+        /// <summary>
+        ///     The user is active using the web application.
+        /// </summary>
+        Web
+    }
+}

--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -18,7 +18,6 @@ namespace Discord
         /// <summary>
         ///     Gets the set of clients where this user is currently active.
         /// </summary>
-        // TODO: Un-comment ActiveClients definition in IPresence for next breaking update
-        // IImmutableSet<ClientType> ActiveClients { get; }
+        IImmutableSet<ClientType> ActiveClients { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -1,3 +1,6 @@
+
+using System.Collections.Immutable;
+
 namespace Discord
 {
     /// <summary>
@@ -13,5 +16,9 @@ namespace Discord
         ///     Gets the current status of this user.
         /// </summary>
         UserStatus Status { get; }
+        /// <summary>
+        ///     Gets the set of clients where this user is currently active.
+        /// </summary>
+        IImmutableSet<ClientType> ActiveClients { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -18,6 +18,7 @@ namespace Discord
         /// <summary>
         ///     Gets the set of clients where this user is currently active.
         /// </summary>
-        IImmutableSet<ClientType> ActiveClients { get; }
+        // TODO: Un-comment ActiveClients definition in IPresence for 2.1.x breaking update
+        // IImmutableSet<ClientType> ActiveClients { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -18,7 +18,7 @@ namespace Discord
         /// <summary>
         ///     Gets the set of clients where this user is currently active.
         /// </summary>
-        // TODO: Un-comment ActiveClients definition in IPresence for 2.1.x breaking update
+        // TODO: Un-comment ActiveClients definition in IPresence for next breaking update
         // IImmutableSet<ClientType> ActiveClients { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -1,4 +1,3 @@
-
 using System.Collections.Immutable;
 
 namespace Discord

--- a/src/Discord.Net.Rest/API/Common/Presence.cs
+++ b/src/Discord.Net.Rest/API/Common/Presence.cs
@@ -19,6 +19,11 @@ namespace Discord.API
         public Optional<ulong[]> Roles { get; set; }
         [JsonProperty("nick")]
         public Optional<string> Nick { get; set; }
+        // This property is a Dictionary where each key is the ClientType
+        // and the values are the current client status.
+        // The client status values are all the same.
+        // Example:
+        //   "client_status": { "desktop": "dnd", "mobile": "dnd" }
         [JsonProperty("client_status")]
         public Optional<Dictionary<string, string>> ClientStatus { get; set; }
     }

--- a/src/Discord.Net.Rest/API/Common/Presence.cs
+++ b/src/Discord.Net.Rest/API/Common/Presence.cs
@@ -1,5 +1,6 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Discord.API
 {
@@ -18,5 +19,7 @@ namespace Discord.API
         public Optional<ulong[]> Roles { get; set; }
         [JsonProperty("nick")]
         public Optional<string> Nick { get; set; }
+        [JsonProperty("client_status")]
+        public Optional<Dictionary<string, string>> ClientStatus { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Model = Discord.API.User;
@@ -30,6 +31,8 @@ namespace Discord.Rest
         public virtual IActivity Activity => null;
         /// <inheritdoc />
         public virtual UserStatus Status => UserStatus.Offline;
+        /// <inheritdoc />
+        public virtual IImmutableSet<ClientType> ActiveClients => ImmutableHashSet<ClientType>.Empty;
         /// <inheritdoc />
         public virtual bool IsWebhook => false;
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -319,7 +319,7 @@ namespace Discord.WebSocket
             {
                 var user = SocketGlobalUser.Create(this, state, model);
                 user.GlobalUser.AddRef();
-                user.Presence = new SocketPresence(UserStatus.Online, null);
+                user.Presence = new SocketPresence(UserStatus.Online, null, null);
                 return user;
             });
         }
@@ -427,7 +427,7 @@ namespace Discord.WebSocket
                 return;
             var status = Status;
             var statusSince = _statusSince;
-            CurrentUser.Presence = new SocketPresence(status, Activity);
+            CurrentUser.Presence = new SocketPresence(status, Activity, null);
 
             var gameModel = new GameModel();
             // Discord only accepts rich presence over RPC, don't even bother building a payload

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketPresence.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketPresence.cs
@@ -47,8 +47,7 @@ namespace Discord.WebSocket
             var set = new HashSet<ClientType>();
             foreach (var key in clientTypesDict.Keys)
             {
-                ClientType type;
-                if (Enum.TryParse(key, true, out type))
+                if (Enum.TryParse(key, true, out ClientType type))
                     set.Add(type);
                 // quietly discard ClientTypes that do not match
             }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketPresence.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketPresence.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Model = Discord.API.Presence;
 
@@ -13,15 +16,43 @@ namespace Discord.WebSocket
         public UserStatus Status { get; }
         /// <inheritdoc />
         public IActivity Activity { get; }
-
-        internal SocketPresence(UserStatus status, IActivity activity)
+        /// <inheritdoc />
+        public IImmutableSet<ClientType> ActiveClients { get; }
+        internal SocketPresence(UserStatus status, IActivity activity, IImmutableSet<ClientType> activeClients)
         {
             Status = status;
             Activity= activity;
+            ActiveClients = activeClients;
         }
         internal static SocketPresence Create(Model model)
         {
-            return new SocketPresence(model.Status, model.Game?.ToEntity());
+            var clients = ConvertClientTypesDict(model.ClientStatus.GetValueOrDefault());
+            return new SocketPresence(model.Status, model.Game?.ToEntity(), clients);
+        }
+        /// <summary>
+        ///     Creates a new <see cref="IReadOnlyCollection{T}"/> containing all of the client types
+        ///     where a user is active from the data supplied in the Presence update frame.
+        /// </summary>
+        /// <param name="clientTypesDict">
+        ///     A dictionary keyed by the <see cref="ClientType"/>
+        ///     and where the value is the <see cref="UserStatus"/>.
+        /// </param>
+        /// <returns>
+        ///     A collection of all <see cref="ClientType"/>s that this user is active.
+        /// </returns>
+        private static IImmutableSet<ClientType> ConvertClientTypesDict(IDictionary<string, string> clientTypesDict)
+        {
+            if (clientTypesDict == null || clientTypesDict.Count == 0)
+                return ImmutableHashSet<ClientType>.Empty;
+            var set = new HashSet<ClientType>();
+            foreach (var key in clientTypesDict.Keys)
+            {
+                ClientType type;
+                if (Enum.TryParse(key, true, out type))
+                    set.Add(type);
+                // quietly discard ClientTypes that do not match
+            }
+            return set.ToImmutableHashSet();
         }
 
         /// <summary>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
@@ -24,8 +24,8 @@ namespace Discord.WebSocket
         
         /// <inheritdoc />
         public override bool IsWebhook => false;
-
-        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null); } set { } }
+        /// <inheritdoc />
+        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null, null); } set { } }
         /// <inheritdoc />
         /// <exception cref="NotSupportedException">This field is not supported for an unknown user.</exception>
         internal override SocketGlobalUser GlobalUser =>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -38,6 +38,8 @@ namespace Discord.WebSocket
         public IActivity Activity => Presence.Activity;
         /// <inheritdoc />
         public UserStatus Status => Presence.Status;
+        /// <inheritdoc />
+        public IImmutableSet<ClientType> ActiveClients => Presence.ActiveClients;
         /// <summary>
         ///     Gets mutual guilds shared with this user.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -29,8 +29,8 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public override bool IsWebhook => true;
-
-        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null); } set { } }
+        /// <inheritdoc />
+        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null, null); } set { } }
         internal override SocketGlobalUser GlobalUser => 
             throw new NotSupportedException();
 


### PR DESCRIPTION
Adds support for using the client_status as sent as part of the Presence model. This value can be used to determine if a user is active on the native desktop app, the mobile app, or the website.

From my testing, I only found that this value was supplied over sockets, and not REST. The API sends a dictionary that contains a set of clients and the status on each of them. Given that you cannot have a unique status per device, these values are all the same. I'm speculating that maybe this was done because you cannot really have a Set in JSON (otherwise it'd be an array).

```json
"client_status": { "desktop": "dnd", "mobile": "dnd" }
```

Given that there's already a `Status` property, I ignore the value for each of these keys (assumed to all be the same) and expose an `IImmutableSet<ClientType>`.