### PR TITLE
Fix #1270 Add the AuthorId to MessageDeleteAuditLogData

### DIFF
--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
@@ -39,8 +39,7 @@ namespace Discord.Rest
         ///     Gets the author of the messages that were deleted.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier for the user that the messages were
-        ///     created by.
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the user that created the deleted messages.
         /// </returns>
         public ulong AuthorId { get; }
     }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
@@ -1,4 +1,4 @@
-﻿using Model = Discord.API.AuditLog;
+using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
 namespace Discord.Rest
@@ -8,15 +8,16 @@ namespace Discord.Rest
     /// </summary>
     public class MessageDeleteAuditLogData : IAuditLogData
     {
-        private MessageDeleteAuditLogData(ulong channelId, int count)
+        private MessageDeleteAuditLogData(ulong channelId, int count, ulong authorId)
         {
             ChannelId = channelId;
             MessageCount = count;
+            AuthorId = authorId;
         }
 
         internal static MessageDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            return new MessageDeleteAuditLogData(entry.Options.MessageDeleteChannelId.Value, entry.Options.MessageDeleteCount.Value);
+            return new MessageDeleteAuditLogData(entry.Options.MessageDeleteChannelId.Value, entry.Options.MessageDeleteCount.Value, entry.TargetId.Value);
         }
 
         /// <summary>
@@ -34,5 +35,13 @@ namespace Discord.Rest
         ///     deleted from.
         /// </returns>
         public ulong ChannelId { get; }
+        /// <summary>
+        ///     Gets the author of the messages that were deleted.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the user that the messages were
+        ///     created by.
+        /// </returns>
+        public ulong AuthorId { get; }
     }
 }


### PR DESCRIPTION
Fix #1270

Adds the AuthorId property to MessageDeleteAuditLogData, which is set
by the TargetId in the audit log entry data.
This property is the user id that created those messages in the first place.
I am not aware of any scenario when this value would not be supplied.

Steps I used for testing:

1. Delete 1 or more messages from another user.
2. Download the audit log entries of that guild, and compare the AuthorId.