### PR TITLE
Added a Rest property to DiscordShardedClient

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -36,6 +36,11 @@ namespace Discord.WebSocket
         /// </returns>
         public abstract IActivity Activity { get; protected set; }
 
+        /// <summary>
+        ///     Provides access to a REST-only client with a shared state from this client.
+        /// </summary>
+        public abstract DiscordSocketRestClient Rest { get; }
+
         internal new DiscordSocketApiClient ApiClient => base.ApiClient as DiscordSocketApiClient;
 
         /// <summary>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -37,6 +37,11 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override IReadOnlyCollection<RestVoiceRegion> VoiceRegions => _shards[0].VoiceRegions;
 
+        /// <summary>
+        ///     Provides access to a REST-only client with a shared state from this client.
+        /// </summary>
+        public DiscordSocketRestClient Rest => _shards[0].Rest;
+
         /// <summary> Creates a new REST/WebSocket Discord client. </summary>
         public DiscordShardedClient() : this(null, new DiscordSocketConfig()) { }
         /// <summary> Creates a new REST/WebSocket Discord client. </summary>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -40,7 +40,7 @@ namespace Discord.WebSocket
         /// <summary>
         ///     Provides access to a REST-only client with a shared state from this client.
         /// </summary>
-        public DiscordSocketRestClient Rest => _shards[0].Rest;
+        public override DiscordSocketRestClient Rest => _shards[0].Rest;
 
         /// <summary> Creates a new REST/WebSocket Discord client. </summary>
         public DiscordShardedClient() : this(null, new DiscordSocketConfig()) { }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -44,8 +44,10 @@ namespace Discord.WebSocket
         private RestApplication _applicationInfo;
         private bool _isDisposed;
 
-        /// <summary> Provides access to a REST-only client with a shared state from this client. </summary>
-        public DiscordSocketRestClient Rest { get; }
+        /// <summary>
+        ///     Provides access to a REST-only client with a shared state from this client.
+        /// </summary>
+        public override DiscordSocketRestClient Rest { get; }
         /// <summary> Gets the shard of of this client. </summary>
         public int ShardId { get; }
         /// <summary> Gets the current connection state of this client. </summary>


### PR DESCRIPTION
Just a QoL change so that you don't need to get a specific shard to access the rest client.
