### PR TITLE
Feature: Support filtering audit log entries on user, action type, and before entry id

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -680,12 +680,16 @@ namespace Discord
         /// <param name="limit">The number of audit log entries to fetch.</param>
         /// <param name="mode">The <see cref="CacheMode" /> that determines whether the object should be fetched from cache.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="beforeId">The audit log entry ID to get entries before.</param>
+        /// <param name="actionType">The type of actions to filter.</param>
+        /// <param name="userId">The user ID to filter entries for.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
         ///     of the requested audit log entries.
         /// </returns>
         Task<IReadOnlyCollection<IAuditLogEntry>> GetAuditLogsAsync(int limit = DiscordConfig.MaxAuditLogEntriesPerBatch,
-            CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+            CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null, ulong? beforeId = null, ulong? userId = null,
+            ActionType? actionType = null);
 
         /// <summary>
         ///     Gets a webhook found within this guild.

--- a/src/Discord.Net.Rest/API/Rest/GetAuditLogsParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/GetAuditLogsParams.cs
@@ -1,8 +1,10 @@
-﻿namespace Discord.API.Rest
+namespace Discord.API.Rest
 {
     class GetAuditLogsParams
     {
         public Optional<int> Limit { get; set; }
         public Optional<ulong> BeforeEntryId { get; set; }
+        public Optional<ulong> UserId { get; set; }
+        public Optional<int> ActionType { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1321,15 +1321,25 @@ namespace Discord.API
             var ids = new BucketIds(guildId: guildId);
             Expression<Func<string>> endpoint;
 
-            var query = new StringBuilder();
+            var queryArgs = new StringBuilder();
             if (args.BeforeEntryId.IsSpecified)
-                query.Append($"&before={args.BeforeEntryId.Value}");
+            {
+                queryArgs.Append("&before=")
+                    .Append(args.BeforeEntryId);
+            }
             if (args.UserId.IsSpecified)
-                query.Append($"&user_id={args.UserId.Value}");
+            {
+                queryArgs.Append("&user_id=")
+                    .Append(args.UserId.Value);
+            }
             if (args.ActionType.IsSpecified)
-                query.Append($"&action_type={args.ActionType.Value}");
+            {
+                queryArgs.Append("&action_type=")
+                    .Append(args.ActionType.Value);
+            }
 
-            endpoint = () => $"guilds/{guildId}/audit-logs?limit={limit}{query.ToString()}";
+            // still use string interp for the query w/o params, as this is necessary for CreateBucketId
+            endpoint = () => $"guilds/{guildId}/audit-logs?limit={limit}{queryArgs.ToString()}";
             return await SendAsync<AuditLog>("GET", endpoint, ids, options: options).ConfigureAwait(false);
         }
 

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1321,11 +1321,15 @@ namespace Discord.API
             var ids = new BucketIds(guildId: guildId);
             Expression<Func<string>> endpoint;
 
+            var query = new StringBuilder();
             if (args.BeforeEntryId.IsSpecified)
-                endpoint = () => $"guilds/{guildId}/audit-logs?limit={limit}&before={args.BeforeEntryId.Value}";
-            else
-                endpoint = () => $"guilds/{guildId}/audit-logs?limit={limit}";
+                query.Append($"&before={args.BeforeEntryId.Value}");
+            if (args.UserId.IsSpecified)
+                query.Append($"&user_id={args.UserId.Value}");
+            if (args.ActionType.IsSpecified)
+                query.Append($"&action_type={args.ActionType.Value}");
 
+            endpoint = () => $"guilds/{guildId}/audit-logs?limit={limit}{query.ToString()}";
             return await SendAsync<AuditLog>("GET", endpoint, ids, options: options).ConfigureAwait(false);
         }
 

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -380,7 +380,7 @@ namespace Discord.Rest
 
         // Audit logs
         public static IAsyncEnumerable<IReadOnlyCollection<RestAuditLogEntry>> GetAuditLogsAsync(IGuild guild, BaseDiscordClient client,
-            ulong? from, int? limit, RequestOptions options)
+            ulong? from, int? limit, RequestOptions options, ulong? userId = null, ActionType? actionType = null)
         {
             return new PagedAsyncEnumerable<RestAuditLogEntry>(
                 DiscordConfig.MaxAuditLogEntriesPerBatch,
@@ -392,6 +392,10 @@ namespace Discord.Rest
                     };
                     if (info.Position != null)
                         args.BeforeEntryId = info.Position.Value;
+                    if (userId.HasValue)
+                        args.UserId = userId.Value;
+                    if (actionType.HasValue)
+                        args.ActionType = (int)actionType.Value;
                     var model = await client.ApiClient.GetAuditLogsAsync(guild.Id, args, options);
                     return model.Entries.Select((x) => RestAuditLogEntry.Create(client, model, x)).ToImmutableArray();
                 },

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -627,12 +627,15 @@ namespace Discord.Rest
         /// </summary>
         /// <param name="limit">The number of audit log entries to fetch.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="beforeId">The audit log entry ID to get entries before.</param>
