### PR TITLE
fix: AllowedMentions and AllowedMentionTypes

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
@@ -9,10 +9,13 @@ namespace Discord
     public enum AllowedMentionTypes
     {
         /// <summary>
-        ///     No flag was set.
+        ///     No flag is set.
         /// </summary>
         /// <remarks>
-        ///     It is not used to control mentions and does not mean no mentions will be allowed.
+        ///     This flag is not used to control mentions.
+        ///     <note type="warning">
+        ///         It will always be present and does not mean mentions will not be allowed.
+        ///     </note>
         /// </remarks>
         None        = 0,
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
@@ -11,14 +11,14 @@ namespace Discord
         /// <summary>
         ///     Controls role mentions.
         /// </summary>
-        Roles,
+        Roles       = 1,
         /// <summary>
         ///     Controls user mentions.
         /// </summary>
-        Users,
+        Users       = 2,
         /// <summary>
         ///     Controls <code>@everyone</code> and <code>@here</code> mentions.
         /// </summary>
-        Everyone,
+        Everyone    = 4,
     }
 }

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentionTypes.cs
@@ -9,6 +9,13 @@ namespace Discord
     public enum AllowedMentionTypes
     {
         /// <summary>
+        ///     No flag was set.
+        /// </summary>
+        /// <remarks>
+        ///     It is not used to control mentions and does not mean no mentions will be allowed.
+        /// </remarks>
+        None        = 0,
+        /// <summary>
         ///     Controls role mentions.
         /// </summary>
         Roles       = 1,

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -39,7 +39,7 @@ namespace Discord
         ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
         ///     must be <c>null</c> or empty.
         /// </summary>
-        public List<ulong> RoleIds { get; set; }
+        public List<ulong> RoleIds { get; set; } = new List<ulong>();
 
         /// <summary>
         ///     Gets or sets the list of all user ids that will be mentioned.
@@ -47,7 +47,7 @@ namespace Discord
         ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
         ///     must be <c>null</c> or empty.
         /// </summary>
-        public List<ulong> UserIds { get; set; }
+        public List<ulong> UserIds { get; set; } = new List<ulong>();
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="AllowedMentions"/> class.


### PR DESCRIPTION
## Summary

Currently the values for the flag enum `AllowedMentionTypes` aren't there, so they won't work as expected.

## Changes

- Changed member values
- Added None as 0
- Initialized `UserIds` and `RoleIds` lists