### PR TITLE
Fix NullReferenceException at MESSAGE_CREATE

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1173,9 +1173,13 @@ namespace Discord.WebSocket
                                         {
                                             if (guild != null)
                                             {
-                                                author = data.Member.IsSpecified // member isn't always included, but use it when we can
-                                                    ? guild.AddOrUpdateUser(data.Member.Value)
-                                                    : guild.AddOrUpdateUser(data.Author.Value); // user has no guild-specific data
+                                                if (data.Member.IsSpecified) // member isn't always included, but use it when we can
+                                                {
+                                                    data.Member.Value.User = data.Author.Value;
+                                                    author = guild.AddOrUpdateUser(data.Member.Value);
+                                                }
+                                                else
+                                                    author = guild.AddOrUpdateUser(data.Author.Value); // user has no guild-specific data
                                             }
                                             else if (channel is SocketGroupChannel)
                                                 author = (channel as SocketGroupChannel).GetOrAddUser(data.Author.Value);


### PR DESCRIPTION
After talking at the Discord.Net channel, @Quahu stated the `member` prop doesn't contain the `user` in this payload (and it's described as being partial at https://discordapp.com/developers/docs/resources/channel#message-object ).

I completed it using the `author` prop, that I believe it's the cleanest way of dealing with it (without changing the GuildMember class or the AddOrUpdateUser method).

Fixes #1267 