### PR TITLE
Add default nullable enum typereader

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -435,6 +435,13 @@ namespace Discord.Commands
                 _defaultTypeReaders[type] = reader;
                 return reader;
             }
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            if (underlyingType != null && underlyingType.IsEnum)
+            {
+                reader = NullableTypeReader.Create(underlyingType, EnumTypeReader.GetReader(underlyingType));
+                _defaultTypeReaders[type] = reader;
+                return reader;
+            }
 
             //Is this an entity?
             for (int i = 0; i < _entityTypeReaders.Count; i++)


### PR DESCRIPTION
## Summary

The command service will add a default nullable enum typereader.
It already does the same for other ValueTypes, but since Enums are dealt in another way, they weren't included before.

## Changes

- Nullable enum type readers will be added by default