### PR TITLE
Disallow modifying the CategoryId for CategoryChannels

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
@@ -21,14 +21,5 @@ namespace Discord
         ///     Moves the channel to the following position. This property is zero-based.
         /// </summary>
         public Optional<int> Position { get; set; }
-        /// <summary>
-        ///     Gets or sets the category ID for this channel.
-        /// </summary>
-        /// <remarks>
-        ///     Setting this value to a category's snowflake identifier will change or set this channel's parent to the
-        ///     specified channel; setting this value to <c>0</c> will detach this channel from its parent if one
-        ///     is set.
-        /// </remarks>
-        public Optional<ulong?> CategoryId { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/NestedChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/NestedChannelProperties.cs
@@ -10,7 +10,7 @@ namespace Discord
         /// </summary>
         /// <remarks>
         ///     Setting this value to a category's snowflake identifier will change or set this channel's parent to the
-        ///     specified channel; setting this value to <c>0</c> will detach this channel from its parent if one
+        ///     specified channel; setting this value to <c>null</c> will detach this channel from its parent if one
         ///     is set.
         /// </remarks>
         public Optional<ulong?> CategoryId { get; set; }

--- a/src/Discord.Net.Core/Entities/Channels/NestedChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/NestedChannelProperties.cs
@@ -1,0 +1,18 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Properties that are used to modify an <see cref="INestedChannel"/> with the specified changes.
+    /// </summary>
+    public class NestedChannelProperties : GuildChannelProperties
+    {
+        /// <summary>
+        ///     Gets or sets the category ID for this channel.
+        /// </summary>
+        /// <remarks>
+        ///     Setting this value to a category's snowflake identifier will change or set this channel's parent to the
+        ///     specified channel; setting this value to <c>0</c> will detach this channel from its parent if one
+        ///     is set.
+        /// </remarks>
+        public Optional<ulong?> CategoryId { get; set; }
+    }
+}

--- a/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
@@ -6,7 +6,7 @@ namespace Discord
     ///     Provides properties that are used to modify an <see cref="ITextChannel"/> with the specified changes.
     /// </summary>
     /// <seealso cref="ITextChannel.ModifyAsync(System.Action{TextChannelProperties}, RequestOptions)"/>
-    public class TextChannelProperties : GuildChannelProperties
+    public class TextChannelProperties : NestedChannelProperties
     {
         /// <summary>
         ///     Gets or sets the topic of the channel.

--- a/src/Discord.Net.Core/Entities/Channels/VoiceChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/VoiceChannelProperties.cs
@@ -3,7 +3,7 @@ namespace Discord
     /// <summary>
     ///     Provides properties that are used to modify an <see cref="IVoiceChannel" /> with the specified changes.
     /// </summary>
-    public class VoiceChannelProperties : GuildChannelProperties
+    public class VoiceChannelProperties : NestedChannelProperties
     {
         /// <summary>
         ///     Gets or sets the bitrate of the voice connections in this channel. Must be greater than 8000.

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
@@ -10,8 +10,6 @@ namespace Discord.API.Rest
         public Optional<string> Name { get; set; }
         [JsonProperty("position")]
         public Optional<int> Position { get; set; }
-        [JsonProperty("parent_id")]
-        public Optional<ulong?> CategoryId { get; set; }
         [JsonProperty("permission_overwrites")]
         public Optional<Overwrite[]> Overwrites { get; set; }
     }

--- a/src/Discord.Net.Rest/API/Rest/ModifyNestedChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyNestedChannelParams.cs
@@ -1,0 +1,12 @@
+#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Discord.API.Rest
+{
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    internal class ModifyNestedChannelParams : ModifyGuildChannelParams
+    {
+        [JsonProperty("parent_id")]
+        public Optional<ulong?> CategoryId { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-    internal class ModifyTextChannelParams : ModifyGuildChannelParams
+    internal class ModifyTextChannelParams : ModifyNestedChannelParams
     {
         [JsonProperty("topic")]
         public Optional<string> Topic { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/ModifyVoiceChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyVoiceChannelParams.cs
@@ -1,10 +1,10 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-    internal class ModifyVoiceChannelParams : ModifyGuildChannelParams
+    internal class ModifyVoiceChannelParams : ModifyNestedChannelParams
     {
         [JsonProperty("bitrate")]
         public Optional<int> Bitrate { get; set; }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -27,8 +27,7 @@ namespace Discord.Rest
             var apiArgs = new API.Rest.ModifyGuildChannelParams
             {
                 Name = args.Name,
-                Position = args.Position,
-                CategoryId = args.CategoryId
+                Position = args.Position
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }


### PR DESCRIPTION
This change fixes an issue that was introduced with the INestedChannel type ( #1004 ). Previously, it was possible to use ModifyAsync on a ChannelCategory to set it's CategoryId, since it was just using GuildChannelProperties. This is not supported by the API, and would probably do nothing.
This is a breaking change, however I can't imagine that anyone was trying to nest categories before this. I don't think that it should affect anyone. (Prove me wrong, I guess?)

This change adds the NestedChannelProperties and ModifyNestedChannelParams types, which follow the same class hierarchy as the public-facing channel entities. This allows only guild voice and text channels to modify the CategoryId property.