### PR TITLE
Add support for custom module instantiation logic

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleBuilder.cs
@@ -114,7 +114,7 @@ namespace Discord.Commands.Builders
             return this;
         }
 
-        private ModuleInfo BuildImpl(CommandService service, IServiceProvider services, ModuleInfo parent = null)
+        private ModuleInfo BuildImpl(CommandService service, IServiceProvider services, IModuleFactory factory = null, ModuleInfo parent = null)
         {
             //Default name to first alias
             if (Name == null)
@@ -122,15 +122,15 @@ namespace Discord.Commands.Builders
 
             if (TypeInfo != null && !TypeInfo.IsAbstract)
             {
-                var moduleInstance = ReflectionUtils.CreateObject<IModuleBase>(TypeInfo, service, services);
+                var moduleInstance = service.GetModuleFactory(TypeInfo, services, factory)(services);
                 moduleInstance.OnModuleBuilding(service, this);
             }
 
-            return new ModuleInfo(this, service, services, parent);
+            return new ModuleInfo(this, service, services, factory, parent);
         }
 
         public ModuleInfo Build(CommandService service, IServiceProvider services) => BuildImpl(service, services);
 
-        internal ModuleInfo Build(CommandService service, IServiceProvider services, ModuleInfo parent) => BuildImpl(service, services, parent);
+        internal ModuleInfo Build(CommandService service, IServiceProvider services, IModuleFactory factory, ModuleInfo parent) => BuildImpl(service, services, factory, parent);
     }
 }

--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -197,7 +197,7 @@ namespace Discord.Commands
                 });
             }
 
-            var createInstance = ReflectionUtils.CreateBuilder<IModuleBase>(typeInfo, service);
+            var createInstance = service.GetModuleFactory(typeInfo, serviceprovider);
 
             async Task<IResult> ExecuteCallback(ICommandContext context, object[] args, IServiceProvider services, CommandInfo cmd)
             {

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -151,6 +151,20 @@ namespace Discord.Commands
             }
         }
 
+        internal Func<IServiceProvider, IModuleBase> GetModuleFactory(TypeInfo typeInfo, IServiceProvider services, IModuleFactory factory = null)
+        {
+            factory ??= (IModuleFactory)services.GetService(typeof(IModuleFactory));
+
+            if (factory != null)
+            {
+                return _ => (IModuleBase)factory.CreateBuilder(typeInfo, this)();
+            }
+            else
+            {
+                return ReflectionUtils.CreateBuilder<IModuleBase>(typeInfo, this);
+            }
+        }
+
         /// <summary>
         ///     Add a command module from a <see cref="Type" />.
         /// </summary>

--- a/src/Discord.Net.Commands/IModuleFactory.cs
+++ b/src/Discord.Net.Commands/IModuleFactory.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Reflection;
+
+namespace Discord.Commands
+{
+    /// <summary>
+    ///     Provides a custom logic for creating module instances.
+    /// </summary>
+    public interface IModuleFactory
+    {
+        /// <summary>
+        ///     Creates a builder function for the provided <see cref="TypeInfo" />.
+        /// </summary>
+        /// <param name="typeInfo">The module's type information.</param>
+        /// <param name="commands">The <see cref="CommandService" /> that requested a new module instance.</param>
+        /// <returns>
+        ///     A factory function for the provided module type. 
+        /// </returns>
+        Func<object> CreateBuilder(TypeInfo typeInfo, CommandService commands);
+    }
+}

--- a/src/Discord.Net.Commands/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Commands/Info/ModuleInfo.cs
@@ -61,7 +61,7 @@ namespace Discord.Commands
         /// </summary>
         public bool IsSubmodule => Parent != null;
 
-        internal ModuleInfo(ModuleBuilder builder, CommandService service, IServiceProvider services, ModuleInfo parent = null)
+        internal ModuleInfo(ModuleBuilder builder, CommandService service, IServiceProvider services, IModuleFactory moduleFactory, ModuleInfo parent = null)
         {
             Service = service;
 
@@ -76,7 +76,7 @@ namespace Discord.Commands
             Preconditions = BuildPreconditions(builder).ToImmutableArray();
             Attributes = BuildAttributes(builder).ToImmutableArray();
 
-            Submodules = BuildSubmodules(builder, service, services).ToImmutableArray();
+            Submodules = BuildSubmodules(builder, service, services, moduleFactory).ToImmutableArray();
         }
 
         private static IEnumerable<string> BuildAliases(ModuleBuilder builder, CommandService service)
@@ -106,12 +106,12 @@ namespace Discord.Commands
             return result;
         }
 
-        private List<ModuleInfo> BuildSubmodules(ModuleBuilder parent, CommandService service, IServiceProvider services)
+        private List<ModuleInfo> BuildSubmodules(ModuleBuilder parent, CommandService service, IServiceProvider services, IModuleFactory moduleFactory)
         {
             var result = new List<ModuleInfo>();
 
             foreach (var submodule in parent.Modules)
-                result.Add(submodule.Build(service, services, this));
+                result.Add(submodule.Build(service, services, moduleFactory, this));
 
             return result;
         }


### PR DESCRIPTION
# Summary

Currently `Discord.Net.Commands` implements a simple dependency injector for module instances, but there is no way to override its behavior (except for a custom IServiceProvider, but in many cases it isn't sufficient, because we may want to use a full-featured DI framework for stuff like named dependencies, etc). This pull request adds a new `IModuleFactory` public interface which `CommandService` accepts through `IServiceProvider`.

# Design Decisions

* I wanted to make it work in the least instrusive way possible. It doesn't change `ReflectionUtils.cs` at all, just adds a new layer above it that other components of the library use. My initial implementation just passed around `IModuleFactory` instance as an argument, but I had to change like 10 or so methods to accept it, which is ugly. Consuming it through `IServiceProvider` seems to be the best way + it doesn't break API compatibility
* `IModuleFactory.CreateBuilder` is not a generic method, because I didn't want the consumers to think that the generic type is the actual type of the module (but actually they should use the `TypeInfo`). Also, we can't just expose IModuleBase because it's internal
* `CommandService.GetModuleFactory` is made in such a way that doesn't capture `IServiceProvider` instance and doesn't call `IServiceProvider.GetService` to get `IModuleFactory` on every module instantiation (maybe we should just have it in a field/property inside `CommandService` or not cache it at all and just call `IServiceProvider.GetService` every time?)

# Alternatives

I added this feature in the least intrusive way possible, but we may actually want to have a proper dependency injection support with a more complex interface than `IServiceProvider` and two default implementations (one that doesn't do DI at all and the other one the same as the current one). Maybe for 3.0?