### PR TITLE
Implemented Message Reference Property

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -141,6 +141,18 @@ namespace Discord
         MessageApplication Application { get; }
 
         /// <summary>
+        ///     Gets the reference to the original message if it was crossposted.
+        /// </summary>
+        /// <remarks>
+        ///     Sent with Cross-posted messages, meaning they were published from news channels
+        ///     and received by subscriber channels.
+        /// </remarks>
+        /// <returns>
+        ///     A message's reference, if any is associated.
+        /// </returns>
+        MessageReference Reference { get; }
+
+        /// <summary>
         ///     Gets all reactions included in this message.
         /// </summary>
         IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions { get; }

--- a/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -28,7 +23,11 @@ namespace Discord
         /// </summary>
         public ulong? GuildId { get; internal set; }
 
+        private string DebuggerDisplay
+            => $"Channel ID: ({ChannelId}){(GuildId.HasValue ? $", Guild ID: ({GuildId.Value})" : "")}" +
+            $"{(MessageId.HasValue ? $", Message ID: ({MessageId.Value})" : "")}";
+
         public override string ToString()
-            => $"Guild: {GuildId}, Channel: {ChannelId}, Message: {MessageId}";
+            => DebuggerDisplay;
     }
 }

--- a/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
@@ -11,7 +11,7 @@ namespace Discord
         /// <summary>
         ///     Gets the Message ID of the original message.
         /// </summary>
-        public ulong? MessageId { get; internal set; }
+        public Optional<ulong> MessageId { get; internal set; }
 
         /// <summary>
         ///     Gets the Channel ID of the original message.
@@ -21,11 +21,11 @@ namespace Discord
         /// <summary>
         ///     Gets the Guild ID of the original message.
         /// </summary>
-        public ulong? GuildId { get; internal set; }
+        public Optional<ulong> GuildId { get; internal set; }
 
         private string DebuggerDisplay
-            => $"Channel ID: ({ChannelId}){(GuildId.HasValue ? $", Guild ID: ({GuildId.Value})" : "")}" +
-            $"{(MessageId.HasValue ? $", Message ID: ({MessageId.Value})" : "")}";
+            => $"Channel ID: ({ChannelId}){(GuildId.IsSpecified ? $", Guild ID: ({GuildId.Value})" : "")}" +
+            $"{(MessageId.IsSpecified ? $", Message ID: ({MessageId.Value})" : "")}";
 
         public override string ToString()
             => DebuggerDisplay;

--- a/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    /// <summary>
+    ///     Contains the IDs sent from a crossposted message.
+    /// </summary>
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class MessageReference
+    {
+        /// <summary>
+        ///     Gets the Message ID of the original message.
+        /// </summary>
+        public ulong? MessageId { get; internal set; }
+
+        /// <summary>
+        ///     Gets the Channel ID of the original message.
+        /// </summary>
+        public ulong ChannelId { get; internal set; }
+
+        /// <summary>
+        ///     Gets the Guild ID of the original message.
+        /// </summary>
+        public ulong? GuildId { get; internal set; }
+
+        public override string ToString()
+            => $"Guild: {GuildId}, Channel: {ChannelId}, Message: {MessageId}";
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/Message.cs
+++ b/src/Discord.Net.Rest/API/Common/Message.cs
@@ -50,6 +50,8 @@ namespace Discord.API
         // sent with Rich Presence-related chat embeds
         [JsonProperty("application")]
         public Optional<MessageApplication> Application { get; set; }
+        [JsonProperty("message_reference")]
+        public Optional<MessageReference> Reference { get; set; }
         [JsonProperty("flags")]
         public Optional<MessageFlags> Flags { get; set; }
     }

--- a/src/Discord.Net.Rest/API/Common/MessageReference.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageReference.cs
@@ -5,12 +5,12 @@ namespace Discord.API
     internal class MessageReference
     {
         [JsonProperty("message_id")]
-        public ulong? MessageId { get; set; }
+        public Optional<ulong> MessageId { get; set; }
 
         [JsonProperty("channel_id")]
         public ulong ChannelId { get; set; }
 
         [JsonProperty("guild_id")]
-        public ulong? GuildId { get; set; }
+        public Optional<ulong> GuildId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/MessageReference.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageReference.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class MessageReference
+    {
+        [JsonProperty("message_id")]
+        public ulong? MessageId { get; set; }
+
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; set; }
+
+        [JsonProperty("guild_id")]
+        public ulong? GuildId { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -62,6 +62,8 @@ namespace Discord.Rest
         public MessageActivity Activity { get; private set; }
         /// <inheritdoc />
         public MessageApplication Application { get; private set; }
+        /// <inheritdoc />
+        public MessageReference Reference { get; private set; }
 
         internal RestMessage(BaseDiscordClient discord, ulong id, IMessageChannel channel, IUser author, MessageSource source)
             : base(discord, id)
@@ -105,6 +107,17 @@ namespace Discord.Rest
                 {
                     Type = model.Activity.Value.Type.Value,
                     PartyId = model.Activity.Value.PartyId.GetValueOrDefault()
+                };
+            }
+
+            if(model.Reference.IsSpecified)
+            {
+                // Creates a new Reference from the API model
+                Reference = new MessageReference
+                {
+                    GuildId = model.Reference.Value.GuildId,
+                    ChannelId = model.Reference.Value.ChannelId,
+                    MessageId = model.Reference.Value.MessageId
                 };
             }
 

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -53,6 +53,9 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public MessageApplication Application { get; private set; }
 
+        /// <inheritdoc />
+        public MessageReference Reference { get; private set; }
+
         /// <summary>
         ///     Returns all attachments included in this message.
         /// </summary>
@@ -138,6 +141,17 @@ namespace Discord.WebSocket
                 {
                     Type = model.Activity.Value.Type.Value,
                     PartyId = model.Activity.Value.PartyId.Value
+                };
+            }
+
+            if (model.Reference.IsSpecified)
+            {
+                // Creates a new Reference from the API model
+                Reference = new MessageReference
+                {
+                    GuildId = model.Reference.Value.GuildId,
+                    ChannelId = model.Reference.Value.ChannelId,
+                    MessageId = model.Reference.Value.MessageId
                 };
             }
         }


### PR DESCRIPTION
# Summary

Added support for this new message property as documented in https://discordapp.com/developers/docs/resources/channel#message-object-message-reference-structure.

# Changes

Created both the public and internal structure, with 3 snowflake properties. The Guild and Message snowflakes were made nullable according to the documentation. Also modeled how this property is constructed similarly to other message properties in both `SocketMessage` and `RestMessage`.

# Stable?

This has been tested thoroughly with an existing reference, and so far the snowflakes do match with their original message.
