### PR TITLE
Check for whitespace or newline characters in tokens

### DIFF
--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Text;
 
 namespace Discord

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 
 namespace Discord
@@ -120,6 +122,25 @@ namespace Discord
         }
 
         /// <summary>
+        ///     The set of all characters that are not allowed inside of a token.
+        /// </summary>
+        internal static char[] IllegalTokenCharacters = new char[]
+        {
+            ' ', '\t', '\r', '\n'
+        };
+
+        /// <summary>
+        ///     Checks if the given token contains a whitespace or newline character
+        ///     that would fail to log in.
+        /// </summary>
+        /// <param name="token"> The token to validate. </param>
+        /// <returns>
+        ///     True if the token contains a whitespace or newline character.
+        /// </returns>
+        internal static bool CheckContainsIllegalCharacters(string token)
+            => token.IndexOfAny(IllegalTokenCharacters) != -1;
+
+        /// <summary>
         ///     Checks the validity of the supplied token of a specific type.
         /// </summary>
         /// <param name="tokenType"> The type of token to validate. </param>
@@ -131,6 +152,9 @@ namespace Discord
             // A Null or WhiteSpace token of any type is invalid.
             if (string.IsNullOrWhiteSpace(token))
                 throw new ArgumentNullException(paramName: nameof(token), message: "A token cannot be null, empty, or contain only whitespace.");
+            // ensure that there are no whitespace or newline characters
+            if (CheckContainsIllegalCharacters(token))
+                throw new ArgumentException(message: "The token contains a whitespace or newline character. Ensure that the token has been properly trimmed.", paramName: nameof(token));
 
             switch (tokenType)
             {

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -128,7 +128,7 @@ namespace Discord.API
                 RestClient.SetCancelToken(_loginCancelToken.Token);
 
                 AuthTokenType = tokenType;
-                AuthToken = token;
+                AuthToken = token.Trim();
                 if (tokenType != TokenType.Webhook)
                     RestClient.SetHeader("authorization", GetPrefixedToken(AuthTokenType, AuthToken));
 

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -128,7 +128,7 @@ namespace Discord.API
                 RestClient.SetCancelToken(_loginCancelToken.Token);
 
                 AuthTokenType = tokenType;
-                AuthToken = token.Trim();
+                AuthToken = token;
                 if (tokenType != TokenType.Webhook)
                     RestClient.SetHeader("authorization", GetPrefixedToken(AuthTokenType, AuthToken));
 

--- a/test/Discord.Net.Tests/Tests.TokenUtils.cs
+++ b/test/Discord.Net.Tests/Tests.TokenUtils.cs
@@ -99,6 +99,16 @@ namespace Discord
         [InlineData("937it3ow87i4ery69876wqire")]
         // 57 char bot token
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kK")]
+        // ends with invalid characters
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k ")]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k\n")]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k\t")]
+        [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k\r\n")]
+        // starts with invalid characters
+        [InlineData(" MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k")]
+        [InlineData("\nMTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k")]
+        [InlineData("\tMTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k")]
+        [InlineData("\r\nMTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7k")]
         [InlineData("This is an invalid token, but it passes the check for string length.")]
         // valid token, but passed in twice
         [InlineData("MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWsMTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs")]


### PR DESCRIPTION
This change checks for whitespace or newline characters in the token, and if there are any contained, will warn the user to trim their inputs first.

After discussion in the dnet channel, it was decided that the lib should not modify tokens. This PR was updated to instead validate them. (Previously was `.Trim()`ing them)