### PR TITLE
Use GetMethods instead of DeclaredMethods to allow for inherited commands

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -135,7 +135,8 @@ namespace Discord.Commands
             if (builder.Name == null)
                 builder.Name = typeInfo.Name;
 
-            var validCommands = typeInfo.DeclaredMethods.Where(IsValidCommandDefinition);
+            // Get all methods (including from inherited members), that are valid commands
+            var validCommands = typeInfo.GetMethods().Where(IsValidCommandDefinition);
 
             foreach (var method in validCommands)
             {


### PR DESCRIPTION
## Summary
This change allows modules to inherit Commands, as currently there is no easy way to do this.
It makes a lot of logical sense for this to happen, as classes can be inherited, and most modules are classes. It also means you have to write less code in some cases, which is always nice.

### Changes
Using the GetMethods method instead of the DeclaredMethods property when getting all methods within a module. This includes inherited members.

### Issues
Very slightly impacts performance of `ModuleClassBuilder`, as built in methods `ToString`, `GetHashCode`, `GetType` and `Equals` are also included with `GetMethods` and have to be checked. But unless you have thousands of modules this will likely not be an issue.

### Improvements
Some sort of `[InheritCommandsAttribute(bool)]` could be added, but it doesn't seem necessary.

### Example use case
My use case is adding CRUD methods to a database. Instead of having to create each of these methods for every entity I add to the database, I can have just one abstract module that I inherit for every entity, significantly reducing the amount of work I need to do.

 
