### PR TITLE
Fix the Comparer descriptions not linking the type

### DIFF
--- a/docs/_overwrites/Common/DiscordComparers.Overwrites.md
+++ b/docs/_overwrites/Common/DiscordComparers.Overwrites.md
@@ -1,0 +1,29 @@
+---
+uid: Discord.DiscordComparers.ChannelComparer
+summary: *content
+---
+Gets an [IEqualityComparer](xref:System.Collections.Generic.IEqualityComparer`1)<<xref:Discord.IChannel>> to be used to compare channels.
+
+---
+uid: Discord.DiscordComparers.GuildComparer
+summary: *content
+---
+Gets an [IEqualityComparer](xref:System.Collections.Generic.IEqualityComparer`1)<<xref:Discord.IGuild>> to be used to compare guilds.
+
+---
+uid: Discord.DiscordComparers.MessageComparer
+summary: *content
+---
+Gets an [IEqualityComparer](xref:System.Collections.Generic.IEqualityComparer`1)<<xref:Discord.IMessage>> to be used to compare messages.
+
+---
+uid: Discord.DiscordComparers.RoleComparer
+summary: *content
+---
+Gets an [IEqualityComparer](xref:System.Collections.Generic.IEqualityComparer`1)<<xref:Discord.IRole>> to be used to compare roles.
+
+---
+uid: Discord.DiscordComparers.UserComparer
+summary: *content
+---
+Gets an [IEqualityComparer](xref:System.Collections.Generic.IEqualityComparer`1)<<xref:Discord.IUser>> to be used to compare users.


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1058562/69418272-a82c2e80-0d1a-11ea-9eff-8f07a1f834f5.png)

After:
![image](https://user-images.githubusercontent.com/1058562/69418281-aebaa600-0d1a-11ea-953a-cf2b988798d8.png)
