### PR TITLE
Add GuildMemberJoin for MessageType

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/MessageType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageType.cs
@@ -32,6 +32,10 @@ namespace Discord
         /// <summary>
         ///     The message when another message is pinned.
         /// </summary>
-        ChannelPinnedMessage = 6
+        ChannelPinnedMessage = 6,
+        /// <summary>
+        ///     The message when a new member joined.
+        /// </summary>
+        GuildMemberJoin = 7
     }
 }


### PR DESCRIPTION
# Summary

Adds `GuildMemberJoin` as a new `MessageType` per [Discord API docs](https://discordapp.com/developers/docs/resources/channel#message-object-message-types).