### PR TITLE
Fix #1381 Guild PreferredLocale support

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Discord
 {
     /// <summary>
@@ -84,5 +86,23 @@ namespace Discord
         ///     are enabled, without the need to manipulate the logic of the flag.
         /// </remarks>
         public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
+        /// <summary>
+        ///     Gets or sets the preferred locale of the guild in IETF BCP 47 language tag format.
+        /// </summary>
+        /// <remarks>
+        ///     This property takes precedence over <see cref="PreferredCulture"/>.
+        ///     When it is set, the value of <see cref="PreferredCulture"/>
+        ///     will not be used.
+        /// </remarks>
+        public Optional<string> PreferredLocale { get; set; }
+        /// <summary>
+        ///     Gets or sets the preferred locale of the guild.
+        /// </summary>
+        /// <remarks>
+        ///     The <see cref="PreferredLocale"/> property takes precedence
+        ///     over this property. When <see cref="PreferredLocale"/> is set,
+        ///     the value of <see cref="PreferredCulture"/> will be unused.
+        /// </remarks>
+        public Optional<CultureInfo> PreferredCulture { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -1,6 +1,7 @@
 using Discord.Audio;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -258,6 +259,14 @@ namespace Discord
         ///     language tag format.
         /// </returns>
         string PreferredLocale { get; }
+
+        /// <summary>
+        ///     Gets the preferred culture of this guild.
+        /// </summary>
+        /// <returns>
+        ///     The preferred culture information of this guild.
+        /// </returns>
+        CultureInfo PreferredCulture { get; }
 
         /// <summary>
         ///     Modifies this guild.

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -250,6 +250,16 @@ namespace Discord
         int PremiumSubscriptionCount { get; }
 
         /// <summary>
+        ///     Gets the preferred locale of this guild in IETF BCP 47
+        ///     language tag format.
+        /// </summary>
+        /// <returns>
+        ///     The preferred locale of the guild in IETF BCP 47
+        ///     language tag format.
+        /// </returns>
+        string PreferredLocale { get; }
+
+        /// <summary>
         ///     Modifies this guild.
         /// </summary>
         /// <param name="func">The delegate containing the properties to modify the guild with.</param>

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -58,5 +58,7 @@ namespace Discord.API
         public SystemChannelMessageDeny SystemChannelFlags { get; set; }
         [JsonProperty("premium_subscription_count")]
         public int? PremiumSubscriptionCount { get; set; }
+        [JsonProperty("preferred_locale")]
+        public string PreferredLocale { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
@@ -32,5 +32,7 @@ namespace Discord.API.Rest
         public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
         [JsonProperty("system_channel_flags")]
         public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
+        [JsonProperty("preferred_locale")]
+        public string PreferredLocale { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -68,6 +68,12 @@ namespace Discord.Rest
             if (args.SystemChannelFlags.IsSpecified)
                 apiArgs.SystemChannelFlags = args.SystemChannelFlags.Value;
 
+            // PreferredLocale takes precedence over PreferredCulture
+            if (args.PreferredLocale.IsSpecified)
+                apiArgs.PreferredLocale = args.PreferredLocale.Value;
+            else if (args.PreferredCulture.IsSpecified)
+                apiArgs.PreferredLocale = args.PreferredCulture.Value.Name;
+
             return await client.ApiClient.ModifyGuildAsync(guild.Id, apiArgs, options).ConfigureAwait(false);
         }
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using EmbedModel = Discord.API.GuildEmbed;
@@ -64,6 +65,16 @@ namespace Discord.Rest
         public string Description { get; private set; }
         /// <inheritdoc />
         public int PremiumSubscriptionCount { get; private set; }
+        /// <inheritdoc />
+        public string PreferredLocale { get; private set; }
+
+        /// <summary>
+        ///     Gets the preferred culture of this guild.
+        /// </summary>
+        /// <returns>
+        ///     The preferred culture information of this guild.
+        /// </returns>
+        public CultureInfo PreferredCulture { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -124,6 +135,8 @@ namespace Discord.Rest
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
             PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
+            PreferredLocale = model.PreferredLocale;
+            PreferredCulture = new CultureInfo(PreferredLocale);
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -68,12 +68,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string PreferredLocale { get; private set; }
 
-        /// <summary>
-        ///     Gets the preferred culture of this guild.
-        /// </summary>
-        /// <returns>
-        ///     The preferred culture information of this guild.
-        /// </returns>
+        /// <inheritdoc />
         public CultureInfo PreferredCulture { get; private set; }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -105,6 +106,16 @@ namespace Discord.WebSocket
         public string Description { get; private set; }
         /// <inheritdoc />
         public int PremiumSubscriptionCount { get; private set; }
+        /// <inheritdoc />
+        public string PreferredLocale { get; private set; }
+
+        /// <summary>
+        ///     Gets the preferred culture of this guild.
+        /// </summary>
+        /// <returns>
+        ///     The preferred culture information of this guild.
+        /// </returns>
+        public CultureInfo PreferredCulture { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -374,6 +385,8 @@ namespace Discord.WebSocket
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
             PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
+            PreferredLocale = model.PreferredLocale;
+            PreferredCulture = new CultureInfo(PreferredLocale);
 
             if (model.Emojis != null)
             {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -109,12 +109,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public string PreferredLocale { get; private set; }
 
-        /// <summary>
-        ///     Gets the preferred culture of this guild.
-        /// </summary>
-        /// <returns>
-        ///     The preferred culture information of this guild.
-        /// </returns>
+        /// <inheritdoc />
         public CultureInfo PreferredCulture { get; private set; }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fix #1381 
Adds support for getting and modifying a guild's `preferred_locale`. This is a language tag in IETF BCP 47 format, which works with the built-in `CultureInfo` class.

While Discord only supports a number of cultures (as listed in the linked issue), I think that this restriction should be handled by the API and not by the wrapper.

Happy Hacktoberfest 💀 🎺 