### PR TITLE
Fix #1335 Add isMentionable parameter to CreateRoleAsync in non-breaking manner

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -593,11 +593,13 @@ namespace Discord
         /// <param name="color">The color of the role.</param>
         /// <param name="isHoisted">Whether the role is separated from others on the sidebar.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="isMentionable">Whether the role can be mentioned.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
-        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, RequestOptions options = null);
+        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, RequestOptions options = null, bool isMentionable = false);
+        // TODO Chris-Johnston: 3.x breaking interface change: re-order isMentionable parameter
 
         /// <summary>
         ///     Adds a user to this guild.

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -593,13 +593,26 @@ namespace Discord
         /// <param name="color">The color of the role.</param>
         /// <param name="isHoisted">Whether the role is separated from others on the sidebar.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <param name="isMentionable">Whether the role can be mentioned.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
-        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, RequestOptions options = null, bool isMentionable = false);
-        // TODO Chris-Johnston: 3.x breaking interface change: re-order isMentionable parameter
+        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, RequestOptions options = null);
+        // TODO remove CreateRoleAsync overload that does not have isMentionable when breaking change is acceptable
+        /// <summary>
+        ///     Creates a new role with the provided name.
+        /// </summary>
+        /// <param name="name">The new name for the role.</param>
+        /// <param name="permissions">The guild permission that the role should possess.</param>
+        /// <param name="color">The color of the role.</param>
+        /// <param name="isHoisted">Whether the role is separated from others on the sidebar.</param>
+        /// <param name="isMentionable">Whether the role can be mentioned.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous creation operation. The task result contains the newly created
+        ///     role.
+        /// </returns>
+        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, bool isMentionable = false, RequestOptions options = null);
 
         /// <summary>
         ///     Adds a user to this guild.

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -257,7 +257,7 @@ namespace Discord.Rest
         //Roles
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
         public static async Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
-            string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
+            string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options)
         {
             if (name == null) throw new ArgumentNullException(paramName: nameof(name));
 
@@ -270,6 +270,7 @@ namespace Discord.Rest
                 x.Permissions = (permissions ?? role.Permissions);
                 x.Color = (color ?? Color.Default);
                 x.Hoist = isHoisted;
+                x.Mentionable = isMentionable;
             }, options).ConfigureAwait(false);
 
             return role;

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -530,6 +530,11 @@ namespace Discord.Rest
             return null;
         }
 
+        /// <inheritdoc />
+        public Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
+            bool isHoisted = false, RequestOptions options = null)
+            => CreateRoleAsync(name, permissions, color, isHoisted, false, options);
+
         /// <summary>
         ///     Creates a new role with the provided name.
         /// </summary>
@@ -544,7 +549,7 @@ namespace Discord.Rest
         ///     role.
         /// </returns>
         public async Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
-            bool isHoisted = false, RequestOptions options = null, bool isMentionable = false)
+            bool isHoisted = false, bool isMentionable = false, RequestOptions options = null)
         {
             var role = await GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, isMentionable, options).ConfigureAwait(false);
             _roles = _roles.Add(role.Id, role);
@@ -833,8 +838,11 @@ namespace Discord.Rest
         IRole IGuild.GetRole(ulong id)
             => GetRole(id);
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options, bool isMentionable)
-            => await CreateRoleAsync(name, permissions, color, isHoisted, options, isMentionable).ConfigureAwait(false);
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
+            => await CreateRoleAsync(name, permissions, color, isHoisted, false, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options)
+            => await CreateRoleAsync(name, permissions, color, isHoisted, isMentionable, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IGuildUser> IGuild.AddGuildUserAsync(ulong userId, string accessToken, Action<AddGuildUserProperties> func, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -538,14 +538,15 @@ namespace Discord.Rest
         /// <param name="color">The color of the role.</param>
         /// <param name="isHoisted">Whether the role is separated from others on the sidebar.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="isMentionable">Whether the role can be mentioned.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
         public async Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
-            bool isHoisted = false, RequestOptions options = null)
+            bool isHoisted = false, RequestOptions options = null, bool isMentionable = false)
         {
-            var role = await GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, options).ConfigureAwait(false);
+            var role = await GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, isMentionable, options).ConfigureAwait(false);
             _roles = _roles.Add(role.Id, role);
             return role;
         }
@@ -832,8 +833,8 @@ namespace Discord.Rest
         IRole IGuild.GetRole(ulong id)
             => GetRole(id);
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
-            => await CreateRoleAsync(name, permissions, color, isHoisted, options).ConfigureAwait(false);
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options, bool isMentionable)
+            => await CreateRoleAsync(name, permissions, color, isHoisted, options, isMentionable).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IGuildUser> IGuild.AddGuildUserAsync(ulong userId, string accessToken, Action<AddGuildUserProperties> func, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -679,6 +679,10 @@ namespace Discord.WebSocket
             return null;
         }
 
+        /// <inheritdoc />
+        public Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
+            bool isHoisted = false, RequestOptions options = null)
+            => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, false, options);
         /// <summary>
         ///     Creates a new role with the provided name.
         /// </summary>
@@ -686,15 +690,15 @@ namespace Discord.WebSocket
         /// <param name="permissions">The guild permission that the role should possess.</param>
         /// <param name="color">The color of the role.</param>
         /// <param name="isHoisted">Whether the role is separated from others on the sidebar.</param>
-        /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="isMentionable">Whether the role can be mentioned.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
         public Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
-            bool isHoisted = false, RequestOptions options = null, bool isMentionable = false)
+            bool isHoisted = false, bool isMentionable = false, RequestOptions options = null)
             => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, isMentionable, options);
         internal SocketRole AddRole(RoleModel model)
         {
@@ -1151,8 +1155,11 @@ namespace Discord.WebSocket
         IRole IGuild.GetRole(ulong id)
             => GetRole(id);
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options, bool isMentionable)
-            => await CreateRoleAsync(name, permissions, color, isHoisted, options, isMentionable).ConfigureAwait(false);
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
+            => await CreateRoleAsync(name, permissions, color, isHoisted, false, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options)
+            => await CreateRoleAsync(name, permissions, color, isHoisted, isMentionable, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         Task<IReadOnlyCollection<IGuildUser>> IGuild.GetUsersAsync(CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -687,14 +687,15 @@ namespace Discord.WebSocket
         /// <param name="color">The color of the role.</param>
         /// <param name="isHoisted">Whether the role is separated from others on the sidebar.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="isMentionable">Whether the role can be mentioned.</param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
         public Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
-            bool isHoisted = false, RequestOptions options = null)
-            => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, options);
+            bool isHoisted = false, RequestOptions options = null, bool isMentionable = false)
+            => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, isMentionable, options);
         internal SocketRole AddRole(RoleModel model)
         {
             var role = SocketRole.Create(this, Discord.State, model);
@@ -1150,8 +1151,8 @@ namespace Discord.WebSocket
         IRole IGuild.GetRole(ulong id)
             => GetRole(id);
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
-            => await CreateRoleAsync(name, permissions, color, isHoisted, options).ConfigureAwait(false);
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options, bool isMentionable)
+            => await CreateRoleAsync(name, permissions, color, isHoisted, options, isMentionable).ConfigureAwait(false);
 
         /// <inheritdoc />
         Task<IReadOnlyCollection<IGuildUser>> IGuild.GetUsersAsync(CacheMode mode, RequestOptions options)


### PR DESCRIPTION
Fix #1335 

This PR adds the isMentionable parameter to the CreateRoleAsync method
in a way that prevents it from being interface-breaking. This has been done by adding a method overload.

This parameter determines if the newly created role can be mentioned as it is
created and immediately modified.
