### PR TITLE
Fix #1421 Return empty set when ActiveClients is null

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -40,7 +40,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public UserStatus Status => Presence.Status;
         /// <inheritdoc />
-        public IImmutableSet<ClientType> ActiveClients => Presence.ActiveClients;
+        public IImmutableSet<ClientType> ActiveClients => Presence.ActiveClients ?? ImmutableHashSet<ClientType>.Empty;
         /// <summary>
         ///     Gets mutual guilds shared with this user.
         /// </summary>


### PR DESCRIPTION
Fix #1421 

This change ensures that `SocketUser.ActiveClients` will not return null, but instead an empty set by default. This can happen if the client has not received a presence update for a user, or if the user is not cached.

Also, I was looking at `SocketGuildUser` and noticed that it has its own (redundant?) copy of `SocketPresence`:
https://github.com/discord-net/Discord.Net/blob/dcd9cdd13ee0bd4d337e07d610dd612b6473ff6b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs#L43

I was thinking about having it use the Presence property of `SocketGlobalUser`, although that's exactly what was removed in fd72583a75a1c9ccc1f6040c8611d20c58513e4a

```diff
-        internal override SocketPresence Presence { get { return GlobalUser.Presence; } set { GlobalUser.Presence = value; } }
+        internal override SocketPresence Presence { get; set; }
```
Seems to work just fine if I reverse it, although there may be some edge case that I haven't tried.