### PR TITLE
Set the @everyone IRole for @everyone and @here tags

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -154,7 +154,7 @@ namespace Discord.Rest
                 if (index == -1) break;
                 IRole mentionedRole = null;
                 if (guild != null)
-                    mentionedRole = guild.GetRole(guild.Id);
+                    mentionedRole = guild.EveryoneRole;
 
                 var tagIndex = FindIndex(tags, index);
                 if (tagIndex.HasValue)
@@ -169,7 +169,7 @@ namespace Discord.Rest
                 if (index == -1) break;
                 IRole mentionedRole = null;
                 if (guild != null)
-                    mentionedRole = guild.GetRole(guild.Id);
+                    mentionedRole = guild.EveryoneRole;
 
                 var tagIndex = FindIndex(tags, index);
                 if (tagIndex.HasValue)

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -152,10 +152,13 @@ namespace Discord.Rest
             {
                 index = text.IndexOf("@everyone", index);
                 if (index == -1) break;
+                IRole mentionedRole = null;
+                if (guild != null)
+                    mentionedRole = guild.GetRole(guild.Id);
 
                 var tagIndex = FindIndex(tags, index);
                 if (tagIndex.HasValue)
-                    tags.Insert(tagIndex.Value, new Tag<object>(TagType.EveryoneMention, index, "@everyone".Length, 0, null));
+                    tags.Insert(tagIndex.Value, new Tag<IRole>(TagType.EveryoneMention, index, "@everyone".Length, 0, mentionedRole));
                 index++;
             }
 
@@ -164,10 +167,13 @@ namespace Discord.Rest
             {
                 index = text.IndexOf("@here", index);
                 if (index == -1) break;
+                IRole mentionedRole = null;
+                if (guild != null)
+                    mentionedRole = guild.GetRole(guild.Id);
 
                 var tagIndex = FindIndex(tags, index);
                 if (tagIndex.HasValue)
-                    tags.Insert(tagIndex.Value, new Tag<object>(TagType.HereMention, index, "@here".Length, 0, null));
+                    tags.Insert(tagIndex.Value, new Tag<IRole>(TagType.HereMention, index, "@here".Length, 0, mentionedRole));
                 index++;
             }
 

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -152,13 +152,9 @@ namespace Discord.Rest
             {
                 index = text.IndexOf("@everyone", index);
                 if (index == -1) break;
-                IRole mentionedRole = null;
-                if (guild != null)
-                    mentionedRole = guild.EveryoneRole;
-
                 var tagIndex = FindIndex(tags, index);
                 if (tagIndex.HasValue)
-                    tags.Insert(tagIndex.Value, new Tag<IRole>(TagType.EveryoneMention, index, "@everyone".Length, 0, mentionedRole));
+                    tags.Insert(tagIndex.Value, new Tag<IRole>(TagType.EveryoneMention, index, "@everyone".Length, 0, guild?.EveryoneRole));
                 index++;
             }
 
@@ -167,13 +163,9 @@ namespace Discord.Rest
             {
                 index = text.IndexOf("@here", index);
                 if (index == -1) break;
-                IRole mentionedRole = null;
-                if (guild != null)
-                    mentionedRole = guild.EveryoneRole;
-
                 var tagIndex = FindIndex(tags, index);
                 if (tagIndex.HasValue)
-                    tags.Insert(tagIndex.Value, new Tag<IRole>(TagType.HereMention, index, "@here".Length, 0, mentionedRole));
+                    tags.Insert(tagIndex.Value, new Tag<IRole>(TagType.HereMention, index, "@here".Length, 0, guild?.EveryoneRole));
                 index++;
             }
 


### PR DESCRIPTION
Adds support for setting the `IRole` corresponding to `@everyone` or `@here` in a the tags of a message. Previously this would only set the `TagType`, but leave the value as null.

This does not distinguish between `@everyone` and `@here`, as that's done using `TagType`. The values of both will be the same.

This issue was suggested by @TheCasino 
