### PR TITLE
EmbedBuilderExtensions no longer has an extension for WithAuthor(IGuildUser)

### DIFF
--- a/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
@@ -29,10 +29,6 @@ namespace Discord
         public static EmbedBuilder WithAuthor(this EmbedBuilder builder, IUser user) =>
             builder.WithAuthor($"{user.Username}#{user.Discriminator}", user.GetAvatarUrl());
 
-        /// <summary> Fills the embed author field with the provided user's nickname and avatar URL; username is used if nickname is not set. </summary>
-        public static EmbedBuilder WithAuthor(this EmbedBuilder builder, IGuildUser user) =>
-            builder.WithAuthor($"{user.Nickname ?? user.Username}#{user.Discriminator}", user.GetAvatarUrl());
-
         /// <summary> Converts a <see cref="EmbedType.Rich"/> <see cref="IEmbed"/> object to a <see cref="EmbedBuilder"/>. </summary>
         /// <exception cref="InvalidOperationException">The embed type is not <see cref="EmbedType.Rich"/>.</exception>
         public static EmbedBuilder ToEmbedBuilder(this IEmbed embed)


### PR DESCRIPTION
The embed should not display nickname#discriminator as that's incorrect.
So the extension was scrapped altogether to use the IUser (and by inheritance, IGuildUser) one.
