### PR TITLE
Added id overload for RemoveReactionAsync

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -84,6 +84,23 @@ namespace Discord
         /// <seealso cref="IEmote"/>
         Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null);
         /// <summary>
+        ///     Removes a reaction from message.
+        /// </summary>
+        /// <example>
+        ///     The following example removes the reaction, <c>💕</c>, added by the message author from the message.
+        ///     <code language="cs">
+        ///     await msg.RemoveReactionAsync(new Emoji("\U0001f495"), 84291986575613952);
+        ///     </code>
+        /// </example>
+        /// <param name="emote">The emoji used to react to this message.</param>
+        /// <param name="userId">The id of the user that added the emoji.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation for removing a reaction to this message.
+        /// </returns>
+        /// <seealso cref="IEmote"/>
+        Task RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options = null);
+        /// <summary>
         ///     Removes all reactions from this message.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>

--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -87,13 +87,13 @@ namespace Discord
         ///     Removes a reaction from message.
         /// </summary>
         /// <example>
-        ///     The following example removes the reaction, <c>💕</c>, added by the message author from the message.
+        ///     The following example removes the reaction, <c>💕</c>, added by the user with ID 84291986575613952 from the message.
         ///     <code language="cs">
         ///     await msg.RemoveReactionAsync(new Emoji("\U0001f495"), 84291986575613952);
         ///     </code>
         /// </example>
         /// <param name="emote">The emoji used to react to this message.</param>
-        /// <param name="userId">The id of the user that added the emoji.</param>
+        /// <param name="userId">The ID of the user that added the emoji.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation for removing a reaction to this message.

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -40,9 +40,9 @@ namespace Discord.Rest
             await client.ApiClient.AddReactionAsync(msg.Channel.Id, msg.Id, emote is Emote e ? $"{e.Name}:{e.Id}" : emote.Name, options).ConfigureAwait(false);
         }
 
-        public static async Task RemoveReactionAsync(IMessage msg, IUser user, IEmote emote, BaseDiscordClient client, RequestOptions options)
+        public static async Task RemoveReactionAsync(IMessage msg, ulong userId, IEmote emote, BaseDiscordClient client, RequestOptions options)
         {
-            await client.ApiClient.RemoveReactionAsync(msg.Channel.Id, msg.Id, user.Id, emote is Emote e ? $"{e.Name}:{e.Id}" : emote.Name, options).ConfigureAwait(false);
+            await client.ApiClient.RemoveReactionAsync(msg.Channel.Id, msg.Id, userId, emote is Emote e ? $"{e.Name}:{e.Id}" : emote.Name, options).ConfigureAwait(false);
         }
 
         public static async Task RemoveAllReactionsAsync(IMessage msg, BaseDiscordClient client, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -149,7 +149,10 @@ namespace Discord.Rest
             => MessageHelper.AddReactionAsync(this, emote, Discord, options);
         /// <inheritdoc />
         public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
-            => MessageHelper.RemoveReactionAsync(this, user, emote, Discord, options);
+            => MessageHelper.RemoveReactionAsync(this, user.Id, emote, Discord, options);
+        /// <inheritdoc />
+        public Task RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options = null)
+            => MessageHelper.RemoveReactionAsync(this, userId, emote, Discord, options);
         /// <inheritdoc />
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsAsync(this, Discord, options);

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -145,7 +145,10 @@ namespace Discord.WebSocket
             => MessageHelper.AddReactionAsync(this, emote, Discord, options);
         /// <inheritdoc />
         public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
-            => MessageHelper.RemoveReactionAsync(this, user, emote, Discord, options);
+            => MessageHelper.RemoveReactionAsync(this, user.Id, emote, Discord, options);
+        /// <inheritdoc />
+        public Task RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options = null)
+            => MessageHelper.RemoveReactionAsync(this, userId, emote, Discord, options);
         /// <inheritdoc />
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsAsync(this, Discord, options);


### PR DESCRIPTION
When working in the `ReactionAdded` event if the user wasn't in cache you'd need to use a REST request to fetch them to remove their reaction, doubling your request amount even though all that's required to remove their reaction is the users id (which is provided through the event). 

If there are any other methods that should have an id overload let me know and I'll add it to this PR.