### PR TITLE
fix #1415 Re-add support for overwrite permissions for news channels

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
@@ -25,29 +25,5 @@ namespace Discord.Rest
             return entity;
         }
         public override int SlowModeInterval => throw new NotSupportedException("News channels do not support Slow Mode.");
-        public override Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
-        {
-            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        }
-        public override Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
-        {
-            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        }
-        public override OverwritePermissions? GetPermissionOverwrite(IRole role)
-        {
-            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        }
-        public override OverwritePermissions? GetPermissionOverwrite(IUser user)
-        {
-            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        }
-        public override Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
-        {
-            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        }
-        public override Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
-        {
-            throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -11,7 +11,7 @@ namespace Discord.WebSocket
     /// </summary>
     /// <remarks>
     ///     <note type="warning">
-    ///         Most of the properties and methods featured may not be supported due to the nature of the channel.
+    ///         The <see cref="SlowModeInterval"/> property is not supported for news channels.
     ///     </note>
     /// </remarks>
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
@@ -35,53 +35,5 @@ namespace Discord.WebSocket
         /// </remarks>
         public override int SlowModeInterval
             => throw new NotSupportedException("News channels do not support Slow Mode.");
-        /// <inheritdoc />
-        /// <remarks>
-        ///     <note type="important">
-        ///     This method is not supported by this type. Attempting to use this method will result in a <see cref="NotSupportedException"/>.
-        ///     </note>
-        /// </remarks>
-        public override Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
-            => throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        /// <inheritdoc />
-        /// <remarks>
-        ///     <note type="important">
-        ///     This method is not supported by this type. Attempting to use this method will result in a <see cref="NotSupportedException"/>.
-        ///     </note>
-        /// </remarks>
-        public override Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
-            => throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        /// <inheritdoc />
-        /// <remarks>
-        ///     <note type="important">
-        ///     This property is not supported by this type. Attempting to use this property will result in a <see cref="NotSupportedException"/>.
-        ///     </note>
-        /// </remarks>
-        public override IReadOnlyCollection<Overwrite> PermissionOverwrites
-            => throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        /// <inheritdoc />
-        /// <remarks>
-        ///     <note type="important">
-        ///     This method is not supported by this type. Attempting to use this method will result in a <see cref="NotSupportedException"/>.
-        ///     </note>
-        /// </remarks>
-        public override Task SyncPermissionsAsync(RequestOptions options = null)
-            => throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        /// <inheritdoc />
-        /// <remarks>
-        ///     <note type="important">
-        ///     This method is not supported by this type. Attempting to use this method will result in a <see cref="NotSupportedException"/>.
-        ///     </note>
-        /// </remarks>
-        public override Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
-            => throw new NotSupportedException("News channels do not support Overwrite Permissions.");
-        /// <inheritdoc />
-        /// <remarks>
-        ///     <note type="important">
-        ///     This method is not supported by this type. Attempting to use this method will result in a <see cref="NotSupportedException"/>.
-        ///     </note>
-        /// </remarks>
-        public override Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
-            => throw new NotSupportedException("News channels do not support Overwrite Permissions.");
     }
 }


### PR DESCRIPTION
Fix #1415 

This change updates the NewsChannel classes so that the overwrite permission-related properties no longer throw a NotSupportedException when they are used.
These properties were not initially supported by News/Announcement channels when the feature was first released, but now they are.