### PR TITLE
Audit log improvements

### DIFF
--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
@@ -11,11 +11,14 @@ namespace Discord.Rest
     /// </summary>
     public class ChannelCreateAuditLogData : IAuditLogData
     {
-        private ChannelCreateAuditLogData(ulong id, string name, ChannelType type, IReadOnlyCollection<Overwrite> overwrites)
+        private ChannelCreateAuditLogData(ulong id, string name, ChannelType type, int? rateLimit, bool? nsfw, int? bitrate, IReadOnlyCollection<Overwrite> overwrites)
         {
             ChannelId = id;
             ChannelName = name;
             ChannelType = type;
+            SlowModeInterval = rateLimit;
+            IsNsfw = nsfw;
+            Bitrate = bitrate;
             Overwrites = overwrites;
         }
 
@@ -27,9 +30,15 @@ namespace Discord.Rest
             var overwritesModel = changes.FirstOrDefault(x => x.ChangedProperty == "permission_overwrites");
             var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var rateLimitPerUserModel = changes.FirstOrDefault(x => x.ChangedProperty == "rate_limit_per_user");
+            var nsfwModel = changes.FirstOrDefault(x => x.ChangedProperty == "nsfw");
+            var bitrateModel = changes.FirstOrDefault(x => x.ChangedProperty == "bitrate");
 
             var type = typeModel.NewValue.ToObject<ChannelType>(discord.ApiClient.Serializer);
             var name = nameModel.NewValue.ToObject<string>(discord.ApiClient.Serializer);
+            int? rateLimitPerUser = rateLimitPerUserModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
+            bool? nsfw = nsfwModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            int? bitrate = bitrateModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
 
             foreach (var overwrite in overwritesModel.NewValue)
             {
@@ -41,7 +50,7 @@ namespace Discord.Rest
                 overwrites.Add(new Overwrite(id, permType, new OverwritePermissions(allow, deny)));
             }
 
-            return new ChannelCreateAuditLogData(entry.TargetId.Value, name, type, overwrites.ToReadOnlyCollection());
+            return new ChannelCreateAuditLogData(entry.TargetId.Value, name, type, rateLimitPerUser, nsfw, bitrate, overwrites.ToReadOnlyCollection());
         }
 
         /// <summary>
@@ -65,6 +74,29 @@ namespace Discord.Rest
         ///     The type of channel that was created.
         /// </returns>
         public ChannelType ChannelType { get; }
+        /// <summary>
+        ///     Gets the current slow-mode delay of the created channel.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="Int32"/> representing the time in seconds required before the user can send another
+        ///     message; <c>0</c> if disabled.
+        /// </returns>
+        public int? SlowModeInterval { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the created channel is NSFW.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if the created channel has the NSFW flag enabled; otherwise <c>false</c>.
+        /// </returns>
+        public bool? IsNsfw { get; }
+        /// <summary>
+        ///     Gets the bit-rate that the clients in the created voice channel are requested to use.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="Int32"/> representing the bit-rate (bps) that the created voice channel defines and requests the
+        ///     client(s) to use.
+        /// </returns>
+        public int? Bitrate { get; }
         /// <summary>
         ///     Gets a collection of permission overwrites that was assigned to the created channel.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
@@ -80,6 +80,7 @@ namespace Discord.Rest
         /// <returns>
         ///     An <see cref="Int32"/> representing the time in seconds required before the user can send another
         ///     message; <c>0</c> if disabled.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public int? SlowModeInterval { get; }
         /// <summary>
@@ -87,6 +88,7 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     <c>true</c> if the created channel has the NSFW flag enabled; otherwise <c>false</c>.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public bool? IsNsfw { get; }
         /// <summary>
@@ -95,6 +97,7 @@ namespace Discord.Rest
         /// <returns>
         ///     An <see cref="Int32"/> representing the bit-rate (bps) that the created voice channel defines and requests the
         ///     client(s) to use.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public int? Bitrate { get; }
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
@@ -11,11 +11,14 @@ namespace Discord.Rest
     /// </summary>
     public class ChannelDeleteAuditLogData : IAuditLogData
     {
-        private ChannelDeleteAuditLogData(ulong id, string name, ChannelType type, IReadOnlyCollection<Overwrite> overwrites)
+        private ChannelDeleteAuditLogData(ulong id, string name, ChannelType type, int? rateLimit, bool? nsfw, int? bitrate, IReadOnlyCollection<Overwrite> overwrites)
         {
             ChannelId = id;
             ChannelName = name;
             ChannelType = type;
+            SlowModeInterval = rateLimit;
+            IsNsfw = nsfw;
+            Bitrate = bitrate;
             Overwrites = overwrites;
         }
 
@@ -26,15 +29,21 @@ namespace Discord.Rest
             var overwritesModel = changes.FirstOrDefault(x => x.ChangedProperty == "permission_overwrites");
             var typeModel = changes.FirstOrDefault(x => x.ChangedProperty == "type");
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var rateLimitPerUserModel = changes.FirstOrDefault(x => x.ChangedProperty == "rate_limit_per_user");
+            var nsfwModel = changes.FirstOrDefault(x => x.ChangedProperty == "nsfw");
+            var bitrateModel = changes.FirstOrDefault(x => x.ChangedProperty == "bitrate");
 
             var overwrites = overwritesModel.OldValue.ToObject<API.Overwrite[]>(discord.ApiClient.Serializer)
                 .Select(x => new Overwrite(x.TargetId, x.TargetType, new OverwritePermissions(x.Allow, x.Deny)))
                 .ToList();
             var type = typeModel.OldValue.ToObject<ChannelType>(discord.ApiClient.Serializer);
             var name = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
+            int? rateLimitPerUser = rateLimitPerUserModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer);
+            bool? nsfw = nsfwModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer);
+            int? bitrate = bitrateModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer);
             var id = entry.TargetId.Value;
 
