### PR TITLE
Add support for setting X-RateLimit-Precision

### DIFF
--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -36,7 +36,7 @@ namespace Discord
             typeof(DiscordConfig).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
             typeof(DiscordConfig).GetTypeInfo().Assembly.GetName().Version.ToString(3) ??
             "Unknown";
-        
+
         /// <summary>
         ///     Gets the user agent that Discord.Net uses in its clients.
         /// </summary>
@@ -123,7 +123,7 @@ namespace Discord
         ///     The currently set <see cref="RetryMode"/>.
         /// </returns>
         public RetryMode DefaultRetryMode { get; set; } = RetryMode.AlwaysRetry;
-        
+
         /// <summary>
         ///     Gets or sets the minimum log level severity that will be sent to the Log event.
         /// </summary>
@@ -140,5 +140,17 @@ namespace Discord
         ///     the API version it uses on startup.
         /// </remarks>
         internal bool DisplayInitialLog { get; set; } = true;
+
+        /// <summary>
+        ///     Gets or sets the level of precision of the rate limit reset response.
+        /// </summary>
+        /// <remarks>
+        ///     If set to <see cref="RateLimitPrecision.Second"/>, this value will be rounded up to the
+        ///     nearest second.
+        /// </remarks>
+        /// <returns>
+        ///     The currently set <see cref="RateLimitPrecision"/>.
+        /// </returns>
+        public RateLimitPrecision RateLimitPrecision { get; set; } = RateLimitPrecision.Second;
     }
 }

--- a/src/Discord.Net.Core/RateLimitPrecision.cs
+++ b/src/Discord.Net.Core/RateLimitPrecision.cs
@@ -1,0 +1,18 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Specifies the level of precision to request in the rate limit
+    ///     response header.
+    /// </summary>
+    public enum RateLimitPrecision
+    {
+        /// <summary>
+        ///     Specifies precision rounded up to the nearest whole second
+        /// </summary>
+        Second,
+        /// <summary>
+        ///     Specifies precision rounded to the nearest millisecond.
+        /// </summary>
+        Millisecond
+    }
+}

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -45,17 +45,19 @@ namespace Discord.API
         internal string AuthToken { get; private set; }
         internal IRestClient RestClient { get; private set; }
         internal ulong? CurrentUserId { get; set; }
-
+        public RateLimitPrecision RateLimitPrecision { get; private set; }
+        
         internal JsonSerializer Serializer => _serializer;
 
         /// <exception cref="ArgumentException">Unknown OAuth token type.</exception>
         public DiscordRestApiClient(RestClientProvider restClientProvider, string userAgent, RetryMode defaultRetryMode = RetryMode.AlwaysRetry,
-            JsonSerializer serializer = null)
+            JsonSerializer serializer = null, RateLimitPrecision rateLimitPrecision = RateLimitPrecision.Second)
         {
             _restClientProvider = restClientProvider;
             UserAgent = userAgent;
             DefaultRetryMode = defaultRetryMode;
             _serializer = serializer ?? new JsonSerializer { ContractResolver = new DiscordContractResolver() };
+            RateLimitPrecision = rateLimitPrecision;
 
             RequestQueue = new RequestQueue();
             _stateLock = new SemaphoreSlim(1, 1);
@@ -71,6 +73,7 @@ namespace Discord.API
             RestClient.SetHeader("accept", "*/*");
             RestClient.SetHeader("user-agent", UserAgent);
             RestClient.SetHeader("authorization", GetPrefixedToken(AuthTokenType, AuthToken));
+            RestClient.SetHeader("X-RateLimit-Precision", RateLimitPrecision.ToString().ToLower());
         }
         /// <exception cref="ArgumentException">Unknown OAuth token type.</exception>
         internal static string GetPrefixedToken(TokenType tokenType, string token)

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -21,7 +21,7 @@ namespace Discord.Net
             Remaining = headers.TryGetValue("X-RateLimit-Remaining", out temp) && 
                 int.TryParse(temp, out var remaining) ? remaining : (int?)null;
             Reset = headers.TryGetValue("X-RateLimit-Reset", out temp) && 
