### PR TITLE
Fix #1327 Color.ToString returns wrong value

### DIFF
--- a/src/Discord.Net.Core/Entities/Roles/Color.cs
+++ b/src/Discord.Net.Core/Entities/Roles/Color.cs
@@ -204,8 +204,8 @@ namespace Discord
         ///     A hexadecimal string of the color.
         /// </returns>
         public override string ToString() =>
-            $"#{Convert.ToString(RawValue, 16).PadLeft(6, '0')}";
+            $"#{string.Format("{0:x6}", RawValue)}";
         private string DebuggerDisplay =>
-            $"#{Convert.ToString(RawValue, 16).PadLeft(6, '0')} ({RawValue})";
+            $"#{String.Format("{0:x6}", RawValue)} ({RawValue})";
     }
 }

--- a/src/Discord.Net.Core/Entities/Roles/Color.cs
+++ b/src/Discord.Net.Core/Entities/Roles/Color.cs
@@ -204,8 +204,8 @@ namespace Discord
         ///     A hexadecimal string of the color.
         /// </returns>
         public override string ToString() =>
-            $"#{Convert.ToString(RawValue, 16)}";
+            $"#{Convert.ToString(RawValue, 16).PadLeft(6, '0')}";
         private string DebuggerDisplay =>
-            $"#{Convert.ToString(RawValue, 16)} ({RawValue})";
+            $"#{Convert.ToString(RawValue, 16).PadLeft(6, '0')} ({RawValue})";
     }
 }

--- a/src/Discord.Net.Core/Entities/Roles/Color.cs
+++ b/src/Discord.Net.Core/Entities/Roles/Color.cs
@@ -204,8 +204,8 @@ namespace Discord
         ///     A hexadecimal string of the color.
         /// </returns>
         public override string ToString() =>
-            $"#{string.Format("{0:x6}", RawValue)}";
+            string.Format("#{0:X6}", RawValue);
         private string DebuggerDisplay =>
-            $"#{String.Format("{0:x6}", RawValue)} ({RawValue})";
+            string.Format("#{0:X6} ({0})", RawValue);
     }
 }


### PR DESCRIPTION
Fix #1327 

- Pads Color#ToString to 6 characters long so it returns a valid hexadecimal color value.