### PR TITLE
Fallback on the default value on a failed read

### DIFF
--- a/src/Discord.Net.Commands/Attributes/FallbackToDefaultAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/FallbackToDefaultAttribute.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Discord.Commands
+{
+    /// <summary>
+    ///     When applied to an optional command parameter,
+    ///     indicates that its default value should be used
+    ///     if the TypeReader fails to read a valid value.
+    /// </summary>
+    /// <example>
+    ///     <code language="cs">
+    ///     [Command("stats")]
+    ///     public async Task GetStatsAsync([FallbackToDefault] IUser user = null)
+    ///     {
+    ///         if (user is null)
+    ///         {
+    ///             await ReplyAsync("Couldn't find that user");
+    ///             return;
+    ///         }
+    /// 
+    ///         // ...pull stats
+    ///     }
+    ///     </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class FallbackToDefaultAttribute : Attribute { }
+}

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -90,7 +90,10 @@ namespace Discord.Commands
         public async Task<TypeReaderResult> ParseAsync(ICommandContext context, string input, IServiceProvider services = null)
         {
             services = services ?? EmptyServiceProvider.Instance;
-            return await _reader.ReadAsync(context, input, services).ConfigureAwait(false);
+            var readerResult = await _reader.ReadAsync(context, input, services).ConfigureAwait(false);
+            return (!readerResult.IsSuccess && IsOptional)
+                ? TypeReaderResult.FromSuccess(DefaultValue)
+                : readerResult;
         }
 
         public override string ToString() => Name;

--- a/src/Discord.Net.Commands/Info/ParameterInfo.cs
+++ b/src/Discord.Net.Commands/Info/ParameterInfo.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Discord.Commands
@@ -36,6 +37,7 @@ namespace Discord.Commands
         /// </summary>
         public bool IsRemainder { get; }
         public bool IsMultiple { get; }
+        public bool UseDefaultOnFail { get; }
         /// <summary>
         ///     Gets the type of the parameter.
         /// </summary>
@@ -63,6 +65,7 @@ namespace Discord.Commands
             IsOptional = builder.IsOptional;
             IsRemainder = builder.IsRemainder;
             IsMultiple = builder.IsMultiple;
+            UseDefaultOnFail = (IsOptional && builder.Attributes.Any(attr => attr is FallbackToDefaultAttribute));
 
             Type = builder.ParameterType;
             DefaultValue = builder.DefaultValue;
@@ -91,7 +94,7 @@ namespace Discord.Commands
         {
             services = services ?? EmptyServiceProvider.Instance;
             var readerResult = await _reader.ReadAsync(context, input, services).ConfigureAwait(false);
-            return (!readerResult.IsSuccess && IsOptional)
+            return (!readerResult.IsSuccess && UseDefaultOnFail)
                 ? TypeReaderResult.FromSuccess(DefaultValue)
                 : readerResult;
         }


### PR DESCRIPTION
But only if the command parameter is optional.

Could also be put behind an additional attribute flag so the behavior becomes more explicit.