### PR TITLE
Add .NET Standard 2.1 support Color

### DIFF
--- a/src/Discord.Net.Core/Entities/Roles/Color.cs
+++ b/src/Discord.Net.Core/Entities/Roles/Color.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Diagnostics;
-#if NETSTANDARD2_1 || NETSTANDARD2_0 || NET45
 using StandardColor = System.Drawing.Color;
-#endif
 
 namespace Discord
 {
@@ -190,12 +188,10 @@ namespace Discord
 
         public override int GetHashCode() => RawValue.GetHashCode();
 
-#if NETSTANDARD2_1 || NETSTANDARD2_0 || NET45
         public static implicit operator StandardColor(Color color) =>
             StandardColor.FromArgb((int)color.RawValue);
         public static explicit operator Color(StandardColor color) =>
             new Color((uint)color.ToArgb() << 8 >> 8);
-#endif
 
         /// <summary>
         ///     Gets the hexadecimal representation of the color (e.g. <c>#000ccc</c>).

--- a/src/Discord.Net.Core/Entities/Roles/Color.cs
+++ b/src/Discord.Net.Core/Entities/Roles/Color.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Diagnostics;
-#if NETSTANDARD2_0 || NET45
+#if NETSTANDARD2_1 || NETSTANDARD2_0 || NET45
 using StandardColor = System.Drawing.Color;
 #endif
 
@@ -190,7 +190,7 @@ namespace Discord
 
         public override int GetHashCode() => RawValue.GetHashCode();
 
-#if NETSTANDARD2_0 || NET45
+#if NETSTANDARD2_1 || NETSTANDARD2_0 || NET45
         public static implicit operator StandardColor(Color color) =>
             StandardColor.FromArgb((int)color.RawValue);
         public static explicit operator Color(StandardColor color) =>


### PR DESCRIPTION
Adds NETSTANDARD2_1 as a flag to the Discord Color operator. Fixes #1404 