### PR TITLE
Change priority to user type readers and implement user entity readers

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -275,8 +275,8 @@ namespace Discord.Commands
 
             if (builder.TypeReader == null)
             {
-                builder.TypeReader = service.GetDefaultTypeReader(paramType)
-                    ?? service.GetTypeReaders(paramType)?.FirstOrDefault().Value;
+                builder.TypeReader = service.GetTypeReaders(paramType)?.FirstOrDefault().Value
+                    ?? service.GetDefaultTypeReader(paramType);
             }
         }
 
@@ -290,9 +290,13 @@ namespace Discord.Commands
                     return reader;
             }
 
+            var overrideTypeReader = service.GetOverrideTypeReader(paramType);
+            if (overrideTypeReader != null)
+                return overrideTypeReader;
+
             //We dont have a cached type reader, create one
             reader = ReflectionUtils.CreateObject<TypeReader>(typeReaderType.GetTypeInfo(), service, services);
-            service.AddTypeReader(paramType, reader, false);
+            service.AddOverrideTypeReader(paramType, reader);
 
             return reader;
         }

--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -60,7 +60,7 @@ namespace Discord.Commands.Builders
             if (type.GetTypeInfo().GetCustomAttribute<NamedArgumentTypeAttribute>() != null)
             {
                 IsRemainder = true;
-                var reader = commands.GetTypeReaders(type)?.FirstOrDefault().Value;
+                var reader = commands.GetTypeReaders(type, false)?.FirstOrDefault().Value;
                 if (reader == null)
                 {
                     Type readerType;
@@ -80,8 +80,7 @@ namespace Discord.Commands.Builders
                 return reader;
             }
 
-
-            var readers = commands.GetTypeReaders(type);
+            var readers = commands.GetTypeReaders(type, false);
             if (readers != null)
                 return readers.FirstOrDefault().Value;
             else

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -367,8 +367,13 @@ namespace Discord.Commands
         ///     Adds a custom entity <see cref="TypeReader" /> to this <see cref="CommandService" /> for the supplied
         ///     object type.
         /// </summary>
+        /// <example>
+        ///     <para>The following example adds a custom entity reader to this <see cref="CommandService"/>.</para>
+        ///     <code language="cs" region="AddEntityTypeReader"
+        ///           source="..\..\..\Discord.Net.Examples\Commands\CommandService.Examples.cs" />
+        /// </example>
         /// <typeparam name="T">The object type to be read by the <see cref="TypeReader"/>.</typeparam>
-        /// <param name="typeReaderType">
+        /// <param name="typeReaderGenericType">
         ///     A <see cref="Type" /> that is a generic type definition with a single open argument
         ///     of the <see cref="TypeReader" /> to be added.
         /// </param>
@@ -379,7 +384,7 @@ namespace Discord.Commands
         ///     object type.
         /// </summary>
         /// <param name="type">A <see cref="Type" /> instance for the type to be read.</param>
-        /// <param name="typeReaderType">
+        /// <param name="typeReaderGenericType">
         ///     A <see cref="Type" /> that is a generic type definition with a single open argument
         ///     of the <see cref="TypeReader" /> to be added.
         /// </param>

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -82,8 +82,8 @@ namespace Discord.Commands
         ///     Represents all entity type reader <see cref="Type" />s loaded within <see cref="CommandService"/>.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ILookup{TKey, TElement}"/> that the key is the object type to be read by the <see cref="TypeReader"/>
-        ///     and the element is the type of the <see cref="TypeReader"/> generic definition.
+        ///     A <see cref="ILookup{TKey, TElement}"/>; the key is the object type to be read by the <see cref="TypeReader"/>,
+        ///     while the element is the type of the <see cref="TypeReader"/> generic definition.
         /// </returns>
         public ILookup<Type, Type> EntityTypeReaders => _userEntityTypeReaders.SelectMany(x => x.Value.Select(y => new { x.Key, TypeReaderType = y })).ToLookup(x => x.Key, y => y.TypeReaderType);
 
@@ -368,13 +368,10 @@ namespace Discord.Commands
         /// <example>
         ///     <para>The following example adds a custom entity reader to this <see cref="CommandService"/>.</para>
         ///     <code language="cs" region="AddEntityTypeReader"
-        ///           source="..\..\..\Discord.Net.Examples\Commands\CommandService.Examples.cs" />
+        ///           source="..\Discord.Net.Examples\Commands\CommandService.Examples.cs" />
         /// </example>
         /// <typeparam name="T">The object type to be read by the <see cref="TypeReader"/>.</typeparam>
-        /// <param name="typeReaderGenericType">
-        ///     A <see cref="Type" /> that is a generic type definition with a single open argument
-        ///     of the <see cref="TypeReader" /> to be added.
-        /// </param>
+        /// <param name="typeReaderGenericType">A generic type definition (with one open argument) of the <see cref="TypeReader" />.</param>
         public void AddEntityTypeReader<T>(Type typeReaderGenericType)
             => AddEntityTypeReader(typeof(T), typeReaderGenericType);
         /// <summary>
@@ -382,10 +379,7 @@ namespace Discord.Commands
         ///     object type.
         /// </summary>
         /// <param name="type">A <see cref="Type" /> instance for the type to be read.</param>
-        /// <param name="typeReaderGenericType">
-        ///     A <see cref="Type" /> that is a generic type definition with a single open argument
-        ///     of the <see cref="TypeReader" /> to be added.
-        /// </param>
+        /// <param name="typeReaderGenericType">A generic type definition (with one open argument) of the <see cref="TypeReader" />.</param>
         public void AddEntityTypeReader(Type type, Type typeReaderGenericType)
         {
             if (!typeReaderGenericType.IsGenericTypeDefinition)
@@ -406,6 +400,11 @@ namespace Discord.Commands
         ///     If <typeparamref name="T" /> is a <see cref="ValueType" />, a nullable <see cref="TypeReader" /> will
         ///     also be added.
         /// </summary>
+        /// <example>
+        ///     <para>The following example adds a custom entity reader to this <see cref="CommandService"/>.</para>
+        ///     <code language="cs" region="AddEntityTypeReader2"
+        ///           source="..\Discord.Net.Examples\Commands\CommandService.Examples.cs" />
+        /// </example>
         /// <typeparam name="T">The object type to be read by the <see cref="TypeReader"/>.</typeparam>
         /// <param name="reader">An instance of the <see cref="TypeReader" /> to be added.</param>
         /// <param name="replaceDefault">

--- a/src/Discord.Net.Commands/Readers/NamedArgumentTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/NamedArgumentTypeReader.cs
@@ -136,8 +136,8 @@ namespace Discord.Commands
                 var overridden = prop.GetCustomAttribute<OverrideTypeReaderAttribute>();
                 var reader = (overridden != null)
                     ? ModuleClassBuilder.GetTypeReader(_commands, elemType, overridden.TypeReader, services)
-                    : (_commands.GetDefaultTypeReader(elemType)
-                        ?? _commands.GetTypeReaders(elemType).FirstOrDefault().Value);
+                    : (_commands.GetTypeReaders(elemType, false)?.FirstOrDefault().Value
+                        ?? _commands.GetDefaultTypeReader(elemType));
 
                 if (reader != null)
                 {

--- a/src/Discord.Net.Commands/Readers/TypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/TypeReader.cs
@@ -8,6 +8,7 @@ namespace Discord.Commands
     /// </summary>
     public abstract class TypeReader
     {
+        internal bool IsOverride { get; set; } = false;
         /// <summary>
         ///     Attempts to parse the <paramref name="input"/> into the desired type.
         /// </summary>

--- a/src/Discord.Net.Examples/Commands/CommandService.Examples.cs
+++ b/src/Discord.Net.Examples/Commands/CommandService.Examples.cs
@@ -1,0 +1,32 @@
+using Discord.Commands;
+using JetBrains.Annotations;
+using System;
+using System.Threading.Tasks;
+
+namespace Discord.Net.Examples.Commands
+{
+    [PublicAPI]
+    internal class CommandServiceExamples
+    {
+        #region AddEntityTypeReader
+
+        public void AddCustomEntityReader(CommandService commandService)
+        {
+            commandService.AddEntityTypeReader<IUser>(typeof(MyUserTypeReader<>));
+        }
+
+        public class MyUserTypeReader<T> : TypeReader
+            where T : class, IUser
+        {
+            public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+            {
+                if (ulong.TryParse(input, out var id))
+                    return ((await context.Client.GetUserAsync(id)) is T user)
+                        ? TypeReaderResult.FromSuccess(user)
+                        : TypeReaderResult.FromError(CommandError.ObjectNotFound, "User not found.");
+                return TypeReaderResult.FromError(CommandError.ParseFailed, "Couldn't parse input to ulong.");
+            }
+
+        #endregion
+    }
+}

--- a/src/Discord.Net.Examples/Commands/CommandService.Examples.cs
+++ b/src/Discord.Net.Examples/Commands/CommandService.Examples.cs
@@ -26,6 +26,7 @@ namespace Discord.Net.Examples.Commands
                         : TypeReaderResult.FromError(CommandError.ObjectNotFound, "User not found.");
                 return TypeReaderResult.FromError(CommandError.ParseFailed, "Couldn't parse input to ulong.");
             }
+        }
 
         #endregion
     }

--- a/src/Discord.Net.Examples/Commands/CommandService.Examples.cs
+++ b/src/Discord.Net.Examples/Commands/CommandService.Examples.cs
@@ -10,7 +10,7 @@ namespace Discord.Net.Examples.Commands
     {
         #region AddEntityTypeReader
 
-        public void AddCustomEntityReader(CommandService commandService)
+        public void AddCustomUserEntityReader(CommandService commandService)
         {
             commandService.AddEntityTypeReader<IUser>(typeof(MyUserTypeReader<>));
         }
@@ -24,6 +24,28 @@ namespace Discord.Net.Examples.Commands
                     return ((await context.Client.GetUserAsync(id)) is T user)
                         ? TypeReaderResult.FromSuccess(user)
                         : TypeReaderResult.FromError(CommandError.ObjectNotFound, "User not found.");
+                return TypeReaderResult.FromError(CommandError.ParseFailed, "Couldn't parse input to ulong.");
+            }
+        }
+
+        #endregion
+
+        #region AddEntityTypeReader2
+
+        public void AddCustomChannelEntityReader(CommandService commandService)
+        {
+            commandService.AddEntityTypeReader<IUser>(typeof(MyUserTypeReader<>));
+        }
+
+        public class MyChannelTypeReader<T> : TypeReader
+            where T : class, IChannel
+        {
+            public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+            {
+                if (ulong.TryParse(input, out var id))
+                    return ((await context.Client.GetChannelAsync(id)) is T channel)
+                        ? TypeReaderResult.FromSuccess(channel)
+                        : TypeReaderResult.FromError(CommandError.ObjectNotFound, "Channel not found.");
                 return TypeReaderResult.FromError(CommandError.ParseFailed, "Couldn't parse input to ulong.");
             }
         }

--- a/src/Discord.Net.Examples/Discord.Net.Examples.csproj
+++ b/src/Discord.Net.Examples/Discord.Net.Examples.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Discord.Net.Commands\Discord.Net.Commands.csproj" />
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
     <ProjectReference Include="..\Discord.Net.WebSocket\Discord.Net.WebSocket.csproj" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />


### PR DESCRIPTION
## Summary

This change will rollback the change from #941 that gave priority to default type readers instead of the ones added by the user while also fixing the issue that PR was merged for by creating a specific list for override type readers (so it isn't added like a global one).

It will also give the user the ability to add entity type readers of their own (example: a global IChannel type reader that applies to IMessageChannel etc, like the default one).

## Changes

- Change priority of type readers (user > default).
- Add internal property to type readers to signal a override one and prevent #936 .
- Add `AddEntityTypeReader<T>(Type typeReaderGenericType)` and `AddEntityTypeReader(Type type, Type typeReaderGenericType)` to `CommandService`
- Add logic for entity type readers added by the user (adding a IChannel type reader will apply it to classes/interfaces that implement it, example: IMessageChannel).
- Deprecate `AddTypeReader<T>(TypeReader reader, bool replaceDefault)` and  `AddTypeReader(Type type, TypeReader reader, bool replaceDefault)` (not needed anymore since default type readers don't have priority over the ones added by the user.

## How to use

1. Create a class that inherits from `TypeReader` with a single generic argument that has at least a reference type constraint, e.g. `class CustomUserTypeReader<T> : TypeReader where T : class, IUser`
2. Add it to the command service, e.g. `AddEntityTypeReader<IUser>(typeof(CustomUserTypeReader<>))`
3. Done!

## Examples (with test cases done)

The examples will say what type reader were added (following the order that they were added), the argument used, and the type reader assigned to them. Following this format: `Argument type: Type Reader used`.
Note: default = default Discord.Net type reader, otherwise it's the one added by the user.

### Adding IChannel type reader and IMessageChannel type reader
- IChannel: IChannel
- IMessageChannel: IMessageChannel
- ITextChannel: IMessageChannel
- SocketTextChannel: IMessageChannel
- IVoiceChannel: IChannel
- SocketChannel: IChannel

### Adding only IMessageChannel type reader
- IChannel: default
- IMessageChannel: IMessageChannel
- ITextChannel: IMessageChannel
- SocketTextChannel: IMessageChannel
- IVoiceChannel: default
- SocketChannel: default

### Adding IVoiceChannel type reader and IMessageChannel type reader
- IChannel: default
- IMessageChannel: IMessageChannel
- ITextChannel: IMessageChannel
- SocketTextChannel: IMessageChannel
- IVoiceChannel: IVoiceChannel
- SocketChannel: default

## Notes

This PR includes the change in #1486, so if accepted, please merge that one first since they are the one that fixed and deserve the credit for finding it.

If you have any test case that you want to be done, please comment it here and I can do it since this change might have something I didn't expect and didn't test.