### PR TITLE
Feature: Disconnect guild members from voice channels

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
@@ -67,11 +67,11 @@ namespace Discord
         /// </remarks>
         public Optional<IVoiceChannel> Channel { get; set; }
         /// <summary>
-        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from their current voice channel.
+        ///     Moves a user to a voice channel. Set <see cref="Channel"/> to <c>null</c> to disconnect this user from their current voice channel.
         /// </summary>
         /// <remarks>
         ///     This user MUST already be in a <see cref="IVoiceChannel"/> for this to work.
         /// </remarks>
-        public Optional<ulong?> ChannelId { get; set; }
+        public Optional<ulong> ChannelId { get; set; } // TODO: v3 breaking change, change ChannelId to ulong? to allow for kicking users from voice
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
@@ -59,7 +59,7 @@ namespace Discord
         /// </remarks>
         public Optional<IEnumerable<ulong>> RoleIds { get; set; }
         /// <summary>
-        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from voice.
+        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from their current voice channel.
         /// </summary>
         /// <remarks>
         ///     This user MUST already be in a <see cref="IVoiceChannel"/> for this to work.
@@ -67,7 +67,7 @@ namespace Discord
         /// </remarks>
         public Optional<IVoiceChannel> Channel { get; set; }
         /// <summary>
-        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from voice.
+        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from their current voice channel.
         /// </summary>
         /// <remarks>
         ///     This user MUST already be in a <see cref="IVoiceChannel"/> for this to work.

--- a/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
@@ -59,18 +59,19 @@ namespace Discord
         /// </remarks>
         public Optional<IEnumerable<ulong>> RoleIds { get; set; }
         /// <summary>
-        ///     Moves a user to a voice channel.
+        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from voice.
         /// </summary>
         /// <remarks>
         ///     This user MUST already be in a <see cref="IVoiceChannel"/> for this to work.
+        ///     When set, this property takes precedence over <see cref="ChannelId"/>.
         /// </remarks>
         public Optional<IVoiceChannel> Channel { get; set; }
         /// <summary>
-        ///     Moves a user to a voice channel.
+        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from voice.
         /// </summary>
         /// <remarks>
         ///     This user MUST already be in a <see cref="IVoiceChannel"/> for this to work.
         /// </remarks>
-        public Optional<ulong> ChannelId { get; set; }
+        public Optional<ulong?> ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildMemberParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildMemberParams.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest
@@ -15,6 +15,6 @@ namespace Discord.API.Rest
         [JsonProperty("roles")]
         public Optional<ulong[]> RoleIds { get; set; }
         [JsonProperty("channel_id")]
-        public Optional<ulong> ChannelId { get; set; }
+        public Optional<ulong?> ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
@@ -1,4 +1,4 @@
-﻿using Discord.API.Rest;
+using Discord.API.Rest;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -39,7 +39,7 @@ namespace Discord.Rest
             };
 
             if (args.Channel.IsSpecified)
-                apiArgs.ChannelId = args.Channel.Value.Id;
+                apiArgs.ChannelId = args.Channel.Value?.Id;
             else if (args.ChannelId.IsSpecified)
                 apiArgs.ChannelId = args.ChannelId.Value;
 


### PR DESCRIPTION
Updates `GuildUserProperties` to allow for setting either `Channel` or `ChannelId` to `null`, which will disconnect users from voice channels.

The type of `ChannelId` has been updated from a `ulong` to `ulong?`, which matches the [latest api documentation.](https://discordapp.com/developers/docs/resources/guild#modify-guild-member)
