### PR TITLE
Fixed attempting to access a non-present optional value

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -103,7 +103,7 @@ namespace Discord.Rest
                 Activity = new MessageActivity()
                 {
                     Type = model.Activity.Value.Type.Value,
-                    PartyId = model.Activity.Value.PartyId.Value
+                    PartyId = model.Activity.Value.PartyId.GetValueOrDefault()
                 };
             }
         }


### PR DESCRIPTION
When a party invite is no longer available the party id variable is no longer specified causing the getter to throw;
```
System.InvalidOperationException: This property has no value set.
at Discord.Optional`1.get_Value()
at Discord.Rest.RestMessage.Update(Message model)
at Discord.Rest.RestUserMessage.Update(Message model)
at Discord.Rest.RestUserMessage.Create(BaseDiscordClient discord, IMessageChannel channel, IUser author, Message model)
at Discord.Rest.ChannelHelper.GetMessageAsync(IMessageChannel channel, BaseDiscordClient client, UInt64 id, RequestOptions options)
at Discord.WebSocket.SocketTextChannel.GetMessageAsync(UInt64 id, RequestOptions options)
at Discord.WebSocket.SocketTextChannel.Discord.IMessageChannel.GetMessageAsync(UInt64 id, CacheMode mode, RequestOptions options)
at Submission#0.<<Initialize>>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
```

Ideally, the change would be to make the party id prop optional, but that's a major change, no?