### PR TITLE
Fix packaging part 2, electric boogaloo

### DIFF
--- a/azure/deploy.yml
+++ b/azure/deploy.yml
@@ -14,14 +14,17 @@ steps:
   condition: eq(variables['buildTag'], True)
   inputs:
     command: 'pack'
-    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "$(Build.ArtifactStagingDirectory}" -properties suffix=""
+    packagesToPack: 'src/Discord.Net/Discord.Net.nuspec'
+    versioningScheme: 'off'  
 
 - task: NuGetCommand@2
   displayName: Pack metapackage
   condition: eq(variables['buildTag'], False)
   inputs:
     command: 'pack'
-    arguments: src/Discord.Net/Discord.Net.nuspec -OutputDirectory "$(Build.ArtifactStagingDirectory}" -properties suffix="-$(buildNumber)"
+    packagesToPack: 'src/Discord.Net/Discord.Net.nuspec'
+    versioningScheme: 'off'
+    buildProperties: 'suffix=-$(buildNumber)'
 
 - task: NuGetCommand@2
   displayName: Push to NuGet


### PR DESCRIPTION
Pipelines did some weird escaping to the suffix when it ran the nuget command, and removing the quotes fixes it.

This time around I tested it in my own pipeline and it does appear to work fine.