+        /// <param name="actionType">The type of actions to filter.</param>
+        /// <param name="userId">The user ID to filter entries for.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
         ///     of the requested audit log entries.
         /// </returns>
-        public IAsyncEnumerable<IReadOnlyCollection<RestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null)
-            => GuildHelper.GetAuditLogsAsync(this, Discord, null, limit, options);
+        public IAsyncEnumerable<IReadOnlyCollection<RestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null, ulong? beforeId = null, ulong? userId = null, ActionType? actionType = null)
+            => GuildHelper.GetAuditLogsAsync(this, Discord, beforeId, limit, options, userId: userId, actionType: actionType);
 
         //Webhooks
         /// <summary>
@@ -866,10 +869,11 @@ namespace Discord.Rest
         Task IGuild.DownloadUsersAsync() =>
             throw new NotSupportedException();
 
-        async Task<IReadOnlyCollection<IAuditLogEntry>> IGuild.GetAuditLogsAsync(int limit, CacheMode cacheMode, RequestOptions options)
+        async Task<IReadOnlyCollection<IAuditLogEntry>> IGuild.GetAuditLogsAsync(int limit, CacheMode cacheMode, RequestOptions options,
+            ulong? beforeId, ulong? userId, ActionType? actionType)
         {
             if (cacheMode == CacheMode.AllowDownload)
-                return (await GetAuditLogsAsync(limit, options).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
+                return (await GetAuditLogsAsync(limit, options, beforeId: beforeId, userId: userId, actionType: actionType).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
             else
                 return ImmutableArray.Create<IAuditLogEntry>();
         }

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -801,12 +801,15 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="limit">The number of audit log entries to fetch.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="beforeId">The audit log entry ID to filter entries before.</param>
+        /// <param name="actionType">The type of actions to filter.</param>
+        /// <param name="userId">The user ID to filter entries for.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
         ///     of the requested audit log entries.
         /// </returns>
-        public IAsyncEnumerable<IReadOnlyCollection<RestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null)
-            => GuildHelper.GetAuditLogsAsync(this, Discord, null, limit, options);
+        public IAsyncEnumerable<IReadOnlyCollection<RestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null, ulong? beforeId = null, ulong? userId = null, ActionType? actionType = null)
+            => GuildHelper.GetAuditLogsAsync(this, Discord, beforeId, limit, options, userId: userId, actionType: actionType);
 
         //Webhooks
         /// <summary>
@@ -1160,10 +1163,11 @@ namespace Discord.WebSocket
             => Task.FromResult<IGuildUser>(Owner);
 
         /// <inheritdoc />
-        async Task<IReadOnlyCollection<IAuditLogEntry>> IGuild.GetAuditLogsAsync(int limit, CacheMode cacheMode, RequestOptions options)
+        async Task<IReadOnlyCollection<IAuditLogEntry>> IGuild.GetAuditLogsAsync(int limit, CacheMode cacheMode, RequestOptions options,
+            ulong? beforeId, ulong? userId, ActionType? actionType)
         {
             if (cacheMode == CacheMode.AllowDownload)
-                return (await GetAuditLogsAsync(limit, options).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
+                return (await GetAuditLogsAsync(limit, options, beforeId: beforeId, userId: userId, actionType: actionType).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
             else
                 return ImmutableArray.Create<IAuditLogEntry>();
         }


### PR DESCRIPTION
[Adds support for filtering audit log entires with GetAuditLogsAsync](https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log). Adds the ability to specify a userId and ActionType to filter. Exposes the `beforeId` filter which was already implemented, yet seemingly unused?

I was considering adding overloads for `IUser` and `IAuditLogEntry`, but all the possible combinations of these parameter types would get excessive.