### PR TITLE
Feature: Add newly supported events and endpoint

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -217,6 +217,16 @@ namespace Discord
         Task RemoveAllReactionsAsync(RequestOptions options = null);
 
         /// <summary>
+        ///     Removes all reactions of a given emote in the message. 
+        /// </summary>
+        /// <param name="emote">The emote to clear.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asyncronous removal operation.
+        /// </returns>
+        Task RemoveEmojiReactionsAsync(IEmote emote, RequestOptions options = null);
+
+        /// <summary>
         ///     Gets all users that reacted to a message with a given emote.
         /// </summary>
         /// <example>

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -665,6 +665,19 @@ namespace Discord.API
 
             await SendAsync("DELETE", () => $"channels/{channelId}/messages/{messageId}/reactions", ids, options: options).ConfigureAwait(false);
         }
+
+        public async Task RemoveEmojiReactionsAsync(ulong channelId, ulong messageId, string emoji, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(channelId, 0, nameof(channelId));
+            Preconditions.NotEqual(messageId, 0, nameof(messageId));
+
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(channelId: channelId);
+
+            await SendAsync("DELETE", () => $"channels/{channelId}/messages/{messageId}/reactions/{emoji}", ids, options: options);
+        }
+
         public async Task<IReadOnlyCollection<User>> GetReactionUsersAsync(ulong channelId, ulong messageId, string emoji, GetReactionUsersParams args, RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));

--- a/src/Discord.Net.Rest/Entities/Invites/RestInviteMetadata.cs
+++ b/src/Discord.Net.Rest/Entities/Invites/RestInviteMetadata.cs
@@ -36,6 +36,7 @@ namespace Discord.Rest
             entity.Update(model);
             return entity;
         }
+
         internal void Update(Model model)
         {
             base.Update(model);

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -71,6 +71,11 @@ namespace Discord.Rest
             await client.ApiClient.RemoveAllReactionsAsync(msg.Channel.Id, msg.Id, options).ConfigureAwait(false);
         }
 
+        public static async Task RemoveEmojiReactionsAsync(IMessage msg, IEmote emote, BaseDiscordClient client, RequestOptions options)
+        {
+            await client.ApiClient.RemoveEmojiReactionsAsync(msg.Channel.Id, msg.Id, emote is Emote e ? $"{e.Name}:{e.Id}" : emote.Name, options).ConfigureAwait(false);
+        }
+
         public static IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IMessage msg, IEmote emote,
             int? limit, BaseDiscordClient client, RequestOptions options)
         {

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -182,6 +182,9 @@ namespace Discord.Rest
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsAsync(this, Discord, options);
         /// <inheritdoc />
+        public Task RemoveEmojiReactionsAsync(IEmote emote, RequestOptions options = null)
+            => MessageHelper.RemoveEmojiReactionsAsync(this, emote, Discord, options);
+        /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emote, int limit, RequestOptions options = null)
             => MessageHelper.GetReactionUsersAsync(this, emote, limit, Discord, options);
     }

