### PR TITLE
Added System.Linq reference

### DIFF
--- a/docs/guides/commands/samples/preconditions/require_role.cs
+++ b/docs/guides/commands/samples/preconditions/require_role.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Discord.Commands;
 using Discord.WebSocket;


### PR DESCRIPTION
Use of IReadOnlyCollection#Any requires a reference to System.Linq. It's a small thing, but better copy-paste-ability is never a bad thing.