### PR TITLE
v3-review: core emote implementation

### DIFF
--- a/src/Discord.Net/Discord.Net.csproj
+++ b/src/Discord.Net/Discord.Net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Discord.Net/Entities/Emotes/IEmote.cs
+++ b/src/Discord.Net/Entities/Emotes/IEmote.cs
@@ -1,7 +1,19 @@
 namespace Discord
 {
-    public interface IEmote : IMentionable // TODO: Is `Mention` the correct verbage here?
+    /// <summary>
+    ///     An emote which may be used as a reaction or embedded in chat.
+    ///
+    ///     This includes Unicode emoji as well as unattached guild emotes.
+    /// </summary>
+    public interface IEmote : ITaggable
     {
+        /// <summary>
+        ///     The display-name of the emote.
+        /// </summary>
+        /// <remarks>
+        ///     For Unicode emoji, this is the raw value of the character, not its
+        ///     Unicode display name.
+        /// </remarks>
         string Name { get; }
     }
 }

--- a/src/Discord.Net/Entities/Emotes/IEmote.cs
+++ b/src/Discord.Net/Entities/Emotes/IEmote.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Discord
 {
-    public interface IEmote
+    public interface IEmote : IMentionable // TODO: Is `Mention` the correct verbage here?
     {
         string Name { get; }
     }

--- a/src/Discord.Net/Entities/Emotes/IGuildEmote.cs
+++ b/src/Discord.Net/Entities/Emotes/IGuildEmote.cs
@@ -3,13 +3,17 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
+    /// <summary>
+    ///     An emote attached to a guild. This differs from an <see cref="IEmote"/> in that it contains
+    ///     information relevant to the source guild.
+    /// </summary>
     public interface IGuildEmote : IEmote, ISnowflakeEntity, IDeletable
     {
         /// <summary>
         ///     Gets whether this emoji is managed by an integration.
         /// </summary>
         /// <returns>
-        ///     A boolean that determines whether or not this emote is managed by a Twitch integration.
+        ///     A boolean that determines whether or not this emote is managed by an external integration, such as Twitch.
         /// </returns>
         bool IsManaged { get; }
         /// <summary>

--- a/src/Discord.Net/Entities/Emotes/IGuildEmote.cs
+++ b/src/Discord.Net/Entities/Emotes/IGuildEmote.cs
@@ -1,7 +1,44 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Discord
 {
-    public interface IGuildEmote : IEmote
+    public interface IGuildEmote : IEmote, ISnowflakeEntity, IDeletable
     {
-        // TODO
+        /// <summary>
+        ///     Gets whether this emoji is managed by an integration.
+        /// </summary>
+        /// <returns>
+        ///     A boolean that determines whether or not this emote is managed by a Twitch integration.
+        /// </returns>
+        bool IsManaged { get; }
+        /// <summary>
+        ///     Gets whether this emoji must be wrapped in colons.
+        /// </summary>
+        /// <returns>
+        ///     A boolean that determines whether or not this emote requires the use of colons in chat to be used.
+        /// </returns>
+        bool RequireColons { get; }
+        /// <summary>
+        ///     Gets the roles that are allowed to use this emoji.
+        /// </summary>
+        /// <returns>
+        ///     A read-only list containing snowflake identifiers for roles that are allowed to use this emoji.
+        /// </returns>
+        IReadOnlyList<IRole> Roles { get; }
+        /// <summary>
+        ///     Gets the user ID associated with the creation of this emoji.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="ulong"/> snowflake identifier representing the user who created this emoji; 
+        ///     <c>null</c> if unknown.
+        /// </returns>
+        ulong? CreatorId { get; }
+        /// <summary>
+        ///     Gets the guild this emote sourced from.
+        /// </summary>
+        IGuild Guild { get; }
+
+        Task ModifyAsync(); // TODO
     }
 }

--- a/src/Discord.Net/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net/Entities/Guilds/IGuild.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Discord
 {

--- a/src/Discord.Net/Entities/IMentionable.cs
+++ b/src/Discord.Net/Entities/IMentionable.cs
@@ -1,7 +1,0 @@
-namespace Discord
-{
-    public interface IMentionable
-    {
-        string Mention { get; }
-    }
-}

--- a/src/Discord.Net/Entities/ITaggable.cs
+++ b/src/Discord.Net/Entities/ITaggable.cs
@@ -1,0 +1,7 @@
+namespace Discord
+{
+    public interface ITaggable
+    {
+        string Tag { get; }
+    }
+}

--- a/src/Discord.Net/Entities/Roles/IRole.cs
+++ b/src/Discord.Net/Entities/Roles/IRole.cs
@@ -8,7 +8,7 @@ namespace Discord
     /// <summary>
     ///     Represents a generic role object to be given to a guild user.
     /// </summary>
-    public interface IRole : ISnowflakeEntity, IDeletable, IMentionable, IComparable<IRole>
+    public interface IRole : ISnowflakeEntity, IDeletable, ITaggable, IComparable<IRole>
     {
         /// <summary>
         ///     Gets the guild that owns this role.

--- a/src/Discord.Net/Models/Emotes/AttachedGuildEmote.cs
+++ b/src/Discord.Net/Models/Emotes/AttachedGuildEmote.cs
@@ -30,7 +30,7 @@ namespace Discord
         public IGuild Guild { get; set; }
 
         // IMentionable
-        public string Mention => throw new System.NotImplementedException();
+        public string Mention => EmoteUtilities.FormatGuildEmote(Id, Name);
 
         public Task DeleteAsync()
             => Discord.Rest.DeleteGuildEmojiAsync(Guild.Id, Id);

--- a/src/Discord.Net/Models/Emotes/AttachedGuildEmote.cs
+++ b/src/Discord.Net/Models/Emotes/AttachedGuildEmote.cs
@@ -22,6 +22,7 @@ namespace Discord
             Guild = guild;
         }
 
+        // IGuildEmote
         public bool IsManaged { get; set; }
         public bool RequireColons { get; set; }
         public IReadOnlyList<IRole> Roles { get; set; }
@@ -29,12 +30,14 @@ namespace Discord
         public string Name { get; set; }
         public IGuild Guild { get; set; }
 
-        // IMentionable
-        public string Mention => EmoteUtilities.FormatGuildEmote(Id, Name);
+        // ITaggable
+        public string Tag => EmoteUtilities.FormatGuildEmote(Id, Name);
 
+        // IDeleteable
         public Task DeleteAsync()
             => Discord.Rest.DeleteGuildEmojiAsync(Guild.Id, Id);
 
+        // IGuildEmote
         public Task ModifyAsync() // TODO
         {
             throw new System.NotImplementedException();

--- a/src/Discord.Net/Models/Emotes/AttachedGuildEmote.cs
+++ b/src/Discord.Net/Models/Emotes/AttachedGuildEmote.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Model = Wumpus.Entities.Emoji;
+
+namespace Discord
+{
+    internal class AttachedGuildEmote : SnowflakeEntity, IGuildEmote
+    {
+        public AttachedGuildEmote(Model model, IGuild guild, IDiscordClient discord) : base(discord)
+        {
+            IsManaged = model.Managed.GetValueOrDefault(false);
+            RequireColons = model.RequireColons.GetValueOrDefault(false);
+
+            Wumpus.Snowflake[] roleIds = model.RoleIds.GetValueOrDefault() ?? new Wumpus.Snowflake[0];
+            Role[] roles = new Role[roleIds.Length];
+            for (int i = 0; i < roleIds.Length; i++)
+                roles[i] = null; // TODO guild.GetRole()
+            Roles = roles;
+
+            CreatorId = model.User.IsSpecified ? model.User.Value.Id : (ulong?)null; // TODO: EntityOrId this guy
+            Name = model.Name.ToString();
+            Guild = guild;
+        }
+
+        public bool IsManaged { get; set; }
+        public bool RequireColons { get; set; }
+        public IReadOnlyList<IRole> Roles { get; set; }
+        public ulong? CreatorId { get; set; }
+        public string Name { get; set; }
+        public IGuild Guild { get; set; }
+
+        // IMentionable
+        public string Mention => throw new System.NotImplementedException();
+
+        public Task DeleteAsync()
+            => Discord.Rest.DeleteGuildEmojiAsync(Guild.Id, Id);
+
+        public Task ModifyAsync() // TODO
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/Discord.Net/Models/Emotes/Emoji.cs
+++ b/src/Discord.Net/Models/Emotes/Emoji.cs
@@ -9,6 +9,6 @@ namespace Discord
         }
 
         public string Name { get; set; }
-        public string Mention => Name;
+        public string Tag => Name;
     }
 }

--- a/src/Discord.Net/Models/Emotes/Emoji.cs
+++ b/src/Discord.Net/Models/Emotes/Emoji.cs
@@ -1,0 +1,14 @@
+namespace Discord
+{
+    internal class Emoji : IEmote
+    {
+        public Emoji(string name)
+        {
+            // TODO: validation?
+            Name = name;
+        }
+
+        public string Name { get; set; }
+        public string Mention => Name;
+    }
+}

--- a/src/Discord.Net/Models/Emotes/Emote.cs
+++ b/src/Discord.Net/Models/Emotes/Emote.cs
@@ -13,6 +13,6 @@ namespace Discord
         public ulong Id { get; set; }
         public string Name { get; set; }
 
-        public string Mention => EmoteUtilities.FormatGuildEmote(Id, Name);
+        public string Tag => EmoteUtilities.FormatGuildEmote(Id, Name);
     }
 }

--- a/src/Discord.Net/Models/Emotes/Emote.cs
+++ b/src/Discord.Net/Models/Emotes/Emote.cs
@@ -1,0 +1,18 @@
+namespace Discord
+{
+    // placeholder for user-constructed guild emotes
+    // TODO: naming - should be called GuildEmote? but does not impl IGuildEmote, so maybe not...
+    internal class Emote : IEmote
+    {
+        public Emote(ulong id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public ulong Id { get; set; }
+        public string Name { get; set; }
+
+        public string Mention => throw new System.NotImplementedException(); // TODO: EmojiUtils
+    }
+}

--- a/src/Discord.Net/Models/Emotes/Emote.cs
+++ b/src/Discord.Net/Models/Emotes/Emote.cs
@@ -13,6 +13,6 @@ namespace Discord
         public ulong Id { get; set; }
         public string Name { get; set; }
 
-        public string Mention => throw new System.NotImplementedException(); // TODO: EmojiUtils
+        public string Mention => EmoteUtilities.FormatGuildEmote(Id, Name);
     }
 }

