### PR TITLE
fix: NullRef at GUILD_DELETE

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1771,17 +1771,7 @@ namespace Discord.WebSocket
             return guild;
         }
         internal SocketGuild RemoveGuild(ulong id)
-        {
-            var guild = State.RemoveGuild(id);
-            if (guild != null)
-            {
-                foreach (var _ in guild.Channels)
-                    State.RemoveChannel(id);
-                foreach (var user in guild.Users)
-                    user.GlobalUser.RemoveRef(this);
-            }
-            return guild;
-        }
+            => State.RemoveGuild(id);
 
         /// <exception cref="InvalidOperationException">Unexpected channel type is created.</exception>
         internal ISocketPrivateChannel AddPrivateChannel(API.Channel model, ClientState state)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -809,13 +809,14 @@ namespace Discord.WebSocket
             var members = Users;
             var self = CurrentUser;
             _members.Clear();
-            _members.TryAdd(self.Id, self);
+            if (self != null)
+                _members.TryAdd(self.Id, self);
 
             DownloadedMemberCount = _members.Count;
 
             foreach (var member in members)
             {
-                if (member.Id != self.Id)
+                if (member.Id != self?.Id)
                     member.GlobalUser.RemoveRef(Discord);
             }
         }


### PR DESCRIPTION
## Summary

When leaving a guild `GUILD_MEMBER_REMOVE` will be received before `GUILD_DELETE`, so it'll remove the self reference to the bot that will then throw a null ref at `GUILD_DELETE` and not raise the event due to it.

Also removed unnecessary code from `DiscordSocketClient.RemoveGuild` since the same will be done in `StateClient.RemoveGuild` (and the channel remove was wrong, using the guild id).

Fixes #1541 

## Changes

- Check for null in `SocketGuild.PurgeGuildUserCache`
- Remove unnecessary code in `DiscordSocketClient.RemoveGuild`