### PR TITLE
Bug: Use double precision for X-Reset-After, set CultureInfo when parsing numeric types

### DIFF
--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -47,7 +47,7 @@ namespace Discord.Commands
             if (index >= 0)
             {
                 string username = input.Substring(0, index);
-                if (ushort.TryParse(input.Substring(index + 1), NumberStyles.None, CultureInfo.InvariantCulture, out ushort discriminator))
+                if (ushort.TryParse(input.Substring(index + 1), out ushort discriminator))
                 {
                     var channelUser = await channelUsers.FirstOrDefault(x => x.DiscriminatorValue == discriminator &&
                         string.Equals(username, x.Username, StringComparison.OrdinalIgnoreCase)).ConfigureAwait(false);

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -47,7 +47,7 @@ namespace Discord.Commands
             if (index >= 0)
             {
                 string username = input.Substring(0, index);
-                if (ushort.TryParse(input.Substring(index + 1), out ushort discriminator))
+                if (ushort.TryParse(input.Substring(index + 1), NumberStyles.None, CultureInfo.InvariantCulture, out ushort discriminator))
                 {
                     var channelUser = await channelUsers.FirstOrDefault(x => x.DiscriminatorValue == discriminator &&
                         string.Equals(username, x.Username, StringComparison.OrdinalIgnoreCase)).ConfigureAwait(false);

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace Discord
@@ -76,7 +77,7 @@ namespace Discord
                 var bytes = Convert.FromBase64String(encoded);
                 var idStr = Encoding.UTF8.GetString(bytes);
                 // try to parse a ulong from the resulting string
-                if (ulong.TryParse(idStr, out var id))
+                if (ulong.TryParse(idStr, NumberStyles.None, CultureInfo.InvariantCulture, out var id))
                     return id;
             }
             catch (DecoderFallbackException)

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1488,7 +1488,7 @@ namespace Discord.API
                     builder.Append(format, lastIndex, leftIndex - lastIndex);
                     int rightIndex = format.IndexOf("}", leftIndex);
 
-                    int argId = int.Parse(format.Substring(leftIndex + 1, rightIndex - leftIndex - 1));
+                    int argId = int.Parse(format.Substring(leftIndex + 1, rightIndex - leftIndex - 1), NumberStyles.None, CultureInfo.InvariantCulture);
                     string fieldName = GetFieldName(methodArgs[argId + 1]);
 
                     var mappedId = BucketIds.GetIndex(fieldName);

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Tasks;
 using Model = Discord.API.User;
 
@@ -57,7 +58,7 @@ namespace Discord.Rest
             if (model.Avatar.IsSpecified)
                 AvatarId = model.Avatar.Value;
             if (model.Discriminator.IsSpecified)
-                DiscriminatorValue = ushort.Parse(model.Discriminator.Value);
+                DiscriminatorValue = ushort.Parse(model.Discriminator.Value, NumberStyles.None, CultureInfo.InvariantCulture);
             if (model.Bot.IsSpecified)
                 IsBot = model.Bot.Value;
             if (model.Username.IsSpecified)

--- a/src/Discord.Net.Rest/Net/Converters/UInt64EntityOrIdConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/UInt64EntityOrIdConverter.cs
@@ -1,6 +1,7 @@
-﻿using Discord.API;
+using Discord.API;
 using Newtonsoft.Json;
 using System;
+using System.Globalization;
 
 namespace Discord.Net.Converters
 {
@@ -23,7 +24,7 @@ namespace Discord.Net.Converters
             {
                 case JsonToken.String:
                 case JsonToken.Integer:
-                    return new EntityOrId<T>(ulong.Parse(reader.ReadAsString()));
+                    return new EntityOrId<T>(ulong.Parse(reader.ReadAsString(), NumberStyles.None, CultureInfo.InvariantCulture));
                 default:
                     T obj;
                     if (_innerConverter != null)

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Discord.Net
 {
@@ -21,7 +22,7 @@ namespace Discord.Net
             Remaining = headers.TryGetValue("X-RateLimit-Remaining", out temp) && 
                 int.TryParse(temp, out var remaining) ? remaining : (int?)null;
             Reset = headers.TryGetValue("X-RateLimit-Reset", out temp) && 
-                double.TryParse(temp, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
+                double.TryParse(temp, NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
             RetryAfter = headers.TryGetValue("Retry-After", out temp) &&
                 int.TryParse(temp, out var retryAfter) ? retryAfter : (int?)null;
             Lag = headers.TryGetValue("Date", out temp) &&

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -21,7 +21,7 @@ namespace Discord.Net
             Remaining = headers.TryGetValue("X-RateLimit-Remaining", out temp) && 
                 int.TryParse(temp, out var remaining) ? remaining : (int?)null;
             Reset = headers.TryGetValue("X-RateLimit-Reset", out temp) && 
-                float.TryParse(temp, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
+                double.TryParse(temp, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
             RetryAfter = headers.TryGetValue("Retry-After", out temp) &&
                 int.TryParse(temp, out var retryAfter) ? retryAfter : (int?)null;
             Lag = headers.TryGetValue("Date", out temp) &&

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -18,15 +18,15 @@ namespace Discord.Net
             IsGlobal = headers.TryGetValue("X-RateLimit-Global", out string temp) &&
                        bool.TryParse(temp, out var isGlobal) && isGlobal;
             Limit = headers.TryGetValue("X-RateLimit-Limit", out temp) && 
-                int.TryParse(temp, out var limit) ? limit : (int?)null;
+                int.TryParse(temp, NumberStyles.None, CultureInfo.InvariantCulture, out var limit) ? limit : (int?)null;
             Remaining = headers.TryGetValue("X-RateLimit-Remaining", out temp) && 
-                int.TryParse(temp, out var remaining) ? remaining : (int?)null;
+                int.TryParse(temp, NumberStyles.None, CultureInfo.InvariantCulture, out var remaining) ? remaining : (int?)null;
             Reset = headers.TryGetValue("X-RateLimit-Reset", out temp) && 
-                double.TryParse(temp, NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
+                double.TryParse(temp, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
             RetryAfter = headers.TryGetValue("Retry-After", out temp) &&
-                int.TryParse(temp, out var retryAfter) ? retryAfter : (int?)null;
+                int.TryParse(temp, NumberStyles.None, CultureInfo.InvariantCulture, out var retryAfter) ? retryAfter : (int?)null;
             Lag = headers.TryGetValue("Date", out temp) &&
-                DateTimeOffset.TryParse(temp, out var date) ? DateTimeOffset.UtcNow - date : (TimeSpan?)null;
+                DateTimeOffset.TryParse(temp, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ? DateTimeOffset.UtcNow - date : (TimeSpan?)null;
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord.Rest;
@@ -60,10 +61,10 @@ namespace Discord.WebSocket
             }
             if (model.Discriminator.IsSpecified)
             {
-                var newVal = ushort.Parse(model.Discriminator.Value);
+                var newVal = ushort.Parse(model.Discriminator.Value, NumberStyles.None, CultureInfo.InvariantCulture);
                 if (newVal != DiscriminatorValue)
                 {
-                    DiscriminatorValue = ushort.Parse(model.Discriminator.Value);
+                    DiscriminatorValue = ushort.Parse(model.Discriminator.Value, NumberStyles.None, CultureInfo.InvariantCulture);
                     hasChanges = true;
                 }
             }

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -132,7 +133,7 @@ namespace Discord.Webhook
             {
                 // ensure that the first group is a ulong, set the _webhookId
                 // 0th group is always the entire match, so start at index 1
-                if (!(match.Groups[1].Success && ulong.TryParse(match.Groups[1].Value, out webhookId)))
+                if (!(match.Groups[1].Success && ulong.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out webhookId)))
                     throw ex("The webhook Id could not be parsed.");
 
                 if (!match.Groups[2].Success)


### PR DESCRIPTION
Fixes #1374 . This PR addresses two issues that were found with parsing the X-Reset-After header.

Float did not contain enough precision to store the millisecond unix time value, which resulted in the second and millisecond values being slightly off.

```cs
> DateTimeOffset.FromUnixTimeMilliseconds((long)(1470173022.123f * 1000)).Millisecond
160 // wrong

> DateTimeOffset.FromUnixTimeMilliseconds((long)(1470173022.123 * 1000)).Millisecond
123 // correct
```

As a continuation of #1376 , occurrences of Parse or TryParse of numeric types were updated to explicitly state the NumberStyle and IFormatProvider, not just in RateLimitInfo. This is to prevent against this bug re-appearing in the future.