### PR TITLE
Fix broken ChannelPermissions test, refactor TestChannelPermissionModify

### DIFF
--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -75,7 +75,8 @@ namespace Discord
                 | ChannelPermission.DeafenMembers
                 | ChannelPermission.MoveMembers
                 | ChannelPermission.UseVAD
-                | ChannelPermission.ManageRoles);
+                | ChannelPermission.ManageRoles
+                | ChannelPermission.PrioritySpeaker);
 
             Assert.Equal(voiceChannel, ChannelPermissions.Voice.RawValue);
 

--- a/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
+++ b/test/Discord.Net.Tests/Tests.ChannelPermissions.cs
@@ -110,231 +110,55 @@ namespace Discord
         [Fact]
         public Task TestChannelPermissionModify()
         {
-            // test channel permission modify
-
+            // test that channel permissions could be modified correctly
             var perm = new ChannelPermissions();
 
-            // ensure that the permission is initially false
-            Assert.False(perm.CreateInstantInvite);
+            void Check(ChannelPermission permission,
+                Func<ChannelPermissions, bool> has,
+                Func<ChannelPermissions, bool, ChannelPermissions> modify)
+            {
+                // ensure permission initially false
+                // use both the function and Has to ensure that the GetPermission
+                // function is working
+                Assert.False(has(perm));
+                Assert.False(perm.Has(permission));
 
-            // ensure that when modified it works
-            perm = perm.Modify(createInstantInvite: true);
-            Assert.True(perm.CreateInstantInvite);
-            Assert.Equal((ulong)ChannelPermission.CreateInstantInvite, perm.RawValue);
+                // enable it, and ensure that it gets set
+                perm = modify(perm, true);
+                Assert.True(has(perm));
+                Assert.True(perm.Has(permission));
 
-            // set false again, move on to next permission
-            perm = perm.Modify(createInstantInvite: false);
-            Assert.False(perm.CreateInstantInvite);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+                // set it false again
+                perm = modify(perm, false);
+                Assert.False(has(perm));
+                Assert.False(perm.Has(permission));
 
-            // individual permission test
-            Assert.False(perm.ManageChannel);
+                // ensure that no perms are set now
+                Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
+            }
 
-            perm = perm.Modify(manageChannel: true);
-            Assert.True(perm.ManageChannel);
-            Assert.Equal((ulong)ChannelPermission.ManageChannels, perm.RawValue);
+            Check(ChannelPermission.CreateInstantInvite, x => x.CreateInstantInvite, (p, enable) => p.Modify(createInstantInvite: enable));
+            Check(ChannelPermission.ManageChannels, x => x.ManageChannel, (p, enable) => p.Modify(manageChannel: enable));
+            Check(ChannelPermission.AddReactions, x => x.AddReactions, (p, enable) => p.Modify(addReactions: enable));
+            Check(ChannelPermission.ViewChannel, x => x.ViewChannel, (p, enable) => p.Modify(viewChannel: enable));
+            Check(ChannelPermission.SendMessages, x => x.SendMessages, (p, enable) => p.Modify(sendMessages: enable));
+            Check(ChannelPermission.SendTTSMessages, x => x.SendTTSMessages, (p, enable) => p.Modify(sendTTSMessages: enable));
+            Check(ChannelPermission.ManageMessages, x => x.ManageMessages, (p, enable) => p.Modify(manageMessages: enable));
+            Check(ChannelPermission.EmbedLinks, x => x.EmbedLinks, (p, enable) => p.Modify(embedLinks: enable));
+            Check(ChannelPermission.AttachFiles, x => x.AttachFiles, (p, enable) => p.Modify(attachFiles: enable));
+            Check(ChannelPermission.ReadMessageHistory, x => x.ReadMessageHistory, (p, enable) => p.Modify(readMessageHistory: enable));
+            Check(ChannelPermission.MentionEveryone, x => x.MentionEveryone, (p, enable) => p.Modify(mentionEveryone: enable));
+            Check(ChannelPermission.UseExternalEmojis, x => x.UseExternalEmojis, (p, enable) => p.Modify(useExternalEmojis: enable));
+            Check(ChannelPermission.Connect, x => x.Connect, (p, enable) => p.Modify(connect: enable));
+            Check(ChannelPermission.Speak, x => x.Speak, (p, enable) => p.Modify(speak: enable));
+            Check(ChannelPermission.MuteMembers, x => x.MuteMembers, (p, enable) => p.Modify(muteMembers: enable));
+            Check(ChannelPermission.DeafenMembers, x => x.DeafenMembers, (p, enable) => p.Modify(deafenMembers: enable));
+            Check(ChannelPermission.MoveMembers, x => x.MoveMembers, (p, enable) => p.Modify(moveMembers: enable));
+            Check(ChannelPermission.UseVAD, x => x.UseVAD, (p, enable) => p.Modify(useVoiceActivation: enable));
+            Check(ChannelPermission.ManageRoles, x => x.ManageRoles, (p, enable) => p.Modify(manageRoles: enable));
+            Check(ChannelPermission.ManageWebhooks, x => x.ManageWebhooks, (p, enable) => p.Modify(manageWebhooks: enable));
+            Check(ChannelPermission.PrioritySpeaker, x => x.PrioritySpeaker, (p, enable) => p.Modify(prioritySpeaker: enable));
 
-            perm = perm.Modify(manageChannel: false);
-            Assert.False(perm.ManageChannel);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.AddReactions);
-
-            perm = perm.Modify(addReactions: true);
-            Assert.True(perm.AddReactions);
-            Assert.Equal((ulong)ChannelPermission.AddReactions, perm.RawValue);
-
-            perm = perm.Modify(addReactions: false);
-            Assert.False(perm.AddReactions);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.ViewChannel);
-
-            perm = perm.Modify(viewChannel: true);
-            Assert.True(perm.ViewChannel);
-            Assert.Equal((ulong)ChannelPermission.ViewChannel, perm.RawValue);
-
-            perm = perm.Modify(viewChannel: false);
-            Assert.False(perm.ViewChannel);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.SendMessages);
-
-            perm = perm.Modify(sendMessages: true);
-            Assert.True(perm.SendMessages);
-            Assert.Equal((ulong)ChannelPermission.SendMessages, perm.RawValue);
-
-            perm = perm.Modify(sendMessages: false);
-            Assert.False(perm.SendMessages);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.SendTTSMessages);
-
-            perm = perm.Modify(sendTTSMessages: true);
-            Assert.True(perm.SendTTSMessages);
-            Assert.Equal((ulong)ChannelPermission.SendTTSMessages, perm.RawValue);
-
-            perm = perm.Modify(sendTTSMessages: false);
-            Assert.False(perm.SendTTSMessages);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.ManageMessages);
-
-            perm = perm.Modify(manageMessages: true);
-            Assert.True(perm.ManageMessages);
-            Assert.Equal((ulong)ChannelPermission.ManageMessages, perm.RawValue);
-
-            perm = perm.Modify(manageMessages: false);
-            Assert.False(perm.ManageMessages);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.EmbedLinks);
-
-            perm = perm.Modify(embedLinks: true);
-            Assert.True(perm.EmbedLinks);
-            Assert.Equal((ulong)ChannelPermission.EmbedLinks, perm.RawValue);
-
-            perm = perm.Modify(embedLinks: false);
-            Assert.False(perm.EmbedLinks);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.AttachFiles);
-
-            perm = perm.Modify(attachFiles: true);
-            Assert.True(perm.AttachFiles);
-            Assert.Equal((ulong)ChannelPermission.AttachFiles, perm.RawValue);
-
-            perm = perm.Modify(attachFiles: false);
-            Assert.False(perm.AttachFiles);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.ReadMessageHistory);
-
-            perm = perm.Modify(readMessageHistory: true);
-            Assert.True(perm.ReadMessageHistory);
-            Assert.Equal((ulong)ChannelPermission.ReadMessageHistory, perm.RawValue);
-
-            perm = perm.Modify(readMessageHistory: false);
-            Assert.False(perm.ReadMessageHistory);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.MentionEveryone);
-
-            perm = perm.Modify(mentionEveryone: true);
-            Assert.True(perm.MentionEveryone);
-            Assert.Equal((ulong)ChannelPermission.MentionEveryone, perm.RawValue);
-
-            perm = perm.Modify(mentionEveryone: false);
-            Assert.False(perm.MentionEveryone);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.UseExternalEmojis);
-
-            perm = perm.Modify(useExternalEmojis: true);
-            Assert.True(perm.UseExternalEmojis);
-            Assert.Equal((ulong)ChannelPermission.UseExternalEmojis, perm.RawValue);
-
-            perm = perm.Modify(useExternalEmojis: false);
-            Assert.False(perm.UseExternalEmojis);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.Connect);
-
-            perm = perm.Modify(connect: true);
-            Assert.True(perm.Connect);
-            Assert.Equal((ulong)ChannelPermission.Connect, perm.RawValue);
-
-            perm = perm.Modify(connect: false);
-            Assert.False(perm.Connect);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.Speak);
-
-            perm = perm.Modify(speak: true);
-            Assert.True(perm.Speak);
-            Assert.Equal((ulong)ChannelPermission.Speak, perm.RawValue);
-
-            perm = perm.Modify(speak: false);
-            Assert.False(perm.Speak);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.MuteMembers);
-
-            perm = perm.Modify(muteMembers: true);
-            Assert.True(perm.MuteMembers);
-            Assert.Equal((ulong)ChannelPermission.MuteMembers, perm.RawValue);
-
-            perm = perm.Modify(muteMembers: false);
-            Assert.False(perm.MuteMembers);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.DeafenMembers);
-
-            perm = perm.Modify(deafenMembers: true);
-            Assert.True(perm.DeafenMembers);
-            Assert.Equal((ulong)ChannelPermission.DeafenMembers, perm.RawValue);
-
-            perm = perm.Modify(deafenMembers: false);
-            Assert.False(perm.DeafenMembers);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.MoveMembers);
-
-            perm = perm.Modify(moveMembers: true);
-            Assert.True(perm.MoveMembers);
-            Assert.Equal((ulong)ChannelPermission.MoveMembers, perm.RawValue);
-
-            perm = perm.Modify(moveMembers: false);
-            Assert.False(perm.MoveMembers);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.UseVAD);
-
-            perm = perm.Modify(useVoiceActivation: true);
-            Assert.True(perm.UseVAD);
-            Assert.Equal((ulong)ChannelPermission.UseVAD, perm.RawValue);
-
-            perm = perm.Modify(useVoiceActivation: false);
-            Assert.False(perm.UseVAD);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.ManageRoles);
-
-            perm = perm.Modify(manageRoles: true);
-            Assert.True(perm.ManageRoles);
-            Assert.Equal((ulong)ChannelPermission.ManageRoles, perm.RawValue);
-
-            perm = perm.Modify(manageRoles: false);
-            Assert.False(perm.ManageRoles);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
-
-            // individual permission test
-            Assert.False(perm.ManageWebhooks);
-
-            perm = perm.Modify(manageWebhooks: true);
-            Assert.True(perm.ManageWebhooks);
-            Assert.Equal((ulong)ChannelPermission.ManageWebhooks, perm.RawValue);
-
-            perm = perm.Modify(manageWebhooks: false);
-            Assert.False(perm.ManageWebhooks);
-            Assert.Equal(ChannelPermissions.None.RawValue, perm.RawValue);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Fixes a failing ChannelPermissions unit test [that was failing because of a new flag added](https://github.com/discord-net/Discord.Net/commit/c1d78189e11969c4ff9054bcd29323a3ffef7a54#diff-910c2bb51f8a8d8bd22bb3433c392ecaR15) without updating the tests.

In addition, this PR refactors the TestChannelPermissionModify test so that multiple lines don't have to be copy-pasted for each of the flags, and cuts this down from ~200 lines (yikes) to around 50.
I've also added the PrioritySpeaker flag to this test.

Some of the tests that I've added to other types are equally difficult to maintain, so I'm thinking that I'll want to clean those up. (Or re-do them, when we split up the unit and integration tests)