### PR TITLE
News channel message publish

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -58,13 +58,16 @@ namespace Discord
         Task UnpinAsync(RequestOptions options = null);
 
         /// <summary>
-        ///     Publish this message when executed in a News Channel.
+        ///     Publish (crosspost) this message.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation for publishing this message.
         /// </returns>
-        Task PublishAsync(RequestOptions options = null);
+        /// <remarks>
+        ///     Publishing (crossposting) is only available in news channels.
+        /// </remarks>
+        Task CrosspostAsync(RequestOptions options = null);
 
         /// <summary>
         ///     Transforms this message's text into a human-readable form by resolving its tags.

--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -58,14 +58,17 @@ namespace Discord
         Task UnpinAsync(RequestOptions options = null);
 
         /// <summary>
-        ///     Publish (crosspost) this message.
+        ///     Publishes (crossposts) this message.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation for publishing this message.
         /// </returns>
         /// <remarks>
-        ///     Publishing (crossposting) is only available in news channels.
+        ///     <note type="warning">
+        ///         This call will throw an <see cref="InvalidOperationException"/> if attempted in a non-news channel.
+        ///     </note>
+        ///     This method will publish (crosspost) the message. Please note, publishing (crossposting), is only available in news channels.
         /// </remarks>
         Task CrosspostAsync(RequestOptions options = null);
 

--- a/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IUserMessage.cs
@@ -58,6 +58,15 @@ namespace Discord
         Task UnpinAsync(RequestOptions options = null);
 
         /// <summary>
+        ///     Publish this message when executed in a News Channel.
+        /// </summary>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation for publishing this message.
+        /// </returns>
+        Task PublishAsync(RequestOptions options = null);
+
+        /// <summary>
         ///     Transforms this message's text into a human-readable form by resolving its tags.
         /// </summary>
         /// <param name="userHandling">Determines how the user tag should be handled.</param>

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -695,6 +695,15 @@ namespace Discord.API
             var ids = new BucketIds(channelId: channelId);
             await SendAsync("POST", () => $"channels/{channelId}/typing", ids, options: options).ConfigureAwait(false);
         }
+        public async Task PublishAsync(ulong channelId, ulong messageId, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(channelId, 0, nameof(channelId));
+            Preconditions.NotEqual(messageId, 0, nameof(messageId));
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(channelId: channelId);
+            await SendAsync("POST", () => $"channels/{channelId}/messages/{messageId}/crosspost", ids, options: options).ConfigureAwait(false);
+        }
 
         //Channel Permissions
         public async Task ModifyChannelPermissionsAsync(ulong channelId, ulong targetId, ModifyChannelPermissionsParams args, RequestOptions options = null)

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -695,7 +695,7 @@ namespace Discord.API
             var ids = new BucketIds(channelId: channelId);
             await SendAsync("POST", () => $"channels/{channelId}/typing", ids, options: options).ConfigureAwait(false);
         }
-        public async Task PublishAsync(ulong channelId, ulong messageId, RequestOptions options = null)
+        public async Task CrosspostAsync(ulong channelId, ulong messageId, RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));
             Preconditions.NotEqual(messageId, 0, nameof(messageId));

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -44,8 +44,10 @@ namespace Discord.Rest
             };
             return await client.ApiClient.ModifyMessageAsync(msg.Channel.Id, msg.Id, apiArgs, options).ConfigureAwait(false);
         }
+
         public static Task DeleteAsync(IMessage msg, BaseDiscordClient client, RequestOptions options)
             => DeleteAsync(msg.Channel.Id, msg.Id, client, options);
