### PR TITLE
Made Channel ID Nullable per API documentation

### DIFF
--- a/src/Discord.Net.Rest/API/Common/GuildEmbed.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildEmbed.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -8,6 +8,6 @@ namespace Discord.API
         [JsonProperty("enabled")]
         public bool Enabled { get; set; }
         [JsonProperty("channel_id")]
-        public ulong ChannelId { get; set; }
+        public ulong? ChannelId { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Per Discord API documentation - Guild embed response can return a null value for Channel ID. 

https://discord.com/developers/docs/resources/guild#guild-widget-object

Resolves #1513 

## Changes

Made ChannelId property nullable