--- a/src/Discord.Net/Models/Emotes/EmoteBuilder.cs
+++ b/src/Discord.Net/Models/Emotes/EmoteBuilder.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Discord
+{
+    public static class EmoteBuilder
+    {
+        public static IEmote FromEmoji(string emoji)
+            => new Emoji(emoji);
+        public static IEmote FromMention(string mention)
+            => throw new NotImplementedException(); // TODO: emoteutil
+        public static IEmote FromID(ulong id, string name)
+            => new Emote(id, name);
+    }
+}

--- a/src/Discord.Net/Models/Emotes/EmoteBuilder.cs
+++ b/src/Discord.Net/Models/Emotes/EmoteBuilder.cs
@@ -2,12 +2,56 @@ using System;
 
 namespace Discord
 {
+    /// <summary>
+    ///     Methods to create an <see cref="IEmote"/>.
+    /// </summary>
     public static class EmoteBuilder
     {
-        public static IEmote FromEmoji(string emoji)
+        /// <summary>
+        ///     Creates an emote from a raw unicode emoji.
+        /// </summary>
+        /// <param name="emoji">The unicode character this emoji should be created from.</param>
+        public static IEmote FromUnicodeEmoji(string emoji)
             => new Emoji(emoji);
-        public static IEmote FromMention(string mention)
-            => throw new NotImplementedException(); // TODO: emoteutil
+
+        /// <summary>
+        ///     Creates an emote from an escaped tag.
+        /// </summary>
+        /// <param name="mention">The escaped mention tag for an emote.</param>
+        /// <exception cref="ArgumentException">Throws if the passed tag was of an invalid format.</exception>
+        public static IEmote FromTag(string tag)
+        {
+            if (EmoteUtilities.TryParseGuildEmote(tag.AsSpan(), out var result))
+            {
+                var (id, name) = result;
+                return new Emote(id, name);
+            }
+            throw new ArgumentException("Passed emote tag was of an invalid format", nameof(tag));
+        }
+
+        /// <summary>
+        ///     Creates an emote from an escaped tag.
+        /// </summary>
+        /// <param name="tag">The escaped mention tag for an emote.</param>
+        /// <returns>Returns true if the emote could be created; returns false if it was of an invalid format.</returns>
+        public static bool TryFromTag(string tag, out IEmote result)
+        {
+            if (EmoteUtilities.TryParseGuildEmote(tag.AsSpan(), out var r))
+            {
+                var (id, name) = r;
+                result = new Emote(id, name);
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        /// <summary>
+        ///     Creates an emote from a raw snowflake and name.
+        /// </summary>
+        /// <param name="id">The snowflake ID of the guild emote.</param>
+        /// <param name="name">The name of the guild emote.</param>
         public static IEmote FromID(ulong id, string name)
             => new Emote(id, name);
     }

--- a/src/Discord.Net/Models/Roles/Role.cs
+++ b/src/Discord.Net/Models/Roles/Role.cs
@@ -31,7 +31,7 @@ namespace Discord
         public string Name { get; set; }
         public GuildPermissions Permissions { get; set; }
         public int Position { get; set; }
-        public string Mention => throw new NotImplementedException(); // TODO: MentionUtils
+        public string Tag => throw new NotImplementedException(); // TODO: MentionUtils
 
         public Task DeleteAsync()
             => Discord.Rest.DeleteGuildRoleAsync(Guild.Id, Id);

--- a/src/Discord.Net/Utilities/EmoteUtilities.cs
+++ b/src/Discord.Net/Utilities/EmoteUtilities.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Discord
+{
+    public static class EmoteUtilities
+    {
+        public static string FormatGuildEmote(ulong id, string name)
+            => $"<:{name}:{id}>";
+
+        public static (ulong, string) ParseGuildEmote(string formatted)
+        {
+            if (formatted.IndexOf('<') != 0 || formatted.IndexOf(':') != 1 || formatted.IndexOf('>') != formatted.Length-1)
+                throw new ArgumentException("passed string does not match a guild emote format", nameof(formatted)); // TODO: grammar
+
+            int closingIndex = formatted.IndexOf(':', 2);
+            if (closingIndex < 0)
+                throw new ArgumentException("passed string does not match a guild emote format", nameof(formatted));
+
+            string name = formatted.Substring(2, closingIndex-2);
+            string idStr = formatted.Substring(closingIndex + 1);
+            idStr = idStr.Substring(0, idStr.Length - 1); // ignore closing >
+            ulong id = ulong.Parse(idStr); // TODO: TryParse here?
+
+            return (id, name);
+        }
+    }
+}

--- a/test/Discord.Tests.Unit/Utilities/EmoteTests.cs
+++ b/test/Discord.Tests.Unit/Utilities/EmoteTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace Discord.Tests.Unit
@@ -9,9 +8,10 @@ namespace Discord.Tests.Unit
         public void Parse()
         {
             string input = "<:gopher:243902586946715658>";
-            var (resultId, resultName) = EmoteUtilities.ParseGuildEmote(input);
-            Assert.Equal(243902586946715658UL, resultId);
-            Assert.Equal("gopher", resultName);
+            var success = EmoteUtilities.TryParseGuildEmote(input, out var result);
+            var (id, name) = result;
+            Assert.Equal(243902586946715658UL, id);
+            Assert.Equal("gopher", name);
         }
 
         [Theory]
@@ -21,7 +21,8 @@ namespace Discord.Tests.Unit
         [InlineData("<:foo>")]
         public void Parse_Fail(string data)
         {
-            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote(data));
+            var success = EmoteUtilities.TryParseGuildEmote(data, out _);
+            Assert.False(success);
         }
 
         [Fact]

--- a/test/Discord.Tests.Unit/Utilities/EmoteTests.cs
+++ b/test/Discord.Tests.Unit/Utilities/EmoteTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Discord.Tests.Unit
+{
+    public class EmoteTests
+    {
+        [Fact]
+        public void Parse()
+        {
+            string input = "<:gopher:243902586946715658>";
+            var (resultId, resultName) = EmoteUtilities.ParseGuildEmote(input);
+            Assert.Equal(243902586946715658UL, resultId);
+            Assert.Equal("gopher", resultName);
+
+            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("foo"));
+            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("<foo"));
+            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("<:foo"));
+            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("<:foo>"));
+        }
+
+        [Fact]
+        public void Format()
+        {
+            string result = EmoteUtilities.FormatGuildEmote(243902586946715658, "gopher");
+            Assert.Equal("<:gopher:243902586946715658>", result);
+        }
+    }
+}