-            return new ChannelDeleteAuditLogData(id, name, type, overwrites.ToReadOnlyCollection());
+            return new ChannelDeleteAuditLogData(id, name, type, rateLimitPerUser, nsfw, bitrate, overwrites.ToReadOnlyCollection());
         }
 
         /// <summary>
@@ -58,6 +67,29 @@ namespace Discord.Rest
         ///     The type of channel that was deleted.
         /// </returns>
         public ChannelType ChannelType { get; }
+        /// <summary>
+        ///     Gets the slow-mode delay of the deleted channel.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="Int32"/> representing the time in seconds required before the user can send another
+        ///     message; <c>0</c> if disabled.
+        /// </returns>
+        public int? SlowModeInterval { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the deleted channel was NSFW.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this channel had the NSFW flag enabled; otherwise <c>false</c>.
+        /// </returns>
+        public bool? IsNsfw { get; }
+        /// <summary>
+        ///     Gets the bit-rate of this channel if applicable.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="Int32"/> representing the bit-rate set of the voice channel; <c>null</c> if not
+        ///     applicable.
+        /// </returns>
+        public int? Bitrate { get; }
         /// <summary>
         ///     Gets a collection of permission overwrites that was assigned to the deleted channel.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
@@ -73,6 +73,7 @@ namespace Discord.Rest
         /// <returns>
         ///     An <see cref="Int32"/> representing the time in seconds required before the user can send another
         ///     message; <c>0</c> if disabled.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public int? SlowModeInterval { get; }
         /// <summary>
@@ -80,14 +81,15 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     <c>true</c> if this channel had the NSFW flag enabled; otherwise <c>false</c>.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public bool? IsNsfw { get; }
         /// <summary>
         ///     Gets the bit-rate of this channel if applicable.
         /// </summary>
         /// <returns>
-        ///     An <see cref="Int32"/> representing the bit-rate set of the voice channel; <c>null</c> if not
-        ///     applicable.
+        ///     An <see cref="Int32"/> representing the bit-rate set of the voice channel.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public int? Bitrate { get; }
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
@@ -34,6 +34,7 @@ namespace Discord.Rest
         /// <returns>
         ///     An <see cref="Int32"/> representing the time in seconds required before the user can send another
         ///     message; <c>0</c> if disabled.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public int? SlowModeInterval { get; }
         /// <summary>
@@ -41,14 +42,15 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     <c>true</c> if this channel has the NSFW flag enabled; otherwise <c>false</c>.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public bool? IsNsfw { get; }
         /// <summary>
         ///     Gets the bit-rate of this channel if applicable.
         /// </summary>
         /// <returns>
-        ///     An <see cref="System.Int32"/> representing the bit-rate set for the voice channel; <c>null</c> if not
-        ///     applicable.
+        ///     An <see cref="Int32"/> representing the bit-rate set for the voice channel;
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public int? Bitrate { get; }
     }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
