### PR TITLE
feature: Add Direction.Around to GetMessagesAsync

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -119,7 +119,7 @@ namespace Discord.Rest
                     return GetMessagesAsync(channel, client, fromMessageId.Value + 1, Direction.Before, around + 1, options) //Need to include the message itself
                         .Concat(GetMessagesAsync(channel, client, fromMessageId, Direction.After, around, options));
                 else //Shouldn't happen since there's no public overload for ulong? and Direction
-                    return GetMessagesAsync(channel, client, null, Direction.Before, around, options);
+                    return GetMessagesAsync(channel, client, null, Direction.Before, around + 1, options);
             }
 
             return new PagedAsyncEnumerable<RestMessage>(

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -63,26 +63,8 @@ namespace Discord.WebSocket
                 if (!_messages.TryGetValue(fromMessageId.Value, out SocketMessage msg))
                     return ImmutableArray<SocketMessage>.Empty;
                 int around = limit / 2;
-                var before = _orderedMessages
-                    .Where(x => x < fromMessageId.Value)
-                    .Select(x =>
-                    {
-                        if (_messages.TryGetValue(x, out SocketMessage msg))
-                            return msg;
-                        return null;
-                    })
-                    .Where(x => x != null)
-                    .Take(around);
-                var after = _orderedMessages
-                    .Where(x => x > fromMessageId.Value)
-                    .Select(x =>
-                    {
-                        if (_messages.TryGetValue(x, out SocketMessage msg))
-                            return msg;
-                        return null;
-                    })
-                    .Where(x => x != null)
-                    .Take(around);
+                var before = GetMany(fromMessageId, Direction.Before, around);
+                var after = GetMany(fromMessageId, Direction.After, around);
 
                 return before.Concat(new SocketMessage[] { msg }).Concat(after).ToImmutableArray();
             }

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -71,8 +71,8 @@ namespace Discord.WebSocket
 
             if (dir == Direction.Before)
                 cachedMessageIds = cachedMessageIds.Reverse();
-            if (dir == Direction.Around)
-                limit /= 2;
+            if (dir == Direction.Around) //Only happens if fromMessageId is null, should only get "around" and itself (+1)
+                limit = limit / 2 + 1;
 
             return cachedMessageIds
                 .Select(x =>

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -64,9 +64,9 @@ namespace Discord.WebSocket
                     return ImmutableArray<SocketMessage>.Empty;
                 int around = limit / 2;
                 var before = GetMany(fromMessageId, Direction.Before, around);
-                var after = GetMany(fromMessageId, Direction.After, around);
+                var after = GetMany(fromMessageId, Direction.After, around).Reverse();
 
-                return before.Concat(new SocketMessage[] { msg }).Concat(after).ToImmutableArray();
+                return after.Concat(new SocketMessage[] { msg }).Concat(before).ToImmutableArray();
             }
 
             if (dir == Direction.Before)


### PR DESCRIPTION
## Summary

This PR will add the missing implementation for Direction.Around.
If the limit is inside the max for discord, it will use "around", otherwise it'll query before and after since discord doesn't give any other ways to do it.

## Changes

- Add Direction.Around logic for cache and rest
- Do not return empty pages if cache doesn't have any
- Use cache for Direction.After when possible