### PR TITLE
Implement missing audit log types

### DIFF
--- a/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
@@ -61,6 +61,18 @@ namespace Discord
         ///     A guild member's role collection was updated.
         /// </summary>
         MemberRoleUpdated = 25,
+        /// <summary>
+        ///     A guild member moved to a voice channel.
+        /// </summary>
+        MemberMoved = 26,
+        /// <summary>
+        ///     A guild member disconnected from a voice channel.
+        /// </summary>
+        MemberDisconnected = 27,
+        /// <summary>
+        ///     A bot was added to this guild.
+        /// </summary>
+        BotAdded = 28,
 
         /// <summary>
         ///     A role was created in this guild.
@@ -117,6 +129,18 @@ namespace Discord
         /// <summary>
         ///     A message was deleted from this guild.
         /// </summary>
-        MessageDeleted = 72
+        MessageDeleted = 72,
+        /// <summary>
+        ///     Multiple messages were deleted from this guild.
+        /// </summary>
+        MessageBulkDeleted = 73,
+        /// <summary>
+        ///     A message was pinned from this guild.
+        /// </summary>
+        MessagePinned = 74,
+        /// <summary>
+        ///     A message was unpinned from this guild.
+        /// </summary>
+        MessageUnpinned = 75,
     }
 }

--- a/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
@@ -4,11 +4,12 @@ namespace Discord.API
 {
     internal class AuditLogOptions
     {
-        //Message delete
         [JsonProperty("count")]
-        public int? MessageDeleteCount { get; set; }
+        public int? Count { get; set; }
         [JsonProperty("channel_id")]
-        public ulong? MessageDeleteChannelId { get; set; }
+        public ulong? ChannelId { get; set; }
+        [JsonProperty("message_id")]
+        public ulong? MessageId { get; set; }
 
         //Prune
         [JsonProperty("delete_member_days")]

--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -27,6 +27,9 @@ namespace Discord.Rest
             [ActionType.Unban] = UnbanAuditLogData.Create,
             [ActionType.MemberUpdated] = MemberUpdateAuditLogData.Create,
             [ActionType.MemberRoleUpdated] = MemberRoleAuditLogData.Create,
+            [ActionType.MemberMoved] = MemberMoveAuditLogData.Create,
+            [ActionType.MemberDisconnected] = MemberDisconnectAuditLogData.Create,
+            [ActionType.BotAdded] = BotAddAuditLogData.Create,
 
             [ActionType.RoleCreated] = RoleCreateAuditLogData.Create,
             [ActionType.RoleUpdated] = RoleUpdateAuditLogData.Create,
@@ -45,6 +48,9 @@ namespace Discord.Rest
             [ActionType.EmojiDeleted] = EmoteDeleteAuditLogData.Create,
 
             [ActionType.MessageDeleted] = MessageDeleteAuditLogData.Create,
+            [ActionType.MessageBulkDeleted] = MessageBulkDeleteAuditLogData.Create,
+            [ActionType.MessagePinned] = MessagePinAuditLogData.Create,
+            [ActionType.MessageUnpinned] = MessageUnpinAuditLogData.Create,
         };
 
         public static IAuditLogData CreateData(BaseDiscordClient discord, Model log, EntryModel entry)

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BotAddAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BotAddAuditLogData.cs
@@ -1,0 +1,29 @@
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to a adding a bot to a guild.
+    /// </summary>
+    public class BotAddAuditLogData : IAuditLogData
+    {
+        private BotAddAuditLogData(ulong botId)
+        {
+            BotId = botId;
+        }
+
+        internal static BotAddAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new BotAddAuditLogData(entry.TargetId.Value);
+        }
+
+        /// <summary>
+        ///     Gets the ID of the bot that was added.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the bot that was added.
+        /// </returns>
+        public ulong BotId { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BotAddAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BotAddAuditLogData.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
@@ -8,22 +10,23 @@ namespace Discord.Rest
     /// </summary>
     public class BotAddAuditLogData : IAuditLogData
     {
-        private BotAddAuditLogData(ulong botId)
+        private BotAddAuditLogData(IUser bot)
         {
-            BotId = botId;
+            Target = bot;
         }
 
         internal static BotAddAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            return new BotAddAuditLogData(entry.TargetId.Value);
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            return new BotAddAuditLogData(RestUser.Create(discord, userInfo));
         }
 
         /// <summary>
-        ///     Gets the ID of the bot that was added.
+        ///     Gets the bot that was added.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier for the bot that was added.
+        ///     A user object representing the bot.
         /// </returns>
-        public ulong BotId { get; }
+        public IUser Target { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberDisconnectAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberDisconnectAuditLogData.cs
@@ -1,0 +1,29 @@
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to disconnecting members from voice channels.
+    /// </summary>
+    public class MemberDisconnectAuditLogData : IAuditLogData
+    {
+        private MemberDisconnectAuditLogData(int count)
+        {
+            MemberCount = count;
+        }
+
+        internal static MemberDisconnectAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new MemberDisconnectAuditLogData(entry.Options.Count.Value);
+        }
+
+        /// <summary>
+        ///     Gets the number of members that were disconnected.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="int"/> representing the number of members that were disconnected from a voice channel.
+        /// </returns>
+        public int MemberCount { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberMoveAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberMoveAuditLogData.cs
@@ -1,0 +1,37 @@
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to moving members between voice channels.
+    /// </summary>
+    public class MemberMoveAuditLogData : IAuditLogData
+    {
+        private MemberMoveAuditLogData(ulong channelId, int count)
+        {
+            ChannelId = channelId;
+            MemberCount = count;
+        }
+
+        internal static MemberMoveAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new MemberMoveAuditLogData(entry.Options.ChannelId.Value, entry.Options.Count.Value);
+        }
+
+        /// <summary>
+        ///     Gets the ID of the channel that the members were moved to.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the channel that the members were moved to.
+        /// </returns>
+        public ulong ChannelId { get; }
+        /// <summary>
+        ///     Gets the number of members that were moved.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="int"/> representing the number of members that were moved to another voice channel.
+        /// </returns>
+        public int MemberCount { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageBulkDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageBulkDeleteAuditLogData.cs
@@ -1,0 +1,38 @@
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to message deletion(s).
+    /// </summary>
+    public class MessageBulkDeleteAuditLogData : IAuditLogData
+    {
+        private MessageBulkDeleteAuditLogData(ulong channelId, int count)
+        {
+            ChannelId = channelId;
+            MessageCount = count;
+        }
+
+        internal static MessageBulkDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new MessageBulkDeleteAuditLogData(entry.TargetId.Value, entry.Options.Count.Value);
+        }
+
+        /// <summary>
+        ///     Gets the ID of the channel that the messages were deleted from.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the channel that the messages were
+        ///     deleted from.
+        /// </returns>
+        public ulong ChannelId { get; }
+        /// <summary>
+        ///     Gets the number of messages that were deleted.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="int"/> representing the number of messages that were deleted from the channel.
+        /// </returns>
+        public int MessageCount { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
@@ -17,7 +17,7 @@ namespace Discord.Rest
 
         internal static MessageDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            return new MessageDeleteAuditLogData(entry.Options.MessageDeleteChannelId.Value, entry.Options.MessageDeleteCount.Value, entry.TargetId.Value);
+            return new MessageDeleteAuditLogData(entry.Options.ChannelId.Value, entry.Options.Count.Value, entry.TargetId.Value);
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
@@ -8,16 +10,17 @@ namespace Discord.Rest
     /// </summary>
     public class MessageDeleteAuditLogData : IAuditLogData
     {
-        private MessageDeleteAuditLogData(ulong channelId, int count, ulong authorId)
+        private MessageDeleteAuditLogData(ulong channelId, int count, IUser user)
         {
             ChannelId = channelId;
             MessageCount = count;
-            AuthorId = authorId;
+            Target = user;
         }
 
         internal static MessageDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            return new MessageDeleteAuditLogData(entry.Options.ChannelId.Value, entry.Options.Count.Value, entry.TargetId.Value);
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            return new MessageDeleteAuditLogData(entry.Options.ChannelId.Value, entry.Options.Count.Value, RestUser.Create(discord, userInfo));
         }
 
         /// <summary>
@@ -36,11 +39,11 @@ namespace Discord.Rest
         /// </returns>
         public ulong ChannelId { get; }
         /// <summary>
-        ///     Gets the author of the messages that were deleted.
+        ///     Gets the user of the messages that were deleted.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier for the user that created the deleted messages.
+        ///     A user object representing the user that created the deleted messages.
         /// </returns>
-        public ulong AuthorId { get; }
+        public IUser Target { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
@@ -1,0 +1,45 @@
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to a pinned message.
+    /// </summary>
+    public class MessagePinAuditLogData : IAuditLogData
+    {
+        private MessagePinAuditLogData(ulong messageId, ulong channelId, ulong authorId)
+        {
+            MessageId = messageId;
+            ChannelId = channelId;
+            AuthorId = authorId;
+        }
+
+        internal static MessagePinAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new MessagePinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, entry.TargetId.Value);
+        }
+
+        /// <summary>
+        ///     Gets the ID of the messages that was pinned.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the messages that was pinned.
+        /// </returns>
+        public ulong MessageId { get; }
+        /// <summary>
+        ///     Gets the ID of the channel that the message was pinned from.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the channel that the message was pinned from.
+        /// </returns>
+        public ulong ChannelId { get; }
+        /// <summary>
+        ///     Gets the author of the message that was pinned.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the user whose message was pinned.
+        /// </returns>
+        public ulong AuthorId { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
@@ -8,16 +10,17 @@ namespace Discord.Rest
     /// </summary>
     public class MessagePinAuditLogData : IAuditLogData
     {
-        private MessagePinAuditLogData(ulong messageId, ulong channelId, ulong authorId)
+        private MessagePinAuditLogData(ulong messageId, ulong channelId, IUser user)
         {
             MessageId = messageId;
             ChannelId = channelId;
-            AuthorId = authorId;
+            Target = user;
         }
 
         internal static MessagePinAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            return new MessagePinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, entry.TargetId.Value);
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            return new MessagePinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, RestUser.Create(discord, userInfo));
         }
 
         /// <summary>
@@ -35,11 +38,11 @@ namespace Discord.Rest
         /// </returns>
         public ulong ChannelId { get; }
         /// <summary>
-        ///     Gets the author of the message that was pinned.
+        ///     Gets the user of the message that was pinned.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier for the user whose message was pinned.
+        ///     A user object representing the user that created the pinned message.
         /// </returns>
-        public ulong AuthorId { get; }
+        public IUser Target { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 
@@ -8,16 +10,17 @@ namespace Discord.Rest
     /// </summary>
     public class MessageUnpinAuditLogData : IAuditLogData
     {
-        private MessageUnpinAuditLogData(ulong messageId, ulong channelId, ulong authorId)
+        private MessageUnpinAuditLogData(ulong messageId, ulong channelId, IUser user)
         {
             MessageId = messageId;
             ChannelId = channelId;
-            AuthorId = authorId;
+            Target = user;
         }
 
         internal static MessageUnpinAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            return new MessageUnpinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, entry.TargetId.Value);
+            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+            return new MessageUnpinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, RestUser.Create(discord, userInfo));
         }
 
         /// <summary>
@@ -35,11 +38,11 @@ namespace Discord.Rest
         /// </returns>
         public ulong ChannelId { get; }
         /// <summary>
-        ///     Gets the author of the message that was unpinned.
+        ///     Gets the user of the message that was unpinned.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier for the user whose message was unpinned.
+        ///     A user object representing the user that created the unpinned message.
         /// </returns>
-        public ulong AuthorId { get; }
+        public IUser Target { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
@@ -1,0 +1,45 @@
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to an unpinned message.
+    /// </summary>
+    public class MessageUnpinAuditLogData : IAuditLogData
+    {
+        private MessageUnpinAuditLogData(ulong messageId, ulong channelId, ulong authorId)
+        {
+            MessageId = messageId;
+            ChannelId = channelId;
+            AuthorId = authorId;
+        }
+
+        internal static MessageUnpinAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            return new MessageUnpinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, entry.TargetId.Value);
+        }
+
+        /// <summary>
+        ///     Gets the ID of the messages that was unpinned.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the messages that was unpinned.
+        /// </returns>
+        public ulong MessageId { get; }
+        /// <summary>
+        ///     Gets the ID of the channel that the message was unpinned from.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the channel that the message was unpinned from.
+        /// </returns>
+        public ulong ChannelId { get; }
+        /// <summary>
+        ///     Gets the author of the message that was unpinned.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the user whose message was unpinned.
+        /// </returns>
+        public ulong AuthorId { get; }
+    }
+}


### PR DESCRIPTION
**New Types**
- BotAddAuditLogData
- MemberDisconnectAuditLogData
- MemberMoveAuditLogData
- MessageBulkDeleteAuditLogData
- MessagePinAuditLogData
- MessageUnpinAuditLogData

**Internal Changes**
- Renamed MessageDeleteCount to Count
- Renamed MessageDeleteChannelId to ChannelId

**Breaking Change**
- MessageDeleteAuditLogData property `AuthorId` of type `ulong` is now `Target` of type `IUser`