-                int.TryParse(temp, out var reset) ? DateTimeOffset.FromUnixTimeSeconds(reset) : (DateTimeOffset?)null;
+                float.TryParse(temp, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
             RetryAfter = headers.TryGetValue("Retry-After", out temp) &&
                 int.TryParse(temp, out var retryAfter) ? retryAfter : (int?)null;
             Lag = headers.TryGetValue("Date", out temp) &&

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -80,7 +80,8 @@ namespace Discord.WebSocket
         internal BaseSocketClient(DiscordSocketConfig config, DiscordRestApiClient client)
             : base(config, client) => BaseConfig = config;
         private static DiscordSocketApiClient CreateApiClient(DiscordSocketConfig config)
-            => new DiscordSocketApiClient(config.RestClientProvider, config.WebSocketProvider, DiscordRestConfig.UserAgent);
+            => new DiscordSocketApiClient(config.RestClientProvider, config.WebSocketProvider, DiscordRestConfig.UserAgent,
+                rateLimitPrecision: config.RateLimitPrecision);
 
         /// <summary>
         ///     Gets a Discord application information for the logged-in user.

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -85,7 +85,8 @@ namespace Discord.WebSocket
             }
         }
         private static API.DiscordSocketApiClient CreateApiClient(DiscordSocketConfig config)
-            => new API.DiscordSocketApiClient(config.RestClientProvider, config.WebSocketProvider, DiscordRestConfig.UserAgent);
+            => new API.DiscordSocketApiClient(config.RestClientProvider, config.WebSocketProvider, DiscordRestConfig.UserAgent,
+                rateLimitPrecision: config.RateLimitPrecision);
 
         internal override async Task OnLoginAsync(TokenType tokenType, string token)
         {

--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -38,8 +38,9 @@ namespace Discord.API
         public ConnectionState ConnectionState { get; private set; }
 
         public DiscordSocketApiClient(RestClientProvider restClientProvider, WebSocketProvider webSocketProvider, string userAgent,
-            string url = null, RetryMode defaultRetryMode = RetryMode.AlwaysRetry, JsonSerializer serializer = null)
-            : base(restClientProvider, userAgent, defaultRetryMode, serializer)
+            string url = null, RetryMode defaultRetryMode = RetryMode.AlwaysRetry, JsonSerializer serializer = null,
+            RateLimitPrecision rateLimitPrecision = RateLimitPrecision.Second)
+            : base(restClientProvider, userAgent, defaultRetryMode, serializer, rateLimitPrecision)
         {
             _gatewayUrl = url;
             if (url != null)

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -176,7 +176,8 @@ namespace Discord.WebSocket
             _largeGuilds = new ConcurrentQueue<ulong>();
         }
         private static API.DiscordSocketApiClient CreateApiClient(DiscordSocketConfig config)
-            => new API.DiscordSocketApiClient(config.RestClientProvider, config.WebSocketProvider, DiscordRestConfig.UserAgent, config.GatewayHost);
+            => new API.DiscordSocketApiClient(config.RestClientProvider, config.WebSocketProvider, DiscordRestConfig.UserAgent, config.GatewayHost,
+                rateLimitPrecision: config.RateLimitPrecision);
         /// <inheritdoc />
         internal override void Dispose(bool disposing)
         {


### PR DESCRIPTION
Implements feature described in https://github.com/discordapp/discord-api-docs/pull/1064

Adds an option to specify `RateLimitPrecision` in `DiscordConfig` so that the `X-RateLimit-Reset` response header can be more precise. This feature is not yet deployed (from what I have found by hitting ratelimits).

https://github.com/discordapp/discord-api-docs/pull/1069 Adds X-RateLimit-Reset-After, which instead of specifying the timestamp when ratelimits are reset, specifies the amount of time to delay. This comes with a caveat:

> network latency will cause you to be less efficient than using X-RateLimit-Reset with a synchronized clock source.

Should we even bother with `X-RateLimit-Reset-After`?

Also, when converting from the `RateLimitPrecision` to a string for the header:

https://github.com/discord-net/Discord.Net/blob/0c7d59040803ff12319579e19512c0c6cf76f882/src/Discord.Net.Rest/DiscordRestApiClient.cs#L76

Do we think that `.ToString().ToLower()` is fine, or should we add an extension or util method to convert `RateLimitPrecision` into strings?