--- a/src/Discord.Net.WebSocket/API/InviteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/InviteEvent.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class InviteEvent : InviteMetadata
+    {
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; set; }
+
+        [JsonProperty("guild_id")]
+        public ulong GuildId { get; set; }
+    }
+}

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -236,11 +236,11 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
 
         /// <summary> Fired when all reactions of a specific reaction are removed.</summary>
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionsClearedEmoji { 
-            add { _reactionsClearedEmojiEvent.Add(value); }
-            remove { _reactionsClearedEmojiEvent.Remove(value); }
+        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> RemovedEmojiReactions { 
+            add { _removedEmojiReactionsEvent.Add(value); }
+            remove { _removedEmojiReactionsEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionsClearedEmojiEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _removedEmojiReactionsEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
 
 
         //Roles

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -235,6 +235,14 @@ namespace Discord.WebSocket
         }
         internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
 
+        /// <summary> Fired when all reactions of a specific reaction are removed.</summary>
+        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionsClearedEmoji { 
+            add { _reactionsClearedEmojiEvent.Add(value); }
+            remove { _reactionsClearedEmojiEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionsClearedEmojiEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
+
+
         //Roles
         /// <summary> Fired when a role is created. </summary>
         public event Func<SocketRole, Task> RoleCreated {
@@ -292,6 +300,21 @@ namespace Discord.WebSocket
             remove { _guildUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuild, SocketGuild, Task>> _guildUpdatedEvent = new AsyncEvent<Func<SocketGuild, SocketGuild, Task>>();
+
+        //Invites
+        /// <summary> Fired when an invite is created.</summary
+        public event Func<SocketInvite, Task> InviteCreated {
+            add { _inviteCreatedEvent.Add(value); }
+            remove { _inviteCreatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketInvite, Task>> _inviteCreatedEvent = new AsyncEvent<Func<SocketInvite, Task>>();
+        /// <summary>Fired when an invite is deleted.</summary>
+        public event Func<SocketInvite, Task> InviteDeleted
+        {
+            add { _inviteDeletedEvent.Add(value); }
+            remove { _inviteDeletedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketInvite, Task>> _inviteDeletedEvent = new AsyncEvent<Func<SocketInvite, Task>>();
 
         //Users
         /// <summary> Fired when a user joins a guild. </summary>

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -302,7 +302,7 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<SocketGuild, SocketGuild, Task>> _guildUpdatedEvent = new AsyncEvent<Func<SocketGuild, SocketGuild, Task>>();
 
         //Invites
-        /// <summary> Fired when an invite is created.</summary
+        /// <summary> Fired when an invite is created.</summary>
         public event Func<SocketInvite, Task> InviteCreated {
             add { _inviteCreatedEvent.Add(value); }
             remove { _inviteCreatedEvent.Remove(value); }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -313,7 +313,7 @@ namespace Discord.WebSocket
             client.ReactionAdded += (cache, channel, reaction) => _reactionAddedEvent.InvokeAsync(cache, channel, reaction);
             client.ReactionRemoved += (cache, channel, reaction) => _reactionRemovedEvent.InvokeAsync(cache, channel, reaction);
             client.ReactionsCleared += (cache, channel) => _reactionsClearedEvent.InvokeAsync(cache, channel);
-            client.ReactionsClearedEmoji += (cache, channel, reaction) => _reactionsClearedEmojiEvent.InvokeAsync(cache, channel, reaction);
+            client.RemovedEmojiReactions += (cache, channel, reaction) => _removedEmojiReactionsEvent.InvokeAsync(cache, channel, reaction);
 
             client.RoleCreated += (role) => _roleCreatedEvent.InvokeAsync(role);
             client.RoleDeleted += (role) => _roleDeletedEvent.InvokeAsync(role);

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -313,6 +313,7 @@ namespace Discord.WebSocket
             client.ReactionAdded += (cache, channel, reaction) => _reactionAddedEvent.InvokeAsync(cache, channel, reaction);
             client.ReactionRemoved += (cache, channel, reaction) => _reactionRemovedEvent.InvokeAsync(cache, channel, reaction);
             client.ReactionsCleared += (cache, channel) => _reactionsClearedEvent.InvokeAsync(cache, channel);
+            client.ReactionsClearedEmoji += (cache, channel, reaction) => _reactionsClearedEmojiEvent.InvokeAsync(cache, channel, reaction);
 
             client.RoleCreated += (role) => _roleCreatedEvent.InvokeAsync(role);
             client.RoleDeleted += (role) => _roleDeletedEvent.InvokeAsync(role);
@@ -324,6 +325,9 @@ namespace Discord.WebSocket
             client.GuildUnavailable += (guild) => _guildUnavailableEvent.InvokeAsync(guild);
             client.GuildMembersDownloaded += (guild) => _guildMembersDownloadedEvent.InvokeAsync(guild);
             client.GuildUpdated += (oldGuild, newGuild) => _guildUpdatedEvent.InvokeAsync(oldGuild, newGuild);
+
+            client.InviteCreated += (invite) => _inviteCreatedEvent.InvokeAsync(invite);
+            client.InviteDeleted += (invite) => _inviteDeletedEvent.InvokeAsync(invite);
 
             client.UserJoined += (user) => _userJoinedEvent.InvokeAsync(user);
             client.UserLeft += (user) => _userLeftEvent.InvokeAsync(user);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1401,7 +1401,7 @@ namespace Discord.WebSocket
 
                                         cachedMsg?.ClearReactionsEmoji(reaction);
 
-                                        await TimedInvokeAsync(_reactionsClearedEmojiEvent, nameof(ReactionsClearedEmoji), cacheable, channel, reaction).ConfigureAwait(false);
+                                        await TimedInvokeAsync(_removedEmojiReactionsEvent, nameof(RemovedEmojiReactions), cacheable, channel, reaction).ConfigureAwait(false);
                                     }
                                     else
                                     {

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -13,22 +13,22 @@ namespace Discord.WebSocket
     public class SocketInvite : SocketEntity<string>
     {
         /// <summary>
-        ///     Gets the channel in which this invite was created.
+        ///     Gets the channel where this invite was created.
         /// </summary>
         public ISocketMessageChannel Channel { get; private set; }
 
         /// <summary>
-        ///     Gets the channel ID in which this invite was created.
+        ///     Gets the channel ID where this invite was created.
         /// </summary>
         public ulong ChannelId { get; private set; }
 
         /// <summary>
-        ///     Gets the guild in which this invite was created.
+        ///     Gets the guild where this invite was created.
         /// </summary>
         public IGuild Guild { get; private set; }
 
         /// <summary>
-        ///     Gets the guild ID in which this invite was created.
+        ///     Gets the guild ID where this invite was created.
         /// </summary>
         public ulong GuildId { get; private set; }
 

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Model = Discord.API.InviteEvent;
+
+namespace Discord.WebSocket
+{
+    public class SocketInvite : SocketEntity<string>
+    {
+        public ISocketMessageChannel Channel { get; private set; }
+
+        public ulong ChannelId { get; private set; }
+
+        public IGuild Guild { get; private set; }
+
+        public ulong GuildId { get; private set; }
+
+        public string Code { get; private set; }
+
+        public SocketUser Inviter { get; private set; }
+
+        public DateTimeOffset CreatedAt { get; private set; }
+
+        public int MaxAge { get; private set; }
+
+        public int MaxUses { get; private set; }
+
+        public int Uses { get; set; }
+
+        public bool Temporary { get; private set; }
+
+        internal SocketInvite(DiscordSocketClient discord, Model model)
+            : base(discord, model.Code)
+        {
+        }
+
+        internal static SocketInvite Create(DiscordSocketClient discord, Model model, SocketUser inviter, IGuild guild, ISocketMessageChannel channel)
+        {
+            var entity = new SocketInvite(discord, model);
+            entity.Update(model, inviter, guild, channel);
+            return entity;
+        }
+
+        internal static SocketInvite Create(DiscordSocketClient discord, Model model, IGuild guild, ISocketMessageChannel channel)
+        {
+            var entity = new SocketInvite(discord, model);
+            entity.Update(model.Code, guild, channel);
+            return entity;
+        }
+
+        internal void Update(Model model, SocketUser inviter, IGuild guild, ISocketMessageChannel channel)
+        {
+            Channel = channel;
+            ChannelId = model.ChannelId;
+            Guild = guild;
+            GuildId = model.GuildId;
+            Code = model.Code;
+            Inviter = inviter;
+            CreatedAt = model.CreatedAt.Value;
+            MaxAge = model.MaxAge.Value;
+            MaxUses = model.MaxUses.Value;
+            Uses = model.Uses.Value;
+            Temporary = model.Temporary;
+        }
+
+        internal void Update(string code, IGuild guild, ISocketMessageChannel channel)
+        {
+            Code = code;
+            Guild = guild;
+            GuildId = guild.Id;
+            Channel = channel;
+            ChannelId = channel.Id;
+        }
+
+
+    }
+}

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -7,29 +7,65 @@ using Model = Discord.API.InviteEvent;
 
 namespace Discord.WebSocket
 {
+    /// <summary>
+    ///     Represents a WebSocket-based invite.
+    /// </summary>
     public class SocketInvite : SocketEntity<string>
     {
+        /// <summary>
+        ///     Gets the channel in which this invite was created.
+        /// </summary>
         public ISocketMessageChannel Channel { get; private set; }
 
+        /// <summary>
+        ///     Gets the channel ID in which this invite was created.
+        /// </summary>
         public ulong ChannelId { get; private set; }
 
+        /// <summary>
+        ///     Gets the guild in which this invite was created.
+        /// </summary>
         public IGuild Guild { get; private set; }
 
+        /// <summary>
+        ///     Gets the guild ID in which this invite was created.
+        /// </summary>
         public ulong GuildId { get; private set; }
 
+        /// <summary>
+        ///     Gets the unique identifier for this invite.
+        /// </summary>
         public string Code { get; private set; }
 
-        public SocketUser Inviter { get; private set; }
+        /// <summary>
+        ///     Gets the user who created this invite.
+        /// </summary>
+        public Optional<SocketUser> Inviter { get; private set; }
 
-        public DateTimeOffset CreatedAt { get; private set; }
+        /// <summary>
+        ///     Gets when this invite was created.
+        /// </summary>
+        public Optional<DateTimeOffset> CreatedAt { get; private set; }
 
-        public int MaxAge { get; private set; }
+        /// <summary>
+        ///     Gets the time (in seconds) until the invite expires.
+        /// </summary>
+        public Optional<int> MaxAge { get; private set; }
 
-        public int MaxUses { get; private set; }
+        /// <summary>
+        ///     Gets the max number of uses this invite may have.
+        /// </summary>
+        public Optional<int> MaxUses { get; private set; }
 
-        public int Uses { get; set; }
+        /// <summary>
+        ///     Gets the number of times this invite has been used.
+        /// </summary>
+        public Optional<int> Uses { get; set; }
 
-        public bool Temporary { get; private set; }
+        /// <summary>
+        ///     Gets a value that indicates whether the invite is a temporary one.
+        /// </summary>
+        public Optional<bool> IsTemporary { get; private set; }
 
         internal SocketInvite(DiscordSocketClient discord, Model model)
             : base(discord, model.Code)
@@ -62,7 +98,7 @@ namespace Discord.WebSocket
             MaxAge = model.MaxAge.Value;
             MaxUses = model.MaxUses.Value;
             Uses = model.Uses.Value;
-            Temporary = model.Temporary;
+            IsTemporary = model.Temporary;
         }
 
         internal void Update(string code, IGuild guild, ISocketMessageChannel channel)

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -197,9 +197,10 @@ namespace Discord.WebSocket
                 _reactions.Remove(reaction);
         }
         internal void ClearReactions()
-        {
-            _reactions.Clear();
-        }
+            => _reactions.Clear();
+
+        internal void ClearReactionsEmoji(SocketReaction reaction)
+            => _reactions.RemoveAll(r => r.Emote.Equals(reaction));
 
         /// <inheritdoc />
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -215,6 +215,9 @@ namespace Discord.WebSocket
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsAsync(this, Discord, options);
         /// <inheritdoc />
+        public Task RemoveEmojiReactionsAsync(IEmote emote, RequestOptions options = null)
+            => MessageHelper.RemoveEmojiReactionsAsync(this, emote, Discord, options);
+        /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emote, int limit, RequestOptions options = null)
             => MessageHelper.GetReactionUsersAsync(this, emote, limit, Discord, options);
     }


### PR DESCRIPTION
# Summary
Implements new event and endpoint support as documented in a discord docs PR [here](https://github.com/discordapp/discord-api-docs/pull/1309).

# Details
This PR introduces a few new events that bots can now interact with:

`InviteCreated` - Fired when an invite is created, emits a `SocketInvite` argument.

`InviteDeleted` - Fired when an invite is deleted, emits a partial `SocketInvite` argument.

`RemovedEmojiReactions` - Fired when all of a specific reaction are deleted, emits a `SocketReaction` argument.

SocketInvite is a new class to handle these invites over the Websocket, mainly due to the properties sent being unique to other invite models.

Additionally, there is an endpoint that can be used to directly cause the `RemovedEmojiReactions` event:

`IMessage.RemoveEmojiReactionsAsync(IEmote)` - Clears the message of all reactions of a specific emote, specified by IEmote.

# Notes
I chose to include the endpoint in the same PR as the events, as the endpoint directly causes the `RemovedEmojiReactions` event, and it is the only way to test it.