### PR TITLE
Initialize ImmutableArray fields

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -16,10 +16,10 @@ namespace Discord.Rest
     {
         private bool _isMentioningEveryone, _isTTS, _isPinned;
         private long? _editedTimestampTicks;
-        private ImmutableArray<Attachment> _attachments;
-        private ImmutableArray<Embed> _embeds;
-        private ImmutableArray<ITag> _tags;
-        private ImmutableArray<RestReaction> _reactions;
+        private ImmutableArray<Attachment> _attachments = ImmutableArray.Create<Attachment>();
+        private ImmutableArray<Embed> _embeds = ImmutableArray.Create<Embed>();
+        private ImmutableArray<ITag> _tags = ImmutableArray.Create<ITag>();
+        private ImmutableArray<RestReaction> _reactions = ImmutableArray.Create<RestReaction>();
 
         /// <inheritdoc />
         public override bool IsTTS => _isTTS;

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -18,9 +18,9 @@ namespace Discord.WebSocket
         private readonly List<SocketReaction> _reactions = new List<SocketReaction>();
         private bool _isMentioningEveryone, _isTTS, _isPinned;
         private long? _editedTimestampTicks;
-        private ImmutableArray<Attachment> _attachments;
-        private ImmutableArray<Embed> _embeds;
-        private ImmutableArray<ITag> _tags;
+        private ImmutableArray<Attachment> _attachments = ImmutableArray.Create<Attachment>();
+        private ImmutableArray<Embed> _embeds = ImmutableArray.Create<Embed>();
+        private ImmutableArray<ITag> _tags = ImmutableArray.Create<ITag>();
         
         /// <inheritdoc />
         public override bool IsTTS => _isTTS;


### PR DESCRIPTION
Fixes #1291.

I opted to use `Create<T>()` to stay consistent, but I'd still say calling `ImmutableArray<T>.Empty` directly would keep things more efficient (wouldn't do more than a `ldsfld` whereas `Create<T>()` would do a `call`+`ldsfld`+`ret` if inlining fails).