### PR TITLE
feature: Add MESSAGE_REACTION_REMOVE_EMOJI and RemoveAllReactionsForEmoteAsync

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -215,6 +215,15 @@ namespace Discord
         ///     A task that represents the asynchronous removal operation.
         /// </returns>
         Task RemoveAllReactionsAsync(RequestOptions options = null);
+        /// <summary>
+        ///     Removes all reactions with a specific emoji from this message.
+        /// </summary>
+        /// <param name="emote">The emoji used to react to this message.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous removal operation.
+        /// </returns>
+        Task RemoveAllReactionsForEmoteAsync(IEmote emote, RequestOptions options = null);
 
         /// <summary>
         ///     Gets all users that reacted to a message with a given emote.

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -660,6 +660,18 @@ namespace Discord.API
 
             await SendAsync("DELETE", () => $"channels/{channelId}/messages/{messageId}/reactions", ids, options: options).ConfigureAwait(false);
         }
+        public async Task RemoveAllReactionsForEmoteAsync(ulong channelId, ulong messageId, string emoji, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(channelId, 0, nameof(channelId));
+            Preconditions.NotEqual(messageId, 0, nameof(messageId));
+            Preconditions.NotNullOrWhitespace(emoji, nameof(emoji));
+
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(channelId: channelId);
+
+            await SendAsync("DELETE", () => $"channels/{channelId}/messages/{messageId}/reactions/{emoji}", ids, options: options).ConfigureAwait(false);
+        }
         public async Task<IReadOnlyCollection<User>> GetReactionUsersAsync(ulong channelId, ulong messageId, string emoji, GetReactionUsersParams args, RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -78,6 +78,11 @@ namespace Discord.Rest
             await client.ApiClient.RemoveAllReactionsAsync(msg.Channel.Id, msg.Id, options).ConfigureAwait(false);
         }
 
+        public static async Task RemoveAllReactionsForEmoteAsync(IMessage msg, IEmote emote, BaseDiscordClient client, RequestOptions options)
+        {
+            await client.ApiClient.RemoveAllReactionsForEmoteAsync(msg.Channel.Id, msg.Id, emote is Emote e ? $"{e.Name}:{e.Id}" : emote.Name, options).ConfigureAwait(false);
+        }
+
         public static IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IMessage msg, IEmote emote,
             int? limit, BaseDiscordClient client, RequestOptions options)
         {

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -182,6 +182,9 @@ namespace Discord.Rest
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsAsync(this, Discord, options);
         /// <inheritdoc />
+        public Task RemoveAllReactionsForEmoteAsync(IEmote emote, RequestOptions options = null)
+            => MessageHelper.RemoveAllReactionsForEmoteAsync(this, emote, Discord, options);
+        /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emote, int limit, RequestOptions options = null)
             => MessageHelper.GetReactionUsersAsync(this, emote, limit, Discord, options);
     }

--- a/src/Discord.Net.WebSocket/API/Gateway/RemoveAllReactionsForEmoteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/RemoveAllReactionsForEmoteEvent.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Discord.API.Gateway
+{
+    internal class RemoveAllReactionsForEmoteEvent
+    {
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; set; }
+        [JsonProperty("guild_id")]
+        public Optional<ulong> GuildId { get; set; }
+        [JsonProperty("message_id")]
+        public ulong MessageId { get; set; }
+        [JsonProperty("emoji")]
+        public Emoji Emoji { get; set; }
+    }
+}

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -234,6 +234,28 @@ namespace Discord.WebSocket
             remove { _reactionsClearedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
+        /// <summary>
+        ///     Fired when all reactions to a message with a specific emote are removed.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         This event is fired when all reactions to a message with a specific emote are removed.
+        ///         The event handler must return a <see cref="Task"/> and accept a <see cref="ISocketMessageChannel"/> and
+        ///         a <see cref="IEmote"/> as its parameters.
+        ///     </para>
+        ///     <para>
+        ///         The channel where this message was sent will be passed into the <see cref="ISocketMessageChannel"/> parameter.
+        ///     </para>
+        ///     <para>
+        ///         The emoji that all reactions had and were removed will be passed into the <see cref="IEmote"/> parameter.
+        ///     </para>
+        /// </remarks>
+        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, IEmote, Task> ReactionsRemovedForEmote
+        {
+            add { _reactionsRemovedForEmoteEvent.Add(value); }
+            remove { _reactionsRemovedForEmoteEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, IEmote, Task>> _reactionsRemovedForEmoteEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, IEmote, Task>>();
 
         //Roles
         /// <summary> Fired when a role is created. </summary>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -313,6 +313,7 @@ namespace Discord.WebSocket
             client.ReactionAdded += (cache, channel, reaction) => _reactionAddedEvent.InvokeAsync(cache, channel, reaction);
             client.ReactionRemoved += (cache, channel, reaction) => _reactionRemovedEvent.InvokeAsync(cache, channel, reaction);
             client.ReactionsCleared += (cache, channel) => _reactionsClearedEvent.InvokeAsync(cache, channel);
+            client.ReactionsRemovedForEmote += (cache, channel, emote) => _reactionsRemovedForEmoteEvent.InvokeAsync(cache, channel, emote);
 
             client.RoleCreated += (role) => _roleCreatedEvent.InvokeAsync(role);
             client.RoleDeleted += (role) => _roleDeletedEvent.InvokeAsync(role);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1406,12 +1406,7 @@ namespace Discord.WebSocket
                                             : Optional.Create(cachedMsg);
 
                                         var cacheable = new Cacheable<IUserMessage, ulong>(cachedMsg, data.MessageId, isCached, async () => await channel.GetMessageAsync(data.MessageId).ConfigureAwait(false) as IUserMessage);
-
-                                        IEmote emote;
-                                        if (data.Emoji.Id.HasValue)
-                                            emote = new Emote(data.Emoji.Id.Value, data.Emoji.Name, data.Emoji.Animated.GetValueOrDefault());
-                                        else
-                                            emote = new Emoji(data.Emoji.Name);
+                                        var emote = data.Emoji.ToIEmote();
 
                                         cachedMsg?.RemoveAllReactionsForEmoteAsync(emote);
 

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -200,6 +200,10 @@ namespace Discord.WebSocket
         {
             _reactions.Clear();
         }
+        internal void RemoveReactionsForEmote(IEmote emote)
+        {
+            _reactions.RemoveAll(x => x.Emote.Equals(emote));
+        }
 
         /// <inheritdoc />
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
@@ -213,6 +217,9 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsAsync(this, Discord, options);
+        /// <inheritdoc />
+        public Task RemoveAllReactionsForEmoteAsync(IEmote emote, RequestOptions options = null)
+            => MessageHelper.RemoveAllReactionsForEmoteAsync(this, emote, Discord, options);
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emote, int limit, RequestOptions options = null)
             => MessageHelper.GetReactionUsersAsync(this, emote, limit, Discord, options);


### PR DESCRIPTION
## Summary

This PR will add a new method, `RemoveAllReactionsForEmoteAsync`, that will remove all reactions with a specific emote from a message and add a new event related to it, `MESSAGE_REACTION_REMOVE_EMOJI`.

Fixes #1543 

## Changes
- Add method `RemoveAllReactionsForEmoteAsync` to `IMessage`
- Add event `ReactionsRemovedForEmote`