### PR TITLE
Fixed optionals having IsSpecified true when objects weren't in cache

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1296,7 +1296,7 @@ namespace Discord.WebSocket
                                         bool isCached = cachedMsg != null;
                                         var user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
 
-                                        var optionalMsg = cachedMsg is null
+                                        var optionalMsg = !isCached
                                             ? Optional.Create<SocketUserMessage>()
                                             : Optional.Create(cachedMsg);
 
@@ -1329,7 +1329,7 @@ namespace Discord.WebSocket
                                         bool isCached = cachedMsg != null;
                                         var user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
 
-                                        var optionalMsg = cachedMsg is null
+                                        var optionalMsg = !isCached
                                             ? Optional.Create<SocketUserMessage>()
                                             : Optional.Create(cachedMsg);
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1295,7 +1295,16 @@ namespace Discord.WebSocket
                                         var cachedMsg = channel.GetCachedMessage(data.MessageId) as SocketUserMessage;
                                         bool isCached = cachedMsg != null;
                                         var user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
-                                        var reaction = SocketReaction.Create(data, channel, cachedMsg, Optional.Create(user));
+
+                                        var optionalMsg = cachedMsg is null
+                                            ? Optional.Create<SocketUserMessage>()
+                                            : Optional.Create(cachedMsg);
+
+                                        var optionalUser = user is null
+                                            ? Optional.Create<IUser>()
+                                            : Optional.Create(user);
+
+                                        var reaction = SocketReaction.Create(data, channel, optionalMsg, optionalUser);
                                         var cacheable = new Cacheable<IUserMessage, ulong>(cachedMsg, data.MessageId, isCached, async () => await channel.GetMessageAsync(data.MessageId).ConfigureAwait(false) as IUserMessage);
 
                                         cachedMsg?.AddReaction(reaction);
@@ -1319,7 +1328,16 @@ namespace Discord.WebSocket
                                         var cachedMsg = channel.GetCachedMessage(data.MessageId) as SocketUserMessage;
                                         bool isCached = cachedMsg != null;
                                         var user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
-                                        var reaction = SocketReaction.Create(data, channel, cachedMsg, Optional.Create(user));
+
+                                        var optionalMsg = cachedMsg is null
+                                            ? Optional.Create<SocketUserMessage>()
+                                            : Optional.Create(cachedMsg);
+
+                                        var optionalUser = user is null
+                                            ? Optional.Create<IUser>()
+                                            : Optional.Create(user);
+
+                                        var reaction = SocketReaction.Create(data, channel, optionalMsg, optionalUser);
                                         var cacheable = new Cacheable<IUserMessage, ulong>(cachedMsg, data.MessageId, isCached, async () => await channel.GetMessageAsync(data.MessageId).ConfigureAwait(false) as IUserMessage);
 
                                         cachedMsg?.RemoveReaction(reaction);


### PR DESCRIPTION
Whilst working in the ReactionAdded and Removed events if a message/user wasn't in cache then `null` would be passed to the optional ctors leading to `IsSpecified` to be returning `true` 