### PR TITLE
Add missing xmldoc for inherited precondition properties and NotAGuildErrorMessage

### DIFF
--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
@@ -17,7 +17,12 @@ namespace Discord.Commands
         ///     Gets the specified <see cref="Discord.ChannelPermission" /> of the precondition.
         /// </summary>
         public ChannelPermission? ChannelPermission { get; }
+        /// <inheritdoc />
         public override string ErrorMessage { get; set; }
+        /// <summary>
+        ///     Gets or sets the error message if the precondition
+        ///     fails due to being run outside of a Guild channel.
+        /// </summary>
         public string NotAGuildErrorMessage { get; set; }
 
         /// <summary>

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireContextAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireContextAttribute.cs
@@ -33,6 +33,7 @@ namespace Discord.Commands
         ///     Gets the context required to execute the command.
         /// </summary>
         public ContextType Contexts { get; }
+        /// <inheritdoc />
         public override string ErrorMessage { get; set; }
 
         /// <summary> Requires the command to be invoked in the specified context. </summary>

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireNsfwAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireNsfwAttribute.cs
@@ -30,6 +30,7 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class RequireNsfwAttribute : PreconditionAttribute
     {
+        /// <inheritdoc />
         public override string ErrorMessage { get; set; }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
@@ -34,6 +34,7 @@ namespace Discord.Commands
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class RequireOwnerAttribute : PreconditionAttribute
     {
+        /// <inheritdoc />
         public override string ErrorMessage { get; set; }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
@@ -17,7 +17,12 @@ namespace Discord.Commands
         ///     Gets the specified <see cref="Discord.ChannelPermission" /> of the precondition.
         /// </summary>
         public ChannelPermission? ChannelPermission { get; }
+        /// <inheritdoc />
         public override string ErrorMessage { get; set; }
+        /// <summary>
+        ///     Gets or sets the error message if the precondition
+        ///     fails due to being run outside of a Guild channel.
+        /// </summary>
         public string NotAGuildErrorMessage { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Updates some missing xmldoc for some of the precondition types.

- adds inheritdoc tag to the inherited ErrorMessage properties of several preconditions

- adds xmldoc summary for the NotAGuildErrorMessage properties of RequireUserPermissionAttribute and RequireBotPermissionAttribute