### PR TITLE
Move content check for ModifyMessage

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -602,13 +602,8 @@ namespace Discord.API
             Preconditions.NotEqual(channelId, 0, nameof(channelId));
             Preconditions.NotEqual(messageId, 0, nameof(messageId));
             Preconditions.NotNull(args, nameof(args));
-            if (args.Content.IsSpecified)
-            {
-                if (!args.Embed.IsSpecified)
-                    Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
-                if (args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
-                    throw new ArgumentOutOfRangeException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
-            }
+            if (args.Content.IsSpecified && args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
+                throw new ArgumentOutOfRangeException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(channelId: channelId);

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -32,6 +32,11 @@ namespace Discord.Rest
             var args = new MessageProperties();
             func(args);
 
+            bool hasText = args.Content.IsSpecified ? !string.IsNullOrEmpty(args.Content.Value) : !string.IsNullOrEmpty(msg.Content);
+            bool hasEmbed = args.Embed.IsSpecified ? args.Embed.Value != null : msg.Embeds.Any();
+            if (!hasText && !hasEmbed)
+                Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
+
             var apiArgs = new API.Rest.ModifyMessageParams
             {
                 Content = args.Content,


### PR DESCRIPTION
## Summary

It's not possible to know if the message has an embed without the message cache, so we shouldn't assume or block the user from setting the content to null or empty, it should be done only when we have it.

Fix #1501 

## Changes

- Moved content check from `DiscordRestApiClient` to `MessageHelper`.
- Added a check for content and embed, not having both will preemptively throw an exception. 