### PR TITLE
Add ChannelFollowAdd MessageType

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/MessageType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageType.cs
@@ -52,6 +52,10 @@ namespace Discord
         /// <summary>
         ///     The message for when a guild reaches Tier 3 of Nitro boosts.
         /// </summary>
-        UserPremiumGuildSubscriptionTier3 = 11
+        UserPremiumGuildSubscriptionTier3 = 11,
+        /// <summary>
+        ///     The message for when a news channel subscription is added to a text channel.
+        /// </summary>
+        ChannelFollowAdd = 12,
     }
 }


### PR DESCRIPTION
Adds the new MessageType for system messages indicating that a webhook for a news channel has been added to a text channel.

See: https://discordapp.com/developers/docs/resources/channel#message-object-message-types and https://discordapp.com/channels/81384788765712384/381889909113225237/612482392476745748