### PR TITLE
Feature: Model updates related to guild boosting

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -92,7 +92,6 @@ namespace Discord
                 return $"{DiscordConfig.CDNUrl}banners/{guildId}/{vanityId}.jpg" + (size.HasValue ? $"?size={size}" : string.Empty);
             return null;
         }
-        //    => vanityId != null ? $"{DiscordConfig.CDNUrl}banners/{guildId}/{vanityId}.jpg?size={size}" : null;
         /// <summary>
         ///     Returns an emoji URL.
         /// </summary>

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -76,6 +76,18 @@ namespace Discord
         /// </returns>
         public static string GetChannelIconUrl(ulong channelId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}channel-icons/{channelId}/{iconId}.jpg" : null;
+
+        /// <summary>
+        ///     Returns a guild vanity URL.
+        /// </summary>
+        /// <param name="guildId">The guild snowflake identifier.</param>
+        /// <param name="vanityId">The vanity image identifier.</param>
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
+        /// <returns>
+        ///     A URL pointing to the guild's vanity image.
+        /// </returns>
+        public static string GetGuildVanityUrl(ulong guildId, string vanityId, ushort size)
+            => vanityId != null ? $"{DiscordConfig.CDNUrl}banners/{guildId}/{vanityId}.jpg?size={size}" : null;
         /// <summary>
         ///     Returns an emoji URL.
         /// </summary>

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -23,7 +23,7 @@ namespace Discord
         /// </summary>
         /// <param name="userId">The user snowflake identifier.</param>
         /// <param name="avatarId">The avatar identifier.</param>
-        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
+        /// <param name="size">The size of the image to return in horizontal pixels. This can be any power of two between 16 and 2048.</param>
         /// <param name="format">The format to return.</param>
         /// <returns>
         ///     A URL pointing to the user's avatar in the specified size.
@@ -82,7 +82,7 @@ namespace Discord
         /// </summary>
         /// <param name="guildId">The guild snowflake identifier.</param>
         /// <param name="vanityId">The vanity image identifier.</param>
-        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
+        /// <param name="size">The size of the image to return in horizontal pixels. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A URL pointing to the guild's vanity image.
         /// </returns>

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -78,18 +78,18 @@ namespace Discord
             => iconId != null ? $"{DiscordConfig.CDNUrl}channel-icons/{channelId}/{iconId}.jpg" : null;
 
         /// <summary>
-        ///     Returns a guild vanity URL.
+        ///     Returns a guild banner URL.
         /// </summary>
         /// <param name="guildId">The guild snowflake identifier.</param>
-        /// <param name="vanityId">The vanity image identifier.</param>
-        /// <param name="size">The size of the image to return in horizontal pixels. This can be any power of two between 16 and 2048.</param>
+        /// <param name="bannerId">The banner image identifier.</param>
+        /// <param name="size">The size of the image to return in horizontal pixels. This can be any power of two between 16 and 2048 inclusive.</param>
         /// <returns>
-        ///     A URL pointing to the guild's vanity image.
+        ///     A URL pointing to the guild's banner image.
         /// </returns>
-        public static string GetGuildVanityUrl(ulong guildId, string vanityId, ushort? size = null)
+        public static string GetGuildBannerUrl(ulong guildId, string bannerId, ushort? size = null)
         {
-            if (!string.IsNullOrEmpty(vanityId))
-                return $"{DiscordConfig.CDNUrl}banners/{guildId}/{vanityId}.jpg" + (size.HasValue ? $"?size={size}" : string.Empty);
+            if (!string.IsNullOrEmpty(bannerId))
+                return $"{DiscordConfig.CDNUrl}banners/{guildId}/{bannerId}.jpg" + (size.HasValue ? $"?size={size}" : string.Empty);
             return null;
         }
         /// <summary>

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -86,8 +86,13 @@ namespace Discord
         /// <returns>
         ///     A URL pointing to the guild's vanity image.
         /// </returns>
-        public static string GetGuildVanityUrl(ulong guildId, string vanityId, ushort size)
-            => vanityId != null ? $"{DiscordConfig.CDNUrl}banners/{guildId}/{vanityId}.jpg?size={size}" : null;
+        public static string GetGuildVanityUrl(ulong guildId, string vanityId, ushort? size = null)
+        {
+            if (!string.IsNullOrEmpty(vanityId))
+                return $"{DiscordConfig.CDNUrl}banners/{guildId}/{vanityId}.jpg" + (size.HasValue ? $"?size={size}" : string.Empty);
+            return null;
+        }
+        //    => vanityId != null ? $"{DiscordConfig.CDNUrl}banners/{guildId}/{vanityId}.jpg?size={size}" : null;
         /// <summary>
         ///     Returns an emoji URL.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -72,8 +72,14 @@ namespace Discord
         public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
         /// <summary>
         ///     Gets or sets the flags that DISABLE types of system channels.
