### PR TITLE
fix: Different ratelimits for the same route (implement discord buckets)

### DIFF
--- a/src/Discord.Net.Core/Net/BucketId.cs
+++ b/src/Discord.Net.Core/Net/BucketId.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Discord.Net
+{
+    public class BucketId : IEquatable<BucketId>
+    {
+        public string HttpMethod { get; }
+        public string Endpoint { get; }
+        public IOrderedEnumerable<KeyValuePair<string, string>> MajorParams { get; }
+        public string BucketHash { get; }
+
+        public bool IsHashBucket { get => BucketHash != null; }
+
+        private BucketId(string httpMethod, string endpoint, IEnumerable<KeyValuePair<string, string>> majorParams, string bucketHash)
+        {
+            HttpMethod = httpMethod;
+            Endpoint = endpoint;
+            MajorParams = majorParams.OrderBy(x => x.Key);
+            BucketHash = bucketHash;
+        }
+
+        public static BucketId Create(string httpMethod, string endpoint, Dictionary<string, string> majorParams)
+        {
+            Preconditions.NotNullOrWhitespace(httpMethod, nameof(httpMethod));
+            Preconditions.NotNullOrWhitespace(endpoint, nameof(endpoint));
+            majorParams ??= new Dictionary<string, string>();
+            return new BucketId(httpMethod, endpoint, majorParams, null);
+        }
+
+        public static BucketId Create(string hash, BucketId oldBucket)
+        {
+            Preconditions.NotNullOrWhitespace(hash, nameof(hash));
+            Preconditions.NotNull(oldBucket, nameof(oldBucket));
+            return new BucketId(null, null, oldBucket.MajorParams, hash);
+        }
+
+        public string GetBucketHash()
+            => IsHashBucket ? $"{BucketHash}:{string.Join("/", MajorParams.Select(x => x.Value))}" : null;
+
+        public string GetUniqueEndpoint()
+            => HttpMethod != null ? $"{HttpMethod} {Endpoint}" : Endpoint;
+
+        public override bool Equals(object obj)
+            => Equals(obj as BucketId);
+
+        public override int GetHashCode()
+            =>  IsHashBucket ? (BucketHash, string.Join("/", MajorParams.Select(x => x.Value))).GetHashCode() : (HttpMethod, Endpoint).GetHashCode();
+
+        public override string ToString()
+            => GetBucketHash() ?? GetUniqueEndpoint();
+
+        public bool Equals(BucketId other)
+        {
+            if (other is null)
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            if (GetType() != other.GetType())
+                return false;
+            return ToString() == other.ToString();
+        }        
+    }
+}