@@ -5,12 +5,13 @@ namespace Discord.Rest
     /// </summary>
     public struct ChannelInfo
     {
-        internal ChannelInfo(string name, string topic, int? bitrate, int? limit)
+        internal ChannelInfo(string name, string topic, int? rateLimit, bool? nsfw, int? bitrate)
         {
             Name = name;
             Topic = topic;
+            SlowModeInterval = rateLimit;
+            IsNsfw = nsfw;
             Bitrate = bitrate;
-            UserLimit = limit;
         }
 
         /// <summary>
@@ -28,6 +29,21 @@ namespace Discord.Rest
         /// </returns>
         public string Topic { get; }
         /// <summary>
+        ///     Gets the current slow-mode delay of this channel.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="Int32"/> representing the time in seconds required before the user can send another
+        ///     message; <c>0</c> if disabled.
+        /// </returns>
+        public int? SlowModeInterval { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether this channel is NSFW.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this channel has the NSFW flag enabled; otherwise <c>false</c>.
+        /// </returns>
+        public bool? IsNsfw { get; }
+        /// <summary>
         ///     Gets the bit-rate of this channel if applicable.
         /// </summary>
         /// <returns>
@@ -35,13 +51,5 @@ namespace Discord.Rest
         ///     applicable.
         /// </returns>
         public int? Bitrate { get; }
-        /// <summary>
-        ///     Gets the number of users allowed to be in this channel if applicable.
-        /// </summary>
-        /// <returns>
-        ///     An <see cref="System.Int32" /> representing the number of users allowed to be in this voice channel; 
-        ///     <c>null</c> if not applicable.
-        /// </returns>
-        public int? UserLimit { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelUpdateAuditLogData.cs
@@ -23,20 +23,23 @@ namespace Discord.Rest
 
             var nameModel = changes.FirstOrDefault(x => x.ChangedProperty == "name");
             var topicModel = changes.FirstOrDefault(x => x.ChangedProperty == "topic");
+            var rateLimitPerUserModel = changes.FirstOrDefault(x => x.ChangedProperty == "rate_limit_per_user");
+            var nsfwModel = changes.FirstOrDefault(x => x.ChangedProperty == "nsfw");
             var bitrateModel = changes.FirstOrDefault(x => x.ChangedProperty == "bitrate");
-            var userLimitModel = changes.FirstOrDefault(x => x.ChangedProperty == "user_limit");
 
             string oldName = nameModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
                 newName = nameModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
             string oldTopic = topicModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
                 newTopic = topicModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
+            int? oldRateLimitPerUser = rateLimitPerUserModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
+                newRateLimitPerUser = rateLimitPerUserModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
+            bool? oldNsfw = nsfwModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
+                newNsfw = nsfwModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
             int? oldBitrate = bitrateModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
                 newBitrate = bitrateModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
-            int? oldLimit = userLimitModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
-                newLimit = userLimitModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
 
-            var before = new ChannelInfo(oldName, oldTopic, oldBitrate, oldLimit);
-            var after = new ChannelInfo(newName, newTopic, newBitrate, newLimit);
+            var before = new ChannelInfo(oldName, oldTopic, oldRateLimitPerUser, oldNsfw, oldBitrate);
+            var after = new ChannelInfo(newName, newTopic, newRateLimitPerUser, newNsfw, newBitrate);
 
             return new ChannelUpdateAuditLogData(entry.TargetId.Value, before, after);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
@@ -92,7 +92,7 @@ namespace Discord.Rest
         /// <returns>
         ///     The level of explicit content filtering.
         /// </returns>
-        ExplicitContentFilterLevel? ExplicitContentFilter { get; }
+        public ExplicitContentFilterLevel? ExplicitContentFilter { get; }
         /// <summary>
         ///     Gets the ID of the channel where randomized welcome messages are sent.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
@@ -32,11 +32,16 @@ namespace Discord.Rest
         /// <returns>
         ///     An <see cref="int"/> representing the amount of time in seconds for a user to be marked as inactive
         ///     and moved into the AFK voice channel.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public int? AfkTimeout { get; }
         /// <summary>
         ///     Gets the default message notifications for users who haven't explicitly set their notification settings.
         /// </summary>
+        /// <returns>
+        ///     The default message notifications setting of this guild.
+        ///     <c>null</c> if this is not mentioned in this entry.
+        /// </returns>
         public DefaultMessageNotifications? DefaultMessageNotifications { get; }
         /// <summary>
         ///     Gets the ID of the AFK voice channel for this guild.
@@ -69,6 +74,7 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     The level of requirements.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public VerificationLevel? VerificationLevel { get; }
         /// <summary>
@@ -84,6 +90,7 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     The level of MFA requirement.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public MfaLevel? MfaLevel { get; }
         /// <summary>
@@ -94,11 +101,11 @@ namespace Discord.Rest
         /// </returns>
         public ExplicitContentFilterLevel? ExplicitContentFilter { get; }
         /// <summary>
-        ///     Gets the ID of the channel where randomized welcome messages are sent.
+        ///     Gets the ID of the channel where system messages are sent.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the system channel where randomized
-        ///     welcome messages are sent; <c>null</c> if none is set.
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the channel where system
+        ///     messages are sent; <c>null</c> if none is set.
         /// </returns>
         public ulong? SystemChannelId { get; }
         /// <summary>
@@ -114,6 +121,7 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     <c>true</c> if this guild can be embedded via widgets; otherwise <c>false</c>.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public bool? IsEmbeddable { get; }
     }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
@@ -7,7 +7,8 @@ namespace Discord.Rest
     {
         internal GuildInfo(int? afkTimeout, DefaultMessageNotifications? defaultNotifs,
             ulong? afkChannel, string name, string region, string icon,
-            VerificationLevel? verification, IUser owner, MfaLevel? mfa, int? filter)
+            VerificationLevel? verification, IUser owner, MfaLevel? mfa, ExplicitContentFilterLevel? filter,
+            ulong? systemChannel, ulong? widgetChannel, bool? widget)
         {
             AfkTimeout = afkTimeout;
             DefaultMessageNotifications = defaultNotifs;
@@ -18,7 +19,10 @@ namespace Discord.Rest
             VerificationLevel = verification;
             Owner = owner;
             MfaLevel = mfa;
-            ContentFilterLevel = filter;
+            ExplicitContentFilter = filter;
+            SystemChannelId = systemChannel;
+            EmbedChannelId = widgetChannel;
+            IsEmbeddable = widget;
         }
 
         /// <summary>
@@ -82,6 +86,35 @@ namespace Discord.Rest
         ///     The level of MFA requirement.
         /// </returns>
         public MfaLevel? MfaLevel { get; }
-        public int? ContentFilterLevel { get; }
+        /// <summary>
+        ///     Gets the level of content filtering applied to user's content in a Guild.
+        /// </summary>
+        /// <returns>
+        ///     The level of explicit content filtering.
+        /// </returns>
+        ExplicitContentFilterLevel? ExplicitContentFilter { get; }
+        /// <summary>
+        ///     Gets the ID of the channel where randomized welcome messages are sent.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the system channel where randomized
+        ///     welcome messages are sent; <c>null</c> if none is set.
+        /// </returns>
+        public ulong? SystemChannelId { get; }
+        /// <summary>
+        ///     Gets the ID of the widget embed channel of this guild.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the embedded channel found within the
+        ///     widget settings of this guild; <c>null</c> if none is set.
+        /// </returns>
+        public ulong? EmbedChannelId { get; }
+        /// <summary>
+        ///     Gets a value that indicates whether this guild is embeddable (i.e. can use widget).
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this guild can be embedded via widgets; otherwise <c>false</c>.
+        /// </returns>
+        public bool? IsEmbeddable { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildUpdateAuditLogData.cs
@@ -30,6 +30,9 @@ namespace Discord.Rest
             var ownerIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "owner_id");
             var mfaLevelModel = changes.FirstOrDefault(x => x.ChangedProperty == "mfa_level");
             var contentFilterModel = changes.FirstOrDefault(x => x.ChangedProperty == "explicit_content_filter");
+            var systemChannelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "system_channel_id");
+            var widgetChannelIdModel = changes.FirstOrDefault(x => x.ChangedProperty == "widget_channel_id");
+            var widgetEnabledModel = changes.FirstOrDefault(x => x.ChangedProperty == "widget_enabled");
 
             int? oldAfkTimeout = afkTimeoutModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
                 newAfkTimeout = afkTimeoutModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
@@ -49,8 +52,14 @@ namespace Discord.Rest
                 newOwnerId = ownerIdModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
             MfaLevel? oldMfaLevel = mfaLevelModel?.OldValue?.ToObject<MfaLevel>(discord.ApiClient.Serializer),
                 newMfaLevel = mfaLevelModel?.NewValue?.ToObject<MfaLevel>(discord.ApiClient.Serializer);
-            int? oldContentFilter = contentFilterModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer),
-                newContentFilter = contentFilterModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
+            ExplicitContentFilterLevel? oldContentFilter = contentFilterModel?.OldValue?.ToObject<ExplicitContentFilterLevel>(discord.ApiClient.Serializer),
+                newContentFilter = contentFilterModel?.NewValue?.ToObject<ExplicitContentFilterLevel>(discord.ApiClient.Serializer);
+            ulong? oldSystemChannelId = systemChannelIdModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer),
+                newSystemChannelId = systemChannelIdModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            ulong? oldWidgetChannelId = widgetChannelIdModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer),
+                newWidgetChannelId = widgetChannelIdModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            bool? oldWidgetEnabled = widgetEnabledModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
+                newWidgetEnabled = widgetEnabledModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
 
             IUser oldOwner = null;
             if (oldOwnerId != null)
