### PR TITLE
Add SelfStream voice state property

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IVoiceState.cs
+++ b/src/Discord.Net.Core/Entities/Users/IVoiceState.cs
@@ -55,5 +55,12 @@ namespace Discord
         ///     Gets the unique identifier for this user's voice session.
         /// </summary>
         string VoiceSessionId { get; }
+        /// <summary>
+        ///     Gets a value that indicates if this user is streaming in a voice channel.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if the user is streaming; otherwise <c>false</c>.
+        /// </returns>
+        bool IsStream { get; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/VoiceState.cs
+++ b/src/Discord.Net.Rest/API/Common/VoiceState.cs
@@ -26,5 +26,7 @@ namespace Discord.API
         public bool SelfMute { get; set; }
         [JsonProperty("suppress")]
         public bool Suppress { get; set; }
+        [JsonProperty("self_stream")]
+        public bool SelfStream { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestGroupUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGroupUser.cs
@@ -35,5 +35,7 @@ namespace Discord.Rest
         IVoiceChannel IVoiceState.VoiceChannel => null;
         /// <inheritdoc />
         string IVoiceState.VoiceSessionId => null;
+        /// <inheritdoc />
+        bool IVoiceState.IsStream => false;
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -151,5 +151,7 @@ namespace Discord.Rest
         IVoiceChannel IVoiceState.VoiceChannel => null;
         /// <inheritdoc />
         string IVoiceState.VoiceSessionId => null;
+        /// <inheritdoc />
+        bool IVoiceState.IsStream => false;
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
@@ -95,5 +95,7 @@ namespace Discord.Rest
         IVoiceChannel IVoiceState.VoiceChannel => null;
         /// <inheritdoc />
         string IVoiceState.VoiceSessionId => null;
+        /// <inheritdoc />
+        bool IVoiceState.IsStream => false;
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
@@ -61,5 +61,7 @@ namespace Discord.WebSocket
         IVoiceChannel IVoiceState.VoiceChannel => null;
         /// <inheritdoc />
         string IVoiceState.VoiceSessionId => null;
+        /// <inheritdoc />
+        bool IVoiceState.IsStream => false;
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -55,6 +55,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public bool IsMuted => VoiceState?.IsMuted ?? false;
         /// <inheritdoc />
+        public bool IsStream => VoiceState?.IsStream ?? false;
+        /// <inheritdoc />
         public DateTimeOffset? JoinedAt => DateTimeUtils.FromTicks(_joinedAtTicks);
         /// <summary>
         ///     Returns a collection of roles that the user possesses.

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketVoiceState.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketVoiceState.cs
@@ -24,6 +24,7 @@ namespace Discord.WebSocket
             Deafened = 0x04,
             SelfMuted = 0x08,
             SelfDeafened = 0x10,
+            SelfStream = 0x20,
         }
 
         private readonly Flags _voiceStates;
@@ -46,7 +47,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public bool IsSelfDeafened => (_voiceStates & Flags.SelfDeafened) != 0;
         /// <inheritdoc />
-        public bool IsStream { get; }
+        public bool IsStream => (_voiceStates & Flags.SelfStream) != 0;
 
         internal SocketVoiceState(SocketVoiceChannel voiceChannel, string sessionId, bool isSelfMuted, bool isSelfDeafened, bool isMuted, bool isDeafened, bool isSuppressed, bool isStream)
         {
@@ -64,9 +65,9 @@ namespace Discord.WebSocket
                 voiceStates |= Flags.Deafened;
             if (isSuppressed)
                 voiceStates |= Flags.Suppressed;
+            if (isStream)
+                voiceStates |= Flags.SelfStream;
             _voiceStates = voiceStates;
-
-            IsStream = isStream;
         }
         internal static SocketVoiceState Create(SocketVoiceChannel voiceChannel, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketVoiceState.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketVoiceState.cs
@@ -13,7 +13,7 @@ namespace Discord.WebSocket
         /// <summary>
         ///     Initializes a default <see cref="SocketVoiceState"/> with everything set to <c>null</c> or <c>false</c>.
         /// </summary>
-        public static readonly SocketVoiceState Default = new SocketVoiceState(null, null, false, false, false, false, false);
+        public static readonly SocketVoiceState Default = new SocketVoiceState(null, null, false, false, false, false, false, false);
 
         [Flags]
         private enum Flags : byte
@@ -45,8 +45,10 @@ namespace Discord.WebSocket
         public bool IsSelfMuted => (_voiceStates & Flags.SelfMuted) != 0;
         /// <inheritdoc />
         public bool IsSelfDeafened => (_voiceStates & Flags.SelfDeafened) != 0;
+        /// <inheritdoc />
+        public bool IsStream { get; }
 
-        internal SocketVoiceState(SocketVoiceChannel voiceChannel, string sessionId, bool isSelfMuted, bool isSelfDeafened, bool isMuted, bool isDeafened, bool isSuppressed)
+        internal SocketVoiceState(SocketVoiceChannel voiceChannel, string sessionId, bool isSelfMuted, bool isSelfDeafened, bool isMuted, bool isDeafened, bool isSuppressed, bool isStream)
         {
             VoiceChannel = voiceChannel;
             VoiceSessionId = sessionId;
@@ -63,10 +65,12 @@ namespace Discord.WebSocket
             if (isSuppressed)
                 voiceStates |= Flags.Suppressed;
             _voiceStates = voiceStates;
+
+            IsStream = isStream;
         }
         internal static SocketVoiceState Create(SocketVoiceChannel voiceChannel, Model model)
         {
-            return new SocketVoiceState(voiceChannel, model.SessionId, model.SelfMute, model.SelfDeaf, model.Mute, model.Deaf, model.Suppress);
+            return new SocketVoiceState(voiceChannel, model.SessionId, model.SelfMute, model.SelfDeaf, model.Mute, model.Deaf, model.Suppress, model.SelfStream);
         }
 
         /// <summary>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -114,5 +114,7 @@ namespace Discord.WebSocket
         IVoiceChannel IVoiceState.VoiceChannel => null;
         /// <inheritdoc />
         string IVoiceState.VoiceSessionId => null;
+        /// <inheritdoc />
+        bool IVoiceState.IsStream => false;
     }
 }


### PR DESCRIPTION
Adds the SelfStream property to IVoiceState which is set true when a user streams to a guild voice channel. This is part of the payload of `VOICE_STATE_UPDATE` (`self_stream`).

Along with this change, I also found the property `self_video`, which I think is meant for group channel streaming. Don't think we need to support that, though.