--- a/src/Discord.Net.Core/Net/BucketId.cs
+++ b/src/Discord.Net.Core/Net/BucketId.cs
@@ -5,41 +5,93 @@ using System.Linq;
 
 namespace Discord.Net
 {
+    /// <summary>
+    ///     Represents a ratelimit bucket.
+    /// </summary>
     public class BucketId : IEquatable<BucketId>
     {
+        /// <summary>
+        ///     Gets the http method used to make the request if available.
+        /// </summary>
         public string HttpMethod { get; }
+        /// <summary>
+        ///     Gets the endpoint that is going to be requested if available.
+        /// </summary>
         public string Endpoint { get; }
-        public IOrderedEnumerable<KeyValuePair<string, string>> MajorParams { get; }
+        /// <summary>
+        ///     Gets the major parameters of the route.
+        /// </summary>
+        public IOrderedEnumerable<KeyValuePair<string, string>> MajorParameters { get; }
+        /// <summary>
+        ///     Gets the hash of this bucket.
+        /// </summary>
+        /// <remarks>
+        ///     The hash is provided by Discord to group ratelimits.
+        /// </remarks>
         public string BucketHash { get; }
-
+        /// <summary>
+        ///     Gets if this bucket is a hash type.
+        /// </summary>
         public bool IsHashBucket { get => BucketHash != null; }
 
-        private BucketId(string httpMethod, string endpoint, IEnumerable<KeyValuePair<string, string>> majorParams, string bucketHash)
+        private BucketId(string httpMethod, string endpoint, IEnumerable<KeyValuePair<string, string>> majorParameters, string bucketHash)
         {
             HttpMethod = httpMethod;
             Endpoint = endpoint;
-            MajorParams = majorParams.OrderBy(x => x.Key);
+            MajorParameters = majorParameters.OrderBy(x => x.Key);
             BucketHash = bucketHash;
         }
 
+        /// <summary>
+        ///     Creates a new <see cref="BucketId"/> based on the
+        ///     <see cref="HttpMethod"/> and <see cref="Endpoint"/>.
+        /// </summary>
+        /// <param name="httpMethod">Http method used to make the request.</param>
+        /// <param name="endpoint">Endpoint that is going to receive requests.</param>
+        /// <param name="majorParams">Major parameters of the route of this endpoint.</param>
+        /// <returns>
+        ///     A <see cref="BucketId"/> based on the <see cref="HttpMethod"/>
+        ///     and the <see cref="Endpoint"> with the provided data.
+        /// </returns>
         public static BucketId Create(string httpMethod, string endpoint, Dictionary<string, string> majorParams)
         {
-            Preconditions.NotNullOrWhitespace(httpMethod, nameof(httpMethod));
             Preconditions.NotNullOrWhitespace(endpoint, nameof(endpoint));
             majorParams ??= new Dictionary<string, string>();
             return new BucketId(httpMethod, endpoint, majorParams, null);
         }
 
+        /// <summary>
+        ///     Creates a new <see cref="BucketId"/> based on a
+        ///     <see cref="BucketHash"/> and a previous <see cref="BucketId"/>.
+        /// </summary>
+        /// <param name="hash">Bucket hash provided by Discord.</param>
+        /// <param name="oldBucket"><see cref="BucketId"/> that is going to be upgraded to a hash type.</param>
+        /// <returns>
+        ///     A <see cref="BucketId"/> based on the <see cref="BucketHash"/>
+        ///     and <see cref="MajorParameters"/>.
+        /// </returns>
         public static BucketId Create(string hash, BucketId oldBucket)
         {
             Preconditions.NotNullOrWhitespace(hash, nameof(hash));
             Preconditions.NotNull(oldBucket, nameof(oldBucket));
-            return new BucketId(null, null, oldBucket.MajorParams, hash);
+            return new BucketId(null, null, oldBucket.MajorParameters, hash);
         }
 
+        /// <summary>
+        ///     Gets the string that will define this bucket as a hash based one.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string"/> that defines this bucket as a hash based one.
+        /// </returns>
         public string GetBucketHash()
-            => IsHashBucket ? $"{BucketHash}:{string.Join("/", MajorParams.Select(x => x.Value))}" : null;
+            => IsHashBucket ? $"{BucketHash}:{string.Join("/", MajorParameters.Select(x => x.Value))}" : null;
 
+        /// <summary>
+        ///     Gets the string that will define this bucket as an endpoint based one.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="string"/> that defines this bucket as an endpoint based one.
+        /// </returns>
         public string GetUniqueEndpoint()
             => HttpMethod != null ? $"{HttpMethod} {Endpoint}" : Endpoint;
 
@@ -47,7 +99,7 @@ namespace Discord.Net
             => Equals(obj as BucketId);
 
         public override int GetHashCode()
-            =>  IsHashBucket ? (BucketHash, string.Join("/", MajorParams.Select(x => x.Value))).GetHashCode() : (HttpMethod, Endpoint).GetHashCode();
+            =>  IsHashBucket ? (BucketHash, string.Join("/", MajorParameters.Select(x => x.Value))).GetHashCode() : (HttpMethod, Endpoint).GetHashCode();
 
         public override string ToString()
             => GetBucketHash() ?? GetUniqueEndpoint();

--- a/src/Discord.Net.Core/Net/BucketId.cs
+++ b/src/Discord.Net.Core/Net/BucketId.cs
@@ -51,7 +51,7 @@ namespace Discord.Net
         /// <param name="majorParams">Major parameters of the route of this endpoint.</param>
         /// <returns>
         ///     A <see cref="BucketId"/> based on the <see cref="HttpMethod"/>
-        ///     and the <see cref="Endpoint"> with the provided data.
+        ///     and the <see cref="Endpoint"/> with the provided data.
         /// </returns>
         public static BucketId Create(string httpMethod, string endpoint, Dictionary<string, string> majorParams)
         {

--- a/src/Discord.Net.Core/RequestOptions.cs
+++ b/src/Discord.Net.Core/RequestOptions.cs
@@ -1,3 +1,4 @@
+using Discord.Net;
 using System.Threading;
 
 namespace Discord
@@ -57,7 +58,7 @@ namespace Discord
 		public bool? UseSystemClock { get; set; }
 
         internal bool IgnoreState { get; set; }
-        internal string BucketId { get; set; }
+        internal BucketId BucketId { get; set; }
         internal bool IsClientBucket { get; set; }
         internal bool IsReactionBucket { get; set; }
 

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -49,9 +49,9 @@ namespace Discord.Rest
             ApiClient.RequestQueue.RateLimitTriggered += async (id, info) =>
             {
                 if (info == null)
-                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {id ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
                 else
-                    await _restLogger.WarningAsync($"Rate limit triggered: {id ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.WarningAsync($"Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
             };
             ApiClient.SentRequest += async (method, endpoint, millis) => await _restLogger.VerboseAsync($"{method} {endpoint}: {millis} ms").ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1490,7 +1490,6 @@ namespace Discord.API
         private static BucketId GetBucketId(string httpMethod, BucketIds ids, Expression<Func<string>> endpointExpr, string callingMethod)
         {
             ids.HttpMethod ??= httpMethod;
-            Debug.WriteLine("GetBucketId: " + CreateBucketId(endpointExpr)(ids));
             return _bucketIdGenerators.GetOrAdd(callingMethod, x => CreateBucketId(endpointExpr))(ids);
         }
 

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -524,7 +524,8 @@ namespace Discord.API
                 throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
             options = RequestOptions.CreateOrClone(options);
 
-            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args, new BucketIds(), clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            var ids = new BucketIds(webhookId: webhookId);
+            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         public async Task<Message> UploadFileAsync(ulong channelId, UploadFileParams args, RequestOptions options = null)
@@ -563,7 +564,8 @@ namespace Discord.API
                     throw new ArgumentOutOfRangeException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
             }
 
-            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args.ToDictionary(), new BucketIds(), clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            var ids = new BucketIds(webhookId: webhookId);
+            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
         public async Task DeleteMessageAsync(ulong channelId, ulong messageId, RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/Net/Queue/ClientBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/ClientBucket.cs
@@ -10,14 +10,14 @@ namespace Discord.Net.Queue
     internal struct ClientBucket
     {
         private static readonly ImmutableDictionary<ClientBucketType, ClientBucket> DefsByType;
-        private static readonly ImmutableDictionary<string, ClientBucket> DefsById;
+        private static readonly ImmutableDictionary<BucketId, ClientBucket> DefsById;
 
         static ClientBucket()
         {
             var buckets = new[]
             {
-                new ClientBucket(ClientBucketType.Unbucketed, "<unbucketed>", 10, 10),
-                new ClientBucket(ClientBucketType.SendEdit, "<send_edit>", 10, 10)
+                new ClientBucket(ClientBucketType.Unbucketed, BucketId.Create(null, "<unbucketed>", null), 10, 10),
+                new ClientBucket(ClientBucketType.SendEdit, BucketId.Create(null, "<send_edit>", null), 10, 10)
             };
 
             var builder = ImmutableDictionary.CreateBuilder<ClientBucketType, ClientBucket>();
@@ -25,21 +25,21 @@ namespace Discord.Net.Queue
                 builder.Add(bucket.Type, bucket);
             DefsByType = builder.ToImmutable();
 
-            var builder2 = ImmutableDictionary.CreateBuilder<string, ClientBucket>();
+            var builder2 = ImmutableDictionary.CreateBuilder<BucketId, ClientBucket>();
             foreach (var bucket in buckets)
                 builder2.Add(bucket.Id, bucket);
             DefsById = builder2.ToImmutable();
         }
 
         public static ClientBucket Get(ClientBucketType type) => DefsByType[type];
-        public static ClientBucket Get(string id) => DefsById[id];
+        public static ClientBucket Get(BucketId id) => DefsById[id];
         
         public ClientBucketType Type { get; }
-        public string Id { get; }
+        public BucketId Id { get; }
         public int WindowCount { get; }
         public int WindowSeconds { get; }
 
-        public ClientBucket(ClientBucketType type, string id, int count, int seconds)
+        public ClientBucket(ClientBucketType type, BucketId id, int count, int seconds)
         {
             Type = type;
             Id = id;

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
@@ -125,16 +125,16 @@ namespace Discord.Net.Queue
         {
             await RateLimitTriggered(bucketId, info).ConfigureAwait(false);
         }
-        internal BucketId UpdateBucketHash(BucketId id, string discordHash)
+        internal (RequestBucket, BucketId) UpdateBucketHash(BucketId id, string discordHash)
         {
             if (!id.IsHashBucket)
             {
                 var bucket = BucketId.Create(discordHash, id);
-                _buckets.GetOrAdd(bucket, _buckets[id]);
+                var hashReqQueue = (RequestBucket)_buckets.GetOrAdd(bucket, _buckets[id]);
                 _buckets.AddOrUpdate(id, bucket, (oldBucket, oldObj) => bucket);
-                return bucket;
+                return (hashReqQueue, bucket);
             }
-            return null;
+            return (null, null);
         }
 
         private async Task RunCleanup()

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -233,6 +233,9 @@ namespace Discord.Net.Queue
 #endif
                 }
 
+                if (info.Bucket != null)
+                    _queue.UpdateBucketHash(request.Options.BucketId, info.Bucket);
+
                 var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 DateTimeOffset? resetTick = null;
 

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -20,11 +20,11 @@ namespace Discord.Net.Queue
         private int _semaphore;
         private DateTimeOffset? _resetTick;
 
-        public string Id { get; private set; }
+        public BucketId Id { get; private set; }
         public int WindowCount { get; private set; }
         public DateTimeOffset LastAttemptAt { get; private set; }
 
-        public RequestBucket(RequestQueue queue, RestRequest request, string id)
+        public RequestBucket(RequestQueue queue, RestRequest request, BucketId id)
         {
             _queue = queue;
             Id = id;
@@ -234,7 +234,7 @@ namespace Discord.Net.Queue
                 }
 
                 if (info.Bucket != null)
-                    _queue.UpdateBucketHash(request.Options.BucketId, info.Bucket);
+                    Id = _queue.UpdateBucketHash(request.Options.BucketId, info.Bucket) ?? Id;
 
                 var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 DateTimeOffset? resetTick = null;

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -277,16 +277,16 @@ namespace Discord.Net.Queue
 #endif
                 }
 
-                /*if (resetTick == null)
+                if (resetTick == null)
                 {
-                    WindowCount = 0; //No rate limit info, disable limits on this bucket (should only ever happen with a user token)
+                    WindowCount = 0; //No rate limit info, disable limits on this bucket
 #if DEBUG_LIMITS
                     Debug.WriteLine($"[{id}] Disabled Semaphore");
 #endif
                     return;
-                }*/
+                }
 
-                if (resetTick != null && (!hasQueuedReset || resetTick > _resetTick))
+                if (!hasQueuedReset || resetTick > _resetTick)
                 {
                     _resetTick = resetTick;
                     LastAttemptAt = resetTick.Value; //Make sure we dont destroy this until after its been reset
@@ -299,8 +299,6 @@ namespace Discord.Net.Queue
                         var _ = QueueReset(id, (int)Math.Ceiling((_resetTick.Value - DateTimeOffset.UtcNow).TotalMilliseconds));
                     }
                 }
-                else if (!hasQueuedReset && _semaphore == 0)
-                    _semaphore = WindowCount; //Prevent getting locked at 0/1 if Discord doesn't send the ratelimit headers
             }
         }
         private async Task QueueReset(int id, int millis)

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -181,8 +181,8 @@ namespace Discord.Net.Queue
                 }
 
                 DateTimeOffset? timeoutAt = request.TimeoutAt;