@@ -68,10 +77,10 @@ namespace Discord.Rest
 
             var before = new GuildInfo(oldAfkTimeout, oldDefaultMessageNotifications,
                 oldAfkChannelId, oldName, oldRegionId, oldIconHash, oldVerificationLevel, oldOwner,
-                oldMfaLevel, oldContentFilter);
+                oldMfaLevel, oldContentFilter, oldSystemChannelId, oldWidgetChannelId, oldWidgetEnabled);
             var after = new GuildInfo(newAfkTimeout, newDefaultMessageNotifications,
                 newAfkChannelId, newName, newRegionId, newIconHash, newVerificationLevel, newOwner,
-                newMfaLevel, newContentFilter);
+                newMfaLevel, newContentFilter, newSystemChannelId, newWidgetChannelId, newWidgetEnabled);
 
             return new GuildUpdateAuditLogData(before, after);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberInfo.cs
@@ -1,5 +1,8 @@
 namespace Discord.Rest
 {
+    /// <summary>
+    ///     Represents information for a member.
+    /// </summary>
     public struct MemberInfo
     {
         internal MemberInfo(string nick, bool? deaf, bool? mute)
@@ -9,8 +12,28 @@ namespace Discord.Rest
             Mute = mute;
         }
 
+        /// <summary>
+        ///     Gets the nickname of the updated member.
+        /// </summary>
+        /// <returns>
+        ///     A string representing the nickname of the updated member; <c>null</c> if none is set.
+        /// </returns>
         public string Nickname { get; }
+        /// <summary>
+        ///     Gets a value that indicates whether the updated member is deafened by the guild.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if the updated member is deafened (i.e. not permitted to listen to or speak to others) by the guild;
+        ///     otherwise <c>false</c>.
+        /// </returns>
         public bool? Deaf { get; }
+        /// <summary>
+        ///     Gets a value that indicates whether the updated member is muted (i.e. not permitted to speak via voice) by the
+        ///     guild.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if the updated member is muted by the guild; otherwise <c>false</c>.
+        /// </returns>
         public bool? Mute { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberInfo.cs
@@ -2,17 +2,15 @@ namespace Discord.Rest
 {
     public struct MemberInfo
     {
-        internal MemberInfo(string nick, bool? deaf, bool? mute, string avatar_hash)
+        internal MemberInfo(string nick, bool? deaf, bool? mute)
         {
             Nickname = nick;
             Deaf = deaf;
             Mute = mute;
-            AvatarHash = avatar_hash;
         }
 
         public string Nickname { get; }
         public bool? Deaf { get; }
         public bool? Mute { get; }
-        public string AvatarHash { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberInfo.cs
@@ -25,6 +25,7 @@ namespace Discord.Rest
         /// <returns>
         ///     <c>true</c> if the updated member is deafened (i.e. not permitted to listen to or speak to others) by the guild;
         ///     otherwise <c>false</c>.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public bool? Deaf { get; }
         /// <summary>
@@ -33,6 +34,7 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     <c>true</c> if the updated member is muted by the guild; otherwise <c>false</c>.
+        ///     <c>null</c> if this is not mentioned in this entry.
         /// </returns>
         public bool? Mute { get; }
     }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
@@ -48,7 +48,19 @@ namespace Discord.Rest
         ///     A user object representing the user who the changes were performed on.
         /// </returns>
         public IUser Target { get; }
+        /// <summary>
+        ///     Gets the member information before the changes.
+        /// </summary>
+        /// <returns>
+        ///     An information object containing the original member information before the changes were made.
+        /// </returns>
         public MemberInfo Before { get; }
+        /// <summary>
+        ///     Gets the member information after the changes.
+        /// </summary>
+        /// <returns>
+        ///     An information object containing the member information after the changes were made.
+        /// </returns>
         public MemberInfo After { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
@@ -24,7 +24,6 @@ namespace Discord.Rest
             var nickModel = changes.FirstOrDefault(x => x.ChangedProperty == "nick");
             var deafModel = changes.FirstOrDefault(x => x.ChangedProperty == "deaf");
             var muteModel = changes.FirstOrDefault(x => x.ChangedProperty == "mute");
-            var avatarModel = changes.FirstOrDefault(x => x.ChangedProperty == "avatar_hash");
 
             string oldNick = nickModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
                 newNick = nickModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
@@ -32,14 +31,12 @@ namespace Discord.Rest
                 newDeaf = deafModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
             bool? oldMute = muteModel?.OldValue?.ToObject<bool>(discord.ApiClient.Serializer),
                 newMute = muteModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
-            string oldAvatar = avatarModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
-                newAvatar = avatarModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
 
             var targetInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
             var user = RestUser.Create(discord, targetInfo);
 
-            var before = new MemberInfo(oldNick, oldDeaf, oldMute, oldAvatar);
-            var after = new MemberInfo(newNick, newDeaf, newMute, newAvatar);
+            var before = new MemberInfo(oldNick, oldDeaf, oldMute);
+            var after = new MemberInfo(newNick, newDeaf, newMute);
 
             return new MemberUpdateAuditLogData(user, before, after);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteCreateAuditLogData.cs
@@ -10,8 +10,9 @@ namespace Discord.Rest
     /// </summary>
     public class OverwriteCreateAuditLogData : IAuditLogData
     {
-        private OverwriteCreateAuditLogData(Overwrite overwrite)
+        private OverwriteCreateAuditLogData(ulong channelId, Overwrite overwrite)
         {
+            ChannelId = channelId;
             Overwrite = overwrite;
         }
 
@@ -30,9 +31,17 @@ namespace Discord.Rest
             var id = entry.Options.OverwriteTargetId.Value;
             var type = entry.Options.OverwriteType;
 
-            return new OverwriteCreateAuditLogData(new Overwrite(id, type, permissions));
+            return new OverwriteCreateAuditLogData(entry.TargetId.Value, new Overwrite(id, type, permissions));
         }
 
+        /// <summary>
+        ///     Gets the ID of the channel that the overwrite was created from.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the channel that the overwrite was
+        ///     created from.
+        /// </returns>
+        public ulong ChannelId { get; }
         /// <summary>
         ///     Gets the permission overwrite object that was created.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteDeleteAuditLogData.cs
@@ -10,8 +10,9 @@ namespace Discord.Rest
     /// </summary>
     public class OverwriteDeleteAuditLogData : IAuditLogData
     {
-        private OverwriteDeleteAuditLogData(Overwrite deletedOverwrite)
+        private OverwriteDeleteAuditLogData(ulong channelId, Overwrite deletedOverwrite)
         {
+            ChannelId = channelId;
             Overwrite = deletedOverwrite;
         }
 
@@ -29,9 +30,17 @@ namespace Discord.Rest
             var id = idModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
             var allow = allowModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
 
-            return new OverwriteDeleteAuditLogData(new Overwrite(id, type, new OverwritePermissions(allow, deny)));
+            return new OverwriteDeleteAuditLogData(entry.TargetId.Value, new Overwrite(id, type, new OverwritePermissions(allow, deny)));
         }
 
+        /// <summary>
+        ///     Gets the ID of the channel that the overwrite was deleted from.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the channel that the overwrite was
+        ///     deleted from.
+        /// </returns>
+        public ulong ChannelId { get; }
         /// <summary>
         ///     Gets the permission overwrite object that was deleted.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
@@ -28,7 +28,7 @@ namespace Discord.Rest
             var beforeAllow = allowModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
             var afterAllow = allowModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
             var beforeDeny = denyModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
-            var afterDeny = denyModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+            var afterDeny = denyModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
 
             var beforePermissions = new OverwritePermissions(beforeAllow ?? 0, beforeDeny ?? 0);
             var afterPermissions = new OverwritePermissions(afterAllow ?? 0, afterDeny ?? 0);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/OverwriteUpdateAuditLogData.cs
@@ -10,8 +10,9 @@ namespace Discord.Rest
     /// </summary>
     public class OverwriteUpdateAuditLogData : IAuditLogData
     {
-        private OverwriteUpdateAuditLogData(OverwritePermissions before, OverwritePermissions after, ulong targetId, PermissionTarget targetType)
+        private OverwriteUpdateAuditLogData(ulong channelId, OverwritePermissions before, OverwritePermissions after, ulong targetId, PermissionTarget targetType)
         {
+            ChannelId = channelId;
             OldPermissions = before;
             NewPermissions = after;
             OverwriteTargetId = targetId;
@@ -35,9 +36,17 @@ namespace Discord.Rest
 
             var type = entry.Options.OverwriteType;
 
-            return new OverwriteUpdateAuditLogData(beforePermissions, afterPermissions, entry.Options.OverwriteTargetId.Value, type);
+            return new OverwriteUpdateAuditLogData(entry.TargetId.Value, beforePermissions, afterPermissions, entry.Options.OverwriteTargetId.Value, type);
         }
 
+        /// <summary>
+        ///     Gets the ID of the channel that the overwrite was updated from.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the channel that the overwrite was
+        ///     updated from.
+        /// </returns>
+        public ulong ChannelId { get; }
         /// <summary>
         ///     Gets the overwrite permissions before the changes.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleUpdateAuditLogData.cs
@@ -36,7 +36,7 @@ namespace Discord.Rest
             string oldName = nameModel?.OldValue?.ToObject<string>(discord.ApiClient.Serializer),
                 newName = nameModel?.NewValue?.ToObject<string>(discord.ApiClient.Serializer);
             ulong? oldPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer),
-                newPermissionsRaw = permissionsModel?.OldValue?.ToObject<ulong>(discord.ApiClient.Serializer);
+                newPermissionsRaw = permissionsModel?.NewValue?.ToObject<ulong>(discord.ApiClient.Serializer);
 
             Color? oldColor = null,
                 newColor = null;


### PR DESCRIPTION
**New**
- ChannelCreateAuditLogData
  - SlowModeInterval¹
  - IsNsfw
  - Bitrate
- ChannelDeleteAuditLogData
  - SlowModeInterval
  - IsNsfw
  - Bitrate
- ChannelInfo
  - SlowModeInterval
  - IsNsfw
- GuildInfo
  - SystemChannelId²
  - EmbedChannelId
  - IsEmbeddable
- OverwriteCreateAuditLogData
  - ChannelId
- OverwriteDeleteAuditLogData
  - ChannelId
- OverwriteUpdateAuditLogData
  - ChannelId

¹ using "rate_limit_per_user" key which is not in the [official docs](https://discordapp.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key) somehow
² using "system_channel_id" key which is also missing in the docs

**Bug Fixes**
- OverwriteUpdateAuditLogData
- RoleUpdateAuditLogData

**Breaking Changes**
- Removed UserLimit in ChannelInfo (there is no "user_limit" key)
- Removed AvatarHash in MemberInfo ("avatar_hash" only exists for webhooks)
- Changed name ContentFilterLevel of type int? to name ExplicitContentFilter of type ExplicitContentFilterLevel? (name change for consistency)