### PR TITLE
Fix package publishing in azure pipelines

### DIFF
--- a/azure/deploy.yml
+++ b/azure/deploy.yml
@@ -1,25 +1,25 @@
 steps:
 - script: |
-    dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "../../artifacts/" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
-    dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "../../artifacts/" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
-    dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "../../artifacts/" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
-    dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "../../artifacts/" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
-    dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "../../artifacts/" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
-    dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "../../artifacts/" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
-    dotnet pack "src\Discord.Net.Analyzers\Discord.Net.Analyzers.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "../../artifacts/" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
+    dotnet pack "src\Discord.Net.Core\Discord.Net.Core.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
+    dotnet pack "src\Discord.Net.Rest\Discord.Net.Rest.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
+    dotnet pack "src\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
+    dotnet pack "src\Discord.Net.Commands\Discord.Net.Commands.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
+    dotnet pack "src\Discord.Net.Webhook\Discord.Net.Webhook.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
+    dotnet pack "src\Discord.Net.Providers.WS4Net\Discord.Net.Providers.WS4Net.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
+    dotnet pack "src\Discord.Net.Analyzers\Discord.Net.Analyzers.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
   displayName: Pack projects
 
 - task: NuGet@0
   inputs:
     command: pack
-    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix=""
+    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "$(Build.ArtifactStagingDirectory)" -properties suffix=""
   displayName: Pack metapackage (release mode)
   condition: eq(variables['buildTag'], True)
 
 - task: NuGet@0
   inputs:
     command: pack
-    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "artifacts" -properties suffix="-$(buildNumber)"
+    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "$(Build.ArtifactStagingDirectory)" -properties suffix="-$(buildNumber)"
   displayName: Pack metapackage
   condition: eq(variables['buildTag'], False)
 
@@ -28,5 +28,5 @@ steps:
   inputs:
     command: push
     nuGetFeedType: external
-    packagesToPush: 'artifacts/*.nupkg'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
     publishFeedCredentials: myget-discord

--- a/azure/deploy.yml
+++ b/azure/deploy.yml
@@ -9,19 +9,23 @@ steps:
     dotnet pack "src\Discord.Net.Analyzers\Discord.Net.Analyzers.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
   displayName: Pack projects
 
-- task: NuGet@0
-  inputs:
-    command: pack
-    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "$(Build.ArtifactStagingDirectory)" -properties suffix=""
+- task: NuGetCommand@2
   displayName: Pack metapackage (release mode)
   condition: eq(variables['buildTag'], True)
-
-- task: NuGet@0
   inputs:
-    command: pack
-    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "$(Build.ArtifactStagingDirectory)" -properties suffix="-$(buildNumber)"
+    command: 'pack'
+    packagesToPack: 'src/Discord.Net/Discord.Net.nuspec'
+    versioningScheme: 'off'
+    buildProperties: 'suffix=""'
+
+- task: NuGetCommand@2
   displayName: Pack metapackage
   condition: eq(variables['buildTag'], False)
+  inputs:
+    command: 'pack'
+    packagesToPack: 'src/Discord.Net/Discord.Net.nuspec'
+    versioningScheme: 'off'
+    buildProperties: 'suffix="-$(buildNumber)"'
 
 - task: NuGetCommand@2
   displayName: Push to NuGet


### PR DESCRIPTION
The newer build agents changed the directory structure so the hardcoded artifact directory naturally broke.
