### PR TITLE
Add Quote Formatting

### DIFF
--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -47,8 +47,10 @@ namespace Discord
         /// <returns>Gets the formatted quote text.</returns> // TODO: better xmldoc
         public static string Quote(string text)
         {
-            if (text == null)
-                return null;
+            // do not modify null or whitespace text
+            // whitespace does not get quoted properly
+            if (string.IsNullOrWhiteSpace(text))
+                return text;
 
             StringBuilder result = new StringBuilder();
 

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -44,7 +44,7 @@ namespace Discord
         ///     Formats a string as a quote.
         /// </summary>
         /// <param name="text">The text to format.</param>
-        /// <returns>Gets the formatted quote text.</returns> // TODO: better xmldoc
+        /// <returns>Gets the formatted quote text.</returns>
         public static string Quote(string text)
         {
             // do not modify null or whitespace text
@@ -76,6 +76,20 @@ namespace Discord
             while (newLineIndex != -1 && startIndex != text.Length);
 
             return result.ToString();
+        }
+        
+        /// <summary>
+        ///     Formats a string as a block quote.
+        /// </summary>
+        /// <param name="text">The text to format.</param>
+        /// <returns>Gets the formatted block quote text.</returns>
+        public static string BlockQuote(string text)
+        {
+            // do not modify null or whitespace
+            if (string.IsNullOrWhiteSpace(text))
+                return text;
+
+            return $">>> {text}";
         }
     }
 }

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Discord
 {
     /// <summary> A helper class for formatting characters. </summary>
@@ -36,6 +38,42 @@ namespace Discord
             foreach (string unsafeChar in SensitiveCharacters)
                 text = text.Replace(unsafeChar, $"\\{unsafeChar}");
             return text;
+        }
+
+        /// <summary>
+        ///     Formats a string as a quote.
+        /// </summary>
+        /// <param name="text">The text to format.</param>
+        /// <returns>Gets the formatted quote text.</returns> // TODO: better xmldoc
+        public static string Quote(string text)
+        {
+            if (text == null)
+                return null;
+
+            StringBuilder result = new StringBuilder();
+
+            int startIndex = 0;
+            int newLineIndex;
+            do
+            {
+                newLineIndex = text.IndexOf('\n', startIndex);
+                if (newLineIndex == -1)
+                {
+                    // read the rest of the string
+                    var str = text.Substring(startIndex);
+                    result.Append($"> {str}");
+                }
+                else
+                {
+                    // read until the next newline
+                    var str = text.Substring(startIndex, newLineIndex - startIndex);
+                    result.Append($"> {str}\n");
+                }
+                startIndex = newLineIndex + 1;
+            }
+            while (newLineIndex != -1 && startIndex != text.Length);
+
+            return result.ToString();
         }
     }
 }

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -6,7 +6,7 @@ namespace Discord
     public static class Format
     {
         // Characters which need escaping
-        private static readonly string[] SensitiveCharacters = { "\\", "*", "_", "~", "`", "|" };
+        private static readonly string[] SensitiveCharacters = { "\\", "*", "_", "~", "`", "|", ">" };
 
         /// <summary> Returns a markdown-formatted string with bold formatting. </summary>
         public static string Bold(string text) => $"**{text}**";

--- a/test/Discord.Net.Tests.Unit/FormatTests.cs
+++ b/test/Discord.Net.Tests.Unit/FormatTests.cs
@@ -46,5 +46,18 @@ namespace Discord
         {
             Assert.Equal(expected, Format.Quote(input));
         }
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("\n", "\n")]
+        [InlineData("foo\n\nbar", ">>> foo\n\nbar")]
+        [InlineData("input", ">>> input")] // single line
+        // should work with CR or CRLF
+        [InlineData("inb4\ngreentext", ">>> inb4\ngreentext")]
+        [InlineData("inb4\r\ngreentext", ">>> inb4\r\ngreentext")]
+        public void BlockQuote(string input, string expected)
+        {
+            Assert.Equal(expected, Format.BlockQuote(input));
+        }
     }
 }

--- a/test/Discord.Net.Tests.Unit/FormatTests.cs
+++ b/test/Discord.Net.Tests.Unit/FormatTests.cs
@@ -14,6 +14,7 @@ namespace Discord
         [InlineData(@"~text~", @"\~text\~")]
         [InlineData(@"`text`", @"\`text\`")]
         [InlineData(@"_text_", @"\_text\_")]
+        [InlineData(@"> text", @"\> text")]
         public void Sanitize(string input, string expected)
         {
             Assert.Equal(expected, Format.Sanitize(input));

--- a/test/Discord.Net.Tests.Unit/FormatTests.cs
+++ b/test/Discord.Net.Tests.Unit/FormatTests.cs
@@ -28,5 +28,22 @@ namespace Discord
             Assert.Equal("```cs\ntest\n```", Format.Code("test", "cs"));
             Assert.Equal("```cs\nanother\none\n```", Format.Code("another\none", "cs"));
         }
+        [Fact]
+        public void QuoteNullString()
+        {
+            Assert.Null(Format.Quote(null));
+        }
+        [Theory]
+        [InlineData("", "> ")]
+        [InlineData("\n", "> \n")]
+        [InlineData("\n ", "> \n>  ")]
+        [InlineData("input", "> input")] // single line
+        // should work with CR or CRLF
+        [InlineData("inb4\ngreentext", "> inb4\n> greentext")]
+        [InlineData("inb4\r\ngreentext", "> inb4\r\n> greentext")]
+        public void Quote(string input, string expected)
+        {
+            Assert.Equal(expected, Format.Quote(input));
+        }
     }
 }

--- a/test/Discord.Net.Tests.Unit/FormatTests.cs
+++ b/test/Discord.Net.Tests.Unit/FormatTests.cs
@@ -35,9 +35,9 @@ namespace Discord
             Assert.Null(Format.Quote(null));
         }
         [Theory]
-        [InlineData("", "> ")]
-        [InlineData("\n", "> \n")]
-        [InlineData("\n ", "> \n>  ")]
+        [InlineData("", "")]
+        [InlineData("\n", "\n")]
+        [InlineData("foo\n\nbar", "> foo\n> \n> bar")]
         [InlineData("input", "> input")] // single line
         // should work with CR or CRLF
         [InlineData("inb4\ngreentext", "> inb4\n> greentext")]


### PR DESCRIPTION
Adds support for block quote text formatting (with unit tests). This feature is currently only implemented in the Canary client. This formatting adds a `> ` to each new line from the input text.

I don't recall if Discord cares about CRLF vs LF line endings, so I just split on LF endings.

This does not check to see that the input text has been already quoted.