### PR TITLE
Fix test that fails on half of the planet 

### DIFF
--- a/test/Discord.Net.Tests.Unit/EmbedBuilderTests.cs
+++ b/test/Discord.Net.Tests.Unit/EmbedBuilderTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace Discord
@@ -250,7 +249,7 @@ namespace Discord
                 .WithFooter("This is the footer", url)
                 .WithImageUrl(url)
                 .WithThumbnailUrl(url)
-                .WithTimestamp(DateTime.MinValue)
+                .WithTimestamp(DateTimeOffset.MinValue)
                 .WithTitle("This is the title")
                 .WithUrl(url)
                 .AddField("Field 1", "Inline", true)


### PR DESCRIPTION
If you happen to live somewhere with a positive offset from UTC, the implicit conversion from `DateTime.MinValue` to `DateTimeOffset` tends to results in a `System.ArgumentOutOfRangeException` as it takes the local timezone into account.