-        ///     This logic is inverted!
         /// </summary>
+        /// <remarks>
+        ///     These flags are inverted. Setting a flag will disable that system channel message from being sent.
+        ///     A value of <see cref="SystemChannelMessageDeny.None"/> will allow all system channel message types to be sent,
+        ///     given that the <see cref="SystemChannelId"/> has also been sent.
+        ///     Refer to the extension methods <see cref="GuildExtensions.GetGuildBoostMessagesEnabled(IGuild)"/> and <see cref="GuildExtensions.GetWelcomeMessagesEnabled(IGuild)"/>
+        ///     to check if these system channel messages are enabled, without the need to manipulate the flags.
+        /// </remarks>
         public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -70,5 +70,10 @@ namespace Discord
         ///     Gets or sets the explicit content filter level of this guild.
         /// </summary>
         public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
+        /// <summary>
+        ///     Gets or sets the flags that DISABLE types of system channels.
+        ///     This logic is inverted!
+        /// </summary>
+        public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -77,8 +77,11 @@ namespace Discord
         ///     These flags are inverted. Setting a flag will disable that system channel message from being sent.
         ///     A value of <see cref="SystemChannelMessageDeny.None"/> will allow all system channel message types to be sent,
         ///     given that the <see cref="SystemChannelId"/> has also been sent.
-        ///     Refer to the extension methods <see cref="GuildExtensions.GetGuildBoostMessagesEnabled(IGuild)"/> and <see cref="GuildExtensions.GetWelcomeMessagesEnabled(IGuild)"/>
-        ///     to check if these system channel messages are enabled, without the need to manipulate the flags.
+        ///     A value of <see cref="SystemChannelMessageDeny.GuildBoost"/> will deny guild boost messages from being sent, and allow all
+        ///     other types of messages.
+        ///     Refer to the extension methods <see cref="GuildExtensions.GetGuildBoostMessagesEnabled(IGuild)"/> and
+        ///     <see cref="GuildExtensions.GetWelcomeMessagesEnabled(IGuild)"/> to check if these system channel messages
+        ///     are enabled, without the need to manipulate the flags.
         /// </remarks>
         public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
     }

--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -71,17 +71,17 @@ namespace Discord
         /// </summary>
         public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
         /// <summary>
-        ///     Gets or sets the flags that DISABLE types of system channels.
+        ///     Gets or sets the flags that DISABLE types of system channel messages.
         /// </summary>
         /// <remarks>
         ///     These flags are inverted. Setting a flag will disable that system channel message from being sent.
         ///     A value of <see cref="SystemChannelMessageDeny.None"/> will allow all system channel message types to be sent,
-        ///     given that the <see cref="SystemChannelId"/> has also been sent.
+        ///     given that the <see cref="SystemChannelId"/> has also been set.
         ///     A value of <see cref="SystemChannelMessageDeny.GuildBoost"/> will deny guild boost messages from being sent, and allow all
         ///     other types of messages.
         ///     Refer to the extension methods <see cref="GuildExtensions.GetGuildBoostMessagesEnabled(IGuild)"/> and
-        ///     <see cref="GuildExtensions.GetWelcomeMessagesEnabled(IGuild)"/> to check if these system channel messages
-        ///     are enabled, without the need to manipulate the flags.
+        ///     <see cref="GuildExtensions.GetWelcomeMessagesEnabled(IGuild)"/> to check if these system channel message types
+        ///     are enabled, without the need to manipulate the logic of the flag.
         /// </remarks>
         public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
     }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -231,6 +231,13 @@ namespace Discord
         ///     The description for the guild; <c>null</c> if none is set.
         /// </returns>
         string Description { get; }
+        /// <summary>
+        ///     Gets the number of premium subscribers of this guild.
+        /// </summary>
+        /// <returns>
+        ///     The number of premium subscribers of this guild.
+        /// </returns>
+        int PremiumSubscriptionCount { get; }
 
         /// <summary>
         ///     Modifies this guild.

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -204,19 +204,29 @@ namespace Discord
         /// </returns>
         PremiumTier PremiumTier { get; }
         /// <summary>
