### PR TITLE
Feature: Add INVITE_CREATE and INVITE_DELETE events

### DIFF
--- a/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
+++ b/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
@@ -2,7 +2,7 @@ namespace Discord
 {
     public enum TargetUserType
     {
-        /// <summary> The invite target user type is not defined. </summary>
+        /// <summary> The invite whose target user type is not defined. </summary>
         Undefined = 0,
         /// <summary> The invite is for a Go Live stream. </summary>
         Stream = 1

--- a/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
+++ b/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
@@ -3,7 +3,7 @@ namespace Discord
     public enum TargetUserType
     {
         /// <summary> The invite target user type is not defined. </summary>
-        NotDefined = 0,
+        Undefined = 0,
         /// <summary> The invite is for a Go Live stream. </summary>
         Stream = 1
     }

--- a/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
+++ b/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
@@ -2,9 +2,13 @@ namespace Discord
 {
     public enum TargetUserType
     {
-        /// <summary> The invite whose target user type is not defined. </summary>
+        /// <summary>
+        ///     The invite whose target user type is not defined.
+        /// </summary>
         Undefined = 0,
-        /// <summary> The invite is for a Go Live stream. </summary>
+        /// <summary>
+        ///     The invite is for a Go Live stream.
+        /// </summary>
         Stream = 1
     }
 }

--- a/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
+++ b/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
@@ -1,0 +1,8 @@
+namespace Discord
+{
+    public enum TargetUserType
+    {
+        /// <summary> The invite is for a Go Live stream. </summary>
+        Stream = 1
+    }
+}

--- a/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
+++ b/src/Discord.Net.Core/Entities/Invites/TargetUserType.cs
@@ -2,6 +2,8 @@ namespace Discord
 {
     public enum TargetUserType
     {
+        /// <summary> The invite target user type is not defined. </summary>
+        NotDefined = 0,
         /// <summary> The invite is for a Go Live stream. </summary>
         Stream = 1
     }

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Discord.API.Gateway
+{
+    internal class InviteCreateEvent
+    {
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; set; }
+        [JsonProperty("code")]
+        public string Code { get; set; }
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+        [JsonProperty("guild_id")]
+        public Optional<ulong> GuildId { get; set; }
+        [JsonProperty("inviter")]
+        public Optional<User> Inviter { get; set; }
+        [JsonProperty("max_age")]
+        public int MaxAge { get; set; }
+        [JsonProperty("max_uses")]
+        public int MaxUses { get; set; }
+        [JsonProperty("temporary")]
+        public bool Temporary { get; set; }
+        [JsonProperty("uses")]
+        public int Uses { get; set; }
+    }
+}

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
@@ -19,6 +19,10 @@ namespace Discord.API.Gateway
         public int MaxAge { get; set; }
         [JsonProperty("max_uses")]
         public int MaxUses { get; set; }
+        [JsonProperty("target_user")]
+        public Optional<User> TargetUser { get; set; }
+        [JsonProperty("target_user_type")]
+        public Optional<TargetUserType> TargetUserType { get; set; }
         [JsonProperty("temporary")]
         public bool Temporary { get; set; }
         [JsonProperty("uses")]

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteDeleteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteDeleteEvent.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+
+namespace Discord.API.Gateway
+{
+    internal class InviteDeleteEvent
+    {
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; set; }
+        [JsonProperty("code")]
+        public string Code { get; set; }
+        [JsonProperty("guild_id")]
+        public Optional<ulong> GuildId { get; set; }
+    }
+}

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -369,7 +369,9 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientRemovedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
 
         //Invites
-        /// <summary> Fired when an invite is created. </summary>
+        /// <summary>
+        ///     Fired when an invite is created.
+        /// </summary>
         /// <remarks>
         ///     <para>
         ///         This event is fired when an invite is created. The event handler must return a
@@ -385,7 +387,9 @@ namespace Discord.WebSocket
             remove { _inviteCreatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketInvite, Task>> _inviteCreatedEvent = new AsyncEvent<Func<SocketInvite, Task>>();
-        /// <summary> Fired when an invite is deleted. </summary>
+        /// <summary>
+        ///     Fired when an invite is deleted.
+        /// </summary>
         /// <remarks>
         ///     <para>
         ///         This event is fired when an invite is deleted. The event handler must return

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -1,3 +1,4 @@
+using Discord.API;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -367,5 +368,22 @@ namespace Discord.WebSocket
             remove { _recipientRemovedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientRemovedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
+
+        //Invites
+        /// <summary> Fired when an invite is created. </summary>
+        public event Func<SocketInvite, Task> InviteCreated
+        {
+            add { _inviteCreatedEvent.Add(value); }
+            remove { _inviteCreatedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketInvite, Task>> _inviteCreatedEvent = new AsyncEvent<Func<SocketInvite, Task>>();
+        /// <summary> Fired when an invite is deleted. </summary>
+        /// <remarks> The string is the invite code. </remarks>
+        public event Func<SocketGuildChannel, string, Task> InviteDeleted
+        {
+            add { _inviteDeletedEvent.Add(value); }
+            remove { _inviteDeletedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuildChannel, string, Task>> _inviteDeletedEvent = new AsyncEvent<Func<SocketGuildChannel, string, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -1,4 +1,3 @@
-using Discord.API;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -370,6 +370,15 @@ namespace Discord.WebSocket
 
         //Invites
         /// <summary> Fired when an invite is created. </summary>
+        /// <remarks>
+        ///     <para>
+        ///         This event is fired when an invite is created. The event handler must return a
+        ///         <see cref="Task"/> and accept a <see cref="SocketInvite"/> as its parameters.
+        ///     </para>
+        ///     <para>
+        ///         The invite created will be passed into the <see cref="SocketInvite"/> parameter.
+        ///     </para>
+        /// </remarks>
         public event Func<SocketInvite, Task> InviteCreated
         {
             add { _inviteCreatedEvent.Add(value); }
@@ -377,7 +386,19 @@ namespace Discord.WebSocket
         }
         internal readonly AsyncEvent<Func<SocketInvite, Task>> _inviteCreatedEvent = new AsyncEvent<Func<SocketInvite, Task>>();
         /// <summary> Fired when an invite is deleted. </summary>
-        /// <remarks> The string is the invite code. </remarks>
+        /// <remarks>
+        ///     <para>
+        ///         This event is fired when an invite is deleted. The event handler must return
+        ///         a <see cref="Task"/> and accept a <see cref="SocketGuildChannel"/> and
+        ///         <see cref="string"> as its parameters.
+        ///     </para>
+        ///     <para>
+        ///         The channel where this invite was will be passed into the <see cref="SocketGuildChannel"/> parameter.
+        ///     </para>
+        ///     <para>
+        ///         The code of the deleted invite will be passed into the <see cref="string"/> parameter.
+        ///     </para>
+        /// </remarks>
         public event Func<SocketGuildChannel, string, Task> InviteDeleted
         {
             add { _inviteDeletedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -373,7 +373,7 @@ namespace Discord.WebSocket
         /// <remarks>
         ///     <para>
         ///         This event is fired when an invite is created. The event handler must return a
-        ///         <see cref="Task"/> and accept a <see cref="SocketInvite"/> as its parameters.
+        ///         <see cref="Task"/> and accept a <see cref="SocketInvite"/> as its parameter.
         ///     </para>
         ///     <para>
         ///         The invite created will be passed into the <see cref="SocketInvite"/> parameter.
@@ -390,10 +390,10 @@ namespace Discord.WebSocket
         ///     <para>
         ///         This event is fired when an invite is deleted. The event handler must return
         ///         a <see cref="Task"/> and accept a <see cref="SocketGuildChannel"/> and
-        ///         <see cref="string"> as its parameters.
+        ///         <see cref="string"/> as its parameter.
         ///     </para>
         ///     <para>
-        ///         The channel where this invite was will be passed into the <see cref="SocketGuildChannel"/> parameter.
+        ///         The channel where this invite was created will be passed into the <see cref="SocketGuildChannel"/> parameter.
         ///     </para>
         ///     <para>
         ///         The code of the deleted invite will be passed into the <see cref="string"/> parameter.

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -337,6 +337,9 @@ namespace Discord.WebSocket
             client.UserIsTyping += (oldUser, newUser) => _userIsTypingEvent.InvokeAsync(oldUser, newUser);
             client.RecipientAdded += (user) => _recipientAddedEvent.InvokeAsync(user);
             client.RecipientRemoved += (user) => _recipientRemovedEvent.InvokeAsync(user);
+
+            client.InviteCreated += (invite) => _inviteCreatedEvent.InvokeAsync(invite);
+            client.InviteDeleted += (channel, invite) => _inviteDeletedEvent.InvokeAsync(channel, invite);
         }
 
         //IDiscordClient

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1650,16 +1650,12 @@ namespace Discord.WebSocket
                                             return;
                                         }
 
-                                        SocketGuildUser inviter = null;
-                                        if (data.Inviter.IsSpecified)
-                                        {
-                                            inviter = guild.GetUser(data.Inviter.Value.Id);
-                                            if (inviter == null)
-                                                inviter = guild.AddOrUpdateUser(data.Inviter.Value);
-                                        }
+                                        SocketGuildUser inviter = data.Inviter.IsSpecified
+                                            ? (guild.GetUser(data.Inviter.Value.Id) ?? guild.AddOrUpdateUser(data.Inviter.Value))
+                                            : null;
 
-                                        SocketUser target =  data.TargetUser.IsSpecified
-                                            ? (guild.GetUser(data.TargetUser.Value.Id) ?? SocketUnknownUser.Create(this, State, data.TargetUser.Value))
+                                        SocketUser target = data.TargetUser.IsSpecified
+                                            ? (guild.GetUser(data.TargetUser.Value.Id) ?? (SocketUser)SocketUnknownUser.Create(this, State, data.TargetUser.Value))
                                             : null;
 
                                         var invite = SocketInvite.Create(this, guild, channel, inviter, target, data);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1658,13 +1658,9 @@ namespace Discord.WebSocket
                                                 inviter = guild.AddOrUpdateUser(data.Inviter.Value);
                                         }
 
-                                        SocketUser target = null;
-                                        if (data.TargetUser.IsSpecified)
-                                        {
-                                            target = guild.GetUser(data.TargetUser.Value.Id);
-                                            if (target == null)
-                                                target = SocketUnknownUser.Create(this, State, data.TargetUser.Value);
-                                        }
+                                        SocketUser target =  data.TargetUser.IsSpecified
+                                            ? (guild.GetUser(data.TargetUser.Value.Id) ?? SocketUnknownUser.Create(this, State, data.TargetUser.Value))
+                                            : null;
 
                                         var invite = SocketInvite.Create(this, guild, channel, inviter, target, data);
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1658,7 +1658,15 @@ namespace Discord.WebSocket
                                                 inviter = guild.AddOrUpdateUser(data.Inviter.Value);
                                         }
 
-                                        var invite = SocketInvite.Create(this, guild, channel, inviter, data);
+                                        SocketUser target = null;
+                                        if (data.TargetUser.IsSpecified)
+                                        {
+                                            target = guild.GetUser(data.TargetUser.Value.Id);
+                                            if (target == null)
+                                                target = SocketUnknownUser.Create(this, State, data.TargetUser.Value);
+                                        }
+
+                                        var invite = SocketInvite.Create(this, guild, channel, inviter, target, data);
 
                                         await TimedInvokeAsync(_inviteCreatedEvent, nameof(InviteCreated), invite).ConfigureAwait(false);
                                     }

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -117,7 +117,7 @@ namespace Discord.WebSocket
             MaxUses = model.MaxUses;
             Uses = model.Uses;
             _createdAtTicks = model.CreatedAt.UtcTicks;
-            TargetUserType = model.TargetUserType.IsSpecified ? model.TargetUserType.Value : TargetUserType.NotDefined;
+            TargetUserType = model.TargetUserType.IsSpecified ? model.TargetUserType.Value : TargetUserType.Undefined;
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -9,7 +9,7 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketInvite : SocketEntity<string>, IInviteMetadata
     {
-         private long _createdAtTicks;
+        private long _createdAtTicks;
 
         /// <inheritdoc />
         public ulong ChannelId { get; private set; }
@@ -24,11 +24,26 @@ namespace Discord.WebSocket
         /// </summary>
         public SocketGuild Guild { get; private set; }
         /// <inheritdoc />
-        ChannelType IInvite.ChannelType => throw new NotImplementedException();
+        ChannelType IInvite.ChannelType
+        {
+            get
+            {
+                switch (Channel)
+                {
+                    case IVoiceChannel voiceChannel: return ChannelType.Voice;
+                    case ICategoryChannel categoryChannel: return ChannelType.Category;
+                    case IDMChannel dmChannel: return ChannelType.DM;
+                    case IGroupChannel groupChannel: return ChannelType.Group;
+                    case SocketNewsChannel socketNewsChannel: return ChannelType.News;
+                    case ITextChannel textChannel: return ChannelType.Text;
+                    default: throw new InvalidOperationException("Invalid channel type.");
+                }
+            }
+        }
         /// <inheritdoc />
-        string IInvite.ChannelName => throw new NotImplementedException();
+        string IInvite.ChannelName => Channel.Name;
         /// <inheritdoc />
-        string IInvite.GuildName => throw new NotImplementedException();
+        string IInvite.GuildName => Guild.Name;
         /// <inheritdoc />
         int? IInvite.PresenceCount => throw new NotImplementedException();
         /// <inheritdoc />
@@ -109,28 +124,9 @@ namespace Discord.WebSocket
         private string DebuggerDisplay => $"{Url} ({Guild?.Name} / {Channel.Name})";
 
         /// <inheritdoc />
-        IGuild IInvite.Guild
-        {
-            get
-            {
-                if (Guild != null)
-                    return Guild;
-                if (Channel is IGuildChannel guildChannel)
-                    return guildChannel.Guild; //If it fails, it'll still return this exception
-                throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
-            }
-        }
+        IGuild IInvite.Guild => Guild;
         /// <inheritdoc />
-        IChannel IInvite.Channel
-        {
-            get
-            {
-                if (Channel != null)
-                    return Channel;
-                throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
-            }
-        }
-
+        IChannel IInvite.Channel => Channel;
         /// <inheritdoc />
         IUser IInviteMetadata.Inviter => Inviter;
     }

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -1,0 +1,137 @@
+using Discord.Rest;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Model = Discord.API.Gateway.InviteCreateEvent;
+
+namespace Discord.WebSocket
+{
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public class SocketInvite : SocketEntity<string>, IInviteMetadata
+    {
+         private long _createdAtTicks;
+
+        /// <inheritdoc />
+        public ulong ChannelId { get; private set; }
+        /// <summary>
+        ///     Gets the channel where this invite was created.
+        /// </summary>
+        public SocketGuildChannel Channel { get; private set; }
+        /// <inheritdoc />
+        public ulong? GuildId { get; private set; }
+        /// <summary>
+        ///     Gets the guild where this invite was created.
+        /// </summary>
+        public SocketGuild Guild { get; private set; }
+        /// <inheritdoc />
+        ChannelType IInvite.ChannelType => throw new NotImplementedException();
+        /// <inheritdoc />
+        string IInvite.ChannelName => throw new NotImplementedException();
+        /// <inheritdoc />
+        string IInvite.GuildName => throw new NotImplementedException();
+        /// <inheritdoc />
+        int? IInvite.PresenceCount => throw new NotImplementedException();
+        /// <inheritdoc />
+        int? IInvite.MemberCount => throw new NotImplementedException();
+        /// <inheritdoc />
+        bool IInviteMetadata.IsRevoked => throw new NotImplementedException();
+        /// <inheritdoc />
+        public bool IsTemporary { get; private set; }
+        /// <inheritdoc />
+        int? IInviteMetadata.MaxAge { get => MaxAge; }
+        /// <inheritdoc />
+        int? IInviteMetadata.MaxUses { get => MaxUses; }
+        /// <inheritdoc />
+        int? IInviteMetadata.Uses { get => Uses; }
+        /// <summary>
+        ///     Gets the time (in seconds) until the invite expires.
+        /// </summary>
+        public int MaxAge { get; private set; }
+        /// <summary>
+        ///     Gets the max number of uses this invite may have.
+        /// </summary>
+        public int MaxUses { get; private set; }
+        /// <summary>
+        ///     Gets the number of times this invite has been used.
+        /// </summary>
+        public int Uses { get; private set; }
+        /// <summary>
+        ///     Gets the user that created this invite if available.
+        /// </summary>
+        public SocketGuildUser Inviter { get; private set; }
+        /// <inheritdoc />
+        DateTimeOffset? IInviteMetadata.CreatedAt => DateTimeUtils.FromTicks(_createdAtTicks);
+        /// <summary>
+        ///     Gets when this invite was created.
+        /// </summary>
+        public DateTimeOffset CreatedAt => DateTimeUtils.FromTicks(_createdAtTicks);
+
+        /// <inheritdoc />
+        public string Code => Id;
+        /// <inheritdoc />
+        public string Url => $"{DiscordConfig.InviteUrl}{Code}";
+
+        internal SocketInvite(DiscordSocketClient discord, SocketGuild guild, SocketGuildChannel channel, SocketGuildUser inviter, string id)
+            : base(discord, id)
+        {
+            Guild = guild;
+            Channel = channel;
+            Inviter = inviter;
+        }
+        internal static SocketInvite Create(DiscordSocketClient discord, SocketGuild guild, SocketGuildChannel channel, SocketGuildUser inviter, Model model)
+        {
+            var entity = new SocketInvite(discord, guild, channel, inviter, model.Code);
+            entity.Update(model);
+            return entity;
+        }
+        internal void Update(Model model)
+        {
+            ChannelId = model.ChannelId;
+            GuildId = model.GuildId.IsSpecified ? model.GuildId.Value : Guild.Id;
+            IsTemporary = model.Temporary;
+            MaxAge = model.MaxAge;
+            MaxUses = model.MaxUses;
+            Uses = model.Uses;
+            _createdAtTicks = model.CreatedAt.UtcTicks;
+        }
+
+        /// <inheritdoc />
+        public Task DeleteAsync(RequestOptions options = null)
+            => InviteHelper.DeleteAsync(this, Discord, options);
+
+        /// <summary>
+        ///     Gets the URL of the invite.
+        /// </summary>
+        /// <returns>
+        ///     A string that resolves to the Url of the invite.
+        /// </returns>
+        public override string ToString() => Url;
+        private string DebuggerDisplay => $"{Url} ({Guild?.Name} / {Channel.Name})";
+
+        /// <inheritdoc />
+        IGuild IInvite.Guild
+        {
+            get
+            {
+                if (Guild != null)
+                    return Guild;
+                if (Channel is IGuildChannel guildChannel)
+                    return guildChannel.Guild; //If it fails, it'll still return this exception
+                throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
+            }
+        }
+        /// <inheritdoc />
+        IChannel IInvite.Channel
+        {
+            get
+            {
+                if (Channel != null)
+                    return Channel;
+                throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
+            }
+        }
+
+        /// <inheritdoc />
+        IUser IInviteMetadata.Inviter => Inviter;
+    }
+}

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -80,22 +80,31 @@ namespace Discord.WebSocket
         ///     Gets when this invite was created.
         /// </summary>
         public DateTimeOffset CreatedAt => DateTimeUtils.FromTicks(_createdAtTicks);
+        /// <summary>
+        ///     Gets the user targeted by this invite if available.
+        /// </summary>
+        public SocketUser TargetUser { get; private set; }
+        /// <summary>
+        ///     Gets the type of the user targeted by this invite if available.
+        /// </summary>
+        public TargetUserType? TargetUserType { get; private set; }
 
         /// <inheritdoc />
         public string Code => Id;
         /// <inheritdoc />
         public string Url => $"{DiscordConfig.InviteUrl}{Code}";
 
-        internal SocketInvite(DiscordSocketClient discord, SocketGuild guild, SocketGuildChannel channel, SocketGuildUser inviter, string id)
+        internal SocketInvite(DiscordSocketClient discord, SocketGuild guild, SocketGuildChannel channel, SocketGuildUser inviter, SocketUser target, string id)
             : base(discord, id)
         {
             Guild = guild;
             Channel = channel;
             Inviter = inviter;
+            TargetUser = target;
         }
-        internal static SocketInvite Create(DiscordSocketClient discord, SocketGuild guild, SocketGuildChannel channel, SocketGuildUser inviter, Model model)
+        internal static SocketInvite Create(DiscordSocketClient discord, SocketGuild guild, SocketGuildChannel channel, SocketGuildUser inviter, SocketUser target, Model model)
         {
-            var entity = new SocketInvite(discord, guild, channel, inviter, model.Code);
+            var entity = new SocketInvite(discord, guild, channel, inviter, target, model.Code);
             entity.Update(model);
             return entity;
         }
@@ -108,6 +117,7 @@ namespace Discord.WebSocket
             MaxUses = model.MaxUses;
             Uses = model.Uses;
             _createdAtTicks = model.CreatedAt.UtcTicks;
+            TargetUserType = model.TargetUserType.IsSpecified ? model.TargetUserType.Value : default(TargetUserType?);
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -85,9 +85,9 @@ namespace Discord.WebSocket
         /// </summary>
         public SocketUser TargetUser { get; private set; }
         /// <summary>
-        ///     Gets the type of the user targeted by this invite if available.
+        ///     Gets the type of the user targeted by this invite.
         /// </summary>
-        public TargetUserType? TargetUserType { get; private set; }
+        public TargetUserType TargetUserType { get; private set; }
 
         /// <inheritdoc />
         public string Code => Id;
@@ -117,7 +117,7 @@ namespace Discord.WebSocket
             MaxUses = model.MaxUses;
             Uses = model.Uses;
             _createdAtTicks = model.CreatedAt.UtcTicks;
-            TargetUserType = model.TargetUserType.IsSpecified ? model.TargetUserType.Value : default(TargetUserType?);
+            TargetUserType = model.TargetUserType.IsSpecified ? model.TargetUserType.Value : TargetUserType.NotDefined;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

This change will add the new gateway events related to invites, [INVITE_CREATE](https://discordapp.com/developers/docs/topics/gateway#invite-create) and [INVITE_DELETE](https://discordapp.com/developers/docs/topics/gateway#invite-delete), introducing a new class, `SocketInvite`.

## Notes

I'm not sure about three points in this PR that might require more opinions.

- Should I try to update the properties Channel, Guild, and Invite in the Update method?
- I'm unsure about the delete event that just returns the code, so it's not possible to instantiate a complete `SocketInvite` and we don't keep invites in the cache (not sure if we should, since there's no event to update this cache so it'll always be outdated or require to update them manually via REST). Should we cache the invites? Should we change the return of INVITE_DELETE to `SocketInvite` even if it only has the code, channel, and guild?
- Should `SocketInvite` implement `IUpdateable` and make it updateable via REST?