### PR TITLE
Add non-capturing overloads of Modify methods

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
@@ -57,6 +57,20 @@ namespace Discord
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
         Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies this guild channel.
+        /// </summary>
+        /// <remarks>
+        ///     This method modifies the current guild channel with the specified properties. To see an example of this
+        ///     method and what properties are available, please refer to <see cref="GuildChannelProperties"/>.
+        /// </remarks>
+        /// <param name="func">The delegate containing the properties to modify the channel with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyAsync<TState>(Action<GuildChannelProperties, TState> func, TState state, RequestOptions options = null);
 
         /// <summary>
         ///     Gets the permission overwrite for a specific role.

--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -83,7 +83,18 @@ namespace Discord
         /// </returns>
         /// <seealso cref="TextChannelProperties"/>
         Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null);
-        
+        /// <summary>
+        ///     Modifies this text channel.
+        /// </summary>
+        /// <param name="func">The delegate containing the properties to modify the channel with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        /// <seealso cref="TextChannelProperties"/>
+        Task ModifyAsync<TState>(Action<TextChannelProperties, TState> func, TState state, RequestOptions options = null);
+
         /// <summary>
         ///     Creates a webhook in this text channel.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
@@ -35,5 +35,16 @@ namespace Discord
         /// </returns>
         /// <seealso cref="VoiceChannelProperties"/>
         Task ModifyAsync(Action<VoiceChannelProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies this voice channel.
+        /// </summary>
+        /// <param name="func">The properties to modify the channel with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        /// <seealso cref="VoiceChannelProperties"/>
+        Task ModifyAsync<TState>(Action<VoiceChannelProperties, TState> func, TState state, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -259,6 +259,16 @@ namespace Discord
         /// </returns>
         Task ModifyAsync(Action<GuildProperties> func, RequestOptions options = null);
         /// <summary>
+        ///     Modifies this guild.
+        /// </summary>
+        /// <param name="func">The delegate containing the properties to modify the guild with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyAsync<TState>(Action<GuildProperties, TState> func, TState state, RequestOptions options = null);
+        /// <summary>
         ///     Modifies this guild's embed channel.
         /// </summary>
         /// <param name="func">The delegate containing the properties to modify the guild widget with.</param>
@@ -267,6 +277,16 @@ namespace Discord
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
         Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies this guild's embed channel.
+        /// </summary>
+        /// <param name="func">The delegate containing the properties to modify the guild widget with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyEmbedAsync<TState>(Action<GuildEmbedProperties, TState> func, TState state, RequestOptions options = null);
         /// <summary>
         ///     Bulk-modifies the order of channels in this guild.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -29,6 +29,26 @@ namespace Discord
         /// </returns>
         Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null);
         /// <summary>
+        ///     Modifies this message.
+        /// </summary>
+        /// <remarks>
+        ///     This method modifies this message with the specified properties. To see an example of this
+        ///     method and what properties are available, please refer to <see cref="MessageProperties"/>.
+        /// </remarks>
+        /// <example>
+        ///     The following example replaces the content of the message with <c>Hello World!</c>.
+        ///     <code language="cs">
+        ///     await msg.ModifyAsync((x, s) =&gt; x.Content = s, "Hello World!");
+        ///     </code>
+        /// </example>
+        /// <param name="func">A delegate containing the properties to modify the message with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyAsync<TState>(Action<MessageProperties, TState> func, TState state, RequestOptions options = null);
+        /// <summary>
         ///     Modifies the suppression of this message.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -79,5 +79,19 @@ namespace Discord
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
         Task ModifyAsync(Action<RoleProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies this role.
+        /// </summary>
+        /// <remarks>
+        ///     This method modifies this role with the specified properties. To see an example of this
+        ///     method and what properties are available, please refer to <see cref="RoleProperties"/>.
+        /// </remarks>
+        /// <param name="func">A delegate containing the properties to modify the role with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyAsync<TState>(Action<RoleProperties, TState> func, TState state, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -108,6 +108,20 @@ namespace Discord
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
         Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies this user's properties in this guild.
+        /// </summary>
+        /// <remarks>
+        ///     This method modifies the current guild user with the specified properties. To see an example of this
+        ///     method and what properties are available, please refer to <see cref="GuildUserProperties"/>.
+        /// </remarks>
+        /// <param name="func">The delegate containing the properties to modify the user with.</param>
+        /// <param name="state">An object to carry state into the delegate to prevent closures.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyAsync<TState>(Action<GuildUserProperties, TState> func, TState state, RequestOptions options = null);
 
         /// <summary>
         ///     Adds the specified role to this user in the guild.

--- a/src/Discord.Net.Core/Entities/Users/ISelfUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/ISelfUser.cs
@@ -59,5 +59,9 @@ namespace Discord
         ///     Modifies the user's properties.
         /// </summary>
         Task ModifyAsync(Action<SelfUserProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies the user's properties.
+        /// </summary>
+        Task ModifyAsync<TState>(Action<SelfUserProperties, TState> func, TState state, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Webhooks/IWebhook.cs
+++ b/src/Discord.Net.Core/Entities/Webhooks/IWebhook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -53,5 +53,9 @@ namespace Discord
         ///     Modifies this webhook.
         /// </summary>
         Task ModifyAsync(Action<WebhookProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies this webhook.
+        /// </summary>
+        Task ModifyAsync<TState>(Action<WebhookProperties, TState> func, TState state, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -18,12 +18,13 @@ namespace Discord.Rest
         {
             await client.ApiClient.DeleteChannelAsync(channel.Id, options).ConfigureAwait(false);
         }
-        public static async Task<Model> ModifyAsync(IGuildChannel channel, BaseDiscordClient client,
-            Action<GuildChannelProperties> func,
+        public static async Task<Model> ModifyAsync<TState>(IGuildChannel channel, BaseDiscordClient client,
+            Action<GuildChannelProperties, TState> func,
+            TState state,
             RequestOptions options)
         {
             var args = new GuildChannelProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new API.Rest.ModifyGuildChannelParams
             {
                 Name = args.Name,
@@ -32,12 +33,13 @@ namespace Discord.Rest
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }
-        public static async Task<Model> ModifyAsync(ITextChannel channel, BaseDiscordClient client,
-            Action<TextChannelProperties> func,
+        public static async Task<Model> ModifyAsync<TState>(ITextChannel channel, BaseDiscordClient client,
+            Action<TextChannelProperties, TState> func,
+            TState state,
             RequestOptions options)
         {
             var args = new TextChannelProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new API.Rest.ModifyTextChannelParams
             {
                 Name = args.Name,
@@ -49,12 +51,13 @@ namespace Discord.Rest
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }
-        public static async Task<Model> ModifyAsync(IVoiceChannel channel, BaseDiscordClient client,
-            Action<VoiceChannelProperties> func,
+        public static async Task<Model> ModifyAsync<TState>(IVoiceChannel channel, BaseDiscordClient client,
+            Action<VoiceChannelProperties, TState> func,
+            TState state,
             RequestOptions options)
         {
             var args = new VoiceChannelProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new API.Rest.ModifyVoiceChannelParams
             {
                 Bitrate = args.Bitrate,

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -65,9 +65,12 @@ namespace Discord.Rest
             Update(model);
         }
         /// <inheritdoc />
-        public async Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public async Task ModifyAsync<TState>(Action<GuildChannelProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await ChannelHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await ChannelHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -47,9 +47,12 @@ namespace Discord.Rest
         }
 
         /// <inheritdoc />
-        public async Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public async Task ModifyAsync<TState>(Action<TextChannelProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await ChannelHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await ChannelHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -41,9 +41,12 @@ namespace Discord.Rest
         }
 
         /// <inheritdoc />
-        public async Task ModifyAsync(Action<VoiceChannelProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<VoiceChannelProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public async Task ModifyAsync<TState>(Action<VoiceChannelProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await ChannelHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await ChannelHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
 

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -15,13 +15,13 @@ namespace Discord.Rest
     {
         //General
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
-        public static async Task<Model> ModifyAsync(IGuild guild, BaseDiscordClient client,
-            Action<GuildProperties> func, RequestOptions options)
+        public static async Task<Model> ModifyAsync<TState>(IGuild guild, BaseDiscordClient client,
+            Action<GuildProperties, TState> func, TState state, RequestOptions options)
         {
             if (func == null) throw new ArgumentNullException(nameof(func));
 
             var args = new GuildProperties();
-            func(args);
+            func(args, state);
 
             var apiArgs = new API.Rest.ModifyGuildParams
             {
@@ -71,13 +71,13 @@ namespace Discord.Rest
             return await client.ApiClient.ModifyGuildAsync(guild.Id, apiArgs, options).ConfigureAwait(false);
         }
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
-        public static async Task<EmbedModel> ModifyEmbedAsync(IGuild guild, BaseDiscordClient client,
-            Action<GuildEmbedProperties> func, RequestOptions options)
+        public static async Task<EmbedModel> ModifyEmbedAsync<TState>(IGuild guild, BaseDiscordClient client,
+            Action<GuildEmbedProperties, TState> func, TState state, RequestOptions options)
         {
             if (func == null) throw new ArgumentNullException(nameof(func));
 
             var args = new GuildEmbedProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new API.Rest.ModifyGuildEmbedParams
             {
                 Enabled = args.Enabled

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -166,17 +166,25 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
-        public async Task ModifyAsync(Action<GuildProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<GuildProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        public async Task ModifyAsync<TState>(Action<GuildProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await GuildHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await GuildHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
 
         /// <inheritdoc />
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
-        public async Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null)
+        public Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null)
+            => ModifyEmbedAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        public async Task ModifyEmbedAsync<TState>(Action<GuildEmbedProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await GuildHelper.ModifyEmbedAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await GuildHelper.ModifyEmbedAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
 

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -13,14 +13,16 @@ namespace Discord.Rest
     {
         /// <exception cref="InvalidOperationException">Only the author of a message may modify the message.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public static async Task<Model> ModifyAsync(IMessage msg, BaseDiscordClient client, Action<MessageProperties> func,
+        public static async Task<Model> ModifyAsync<TState>(IMessage msg, BaseDiscordClient client,
+            Action<MessageProperties, TState> func,
+            TState state,
             RequestOptions options)
         {
             if (msg.Author.Id != client.CurrentUser.Id)
                 throw new InvalidOperationException("Only the author of a message may modify the message.");
 
             var args = new MessageProperties();
-            func(args);
+            func(args, state);
 
             var apiArgs = new API.Rest.ModifyMessageParams
             {

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -124,9 +124,12 @@ namespace Discord.Rest
         }
 
         /// <inheritdoc />
-        public async Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public async Task ModifyAsync<TState>(Action<MessageProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await MessageHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await MessageHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
 

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -57,11 +57,13 @@ namespace Discord.Rest
             Color = new Color(model.Color);
             Permissions = new GuildPermissions(model.Permissions);
         }
-
         /// <inheritdoc />
-        public async Task ModifyAsync(Action<RoleProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<RoleProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public async Task ModifyAsync<TState>(Action<RoleProperties, TState> func, TState state, RequestOptions options = null)
         { 
-            var model = await RoleHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await RoleHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Model = Discord.API.Role;
 using BulkParams = Discord.API.Rest.ModifyGuildRolesParams;
@@ -13,11 +13,11 @@ namespace Discord.Rest
         {
             await client.ApiClient.DeleteGuildRoleAsync(role.Guild.Id, role.Id, options).ConfigureAwait(false);
         }
-        public static async Task<Model> ModifyAsync(IRole role, BaseDiscordClient client, 
-            Action<RoleProperties> func, RequestOptions options)
+        public static async Task<Model> ModifyAsync<TState>(IRole role, BaseDiscordClient client, 
+            Action<RoleProperties, TState> func, TState state, RequestOptions options)
         {
             var args = new RoleProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new API.Rest.ModifyGuildRoleParams
             {
                 Color = args.Color.IsSpecified ? args.Color.Value.RawValue : Optional.Create<uint>(),

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -90,9 +90,12 @@ namespace Discord.Rest
             Update(model);
         }
         /// <inheritdoc />
-        public async Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public async Task ModifyAsync<TState>(Action<GuildUserProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var args = await UserHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var args = await UserHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             if (args.Deaf.IsSpecified)
                 IsDeafened = args.Deaf.Value;
             if (args.Mute.IsSpecified)

--- a/src/Discord.Net.Rest/Entities/Users/RestSelfUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestSelfUser.cs
@@ -65,11 +65,15 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="InvalidOperationException">Unable to modify this object using a different token.</exception>
-        public async Task ModifyAsync(Action<SelfUserProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<SelfUserProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Unable to modify this object using a different token.</exception>
+        public async Task ModifyAsync<TState>(Action<SelfUserProperties, TState> func, TState state, RequestOptions options = null)
         {
             if (Id != Discord.CurrentUser.Id)
                 throw new InvalidOperationException("Unable to modify this object using a different token.");
-            var model = await UserHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await UserHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
     }

--- a/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
@@ -63,6 +63,9 @@ namespace Discord.Rest
         /// <inheritdoc />
         Task IGuildUser.ModifyAsync(Action<GuildUserProperties> func, RequestOptions options) => 
             throw new NotSupportedException("Webhook users cannot be modified.");
+        /// <inheritdoc />
+        Task IGuildUser.ModifyAsync<TState>(Action<GuildUserProperties, TState> func, TState state, RequestOptions options) =>
+            throw new NotSupportedException("Webhook users cannot be modified.");
 
         /// <inheritdoc />
         Task IGuildUser.AddRoleAsync(IRole role, RequestOptions options) => 

--- a/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
@@ -10,11 +10,13 @@ namespace Discord.Rest
 {
     internal static class UserHelper
     {
-        public static async Task<Model> ModifyAsync(ISelfUser user, BaseDiscordClient client, Action<SelfUserProperties> func,
+        public static async Task<Model> ModifyAsync<TState>(ISelfUser user, BaseDiscordClient client,
+            Action<SelfUserProperties, TState> func,
+            TState state,
             RequestOptions options)
         {
             var args = new SelfUserProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new API.Rest.ModifyCurrentUserParams
             {
                 Avatar = args.Avatar.IsSpecified ? args.Avatar.Value?.ToModel() : Optional.Create<ImageModel?>(),
@@ -26,11 +28,13 @@ namespace Discord.Rest
 
             return await client.ApiClient.ModifySelfAsync(apiArgs, options).ConfigureAwait(false);
         }
-        public static async Task<GuildUserProperties> ModifyAsync(IGuildUser user, BaseDiscordClient client, Action<GuildUserProperties> func,
+        public static async Task<GuildUserProperties> ModifyAsync<TState>(IGuildUser user, BaseDiscordClient client,
+            Action<GuildUserProperties, TState> func,
+            TState state,
             RequestOptions options)
         {
             var args = new GuildUserProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new API.Rest.ModifyGuildMemberParams
             {
                 Deaf = args.Deaf,

--- a/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
+++ b/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
@@ -77,9 +77,11 @@ namespace Discord.Rest
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
            => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
 
-        public async Task ModifyAsync(Action<WebhookProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<WebhookProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        public async Task ModifyAsync<TState>(Action<WebhookProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await WebhookHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
+            var model = await WebhookHelper.ModifyAsync(this, Discord, func, state, options).ConfigureAwait(false);
             Update(model);
         }
 

--- a/src/Discord.Net.Rest/Entities/Webhooks/WebhookHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Webhooks/WebhookHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Discord.API.Rest;
 using ImageModel = Discord.API.Image;
@@ -8,11 +8,11 @@ namespace Discord.Rest
 {
     internal static class WebhookHelper
     {
-        public static async Task<Model> ModifyAsync(IWebhook webhook, BaseDiscordClient client,
-            Action<WebhookProperties> func, RequestOptions options)
+        public static async Task<Model> ModifyAsync<TState>(IWebhook webhook, BaseDiscordClient client,
+            Action<WebhookProperties, TState> func, TState state, RequestOptions options)
         {
             var args = new WebhookProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new ModifyWebhookParams
             {
                 Avatar = args.Image.IsSpecified ? args.Image.Value?.ToModel() : Optional.Create<ImageModel?>(),

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -75,7 +75,10 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
-            => ChannelHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public Task ModifyAsync<TState>(Action<GuildChannelProperties, TState> func, TState state, RequestOptions options = null)
+            => ChannelHelper.ModifyAsync(this, Discord, func, state, options);
         /// <inheritdoc />
         public Task DeleteAsync(RequestOptions options = null)
             => ChannelHelper.DeleteAsync(this, Discord, options);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -73,7 +73,10 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null)
-            => ChannelHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public Task ModifyAsync<TState>(Action<TextChannelProperties, TState> func, TState state, RequestOptions options = null)
+            => ChannelHelper.ModifyAsync(this, Discord, func, state, options);
 
         //Messages
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -59,7 +59,10 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<VoiceChannelProperties> func, RequestOptions options = null)
-            => ChannelHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public Task ModifyAsync<TState>(Action<VoiceChannelProperties, TState> func, TState state, RequestOptions options = null)
+            => ChannelHelper.ModifyAsync(this, Discord, func, state, options);
 
         /// <inheritdoc />
         public async Task<IAudioClient> ConnectAsync(bool selfDeaf = false, bool selfMute = false, bool external = false)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -441,12 +441,20 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
         public Task ModifyAsync(Action<GuildProperties> func, RequestOptions options = null)
-            => GuildHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        public Task ModifyAsync<TState>(Action<GuildProperties, TState> func, TState state, RequestOptions options = null)
+            => GuildHelper.ModifyAsync(this, Discord, func, state, options);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
         public Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null)
-            => GuildHelper.ModifyEmbedAsync(this, Discord, func, options);
+            => ModifyEmbedAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        public Task ModifyEmbedAsync<TState>(Action<GuildEmbedProperties, TState> func, TState state, RequestOptions options = null)
+            => GuildHelper.ModifyEmbedAsync(this, Discord, func, state, options);
         /// <inheritdoc />
         public Task ReorderChannelsAsync(IEnumerable<ReorderChannelProperties> args, RequestOptions options = null)
             => GuildHelper.ReorderChannelsAsync(this, Discord, args, options);

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -123,12 +123,17 @@ namespace Discord.WebSocket
                 model.Content = text;
             }
         }
-        
+
         /// <inheritdoc />
         /// <exception cref="InvalidOperationException">Only the author of a message may modify the message.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
-            => MessageHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Only the author of a message may modify the message.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
+        public Task ModifyAsync<TState>(Action<MessageProperties, TState> func, TState state, RequestOptions options = null)
+            => MessageHelper.ModifyAsync(this, Discord, func, state, options);
 
         /// <inheritdoc />
         public Task PinAsync(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -75,7 +75,10 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<RoleProperties> func, RequestOptions options = null)
-            => RoleHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public Task ModifyAsync<TState>(Action<RoleProperties, TState> func, TState state, RequestOptions options = null)
+            => RoleHelper.ModifyAsync(this, Discord, func, state, options);
         /// <inheritdoc />
         public Task DeleteAsync(RequestOptions options = null)
             => RoleHelper.DeleteAsync(this, Discord, options);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -166,7 +166,10 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null)
-            => UserHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public Task ModifyAsync<TState>(Action<GuildUserProperties, TState> func, TState state, RequestOptions options = null)
+            => UserHelper.ModifyAsync(this, Discord, func, state, options);
         /// <inheritdoc />
         public Task KickAsync(string reason = null, RequestOptions options = null)
             => UserHelper.KickAsync(this, Discord, reason, options);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
@@ -88,8 +88,12 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">Unable to modify this object using a different token.</exception>
         public Task ModifyAsync(Action<SelfUserProperties> func, RequestOptions options = null)
-            => UserHelper.ModifyAsync(this, Discord, func, options);
+            => ModifyAsync((props, f) => f(props), func, options);
+        /// <inheritdoc />
+        public Task ModifyAsync<TState>(Action<SelfUserProperties, TState> func, TState state, RequestOptions options = null)
+            => UserHelper.ModifyAsync(this, Discord, func, state, options);
 
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Self)";
         internal new SocketSelfUser Clone() => MemberwiseClone() as SocketSelfUser;

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -78,6 +78,10 @@ namespace Discord.WebSocket
         /// <exception cref="NotSupportedException">Webhook users cannot be modified.</exception>
         Task IGuildUser.ModifyAsync(Action<GuildUserProperties> func, RequestOptions options) => 
             throw new NotSupportedException("Webhook users cannot be modified.");
+        /// <inheritdoc />
+        /// <exception cref="NotSupportedException">Webhook users cannot be modified.</exception>
+        Task IGuildUser.ModifyAsync<TState>(Action<GuildUserProperties, TState> func, TState state, RequestOptions options) =>
+            throw new NotSupportedException("Webhook users cannot be modified.");
 
         /// <inheritdoc />
         /// <exception cref="NotSupportedException">Roles are not supported on webhook users.</exception>

--- a/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
+++ b/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Model = Discord.API.Webhook;
@@ -47,9 +47,11 @@ namespace Discord.Webhook
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
            => CDN.GetUserAvatarUrl(Id, AvatarId, size, format);
 
-        public async Task ModifyAsync(Action<WebhookProperties> func, RequestOptions options = null)
+        public Task ModifyAsync(Action<WebhookProperties> func, RequestOptions options = null)
+            => ModifyAsync((props, f) => f(props), func, options);
+        public async Task ModifyAsync<TState>(Action<WebhookProperties, TState> func, TState state, RequestOptions options = null)
         {
-            var model = await WebhookClientHelper.ModifyAsync(_client, func, options).ConfigureAwait(false);
+            var model = await WebhookClientHelper.ModifyAsync(_client, func, state, options).ConfigureAwait(false);
             Update(model);
         }
 

--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -55,11 +55,11 @@ namespace Discord.Webhook
             return msg.Id;
         }
 
-        public static async Task<WebhookModel> ModifyAsync(DiscordWebhookClient client,
-            Action<WebhookProperties> func, RequestOptions options)
+        public static async Task<WebhookModel> ModifyAsync<TState>(DiscordWebhookClient client,
+            Action<WebhookProperties, TState> func, TState state, RequestOptions options)
         {
             var args = new WebhookProperties();
-            func(args);
+            func(args, state);
             var apiArgs = new ModifyWebhookParams
             {
                 Avatar = args.Image.IsSpecified ? args.Image.Value?.ToModel() : Optional.Create<ImageModel?>(),

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedCategoryChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedCategoryChannel.cs
@@ -61,6 +61,11 @@ namespace Discord
             throw new NotImplementedException();
         }
 
+        public Task ModifyAsync<TState>(Action<GuildChannelProperties, TState> func, TState state, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
         {
             throw new NotImplementedException();

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
@@ -152,7 +152,17 @@ namespace Discord
             throw new NotImplementedException();
         }
 
+        public Task ModifyAsync<TState>(Action<TextChannelProperties, TState> func, TState state, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ModifyAsync<TState>(Action<GuildChannelProperties, TState> func, TState state, RequestOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
@@ -93,7 +93,17 @@ namespace Discord
             throw new NotImplementedException();
         }
 
+        public Task ModifyAsync<TState>(Action<VoiceChannelProperties, TState> func, TState state, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task ModifyAsync(Action<GuildChannelProperties> func, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ModifyAsync<TState>(Action<GuildChannelProperties, TState> func, TState state, RequestOptions options = null)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This is *technically* a breaking change since it modifies the interfaces, but people shouldn't be making their own implementations of our interfaces.

This change adds an overload to all `ModifyAsync` methods (that I could find) to take in a `state` parameter that's forwarded into the callback so they can be written without closing over local state. End users can take advantage of these overloads to keep GC pressure down.