-        ///     Gets the identifier for this guilds vanity image.
-        /// </summary>
-        /// <remarks>
-        ///     An identifier for the vanity image; <c>null</c> if none is set.
-        /// </remarks>
-        string VanityId { get; }
-        /// <summary>
-        ///     Gets the URL of this guild's vanity image.
+        ///     Gets the identifier for this guilds banner image.
         /// </summary>
         /// <returns>
-        ///     A URL pointing to the guild's vanity image; <c>null</c> if none is set.
+        ///     An identifier for the banner image; <c>null</c> if none is set.
         /// </returns>
-        string VanityUrl { get; }
+        string BannerId { get; }
+        /// <summary>
+        ///     Gets the URL of this guild's banner image.
+        /// </summary>
+        /// <remarks>
+        ///     This is referred to as the vanity image in the API.
+        /// </remarks>
+        /// <returns>
+        ///     A URL pointing to the guild's banner image; <c>null</c> if none is set.
+        /// </returns>
+        string BannerUrl { get; }
+        /// <summary>
+        ///     Gets the code for this guild's vanity invite URL.
+        /// </summary>
+        /// <returns>
+        ///     A string containing the vanity invite code for this guild; <c>null</c> if none is set.
+        /// </returns>
+        string VanityURLCode { get; }
         /// <summary>
         ///     Gets the flags for the types of system channels that are disabled.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -213,9 +213,6 @@ namespace Discord
         /// <summary>
         ///     Gets the URL of this guild's banner image.
         /// </summary>
-        /// <remarks>
-        ///     This is referred to as the vanity image in the API.
-        /// </remarks>
         /// <returns>
         ///     A URL pointing to the guild's banner image; <c>null</c> if none is set.
         /// </returns>
@@ -228,10 +225,10 @@ namespace Discord
         /// </returns>
         string VanityURLCode { get; }
         /// <summary>
-        ///     Gets the flags for the types of system channels that are disabled.
+        ///     Gets the flags for the types of system channel messages that are disabled.
         /// </summary>
         /// <returns>
-        ///     The flags for the types of system channel flags that are disabled.
+        ///     The flags for the types of system channel messages that are disabled.
         /// </returns>
         SystemChannelMessageDeny SystemChannelFlags { get; }
         /// <summary>
@@ -244,6 +241,9 @@ namespace Discord
         /// <summary>
         ///     Gets the number of premium subscribers of this guild.
         /// </summary>
+        /// <remarks>
+        ///     This is the number of users who have boosted this guild.
+        /// </remarks>
         /// <returns>
         ///     The number of premium subscribers of this guild.
         /// </returns>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -196,6 +196,41 @@ namespace Discord
         ///     A read-only collection of roles found within this guild.
         /// </returns>
         IReadOnlyCollection<IRole> Roles { get; }
+        /// <summary>
+        ///     Gets the tier of guild boosting in this guild.
+        /// </summary>
+        /// <returns>
+        ///     The tier of guild boosting in this guild.
+        /// </returns>
+        PremiumTier PremiumTier { get; }
+        /// <summary>
+        ///     Gets the identifier for this guilds vanity image.
+        /// </summary>
+        /// <remarks>
+        ///     An identifier for the vanity image; <c>null</c> if none is set.
+        /// </remarks>
+        string VanityId { get; }
+        /// <summary>
+        ///     Gets the URL of this guild's vanity image.
+        /// </summary>
+        /// <returns>
+        ///     A URL pointing to the guild's vanity image; <c>null</c> if none is set.
+        /// </returns>
+        string VanityUrl { get; }
+        /// <summary>
+        ///     Gets the flags for the types of system channels that are disabled.
+        /// </summary>
+        /// <returns>
+        ///     The flags for the types of system channel flags that are disabled.
+        /// </returns>
+        SystemChannelMessageDeny SystemChannelFlags { get; }
+        /// <summary>
+        ///     Gets the description for the guild.
+        /// </summary>
+        /// <returns>
+        ///     The description for the guild; <c>null</c> if none is set.
+        /// </returns>
+        string Description { get; }
 
         /// <summary>
         ///     Modifies this guild.

--- a/src/Discord.Net.Core/Entities/Guilds/PremiumTier.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/PremiumTier.cs
@@ -11,11 +11,11 @@ namespace Discord
         /// </summary>
         Tier1 = 1,
         /// <summary>
-        ///     Used for guilds that have Tier 1 guild boosts.
+        ///     Used for guilds that have Tier 2 guild boosts.
         /// </summary>
         Tier2 = 2,
         /// <summary>