-                int semaphore = 0;
-                if (windowCount > 0 && (semaphore = Interlocked.Decrement(ref _semaphore)) < 0)
+                int semaphore = Interlocked.Decrement(ref _semaphore);
+                if (windowCount > 0 && semaphore < 0)
                 {
                     if (!isRateLimited)
                     {
@@ -291,6 +291,9 @@ namespace Discord.Net.Queue
                 else if (info.ResetAfter.HasValue && (request.Options.UseSystemClock.HasValue ? !request.Options.UseSystemClock.Value : false))
                 {
                     resetTick = DateTimeOffset.UtcNow.Add(info.ResetAfter.Value);
+#if DEBUG_LIMITS
+                    Debug.WriteLine($"[{id}] Reset-After: {info.ResetAfter.Value} ({info.ResetAfter?.TotalMilliseconds} ms)");
+#endif
                 }
                 else if (info.Reset.HasValue)
                 {

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -277,16 +277,16 @@ namespace Discord.Net.Queue
 #endif
                 }
 
-                if (resetTick == null)
+                /*if (resetTick == null)
                 {
                     WindowCount = 0; //No rate limit info, disable limits on this bucket (should only ever happen with a user token)
 #if DEBUG_LIMITS
                     Debug.WriteLine($"[{id}] Disabled Semaphore");
 #endif
                     return;
-                }
+                }*/
 
-                if (!hasQueuedReset || resetTick > _resetTick)
+                if (resetTick != null && (!hasQueuedReset || resetTick > _resetTick))
                 {
                     _resetTick = resetTick;
                     LastAttemptAt = resetTick.Value; //Make sure we dont destroy this until after its been reset
@@ -299,6 +299,8 @@ namespace Discord.Net.Queue
                         var _ = QueueReset(id, (int)Math.Ceiling((_resetTick.Value - DateTimeOffset.UtcNow).TotalMilliseconds));
                     }
                 }
+                else if (!hasQueuedReset && _semaphore == 0)
+                    _semaphore = WindowCount; //Prevent getting locked at 0/1 if Discord doesn't send the ratelimit headers
             }
         }
         private async Task QueueReset(int id, int millis)

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -19,6 +19,7 @@ namespace Discord.Net.Queue
         private readonly RequestQueue _queue;
         private int _semaphore;
         private DateTimeOffset? _resetTick;