--- a/test/Discord.Tests.Unit/Utilities/EmoteTests.cs
+++ b/test/Discord.Tests.Unit/Utilities/EmoteTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace Discord.Tests.Unit
@@ -14,11 +12,16 @@ namespace Discord.Tests.Unit
             var (resultId, resultName) = EmoteUtilities.ParseGuildEmote(input);
             Assert.Equal(243902586946715658UL, resultId);
             Assert.Equal("gopher", resultName);
+        }
 
-            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("foo"));
-            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("<foo"));
-            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("<:foo"));
-            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote("<:foo>"));
+        [Theory]
+        [InlineData("foo")]
+        [InlineData("<foo")]
+        [InlineData("<:foo")]
+        [InlineData("<:foo>")]
+        public void Parse_Fail(string data)
+        {
+            Assert.Throws<ArgumentException>(() => EmoteUtilities.ParseGuildEmote(data));
         }
 
         [Fact]


### PR DESCRIPTION
Requesting API review for this pattern.

Notable points of contention might include `EmoteBuilder`, not sure how I feel about a static class+method to construct something like emotes, though static builders seem best to use with an interface-only pattern.

Implementation of `IGuildEmote` is a little wonky as well; makes sense for `AttachedGuildEmote`, but then `Emote` itself is a bit odd... it can't fit into `IGuildEmote`, and I don't quite like making an `IEmote`->`IGuildEmote`->`ICachedGuildEmote` pattern... maybe this would be most ideal though? Move emote manipulation methods to IGuildEmote, and keep properties on ICachedGuildEmote?