### PR TITLE
Fix #1394 Misworded doc for arguments with the params keyword

### DIFF
--- a/docs/guides/commands/intro.md
+++ b/docs/guides/commands/intro.md
@@ -111,7 +111,7 @@ optional, give it a default value (i.e., `int num = 0`).
 
 #### Parameters with Spaces
 
-To accept a comma-separated list, set the parameter to `params Type[]`.
+To accept a space-separated list, set the parameter to `params Type[]`.
 
 Should a parameter include spaces, the parameter **must** be
 wrapped in quotes. For example, for a command with a parameter


### PR DESCRIPTION
Fix #1394 

This fixes the docs for the command service, where it specifies that arguments that use the `params` keyword are comma separated, when they are actually space separated.

Didn't see any pre-release docs branch on @Still34 's fork, so I'll just PR it here.