### PR TITLE
Add missing fields to Presence

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -19,5 +19,9 @@ namespace Discord
         ///     Gets the set of clients where this user is currently active.
         /// </summary>
         IImmutableSet<ClientType> ActiveClients { get; }
+        /// <summary>
+        ///     Gets the list of activities that this user currently has available.
+        /// </summary>
+        IImmutableList<IActivity> Activities { get; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Presence.cs
+++ b/src/Discord.Net.Rest/API/Common/Presence.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Discord.API
@@ -26,5 +27,9 @@ namespace Discord.API
         //   "client_status": { "desktop": "dnd", "mobile": "dnd" }
         [JsonProperty("client_status")]
         public Optional<Dictionary<string, string>> ClientStatus { get; set; }
+        [JsonProperty("activities")]
+        public List<Game> Activities { get; set; }
+        [JsonProperty("premium_since")]
+        public Optional<DateTimeOffset?> PremiumSince { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -35,6 +35,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public virtual IImmutableSet<ClientType> ActiveClients => ImmutableHashSet<ClientType>.Empty;
         /// <inheritdoc />
+        public virtual IImmutableList<IActivity> Activities => ImmutableList<IActivity>.Empty;
+        /// <inheritdoc />
         public virtual bool IsWebhook => false;
 
         internal RestUser(BaseDiscordClient discord, ulong id)

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -340,7 +340,7 @@ namespace Discord.WebSocket
             {
                 var user = SocketGlobalUser.Create(this, state, model);
                 user.GlobalUser.AddRef();
-                user.Presence = new SocketPresence(UserStatus.Online, null, null);
+                user.Presence = new SocketPresence(UserStatus.Online, null, null, null);
                 return user;
             });
         }
@@ -448,7 +448,7 @@ namespace Discord.WebSocket
                 return;
             var status = Status;
             var statusSince = _statusSince;
-            CurrentUser.Presence = new SocketPresence(status, Activity, null);
+            CurrentUser.Presence = new SocketPresence(status, Activity, null, null);
 
             var gameModel = new GameModel();
             // Discord only accepts rich presence over RPC, don't even bother building a payload

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -154,6 +154,8 @@ namespace Discord.WebSocket
                 Nickname = model.Nick.Value;
             if (model.Roles.IsSpecified)
                 UpdateRoles(model.Roles.Value);
+            if (model.PremiumSince.IsSpecified)
+                _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
         }
         private void UpdateRoles(ulong[] roleIds)
         {

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
@@ -25,7 +25,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override bool IsWebhook => false;
         /// <inheritdoc />
-        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null, null); } set { } }
+        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null, null, null); } set { } }
         /// <inheritdoc />
         /// <exception cref="NotSupportedException">This field is not supported for an unknown user.</exception>
         internal override SocketGlobalUser GlobalUser =>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -41,6 +41,8 @@ namespace Discord.WebSocket
         public UserStatus Status => Presence.Status;
         /// <inheritdoc />
         public IImmutableSet<ClientType> ActiveClients => Presence.ActiveClients ?? ImmutableHashSet<ClientType>.Empty;
+        /// <inheritdoc />
+        public IImmutableList<IActivity> Activities => Presence.Activities ?? ImmutableList<IActivity>.Empty;
         /// <summary>
         ///     Gets mutual guilds shared with this user.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -30,7 +30,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override bool IsWebhook => true;
         /// <inheritdoc />
-        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null, null); } set { } }
+        internal override SocketPresence Presence { get { return new SocketPresence(UserStatus.Offline, null, null, null); } set { } }
         internal override SocketGlobalUser GlobalUser => 
             throw new NotSupportedException();
 


### PR DESCRIPTION
## Summary

There's two fields missing for presences, `activities`, making impossible to get more than one (it's possible, for example, to have a custom status [CustomStatus] and a game [Playing]), and `premium_since`.
This PR will make possible to get all their current activities and update since when they are boosting a server with `PRESENCE_UPDATE`.

Fixes #1428 

## Changes
- Added the property `IImmutableList<IActivity> Activities` to `IPresence`
- Update `SocketGuildUser.PremiumSince` with `PRESENCE_UPDATE`s
- `SocketPresence.ActiveClients` won't ever be `null` now (or `SocketPresence.Activities`)