### PR TITLE
Use a relative path for docs index page logo

### DIFF
--- a/docs/_template/light-dark-theme/styles/dark.css
+++ b/docs/_template/light-dark-theme/styles/dark.css
@@ -304,5 +304,5 @@ span.arrow-r{
 }
 
 .logo-switcher {
-    background: url("/marketing/logo/SVG/Combinationmark White.svg") no-repeat;
+    background: url("../marketing/logo/SVG/Combinationmark White.svg") no-repeat;
 }

--- a/docs/_template/light-dark-theme/styles/gray.css
+++ b/docs/_template/light-dark-theme/styles/gray.css
@@ -311,5 +311,5 @@ span.arrow-r{
 }
 
 .logo-switcher {
-    background: url("/marketing/logo/SVG/Combinationmark White.svg") no-repeat;
+    background: url("../marketing/logo/SVG/Combinationmark White.svg") no-repeat;
 }

--- a/docs/_template/light-dark-theme/styles/light.css
+++ b/docs/_template/light-dark-theme/styles/light.css
@@ -113,5 +113,5 @@ span.arrow-r{
 }
 
 .logo-switcher {
-    background: url("/marketing/logo/SVG/Combinationmark.svg") no-repeat;
+    background: url("../marketing/logo/SVG/Combinationmark.svg") no-repeat;
 }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -83,7 +83,7 @@ namespace Discord.WebSocket
         ///     </note>
         /// </remarks>
         /// <returns>
-        ///     An collection of DM channels that have been opened in this session.
+        ///     A collection of DM channels that have been opened in this session.
         /// </returns>
         public IReadOnlyCollection<SocketDMChannel> DMChannels
             => State.PrivateChannels.OfType<SocketDMChannel>().ToImmutableArray();
@@ -98,7 +98,7 @@ namespace Discord.WebSocket
         ///     </note>
         /// </remarks>
         /// <returns>
-        ///     An collection of group channels that have been opened in this session.
+        ///     A collection of group channels that have been opened in this session.
         /// </returns>
         public IReadOnlyCollection<SocketGroupChannel> GroupChannels
             => State.PrivateChannels.OfType<SocketGroupChannel>().ToImmutableArray();


### PR DESCRIPTION
Changes the paths for the logo on the index page of the documentation
to use relative links instead of absolute ones.

Before:
![before image](https://user-images.githubusercontent.com/16418643/53549630-84202180-3ae9-11e9-90ed-38fb07b3a41c.png)

After:
![after image](https://user-images.githubusercontent.com/16418643/53549635-897d6c00-3ae9-11e9-9ee5-3a7c86dd6fca.png)

The current absolute path is just fine as long as the site is not hosted under another directory. When opening files locally (without serving them in docfx) these images will fail to load.
In addition, if these files are served under a directory that is not the root endpoint (like: `docs.com/stable/`) the images will also break.

I tested these changes locally using these steps:

- Build & serve docs: `docfx docs/docfx.json --serve`
- Verify that logo shows up on index page using all 3 themes
- Open `docs/_site/index.html`
- Verify logo works on all 3 themes

Also includes a minor grammar fix.