### PR TITLE
Feature: Include allowed mentions payload on message creation

### DIFF
--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -31,7 +31,7 @@ namespace Discord.Commands
         /// </param>
         /// <param name="isTTS">Specifies if Discord should read this <paramref name="message"/> aloud using text-to-speech.</param>
         /// <param name="embed">An embed to be displayed alongside the <paramref name="message"/>.</param>
-        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
+        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
         protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
         {
             return await Context.Channel.SendMessageAsync(message, isTTS, embed, options, allowedMentions).ConfigureAwait(false);

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -31,7 +31,10 @@ namespace Discord.Commands
         /// </param>
         /// <param name="isTTS">Specifies if Discord should read this <paramref name="message"/> aloud using text-to-speech.</param>
         /// <param name="embed">An embed to be displayed alongside the <paramref name="message"/>.</param>
-        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
         protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
         {
             return await Context.Channel.SendMessageAsync(message, isTTS, embed, options, allowedMentions).ConfigureAwait(false);

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -31,9 +31,10 @@ namespace Discord.Commands
         /// </param>
         /// <param name="isTTS">Specifies if Discord should read this <paramref name="message"/> aloud using text-to-speech.</param>
         /// <param name="embed">An embed to be displayed alongside the <paramref name="message"/>.</param>
-        protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
+        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
+        protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
         {
-            return await Context.Channel.SendMessageAsync(message, isTTS, embed, options).ConfigureAwait(false);
+            return await Context.Channel.SendMessageAsync(message, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
         }
         /// <summary>
         ///     The method to execute before executing the command.

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -32,7 +32,7 @@ namespace Discord.Commands
         /// <param name="isTTS">Specifies if Discord should read this <paramref name="message"/> aloud using text-to-speech.</param>
         /// <param name="embed">An embed to be displayed alongside the <paramref name="message"/>.</param>
         /// <param name="allowedMentions">
-        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     Specifies if notifications are sent for mentioned users and roles in the <paramref name="message"/>.
         ///     If <c>null</c>, all mentioned roles and users will be notified.
         /// </param>
         protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -32,9 +32,9 @@ namespace Discord.Commands
         /// <param name="isTTS">Specifies if Discord should read this <paramref name="message"/> aloud using text-to-speech.</param>
         /// <param name="embed">An embed to be displayed alongside the <paramref name="message"/>.</param>
         /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
-        protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
         {
-            return await Context.Channel.SendMessageAsync(message, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            return await Context.Channel.SendMessageAsync(message, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
         }
         /// <summary>
         ///     The method to execute before executing the command.

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -23,7 +23,7 @@ namespace Discord
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
+        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -24,7 +24,7 @@ namespace Discord
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
-        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified. If <c>null</c>, all mentioned roles and users will be notified.Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
         ///     If <c>null</c>, all mentioned roles and users will be notified.
         /// </param>
         /// <returns>

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -22,13 +22,13 @@ namespace Discord
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.
         /// </returns>
-        Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null);
+        Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
         /// <summary>
         ///     Sends a file to this message channel with an optional caption.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -22,12 +22,13 @@ namespace Discord
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.
         /// </returns>
-        Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null);
         /// <summary>
         ///     Sends a file to this message channel with an optional caption.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -23,7 +23,10 @@ namespace Discord
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>. If <c>null</c>, all mentioned roles and users will be notified. If <c>null</c>, all mentioned roles and users will be notified.Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
@@ -3,7 +3,7 @@ using System;
 namespace Discord
 {
     /// <summary>
-    ///     Specifies the type of mentions that will be parsed from the message content.
+    ///     Specifies the type of mentions that will be notified from the message content.
     /// </summary>
     [Flags]
     public enum AllowedMentionTypes

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Discord
+{
+    /// <summary>
+    ///     Specifies the type of mentions that will be parsed from the message content.
+    /// </summary>
+    [Flags]
+    public enum AllowedMentionTypes
+    {
+        /// <summary>
+        ///     Controls role mentions.
+        /// </summary>
+        Roles,
+        /// <summary>
+        ///     Controls user mentions.
+        /// </summary>
+        Users,
+        /// <summary>
+        ///     Controls <code>@everyone</code> and <code>@here</code> mentions.
+        /// </summary>
+        Everyone,
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Discord
@@ -7,11 +8,26 @@ namespace Discord
     /// </summary>
     public class AllowedMentions
     {
+        private static readonly Lazy<AllowedMentions> none = new Lazy<AllowedMentions>(() => new AllowedMentions());
+        private static readonly Lazy<AllowedMentions> all = new Lazy<AllowedMentions>(() =>
+            new AllowedMentions(AllowedMentionTypes.Everyone | AllowedMentionTypes.Users | AllowedMentionTypes.Roles));
+
+        /// <summary>
+        ///     Gets a value which indicates that no mentions in the message content should notify users.
+        /// </summary>
+        public static AllowedMentions None => none.Value;
+
+        /// <summary>
+        ///     Gets a value which indicates that all mentions in the message content should notify users.
+        /// </summary>
+        public static AllowedMentions All => all.Value;
+
         /// <summary>
         ///     Gets or sets the type of mentions that will be parsed from the message content.
         ///     The <see cref="AllowedMentionTypes.Users"/> flag is mutually exclusive with the <see cref="UserIds"/>
         ///     property, and the <see cref="AllowedMentionTypes.Roles"/> flag is mutually exclusive with the
         ///     <see cref="RoleIds"/> property.
+        ///     If <c>null</c>, only the Ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
         /// </summary>
         public AllowedMentionTypes? AllowedTypes { get; set; }
 
@@ -30,5 +46,17 @@ namespace Discord
         ///     must be <c>null</c> or empty.
         /// </summary>
         public List<ulong> UserIds { get; set; }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="AllowedMentions"/> class.
+        /// </summary>
+        /// <param name="allowedTypes">
+        ///     The types of mentions to parse from the message content.
+        ///     If <c>null</c>, only the Ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
+        /// </param>
+        public AllowedMentions(AllowedMentionTypes? allowedTypes = null)
+        {
+            AllowedTypes = allowedTypes;
+        }
     }
 }

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -24,15 +24,17 @@ namespace Discord
 
         /// <summary>
         ///     Gets or sets the type of mentions that will be parsed from the message content.
+        /// </summary>
+        /// <remarks>
         ///     The <see cref="AllowedMentionTypes.Users"/> flag is mutually exclusive with the <see cref="UserIds"/>
         ///     property, and the <see cref="AllowedMentionTypes.Roles"/> flag is mutually exclusive with the
         ///     <see cref="RoleIds"/> property.
-        ///     If <c>null</c>, only the Ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
-        /// </summary>
+        ///     If <c>null</c>, only the ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
+        /// </remarks>
         public AllowedMentionTypes? AllowedTypes { get; set; }
 
         /// <summary>
-        ///     Gets or sets the list of all role Ids that will be mentioned.
+        ///     Gets or sets the list of all role ids that will be mentioned.
         ///     This property is mutually exclusive with the <see cref="AllowedMentionTypes.Roles"/>
         ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
         ///     must be <c>null</c> or empty.
@@ -40,7 +42,7 @@ namespace Discord
         public List<ulong> RoleIds { get; set; }
 
         /// <summary>
-        ///     Gets or sets the list of all user Ids that will be mentioned.
+        ///     Gets or sets the list of all user ids that will be mentioned.
         ///     This property is mutually exclusive with the <see cref="AllowedMentionTypes.Users"/>
         ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
         ///     must be <c>null</c> or empty.
@@ -52,7 +54,7 @@ namespace Discord
         /// </summary>
         /// <param name="allowedTypes">
         ///     The types of mentions to parse from the message content.
-        ///     If <c>null</c>, only the Ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
+        ///     If <c>null</c>, only the ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
         /// </param>
         public AllowedMentions(AllowedMentionTypes? allowedTypes = null)
         {

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -3,24 +3,31 @@ using System.Collections.Generic;
 namespace Discord
 {
     /// <summary>
-    ///     Defines which mentions and types of mentions that will notify users from the message text.
+    ///     Defines which mentions and types of mentions that will notify users from the message content.
     /// </summary>
     public class AllowedMentions
     {
         /// <summary>
-        ///     Gets or sets the type of mentions that will notify users.
-        ///     If <c>null</c>, only the role and user Ids specified in <see cref="RoleIds"/>
-        ///     and <see cref="UserIds"/> respectively will be notified.
+        ///     Gets or sets the type of mentions that will be parsed from the message content.
+        ///     The <see cref="AllowedMentionTypes.Users"/> flag is mutually exclusive with the <see cref="UserIds"/>
+        ///     property, and the <see cref="AllowedMentionTypes.Roles"/> flag is mutually exclusive with the
+        ///     <see cref="RoleIds"/> property.
         /// </summary>
         public AllowedMentionTypes? AllowedTypes { get; set; }
 
         /// <summary>
         ///     Gets or sets the list of all role Ids that will be mentioned.
+        ///     This property is mutually exclusive with the <see cref="AllowedMentionTypes.Roles"/>
+        ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
+        ///     must be <c>null</c> or empty.
         /// </summary>
         public List<ulong> RoleIds { get; set; }
 
         /// <summary>
         ///     Gets or sets the list of all user Ids that will be mentioned.
+        ///     This property is mutually exclusive with the <see cref="AllowedMentionTypes.Users"/>
+        ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
+        ///     must be <c>null</c> or empty.
         /// </summary>
         public List<ulong> UserIds { get; set; }
     }

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Discord
 {
     /// <summary>
-    ///     Defines which mentions and types of mentions will notify users from the message text.
+    ///     Defines which mentions and types of mentions that will notify users from the message text.
     /// </summary>
     public class AllowedMentions
     {

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Discord
+{
+    /// <summary>
+    ///     Defines which types of mentions will be parsed from a created message's content.
+    /// </summary>
+    public class AllowedMentions
+    {
+        /// <summary>
+        ///     Gets or sets the allowed mention types to parse from the message content.
+        ///     If <c>null</c>, no users will be notified.
+        /// </summary>
+        public AllowedMentionTypes? AllowedTypes { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the list of all role Ids that can be mentioned.
+        /// </summary>
+        public List<ulong> RoleIds { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the list of all user Ids that can be mentioned.
+        /// </summary>
+        public List<ulong> UserIds { get; set; }
+    }
+}

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -3,23 +3,24 @@ using System.Collections.Generic;
 namespace Discord
 {
     /// <summary>
-    ///     Defines which types of mentions will be parsed from a created message's content.
+    ///     Defines which mentions and types of mentions will notify users from the message text.
     /// </summary>
     public class AllowedMentions
     {
         /// <summary>
-        ///     Gets or sets the allowed mention types to parse from the message content.
-        ///     If <c>null</c>, no users will be notified.
+        ///     Gets or sets the type of mentions that will notify users.
+        ///     If <c>null</c>, only the role and user Ids specified in <see cref="RoleIds"/>
+        ///     and <see cref="UserIds"/> respectively will be notified.
         /// </summary>
         public AllowedMentionTypes? AllowedTypes { get; set; }
 
         /// <summary>
-        ///     Gets or sets the list of all role Ids that can be mentioned.
+        ///     Gets or sets the list of all role Ids that will be mentioned.
         /// </summary>
         public List<ulong> RoleIds { get; set; }
 
         /// <summary>
-        ///     Gets or sets the list of all user Ids that can be mentioned.
+        ///     Gets or sets the list of all user Ids that will be mentioned.
         /// </summary>
         public List<ulong> UserIds { get; set; }
     }

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -28,7 +28,10 @@ namespace Discord
         /// <param name="isTTS">Whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
         /// <returns>
         ///     A task that represents the asynchronous send operation. The task result contains the sent message.
         /// </returns>

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -27,6 +27,7 @@ namespace Discord
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous send operation. The task result contains the sent message.
@@ -35,9 +36,10 @@ namespace Discord
             string text = null,
             bool isTTS = false,
             Embed embed = null,
+            AllowedMentions allowedMentions = null,
             RequestOptions options = null)
         {
-            return await (await user.GetOrCreateDMChannelAsync().ConfigureAwait(false)).SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
+            return await (await user.GetOrCreateDMChannelAsync().ConfigureAwait(false)).SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -28,7 +28,7 @@ namespace Discord
         /// <param name="isTTS">Whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
+        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
         /// <returns>
         ///     A task that represents the asynchronous send operation. The task result contains the sent message.
         /// </returns>

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -27,8 +27,8 @@ namespace Discord
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <returns>
         ///     A task that represents the asynchronous send operation. The task result contains the sent message.
         /// </returns>
@@ -36,10 +36,10 @@ namespace Discord
             string text = null,
             bool isTTS = false,
             Embed embed = null,
-            AllowedMentions allowedMentions = null,
-            RequestOptions options = null)
+            RequestOptions options = null,
+            AllowedMentions allowedMentions = null)
         {
-            return await (await user.GetOrCreateDMChannelAsync().ConfigureAwait(false)).SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            return await (await user.GetOrCreateDMChannelAsync().ConfigureAwait(false)).SendMessageAsync(text, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/API/Common/Message.cs
+++ b/src/Discord.Net.Rest/API/Common/Message.cs
@@ -54,5 +54,7 @@ namespace Discord.API
         public Optional<MessageReference> Reference { get; set; }
         [JsonProperty("flags")]
         public Optional<MessageFlags> Flags { get; set; }
+        [JsonProperty("allowed_mentions")]
+        public Optional<AllowedMentions> AllowedMentions { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateMessageParams.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest
@@ -15,6 +15,8 @@ namespace Discord.API.Rest
         public Optional<bool> IsTTS { get; set; }
         [JsonProperty("embed")]
         public Optional<Embed> Embed { get; set; }
+        [JsonProperty("allowed_mentions")]
+        public Optional<AllowedMentions> AllowedMentions { get; set; }
 
         public CreateMessageParams(string content)
         {

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -167,9 +167,12 @@ namespace Discord.Rest
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         public static async Task<RestUserMessage> SendMessageAsync(IMessageChannel channel, BaseDiscordClient client,
-            string text, bool isTTS, Embed embed, RequestOptions options)
+            string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
         {
-            var args = new CreateMessageParams(text) { IsTTS = isTTS, Embed = embed?.ToModel() };
+            Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
+            Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
+
+            var args = new CreateMessageParams(text) { IsTTS = isTTS, Embed = embed?.ToModel(), AllowedMentions = allowedMentions?.ToModel() };
             var model = await client.ApiClient.CreateMessageAsync(channel.Id, args, options).ConfigureAwait(false);
             return RestUserMessage.Create(client, channel, client.CurrentUser, model);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -172,6 +172,22 @@ namespace Discord.Rest
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
 
+            // check that user flag and user Id list are exclusive, same with role flag and role Id list
+            if (allowedMentions != null && allowedMentions.AllowedTypes.HasValue)
+            {
+                if (allowedMentions.AllowedTypes.Value.HasFlag(AllowedMentionTypes.Users) &&
+                    allowedMentions.UserIds != null && allowedMentions.UserIds.Count > 0)
+                {
+                    throw new ArgumentException("The Users flag is mutually exclusive with the list of User Ids.", nameof(allowedMentions));
+                }
+
+                if (allowedMentions.AllowedTypes.Value.HasFlag(AllowedMentionTypes.Roles) &&
+                    allowedMentions.RoleIds != null && allowedMentions.RoleIds.Count > 0)
+                {
+                    throw new ArgumentException("The Roles flag is mutually exclusive with the list of Role Ids.", nameof(allowedMentions));
+                }
+            }
+
             var args = new CreateMessageParams(text) { IsTTS = isTTS, Embed = embed?.ToModel(), AllowedMentions = allowedMentions?.ToModel() };
             var model = await client.ApiClient.CreateMessageAsync(channel.Id, args, options).ConfigureAwait(false);
             return RestUserMessage.Create(client, channel, client.CurrentUser, model);

--- a/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
@@ -19,7 +19,7 @@ namespace Discord.Rest
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
+        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result

--- a/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
@@ -20,7 +20,10 @@ namespace Discord.Rest
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.

--- a/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
@@ -19,12 +19,13 @@ namespace Discord.Rest
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.
         /// </returns>
-        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null);
         /// <summary>
         ///     Sends a file to this message channel with an optional caption.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
@@ -19,13 +19,13 @@ namespace Discord.Rest
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.
         /// </returns>
-        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null);
+        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
         /// <summary>
         ///     Sends a file to this message channel with an optional caption.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -94,7 +94,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException">

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -93,7 +93,7 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
 
         /// <inheritdoc />
@@ -207,7 +207,7 @@ namespace Discord.Rest
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
-            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            => await SendMessageAsync(text, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
 
         //IChannel
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -206,7 +206,7 @@ namespace Discord.Rest
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -93,8 +93,8 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, null, options);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException">
@@ -206,8 +206,8 @@ namespace Discord.Rest
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IChannel
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -95,7 +95,7 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
@@ -185,7 +185,7 @@ namespace Discord.Rest
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
 
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
-            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            => await SendMessageAsync(text, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
 
         //IAudioChannel
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -184,7 +184,7 @@ namespace Discord.Rest
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
 
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IAudioChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -95,8 +95,8 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException">
@@ -183,8 +183,9 @@ namespace Discord.Rest
 
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
+
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IAudioChannel
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -101,8 +101,8 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
         /// <exception cref="ArgumentException">
@@ -273,8 +273,8 @@ namespace Discord.Rest
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IGuildChannel
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -273,7 +273,7 @@ namespace Discord.Rest
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IGuildChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -101,7 +101,7 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
@@ -274,7 +274,7 @@ namespace Discord.Rest
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
-            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            => await SendMessageAsync(text, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
 
         //IGuildChannel
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/AllowedMentions.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    public class AllowedMentions
+    {
+        [JsonProperty("parse")]
+        public Optional<string[]> Parse { get; set; }
+        // Roles and Users have a max size of 100
+        [JsonProperty("roles")]
+        public Optional<ulong[]> Roles { get; set; }
+        [JsonProperty("users")]
+        public Optional<ulong[]> Users { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -59,6 +60,24 @@ namespace Discord.Rest
             if (entity.Video != null)
                 model.Video = entity.Video.Value.ToModel();
             return model;
+        }
+        public static API.AllowedMentions ToModel(this AllowedMentions entity)
+        {
+            return new API.AllowedMentions()
+            {
+                Parse = entity.AllowedTypes?.EnumerateMentionTypes().ToArray(),
+                Roles = entity.RoleIds?.ToArray(),
+                Users = entity.UserIds?.ToArray(),
+            };
+        }
+        public static IEnumerable<string> EnumerateMentionTypes(this AllowedMentionTypes mentionTypes)
+        {
+            if (mentionTypes.HasFlag(AllowedMentionTypes.Everyone))
+                yield return "everyone";
+            if (mentionTypes.HasFlag(AllowedMentionTypes.Roles))
+                yield return "roles";
+            if (mentionTypes.HasFlag(AllowedMentionTypes.Users))
+                yield return "users";
         }
         public static EmbedAuthor ToEntity(this API.EmbedAuthor model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -28,7 +28,7 @@ namespace Discord.WebSocket
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
+        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -28,12 +28,13 @@ namespace Discord.WebSocket
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="allowedMentions">The types of mentions that will be send with this message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.
         /// </returns>
-        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null);
         /// <summary>
         ///     Sends a file to this message channel with an optional caption.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -28,7 +28,10 @@ namespace Discord.WebSocket
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
-        /// <param name="allowedMentions">The types of mention notifications that will be sent with this message.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -28,16 +28,16 @@ namespace Discord.WebSocket
         /// <param name="text">The message to be sent.</param>
         /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
         /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
         ///     If <c>null</c>, all mentioned roles and users will be notified.
         /// </param>
-        /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous send operation for delivering the message. The task result
         ///     contains the sent message.
         /// </returns>
-        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null);
+        new Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
         /// <summary>
         ///     Sends a file to this message channel with an optional caption.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -235,8 +235,6 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        //async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-        //    => await SendMessageAsync(text, isTTS, embed, null, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -235,7 +235,7 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IChannel

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -135,7 +135,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
@@ -236,7 +236,7 @@ namespace Discord.WebSocket
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
-            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            => await SendMessageAsync(text, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
 
         //IChannel
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -135,8 +135,8 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
@@ -235,8 +235,10 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
+        //async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
+        //    => await SendMessageAsync(text, isTTS, embed, null, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IChannel
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -163,8 +163,8 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
@@ -299,8 +299,10 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
+        //async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
+        //    => await SendMessageAsync(text, isTTS, embed, null, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IAudioChannel
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -163,7 +163,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
@@ -300,7 +300,7 @@ namespace Discord.WebSocket
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
-            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            => await SendMessageAsync(text, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
 
         //IAudioChannel
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -299,7 +299,7 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         //IAudioChannel

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -299,8 +299,6 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        //async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-        //    => await SendMessageAsync(text, isTTS, embed, null, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -161,7 +161,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
@@ -309,7 +309,7 @@ namespace Discord.WebSocket
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
-            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
+            => await SendMessageAsync(text, isTTS, embed, options, allowedMentions).ConfigureAwait(false);
 
         // INestedChannel
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -308,7 +308,7 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         // INestedChannel

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -161,8 +161,8 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
-        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, options);
+        public Task<RestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(this, Discord, text, isTTS, embed, allowedMentions, options);
 
         /// <inheritdoc />
         public Task<RestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
@@ -308,8 +308,10 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => await SendMessageAsync(text, isTTS, embed, options).ConfigureAwait(false);
+        //async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
+        //    => await SendMessageAsync(text, isTTS, embed, null, options).ConfigureAwait(false);
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
+            => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 
         // INestedChannel
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -308,8 +308,6 @@ namespace Discord.WebSocket
         async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
             => await SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler).ConfigureAwait(false);
         /// <inheritdoc />
-        //async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-        //    => await SendMessageAsync(text, isTTS, embed, null, options).ConfigureAwait(false);
         async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, RequestOptions options)
             => await SendMessageAsync(text, isTTS, embed, allowedMentions, options).ConfigureAwait(false);
 

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedDMChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedDMChannel.cs
@@ -83,7 +83,7 @@ namespace Discord
             throw new NotImplementedException();
         }
 
-        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
+        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedDMChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedDMChannel.cs
@@ -83,7 +83,7 @@ namespace Discord
             throw new NotImplementedException();
         }
 
-        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedGroupChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedGroupChannel.cs
@@ -91,7 +91,7 @@ namespace Discord
             throw new NotImplementedException();
         }
 
-        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
+        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedGroupChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedGroupChannel.cs
@@ -91,7 +91,7 @@ namespace Discord
             throw new NotImplementedException();
         }
 
-        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
@@ -177,7 +177,7 @@ namespace Discord
             throw new NotImplementedException();
         }
 
-        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
+        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
         {
             throw new NotImplementedException();
         }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
@@ -177,7 +177,7 @@ namespace Discord
             throw new NotImplementedException();
         }
 
-        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
+        public Task<IUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This change implements the [allowed mentions object] for the payload of message creation, which allows for clients to specify which mentioned users and roles (including `@everyone`) will be notified when the message is sent.

The current version of this change is meant to be non-breaking to the SendMessageAsync interface, but it does not follow the pattern set by other methods where RequestOptions is the last optional parameter. Adding an overload didn't solve this issue as the interfaces became ambiguous.

TODO:
- [x] 6ca6888fe897cd0077ff634253fc0835f3decba0 enforce exclusivity of parsing users/roles with the user/role Id lists 
- [x] af14b7cffe1921776f68691d50e3b3e9c1d50076 make it easier to specify pinging nobody, could add a read-only value which is empty

[allowed mentions object]: https://discordapp.com/developers/docs/resources/channel#allowed-mentions-object