### PR TITLE
MutualGuilds optimization

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -44,6 +44,9 @@ namespace Discord.WebSocket
         /// <summary>
         ///     Gets mutual guilds shared with this user.
         /// </summary>
+        /// <remarks>
+        ///     This property will only include guilds in the same <see cref="DiscordSocketClient"/>.
+        /// </remarks>
         public IReadOnlyCollection<SocketGuild> MutualGuilds
             => Discord.Guilds.Where(g => g.GetUser(Id) != null).ToImmutableArray();
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -45,7 +45,7 @@ namespace Discord.WebSocket
         ///     Gets mutual guilds shared with this user.
         /// </summary>
         public IReadOnlyCollection<SocketGuild> MutualGuilds
-            => Discord.Guilds.Where(g => g.Users.Any(u => u.Id == Id)).ToImmutableArray();
+            => Discord.Guilds.Where(g => g.GetUser(Id) != null).ToImmutableArray();
 
         internal SocketUser(DiscordSocketClient discord, ulong id)
             : base(discord, id)


### PR DESCRIPTION
## Summary

Currently `MutualGuilds` will create a new `IReadOnlyCollection` and loop in it [O(N)], when it could only do a dictionary check [O(1)] with `GetUser` to avoid it.

It might also be confusing for `DiscordShardedClient`s expecting it to retrieve all mutual guilds, when it's limited to the shard it currently is in, so added a remark to it.

## Changes

- Change `.Users.Any(x => x.Id == Id)` to `.GetUser(Id) != null`
- Add remark to `MutualGuilds`