### PR TITLE
API breaking change: Specify WebSocket close code

### DIFF
--- a/src/Discord.Net.Core/Net/WebSockets/IWebSocketClient.cs
+++ b/src/Discord.Net.Core/Net/WebSockets/IWebSocketClient.cs
@@ -14,7 +14,7 @@ namespace Discord.Net.WebSockets
         void SetCancelToken(CancellationToken cancelToken);
 
         Task ConnectAsync(string host);
-        Task DisconnectAsync();
+        Task DisconnectAsync(int closeCode = 1000);
 
         Task SendAsync(byte[] data, int index, int count, bool isText);
     }

--- a/src/Discord.Net.Providers.WS4Net/WS4NetClient.cs
+++ b/src/Discord.Net.Providers.WS4Net/WS4NetClient.cs
@@ -40,7 +40,7 @@ namespace Discord.Net.Providers.WS4Net
             {
                 if (disposing)
                 {
-                    DisconnectInternalAsync(true).GetAwaiter().GetResult();
+                    DisconnectInternalAsync(isDisposing: true).GetAwaiter().GetResult();
                     _lock?.Dispose();
                     _cancelTokenSource?.Dispose();
                 }
@@ -92,19 +92,19 @@ namespace Discord.Net.Providers.WS4Net
             _waitUntilConnect.Wait(_cancelToken);
         }
 
-        public async Task DisconnectAsync()
+        public async Task DisconnectAsync(int closeCode = 1000)
         {
             await _lock.WaitAsync().ConfigureAwait(false);
             try
             {
-                await DisconnectInternalAsync().ConfigureAwait(false);
+                await DisconnectInternalAsync(closeCode: closeCode).ConfigureAwait(false);
             }
             finally
             {
                 _lock.Release();
             }
         }
-        private Task DisconnectInternalAsync(bool isDisposing = false)
+        private Task DisconnectInternalAsync(int closeCode = 1000, bool isDisposing = false)
         {
             _disconnectCancelTokenSource.Cancel();
             if (_client == null)
@@ -112,7 +112,7 @@ namespace Discord.Net.Providers.WS4Net
 
             if (_client.State == WebSocketState.Open)
             {
-                try { _client.Close(1000, ""); }
+                try { _client.Close(closeCode, ""); }
                 catch { }
             }
 

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -47,7 +47,7 @@ namespace Discord.API
         internal ulong? CurrentUserId { get; set; }
         public RateLimitPrecision RateLimitPrecision { get; private set; }
 		internal bool UseSystemClock { get; set; }
-        
+
         internal JsonSerializer Serializer => _serializer;
 
         /// <exception cref="ArgumentException">Unknown OAuth token type.</exception>
@@ -164,7 +164,7 @@ namespace Discord.API
             try { _loginCancelToken?.Cancel(false); }
             catch { }
 
-            await DisconnectInternalAsync().ConfigureAwait(false);
+            await DisconnectInternalAsync(null).ConfigureAwait(false);
             await RequestQueue.ClearAsync().ConfigureAwait(false);
 
             await RequestQueue.SetCancelTokenAsync(CancellationToken.None).ConfigureAwait(false);
@@ -175,7 +175,7 @@ namespace Discord.API
         }
 
         internal virtual Task ConnectInternalAsync() => Task.Delay(0);
-        internal virtual Task DisconnectInternalAsync() => Task.Delay(0);
+        internal virtual Task DisconnectInternalAsync(Exception ex = null) => Task.Delay(0);
 
         //Core
         internal Task SendAsync(string method, Expression<Func<string>> endpointExpr, BucketIds ids,
@@ -1062,7 +1062,7 @@ namespace Discord.API
             {
                 foreach (var roleId in args.RoleIds.Value)
                     Preconditions.NotEqual(roleId, 0, nameof(roleId));
-            }                
+            }
 
             options = RequestOptions.CreateOrClone(options);
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -511,7 +511,7 @@ namespace Discord.WebSocket
                     case GatewayOpCode.Reconnect:
                         {
                             await _gatewayLogger.DebugAsync("Received Reconnect").ConfigureAwait(false);
-                            _connection.Error(new GatewayReconnectException());
+                            _connection.Error(new GatewayReconnectException("Server requested a reconnect"));
                         }
                         break;
                     case GatewayOpCode.Dispatch:
@@ -1689,7 +1689,7 @@ namespace Discord.WebSocket
                     {
                         if (ConnectionState == ConnectionState.Connected && (_guildDownloadTask?.IsCompleted ?? true))
                         {
-                            _connection.Error(new Exception("Server missed last heartbeat"));
+                            _connection.Error(new GatewayReconnectException("Server missed last heartbeat"));
                             return;
                         }
                     }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -264,7 +264,7 @@ namespace Discord.WebSocket
         {
 
             await _gatewayLogger.DebugAsync("Disconnecting ApiClient").ConfigureAwait(false);
-            await ApiClient.DisconnectAsync().ConfigureAwait(false);
+            await ApiClient.DisconnectAsync(ex).ConfigureAwait(false);
 
             //Wait for tasks to complete
             await _gatewayLogger.DebugAsync("Waiting for heartbeater").ConfigureAwait(false);
@@ -511,7 +511,7 @@ namespace Discord.WebSocket
                     case GatewayOpCode.Reconnect:
                         {
                             await _gatewayLogger.DebugAsync("Received Reconnect").ConfigureAwait(false);
-                            _connection.Error(new Exception("Server requested a reconnect"));
+                            _connection.Error(new GatewayReconnectException());
                         }
                         break;
                     case GatewayOpCode.Dispatch:

--- a/src/Discord.Net.WebSocket/GatewayReconnectException.cs
+++ b/src/Discord.Net.WebSocket/GatewayReconnectException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Discord.WebSocket
+{
+    /// <summary>
+    /// An exception thrown when Discord requests the gateway client to
+    /// reconnect.
+    /// </summary>
+    public class GatewayReconnectException : Exception
+    {
+        /// <summary>
+        /// Creates a new instance of the
+        /// <see cref="GatewayReconnectException"/> type.
+        /// </summary>
+        public GatewayReconnectException()
+            : base("Server requested a reconnect")
+        { }
+    }
+}

--- a/src/Discord.Net.WebSocket/GatewayReconnectException.cs
+++ b/src/Discord.Net.WebSocket/GatewayReconnectException.cs
@@ -3,7 +3,7 @@ using System;
 namespace Discord.WebSocket
 {
     /// <summary>
-    /// An exception thrown when Discord requests the gateway client to
+    /// An exception thrown when the gateway client has been requested to
     /// reconnect.
     /// </summary>
     public class GatewayReconnectException : Exception
@@ -12,8 +12,11 @@ namespace Discord.WebSocket
         /// Creates a new instance of the
         /// <see cref="GatewayReconnectException"/> type.
         /// </summary>
-        public GatewayReconnectException()
-            : base("Server requested a reconnect")
+        /// <param name="message">
+        /// The reason why the gateway has been requested to reconnect.
+        /// </param>
+        public GatewayReconnectException(string message)
+            : base(message)
         { }
     }
 }


### PR DESCRIPTION
Should fix #1479, fix #1454 and help overall with resuming sessions.

Unfortunately, I had to introduce an API(/ABI? Might be source-compatible) breaking change to do this, as we weren't able to pipe the close code through to the underlying websocket client.