-        ///     Used for guilds that have Tier 1 guild boosts.
+        ///     Used for guilds that have Tier 3 guild boosts.
         /// </summary>
         Tier3 = 3
     }

--- a/src/Discord.Net.Core/Entities/Guilds/PremiumTier.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/PremiumTier.cs
@@ -1,0 +1,22 @@
+namespace Discord
+{
+    public enum PremiumTier
+    {
+        /// <summary>
+        ///     Used for guilds that have no guild boosts.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        ///     Used for guilds that have Tier 1 guild boosts.
+        /// </summary>
+        Tier1 = 1,
+        /// <summary>
+        ///     Used for guilds that have Tier 1 guild boosts.
+        /// </summary>
+        Tier2 = 2,
+        /// <summary>
+        ///     Used for guilds that have Tier 1 guild boosts.
+        /// </summary>
+        Tier3 = 3
+    }
+}

--- a/src/Discord.Net.Core/Entities/Guilds/SystemChannelMessageDeny.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/SystemChannelMessageDeny.cs
@@ -11,11 +11,11 @@ namespace Discord
         /// </summary>
         None = 0,
         /// <summary>
-        ///     The messages that are sent when a user joins the guild.
+        ///     Deny the messages that are sent when a user joins the guild.
         /// </summary>
         WelcomeMessage = 0b1,
         /// <summary>
-        ///     The messages that are sent when a user boosts the guild.
+        ///     Deny the messages that are sent when a user boosts the guild.
         /// </summary>
         GuildBoost = 0b10
     }

--- a/src/Discord.Net.Core/Entities/Guilds/SystemChannelMessageDeny.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/SystemChannelMessageDeny.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Discord
+{
+    [Flags]
+    public enum SystemChannelMessageDeny
+    {
+        /// <summary>
+        ///     The messages that are sent when a user joins the guild.
+        /// </summary>
+        WelcomeMessage = 0b1,
+        /// <summary>
+        ///     The messages that are sent when a user boosts the guild.
+        /// </summary>
+        GuildBoost = 0b10
+    }
+}

