### PR TITLE
Small typo in documentation

### DIFF
--- a/src/Discord.Net.Commands/CommandServiceConfig.cs
+++ b/src/Discord.Net.Commands/CommandServiceConfig.cs
@@ -44,7 +44,7 @@ namespace Discord.Commands
         /// </summary>
         /// <example>
         /// <code language="cs">
-        /// QuotationMarkAliasMap = new Dictionary&lt;char, char%gt;()
+        /// QuotationMarkAliasMap = new Dictionary&lt;char, char&gt;()
         /// {
         ///     {'\"', '\"' },
         ///     {'“', '”' },


### PR DESCRIPTION
Fix a small typo in the documentation