+
         public static async Task DeleteAsync(ulong channelId, ulong msgId, BaseDiscordClient client,
             RequestOptions options)
         {
@@ -115,6 +117,7 @@ namespace Discord.Rest
         {
             await client.ApiClient.AddPinAsync(msg.Channel.Id, msg.Id, options).ConfigureAwait(false);
         }
+
         public static async Task UnpinAsync(IMessage msg, BaseDiscordClient client,
             RequestOptions options)
         {
@@ -240,6 +243,7 @@ namespace Discord.Rest
 
             return tags.ToImmutable();
         }
+
         private static int? FindIndex(IReadOnlyList<ITag> tags, int index)
         {
             int i = 0;
@@ -253,6 +257,7 @@ namespace Discord.Rest
                 return null; //Overlaps tag before this
             return i;
         }
+
         public static ImmutableArray<ulong> FilterTagsByKey(TagType type, ImmutableArray<ITag> tags)
         {
             return tags
@@ -260,6 +265,7 @@ namespace Discord.Rest
                 .Select(x => x.Key)
                 .ToImmutableArray();
         }
+
         public static ImmutableArray<T> FilterTagsByValue<T>(TagType type, ImmutableArray<ITag> tags)
         {
             return tags
@@ -278,6 +284,15 @@ namespace Discord.Rest
             else if (msg.Author.GetValueOrDefault()?.Bot.GetValueOrDefault(false) == true)
                 return MessageSource.Bot;
             return MessageSource.User;
+        }
+
+        public static Task PublishAsync(IMessage msg, BaseDiscordClient client, RequestOptions options)
+            => PublishAsync(msg.Channel.Id, msg.Id, client, options);
+
+        public static async Task PublishAsync(ulong channelId, ulong msgId, BaseDiscordClient client,
+            RequestOptions options)
+        {
+            await client.ApiClient.PublishAsync(channelId, msgId, options).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -286,13 +286,13 @@ namespace Discord.Rest
             return MessageSource.User;
         }
 
-        public static Task PublishAsync(IMessage msg, BaseDiscordClient client, RequestOptions options)
-            => PublishAsync(msg.Channel.Id, msg.Id, client, options);
+        public static Task CrosspostAsync(IMessage msg, BaseDiscordClient client, RequestOptions options)
+            => CrosspostAsync(msg.Channel.Id, msg.Id, client, options);
 
-        public static async Task PublishAsync(ulong channelId, ulong msgId, BaseDiscordClient client,
+        public static async Task CrosspostAsync(ulong channelId, ulong msgId, BaseDiscordClient client,
             RequestOptions options)
         {
-            await client.ApiClient.PublishAsync(channelId, msgId, options).ConfigureAwait(false);
+            await client.ApiClient.CrosspostAsync(channelId, msgId, options).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -165,7 +165,7 @@ namespace Discord.Rest
         IReadOnlyCollection<IEmbed> IMessage.Embeds => Embeds;
         /// <inheritdoc />
         IReadOnlyCollection<ulong> IMessage.MentionedUserIds => MentionedUsers.Select(x => x.Id).ToImmutableArray();
-       
+
         /// <inheritdoc />
         public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => _reactions.ToDictionary(x => x.Emote, x => new ReactionMetadata { ReactionCount = x.Count, IsMe = x.Me });
 

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -148,12 +148,15 @@ namespace Discord.Rest
             TagHandling roleHandling = TagHandling.Name, TagHandling everyoneHandling = TagHandling.Ignore, TagHandling emojiHandling = TagHandling.Name)
             => MentionUtils.Resolve(this, 0, userHandling, channelHandling, roleHandling, everyoneHandling, emojiHandling);
 
-        public async Task PublishAsync(RequestOptions options = null)
+        /// <inheritdoc />
+        public async Task CrosspostAsync(RequestOptions options = null)
         {
-            if (Channel.GetType() == typeof(RestNewsChannel))
+            if (!(Channel is RestNewsChannel))
             {
-                await MessageHelper.PublishAsync(this, Discord, options);
+                throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");
             }
+
+            await MessageHelper.CrosspostAsync(this, Discord, options);
         }
 
         private string DebuggerDisplay => $"{Author}: {Content} ({Id}{(Attachments.Count > 0 ? $", {Attachments.Count} Attachments" : "")})";

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -149,8 +149,10 @@ namespace Discord.Rest
             => MentionUtils.Resolve(this, 0, userHandling, channelHandling, roleHandling, everyoneHandling, emojiHandling);
 
         /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="RestNewsChannel"/> channel.</exception>
         public async Task CrosspostAsync(RequestOptions options = null)
         {
+            // Validate that the channel is of type RestNewsChannel
             if (!(Channel is RestNewsChannel))
             {
                 throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -152,7 +152,6 @@ namespace Discord.Rest
         /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="RestNewsChannel"/> channel.</exception>
         public async Task CrosspostAsync(RequestOptions options = null)
         {
-            // Validate that the channel is of type RestNewsChannel
             if (!(Channel is RestNewsChannel))
             {
                 throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -148,6 +148,14 @@ namespace Discord.Rest
             TagHandling roleHandling = TagHandling.Name, TagHandling everyoneHandling = TagHandling.Ignore, TagHandling emojiHandling = TagHandling.Name)
             => MentionUtils.Resolve(this, 0, userHandling, channelHandling, roleHandling, everyoneHandling, emojiHandling);
 
+        public async Task PublishAsync(RequestOptions options = null)
+        {
+            if (Channel.GetType() == typeof(RestNewsChannel))
+            {
+                await MessageHelper.PublishAsync(this, Discord, options);
+            }
+        }
+
         private string DebuggerDisplay => $"{Author}: {Content} ({Id}{(Attachments.Count > 0 ? $", {Attachments.Count} Attachments" : "")})";
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -147,16 +147,19 @@ namespace Discord.WebSocket
         public string Resolve(TagHandling userHandling = TagHandling.Name, TagHandling channelHandling = TagHandling.Name,
             TagHandling roleHandling = TagHandling.Name, TagHandling everyoneHandling = TagHandling.Ignore, TagHandling emojiHandling = TagHandling.Name)
             => MentionUtils.Resolve(this, 0, userHandling, channelHandling, roleHandling, everyoneHandling, emojiHandling);
-        
+
+        /// <inheritdoc />
+        public async Task CrosspostAsync(RequestOptions options = null)
+        {
+            if (!(Channel is SocketNewsChannel))
+            {
+                throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");
+            }
+
+            await MessageHelper.CrosspostAsync(this, Discord, options);
+        }
+
         private string DebuggerDisplay => $"{Author}: {Content} ({Id}{(Attachments.Count > 0 ? $", {Attachments.Count} Attachments" : "")})";
         internal new SocketUserMessage Clone() => MemberwiseClone() as SocketUserMessage;
-
-        public async Task PublishAsync(RequestOptions options = null)
-        {
-            if (Channel.GetType() == typeof(SocketNewsChannel))
-            {
-                await MessageHelper.PublishAsync(this, Discord, options);
-            }
-        }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -152,7 +152,6 @@ namespace Discord.WebSocket
         /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="SocketNewsChannel"/> channel.</exception>
         public async Task CrosspostAsync(RequestOptions options = null)
         {
-            // Validate that the channel is of type SocketNewsChannel
             if (!(Channel is SocketNewsChannel))
             {
                 throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -149,8 +149,10 @@ namespace Discord.WebSocket
             => MentionUtils.Resolve(this, 0, userHandling, channelHandling, roleHandling, everyoneHandling, emojiHandling);
 
         /// <inheritdoc />
+        /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="SocketNewsChannel"/> channel.</exception>
         public async Task CrosspostAsync(RequestOptions options = null)
         {
+            // Validate that the channel is of type SocketNewsChannel
             if (!(Channel is SocketNewsChannel))
             {
                 throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -123,7 +123,7 @@ namespace Discord.WebSocket
                 model.Content = text;
             }
         }
-        
+
         /// <inheritdoc />
         /// <exception cref="InvalidOperationException">Only the author of a message may modify the message.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
@@ -150,5 +150,13 @@ namespace Discord.WebSocket
         
         private string DebuggerDisplay => $"{Author}: {Content} ({Id}{(Attachments.Count > 0 ? $", {Attachments.Count} Attachments" : "")})";
         internal new SocketUserMessage Clone() => MemberwiseClone() as SocketUserMessage;
+
+        public async Task PublishAsync(RequestOptions options = null)
+        {
+            if (Channel.GetType() == typeof(SocketNewsChannel))
+            {
+                await MessageHelper.PublishAsync(this, Discord, options);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds in the ability to Publish a new message within a news chnanel. If the channel type is not a news channel, it'll ignore the request to publish. I thought about returning an error here, and this could easily be added. 

Resolves #1528 

## Changes

Addition of the API handler for /crosspost endpoint. 
Addition of PublishAsync to the Socket and Rest Messages.
Only executes if the channels are news channel types.