+        private RequestBucket _redirectBucket;
 
         public BucketId Id { get; private set; }
         public int WindowCount { get; private set; }
@@ -52,6 +53,8 @@ namespace Discord.Net.Queue
             {
                 await _queue.EnterGlobalAsync(id, request).ConfigureAwait(false);
                 await EnterAsync(id, request).ConfigureAwait(false);
+                if (_redirectBucket != null)
+                    return await _redirectBucket.SendAsync(request);
 
 #if DEBUG_LIMITS
                 Debug.WriteLine($"[{id}] Sending...");
@@ -160,6 +163,9 @@ namespace Discord.Net.Queue
 
             while (true)
             {
+                if (_redirectBucket != null)
+                    break;
+
                 if (DateTimeOffset.UtcNow > request.TimeoutAt || request.Options.CancelToken.IsCancellationRequested)
                 {
                     if (!isRateLimited)
@@ -216,13 +222,15 @@ namespace Discord.Net.Queue
             }
         }
 
-        private void UpdateRateLimit(int id, RestRequest request, RateLimitInfo info, bool is429)
+        private void UpdateRateLimit(int id, RestRequest request, RateLimitInfo info, bool is429, bool redirected = false)
         {
             if (WindowCount == 0)
                 return;
 
             lock (_lock)
             {
+                if (redirected)
+                    Interlocked.Decrement(ref _semaphore); //we might still hit a real ratelimit if all tickets were already taken, can't do much about it since we didn't know they were the same
                 bool hasQueuedReset = _resetTick != null;
                 if (info.Limit.HasValue && WindowCount != info.Limit.Value)
                 {
@@ -233,10 +241,20 @@ namespace Discord.Net.Queue
 #endif
                 }
 
-                if (info.Bucket != null)
-                    Id = _queue.UpdateBucketHash(request.Options.BucketId, info.Bucket) ?? Id;
+                if (info.Bucket != null && !redirected)
+                {
+                    (RequestBucket, BucketId) hashBucket = _queue.UpdateBucketHash(request.Options.BucketId, info.Bucket);
+                    if (hashBucket.Item1 is null || hashBucket.Item2 is null)
+                        return;
+                    if (hashBucket.Item1 == this) //this bucket got promoted to a hash queue
+                        Id = hashBucket.Item2;
+                    else
+                    {
+                        _redirectBucket = hashBucket.Item1; //this request should be part of another bucket, this bucket will be disabled, redirect everything
+                        _redirectBucket.UpdateRateLimit(id, request, info, is429, redirected: true); //update the hash bucket ratelimit
+                    }
+                }
 
-                var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 DateTimeOffset? resetTick = null;
 
                 //Using X-RateLimit-Remaining causes a race condition
@@ -253,16 +271,15 @@ namespace Discord.Net.Queue
                     Debug.WriteLine($"[{id}] Retry-After: {info.RetryAfter.Value} ({info.RetryAfter.Value} ms)");
 #endif
                 }
-				else if (info.ResetAfter.HasValue && (request.Options.UseSystemClock.HasValue ? !request.Options.UseSystemClock.Value : false))
-				{
-					resetTick = DateTimeOffset.UtcNow.Add(info.ResetAfter.Value);
-				}
+                else if (info.ResetAfter.HasValue && (request.Options.UseSystemClock.HasValue ? !request.Options.UseSystemClock.Value : false))
+                {
+                    resetTick = DateTimeOffset.UtcNow.Add(info.ResetAfter.Value);
+                }
                 else if (info.Reset.HasValue)
                 {
                     resetTick = info.Reset.Value.AddSeconds(info.Lag?.TotalSeconds ?? 1.0);
 
-					/* millisecond precision makes this unnecessary, retaining in case of regression
-
+                    /* millisecond precision makes this unnecessary, retaining in case of regression
                     if (request.Options.IsReactionBucket)
                         resetTick = DateTimeOffset.Now.AddMilliseconds(250);
 					*/

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -12,6 +12,7 @@ namespace Discord.Net
         public int? RetryAfter { get; }
         public DateTimeOffset? Reset { get; }
 		    public TimeSpan? ResetAfter { get; }
+        public string Bucket { get; }
         public TimeSpan? Lag { get; }
 
         internal RateLimitInfo(Dictionary<string, string> headers)
@@ -28,6 +29,7 @@ namespace Discord.Net
                 int.TryParse(temp, NumberStyles.None, CultureInfo.InvariantCulture, out var retryAfter) ? retryAfter : (int?)null;
 			      ResetAfter = headers.TryGetValue("X-RateLimit-Reset-After", out temp) && 
 				        float.TryParse(temp, out var resetAfter) ? TimeSpan.FromMilliseconds((long)(resetAfter * 1000)) : (TimeSpan?)null;
+            Bucket = headers.TryGetValue("X-RateLimit-Bucket", out temp) ? temp : null;
             Lag = headers.TryGetValue("Date", out temp) &&
                 DateTimeOffset.TryParse(temp, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ? DateTimeOffset.UtcNow - date : (TimeSpan?)null;
         }

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -11,7 +11,7 @@ namespace Discord.Net
         public int? Remaining { get; }
         public int? RetryAfter { get; }
         public DateTimeOffset? Reset { get; }
-		    public TimeSpan? ResetAfter { get; }
+        public TimeSpan? ResetAfter { get; }
         public string Bucket { get; }
         public TimeSpan? Lag { get; }
 
@@ -27,8 +27,8 @@ namespace Discord.Net
                 double.TryParse(temp, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var reset) ? DateTimeOffset.FromUnixTimeMilliseconds((long)(reset * 1000)) : (DateTimeOffset?)null;
             RetryAfter = headers.TryGetValue("Retry-After", out temp) &&
                 int.TryParse(temp, NumberStyles.None, CultureInfo.InvariantCulture, out var retryAfter) ? retryAfter : (int?)null;
-			      ResetAfter = headers.TryGetValue("X-RateLimit-Reset-After", out temp) && 
-				        float.TryParse(temp, out var resetAfter) ? TimeSpan.FromMilliseconds((long)(resetAfter * 1000)) : (TimeSpan?)null;
+			ResetAfter = headers.TryGetValue("X-RateLimit-Reset-After", out temp) &&
+                double.TryParse(temp, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var resetAfter) ? TimeSpan.FromMilliseconds((long)(resetAfter * 1000)) : (TimeSpan?)null;
             Bucket = headers.TryGetValue("X-RateLimit-Bucket", out temp) ? temp : null;
             Lag = headers.TryGetValue("Date", out temp) &&
                 DateTimeOffset.TryParse(temp, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ? DateTimeOffset.UtcNow - date : (TimeSpan?)null;

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -77,9 +77,9 @@ namespace Discord.Webhook
             ApiClient.RequestQueue.RateLimitTriggered += async (id, info) =>
             {
                 if (info == null)
-                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {id ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
                 else
-                    await _restLogger.WarningAsync($"Rate limit triggered: {id ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.WarningAsync($"Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
             };
             ApiClient.SentRequest += async (method, endpoint, millis) => await _restLogger.VerboseAsync($"{method} {endpoint}: {millis} ms").ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary

The same route can have different ratelimits depending on the http method (post, patch, get, ...) and different endpoints can share the same limit on their route.

An example would be `GetMessageAsync` and `IUserMessage.ModifyAsync` that are `GET channels/{channel.id}/messages` and `PATCH channels/{channel.id}/messages` that would previously have the same bucket, `channels/{channel.id}/messages`, but GET has no specific limit, while PATCH does.

The issue happening was:
1. GetMessageAsync is called, it's GET
2. No ratelimit header is returned, so the semaphore is disabled
3. ModifyAsync is called, it's PATCH, but the endpoint is the same so it gets the same bucket as GET
4. The semaphore is disabled so it won't update the limits or try to delay

An easy way to repro it without this fix:
```cs
var c = Context.Client.GetChannel(/*channelId*/) as SocketTextChannel;
var m = await c.GetMessageAsync(/*messageId*/) as IUserMessage; //This will disable the semaphore
for (int i = 0; i < 20; i++)
    _ = m.ModifyAsync(x => x.Content = "test"); //This will trigger the ratelimit (not the preemptive)
```

Fixes #1535 

## Changes

- Add HttpMethod when generating the bucket id.
- Add `X-RateLimit-Bucket` to `RateLimitInfo`
- Add `WebhookId` as a major parameter into `BucketIds`
- Changed the bucket list to fit two kinds of KVPs, Hash and Endpoint Buckets (Hash are shared limits by one or more endpoints, so the list will redirect them to it)
- Add `BucketId` as it's own class
- Change all places that used the bucket id as a `string` to the `BucketId` class

## References

[https://github.com/discord/discord-api-docs/issues/981](https://github.com/discord/discord-api-docs/issues/981)
[https://github.com/discord/discord-api-docs/issues/1551](https://github.com/discord/discord-api-docs/issues/1551)
[https://discord.com/developers/docs/topics/rate-limits#header-format](https://discord.com/developers/docs/topics/rate-limits#header-format)