### PR TITLE
Fix add type reader for entity implementations

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -408,7 +408,7 @@ namespace Discord.Commands
             var typeInfo = type.GetTypeInfo();
             if (typeInfo.IsEnum)
                 return true;
-            return _entityTypeReaders.Any(x => type == x.EntityType || typeInfo.ImplementedInterfaces.Contains(x.TypeReaderType));
+            return _entityTypeReaders.Any(x => type == x.EntityType || typeInfo.ImplementedInterfaces.Contains(x.EntityType));
         }
         internal void AddNullableTypeReader(Type valueType, TypeReader valueTypeReader)
         {
@@ -511,7 +511,7 @@ namespace Discord.Commands
                 await _commandExecutedEvent.InvokeAsync(Optional.Create<CommandInfo>(), context, searchResult).ConfigureAwait(false);
                 return searchResult;
             }
-                
+
 
             var commands = searchResult.Commands;
             var preconditionResults = new Dictionary<CommandMatch, PreconditionResult>();


### PR DESCRIPTION
When adding a type reader that replaces a default type reader,
CommandService checks that it replaces a type in its default type
readers or entity type readers (IMessage, IChannel, IRole, IUser). For
entity types, it checks that the target type is the same as the entity
type or it implements its type reader. Adding a type reader for a
default type reader doesn't make much sense and the original intent was
likely to check that the target type is or implements the entity type.

Fixes #1485.