### PR TITLE
Fix: AudioClient Disconnect Race Condition

### DIFF
--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -106,11 +106,13 @@ namespace Discord
                 finally { _stateLock.Release(); }
             });
         }
-        public virtual Task StopAsync()
+
+        public virtual async Task StopAsync()
         {
             Cancel();
-            _task?.ConfigureAwait(false).GetAwaiter().GetResult();
-            return Task.CompletedTask;
+
+            if (_task != null)
+                await _task.ConfigureAwait(false);
         }
 
         private async Task ConnectAsync(CancellationTokenSource reconnectCancelToken)

--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -109,6 +109,7 @@ namespace Discord
         public virtual Task StopAsync()
         {
             Cancel();
+            _task?.ConfigureAwait(false).GetAwaiter().GetResult();
             return Task.CompletedTask;
         }
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -264,7 +264,9 @@ namespace Discord.WebSocket
                 await heartbeatTask.ConfigureAwait(false);
             _heartbeatTask = null;
 
-            while (_heartbeatTimes.TryDequeue(out _)) { }
+            // Check if heartbeatTimes still contains something. Prevent infinite-looping.
+            if (_heartbeatTimes.Count > 0) 
+                while (_heartbeatTimes.TryDequeue(out _)) { }
             _lastMessageTime = 0;
 
             await _gatewayLogger.DebugAsync("Waiting for guild downloader").ConfigureAwait(false);


### PR DESCRIPTION
Hi There,

This solves a race condition which occurs when disconnecting from voice. Some users may have noticed it, some might not. All this does is await on `_task` found inside the `ConnectionManager` when calling `StopAsync`.

This has only been locally tested, however has been installed onto a public/production bot for real-world testing. It is recommended to test this further before merging in-case of any unexpected issues.