### PR TITLE
RestGuild.GetUsersAsync limited to 100/request instead of supported 1000.

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -343,7 +343,7 @@ namespace Discord.Rest
             ulong? fromUserId, int? limit, RequestOptions options)
         {
             return new PagedAsyncEnumerable<RestGuildUser>(
-                DiscordConfig.MaxMessagesPerBatch,
+                DiscordConfig.MaxUsersPerBatch,
                 async (info, ct) =>
                 {
                     var args = new GetGuildMembersParams
@@ -357,7 +357,7 @@ namespace Discord.Rest
                 },
                 nextPage: (info, lastPage) =>
                 {
-                    if (lastPage.Count != DiscordConfig.MaxMessagesPerBatch)
+                    if (lastPage.Count != DiscordConfig.MaxUsersPerBatch)
                         return false;
                     info.Position = lastPage.Max(x => x.Id);
                     return true;


### PR DESCRIPTION
Fixed `GetUsersAsync` method to use `MaxUsersPerBatch` const as a limit instead of `MaxMessagesPerBatch`.

Requests are now returning up to 1000 guild user entities instead of the previous 100.
