### PR TITLE
Fix: False-positive detection of CustomStatusGame based on Id property

### DIFF
--- a/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.WebSocket/Extensions/EntityExtensions.cs
@@ -10,7 +10,7 @@ namespace Discord.WebSocket
         public static IActivity ToEntity(this API.Game model)
         {
             // Custom Status Game
-            if (model.Id.IsSpecified)
+            if (model.Id.IsSpecified && model.Id.Value == "custom")
             {
                 return new CustomStatusGame()
                 {


### PR DESCRIPTION
This change fixes a bug that was introduced in PR #1406. (regular) Games were falsely detected to be CustomStatusGames, based on the Id property being included in the activity model payload. [Original conversation here.](https://discordapp.com/channels/81384788765712384/381889909113225237/643873873951195166)

This fixes the false detection of Games as CustomStatusGame. An activity will only be considered a CustomStatusGame if the Id has a value of "custom".

This change has been manually tested by listening to the GuildMemberUpdated event, and opening/closing games with a custom status set.