### PR TITLE
Remove null coalescing on ToEmbedBuilder Color

### DIFF
--- a/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Discord
                     IconUrl = embed.Author?.IconUrl,
                     Url = embed.Author?.Url
                 },
-                Color = embed.Color ?? Color.Default,
+                Color = embed.Color,
                 Description = embed.Description,
                 Footer = new EmbedFooterBuilder
                 {


### PR DESCRIPTION
Very simple change, removes the null coalescing operator on the ``EmbedBuilder``'s ``Color`` property in ``ToEmbedBuilder``.

The issue presented before is that if ``ToEmbedBuilder`` is used on an ``Embed`` with no set color, the method would set the color to ``Color.Default``, aka black, which, obviously, doesn't match the original embed.