--- a/src/Discord.Net.Core/Entities/Guilds/SystemChannelMessageDeny.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/SystemChannelMessageDeny.cs
@@ -6,6 +6,11 @@ namespace Discord
     public enum SystemChannelMessageDeny
     {
         /// <summary>
+        ///     Deny none of the system channel messages.
+        ///     This will enable all of the system channel messages.
+        /// </summary>
+        None = 0,
+        /// <summary>
         ///     The messages that are sent when a user joins the guild.
         /// </summary>
         WelcomeMessage = 0b1,

--- a/src/Discord.Net.Core/Entities/Messages/MessageType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageType.cs
@@ -36,6 +36,22 @@ namespace Discord
         /// <summary>
         ///     The message when a new member joined.
         /// </summary>
-        GuildMemberJoin = 7
+        GuildMemberJoin = 7,
+        /// <summary>
+        ///     The message for when a user boosts a guild.
+        /// </summary>
+        UserPremiumGuildSubscription = 8,
+        /// <summary>
+        ///     The message for when a guild reaches Tier 1 of Nitro boosts.
+        /// </summary>
+        UserPremiumGuildSubscriptionTier1 = 9,
+        /// <summary>
+        ///     The message for when a guild reaches Tier 2 of Nitro boosts.
+        /// </summary>
+        UserPremiumGuildSubscriptionTier2 = 10,
+        /// <summary>
+        ///     The message for when a guild reaches Tier 3 of Nitro boosts.
+        /// </summary>
+        UserPremiumGuildSubscriptionTier3 = 11
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -48,6 +48,13 @@ namespace Discord
         /// </returns>
         ulong GuildId { get; }
         /// <summary>
+        ///     Gets the date and time for when this user's guild boost began.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="DateTime"/> for when the user began boosting this guild; <c>null</c> if they are not boosting the guild.
+        /// </returns>
+        DateTime? PremiumSince { get; }
+        /// <summary>
         ///     Gets a collection of IDs for the roles that this user currently possesses in the guild.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -51,9 +51,9 @@ namespace Discord
         ///     Gets the date and time for when this user's guild boost began.
         /// </summary>
         /// <returns>
-        ///     A <see cref="DateTime"/> for when the user began boosting this guild; <c>null</c> if they are not boosting the guild.
+        ///     A <see cref="DateTimeOffset"/> for when the user began boosting this guild; <c>null</c> if they are not boosting the guild.
         /// </returns>
-        DateTime? PremiumSince { get; }
+        DateTimeOffset? PremiumSince { get; }
         /// <summary>
         ///     Gets a collection of IDs for the roles that this user currently possesses in the guild.
         /// </summary>

--- a/src/Discord.Net.Core/Extensions/GuildExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/GuildExtensions.cs
@@ -6,7 +6,7 @@ namespace Discord
     public static class GuildExtensions
     {
         /// <summary>
-        ///     Gets if welcome message system messages are enabled.
+        ///     Gets if welcome system messages are enabled.
         /// </summary>
         /// <param name="guild"> The guild to check. </param>
         /// <returns> A <c>bool</c> indicating if the welcome messages are enabled in the system channel. </returns>

--- a/src/Discord.Net.Core/Extensions/GuildExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/GuildExtensions.cs
@@ -1,0 +1,24 @@
+namespace Discord
+{
+    /// <summary>
+    ///     An extension class for <see cref="IGuild"/>.
+    /// </summary>
+    public static class GuildExtensions
+    {
+        /// <summary>
+        ///     Gets if welcome message system messages are enabled.
+        /// </summary>
+        /// <param name="guild"> The guild to check. </param>
+        /// <returns> A <c>bool</c> indicating if the welcome messages are enabled in the system channel. </returns>
+        public static bool GetWelcomeMessagesEnabled(this IGuild guild)
+            => !guild.SystemChannelFlags.HasFlag(SystemChannelMessageDeny.WelcomeMessage);
+
+        /// <summary>
+        ///     Gets if guild boost system messages are enabled.
+        /// </summary>
+        /// <param name="guild"> The guild to check. </param>
+        /// <returns> A <c>bool</c> indicating if the guild boost messages are enabled in the system channel. </returns>
+        public static bool GetGuildBoostMessagesEnabled(this IGuild guild)
+            => !guild.SystemChannelFlags.HasFlag(SystemChannelMessageDeny.GuildBoost);
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -54,5 +54,7 @@ namespace Discord.API
         // this value is inverted, flags set will turn OFF features
         [JsonProperty("system_channel_flags")]
         public SystemChannelMessageDeny SystemChannelFlags { get; set; }
+        [JsonProperty("premium_subscription_count")]
+        public Optional<int> PremiumSubscriptionCount { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -57,6 +57,6 @@ namespace Discord.API
         [JsonProperty("system_channel_flags")]
         public SystemChannelMessageDeny SystemChannelFlags { get; set; }
         [JsonProperty("premium_subscription_count")]
-        public Optional<int> PremiumSubscriptionCount { get; set; }
+        public int? PremiumSubscriptionCount { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -45,5 +45,12 @@ namespace Discord.API
         public ulong? ApplicationId { get; set; }
         [JsonProperty("system_channel_id")]
         public ulong? SystemChannelId { get; set; }
+        [JsonProperty("premium_tier")]
+        public int PremiumTier { get; set; }
+        [JsonProperty("vanity_url_code")]
+        public string VanityURLCode { get; set; }
+        // this value is inverted, flags set will turn OFF features
+        [JsonProperty("system_channel_flags")]
+        public int SystemChannelFlags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -46,11 +46,13 @@ namespace Discord.API
         [JsonProperty("system_channel_id")]
         public ulong? SystemChannelId { get; set; }
         [JsonProperty("premium_tier")]
-        public int PremiumTier { get; set; }
+        public PremiumTier PremiumTier { get; set; }
         [JsonProperty("vanity_url_code")]
         public string VanityURLCode { get; set; }
+        [JsonProperty("description")]
+        public string Description { get; set; }
         // this value is inverted, flags set will turn OFF features
         [JsonProperty("system_channel_flags")]
-        public int SystemChannelFlags { get; set; }
+        public SystemChannelMessageDeny SystemChannelFlags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -49,6 +49,8 @@ namespace Discord.API
         public PremiumTier PremiumTier { get; set; }
         [JsonProperty("vanity_url_code")]
         public string VanityURLCode { get; set; }
+        [JsonProperty("banner")]
+        public string Banner { get; set; }
         [JsonProperty("description")]
         public string Description { get; set; }
         // this value is inverted, flags set will turn OFF features

--- a/src/Discord.Net.Rest/API/Common/GuildMember.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildMember.cs
@@ -18,7 +18,7 @@ namespace Discord.API
         public Optional<bool> Deaf { get; set; }
         [JsonProperty("mute")]
         public Optional<bool> Mute { get; set; }
-        [JsonProperty("premium_guild_since")]
-        public Optional<DateTime> PremiumSince { get; set; }
+        [JsonProperty("premium_since")]
+        public Optional<DateTimeOffset?> PremiumSince { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildMember.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildMember.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 using System;
 
@@ -18,5 +18,7 @@ namespace Discord.API
         public Optional<bool> Deaf { get; set; }
         [JsonProperty("mute")]
         public Optional<bool> Mute { get; set; }
+        [JsonProperty("premium_guild_since")]
+        public Optional<DateTime> PremiumSince { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
@@ -30,5 +30,7 @@ namespace Discord.API.Rest
         public Optional<ulong> OwnerId { get; set; }
         [JsonProperty("explicit_content_filter")]
         public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
+        [JsonProperty("system_channel_flags")]
+        public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -33,7 +33,8 @@ namespace Discord.Rest
                 Name = args.Name,
                 Splash = args.Splash.IsSpecified ? args.Splash.Value?.ToModel() : Optional.Create<ImageModel?>(),
                 VerificationLevel = args.VerificationLevel,
-                ExplicitContentFilter = args.ExplicitContentFilter
+                ExplicitContentFilter = args.ExplicitContentFilter,
+                SystemChannelFlags = args.SystemChannelFlags
             };
 
             if (args.AfkChannel.IsSpecified)
@@ -63,6 +64,9 @@ namespace Discord.Rest
 
             if (args.ExplicitContentFilter.IsSpecified)
                 apiArgs.ExplicitContentFilter = args.ExplicitContentFilter.Value;
+
+            if (args.SystemChannelFlags.IsSpecified)
+                apiArgs.SystemChannelFlags = args.SystemChannelFlags.Value;
 
             return await client.ApiClient.ModifyGuildAsync(guild.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -55,7 +55,9 @@ namespace Discord.Rest
         /// <inheritdoc />
         public PremiumTier PremiumTier { get; private set; }
         /// <inheritdoc />
-        public string VanityId { get; private set; }
+        public string BannerId { get; private set; }
+        /// <inheritdoc />
+        public string VanityURLCode { get; private set; }
         /// <inheritdoc />
         public SystemChannelMessageDeny SystemChannelFlags { get; private set; }
         /// <inheritdoc />
@@ -73,7 +75,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
         /// <inheritdoc />
-        public string VanityUrl => CDN.GetGuildVanityUrl(Id, VanityId);
+        public string BannerUrl => CDN.GetGuildBannerUrl(Id, BannerId);
 
         /// <summary>
         ///     Gets the built-in role containing all users in this guild.
@@ -117,10 +119,12 @@ namespace Discord.Rest
             ExplicitContentFilter = model.ExplicitContentFilter;
             ApplicationId = model.ApplicationId;
             PremiumTier = model.PremiumTier;
-            VanityId = model.VanityURLCode;
+            VanityURLCode = model.VanityURLCode;
+            BannerId = model.Banner;
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
-            PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
+            if (model.PremiumSubscriptionCount.IsSpecified)
+                PremiumSubscriptionCount = model.PremiumSubscriptionCount.Value;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -52,6 +52,14 @@ namespace Discord.Rest
         internal bool Available { get; private set; }
         /// <inheritdoc />
         public ulong? ApplicationId { get; private set; }
+        /// <inheritdoc />
+        public PremiumTier PremiumTier { get; private set; }
+        /// <inheritdoc />
+        public string VanityId { get; private set; }
+        /// <inheritdoc />
+        public SystemChannelMessageDeny SystemChannelFlags { get; private set; }
+        /// <inheritdoc />
+        public string Description { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -62,6 +70,8 @@ namespace Discord.Rest
         public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
+        /// <inheritdoc />
+        public string VanityUrl => CDN.GetGuildVanityUrl(Id, VanityId);
 
         /// <summary>
         ///     Gets the built-in role containing all users in this guild.
@@ -104,6 +114,10 @@ namespace Discord.Rest
             DefaultMessageNotifications = model.DefaultMessageNotifications;
             ExplicitContentFilter = model.ExplicitContentFilter;
             ApplicationId = model.ApplicationId;
+            PremiumTier = model.PremiumTier;
+            VanityId = model.VanityURLCode;
+            SystemChannelFlags = model.SystemChannelFlags;
+            Description = model.Description;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -60,6 +60,8 @@ namespace Discord.Rest
         public SystemChannelMessageDeny SystemChannelFlags { get; private set; }
         /// <inheritdoc />
         public string Description { get; private set; }
+        /// <inheritdoc />
+        public int PremiumSubscriptionCount { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -118,6 +120,7 @@ namespace Discord.Rest
             VanityId = model.VanityURLCode;
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
+            PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -123,8 +123,7 @@ namespace Discord.Rest
             BannerId = model.Banner;
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
-            if (model.PremiumSubscriptionCount.IsSpecified)
-                PremiumSubscriptionCount = model.PremiumSubscriptionCount.Value;
+            PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -14,6 +14,7 @@ namespace Discord.Rest
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class RestGuildUser : RestUser, IGuildUser
     {
+        private long? _premiumSinceTicks;
         private long? _joinedAtTicks;
         private ImmutableArray<ulong> _roleIds;
 
@@ -25,7 +26,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public bool IsMuted { get; private set; }
         /// <inheritdoc />
-        public DateTime? PremiumSince { get; private set; }
+        public DateTimeOffset? PremiumSince => DateTimeUtils.FromTicks(_premiumSinceTicks);
         /// <inheritdoc />
         public ulong GuildId => Guild.Id;
 
@@ -71,7 +72,7 @@ namespace Discord.Rest
             if (model.Roles.IsSpecified)
                 UpdateRoles(model.Roles.Value);
             if (model.PremiumSince.IsSpecified)
-                PremiumSince = model.PremiumSince.Value;
+                _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
         }
         private void UpdateRoles(ulong[] roleIds)
         {

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -24,7 +24,8 @@ namespace Discord.Rest
         public bool IsDeafened { get; private set; }
         /// <inheritdoc />
         public bool IsMuted { get; private set; }
-
+        /// <inheritdoc />
+        public DateTime? PremiumSince { get; private set; }
         /// <inheritdoc />
         public ulong GuildId => Guild.Id;
 
@@ -69,6 +70,8 @@ namespace Discord.Rest
                 IsMuted = model.Mute.Value;
             if (model.Roles.IsSpecified)
                 UpdateRoles(model.Roles.Value);
+            if (model.PremiumSince.IsSpecified)
+                PremiumSince = model.PremiumSince.Value;
         }
         private void UpdateRoles(ulong[] roleIds)
         {

--- a/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
@@ -14,7 +14,7 @@ namespace Discord.Rest
         public ulong WebhookId { get; }
         internal IGuild Guild { get; }
         /// <inheritdoc />
-        public DateTime? PremiumSince { get; private set; }
+        public DateTimeOffset? PremiumSince { get; private set; }
 
         /// <inheritdoc />
         public override bool IsWebhook => true;

--- a/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
@@ -13,6 +13,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public ulong WebhookId { get; }
         internal IGuild Guild { get; }
+        /// <inheritdoc />
+        public DateTime? PremiumSince { get; private set; }
 
         /// <inheritdoc />
         public override bool IsWebhook => true;

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -93,6 +93,14 @@ namespace Discord.WebSocket
         public string IconId { get; private set; }
         /// <inheritdoc />
         public string SplashId { get; private set; }
+        /// <inheritdoc />
+        public PremiumTier PremiumTier { get; private set; }
+        /// <inheritdoc />
+        public string VanityId { get; private set; }
+        /// <inheritdoc />
+        public SystemChannelMessageDeny SystemChannelFlags { get; private set; }
+        /// <inheritdoc />
+        public string Description { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -100,6 +108,8 @@ namespace Discord.WebSocket
         public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
+        /// <inheritdoc />
+        public string VanityUrl => CDN.GetGuildVanityUrl(Id, VanityId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>
         public bool HasAllMembers => MemberCount == DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
         /// <summary> Indicates whether the guild cache is synced to this guild. </summary>
@@ -354,6 +364,10 @@ namespace Discord.WebSocket
             DefaultMessageNotifications = model.DefaultMessageNotifications;
             ExplicitContentFilter = model.ExplicitContentFilter;
             ApplicationId = model.ApplicationId;
+            PremiumTier = model.PremiumTier;
+            VanityId = model.VanityURLCode;
+            SystemChannelFlags = model.SystemChannelFlags;
+            Description = model.Description;
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -96,7 +96,9 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public PremiumTier PremiumTier { get; private set; }
         /// <inheritdoc />
-        public string VanityId { get; private set; }
+        public string BannerId { get; private set; }
+        /// <inheritdoc />
+        public string VanityURLCode { get; private set; }
         /// <inheritdoc />
         public SystemChannelMessageDeny SystemChannelFlags { get; private set; }
         /// <inheritdoc />
@@ -111,7 +113,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public string SplashUrl => CDN.GetGuildSplashUrl(Id, SplashId);
         /// <inheritdoc />
-        public string VanityUrl => CDN.GetGuildVanityUrl(Id, VanityId);
+        public string BannerUrl => CDN.GetGuildBannerUrl(Id, BannerId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>
         public bool HasAllMembers => MemberCount == DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
         /// <summary> Indicates whether the guild cache is synced to this guild. </summary>
@@ -367,7 +369,8 @@ namespace Discord.WebSocket
             ExplicitContentFilter = model.ExplicitContentFilter;
             ApplicationId = model.ApplicationId;
             PremiumTier = model.PremiumTier;
-            VanityId = model.VanityURLCode;
+            VanityURLCode = model.VanityURLCode;
+            BannerId = model.Banner;
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
             PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -101,6 +101,8 @@ namespace Discord.WebSocket
         public SystemChannelMessageDeny SystemChannelFlags { get; private set; }
         /// <inheritdoc />
         public string Description { get; private set; }
+        /// <inheritdoc />
+        public int PremiumSubscriptionCount { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -368,6 +370,7 @@ namespace Discord.WebSocket
             VanityId = model.VanityURLCode;
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
+            PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -18,6 +18,7 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketGuildUser : SocketUser, IGuildUser
     {
+        private long? _premiumSinceTicks;
         private long? _joinedAtTicks;
         private ImmutableArray<ulong> _roleIds;
 
@@ -75,9 +76,8 @@ namespace Discord.WebSocket
         /// </returns>
         public SocketVoiceState? VoiceState => Guild.GetVoiceState(Id);
         public AudioInStream AudioStream => Guild.GetAudioStream(Id);
-
         /// <inheritdoc />
-        public DateTime? PremiumSince { get; private set; }
+        public DateTimeOffset? PremiumSince => DateTimeUtils.FromTicks(_premiumSinceTicks);
 
         /// <summary>
         ///     Returns the position of the user within the role hierarchy.
@@ -138,6 +138,8 @@ namespace Discord.WebSocket
                 Nickname = model.Nick.Value;
             if (model.Roles.IsSpecified)
                 UpdateRoles(model.Roles.Value);
+            if (model.PremiumSince.IsSpecified)
+                _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
         }
         internal void Update(ClientState state, PresenceModel model, bool updatePresence)
         {

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -76,6 +76,9 @@ namespace Discord.WebSocket
         public SocketVoiceState? VoiceState => Guild.GetVoiceState(Id);
         public AudioInStream AudioStream => Guild.GetAudioStream(Id);
 
+        /// <inheritdoc />
+        public DateTime? PremiumSince { get; private set; }
+
         /// <summary>
         ///     Returns the position of the user within the role hierarchy.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -63,6 +63,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         string IGuildUser.Nickname => null;
         /// <inheritdoc />
+        DateTime? IGuildUser.PremiumSince => null;
+        /// <inheritdoc />
         GuildPermissions IGuildUser.GuildPermissions => GuildPermissions.Webhook;
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -63,7 +63,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         string IGuildUser.Nickname => null;
         /// <inheritdoc />
-        DateTime? IGuildUser.PremiumSince => null;
+        DateTimeOffset? IGuildUser.PremiumSince => null;
         /// <inheritdoc />
         GuildPermissions IGuildUser.GuildPermissions => GuildPermissions.Webhook;
 


### PR DESCRIPTION
Fix #1325

Updates the models of Guild and GuildMember [for changes added related to guild boosting](https://discordapp.com/developers/docs/change-log#added-info-around-nitro-boosting-experiment).

**Guild**
- Add PremiumTier (and enum)
- Add BannerId, BannerUrl (and CDN method to get these images)
- Add VanityURLCode
- Add SystemChannelFlags (and enum)
  - These flags are inverted, so a value of 0 **enables** all of the message types, while `0b11` disables them all. Because of this inverted logic, I've added an extension method to more easily determine the state of the welcome messages and guild boost messages settings. Would it be worth considering something similar for setting this value as well?
- Add Description. I haven't seen this used in any guilds I'm in yet.

**GuildMember**
- Add PremiumSince value, for when the user started boosting. If null, that means they aren't boosting.

**Messages**
- Add more MessageTypes for the various boost-related messages.