### PR TITLE
fix: Incomplete Ready, DownloadUsersAsync, and optimize AlwaysDownloadUsers

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -21,7 +21,12 @@ namespace Discord.WebSocket
             remove { _disconnectedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<Exception, Task>> _disconnectedEvent = new AsyncEvent<Func<Exception, Task>>();
-        /// <summary> Fired when guild data has finished downloading. </summary>
+        /// <summary>
+        ///     Fired when guild data has finished downloading.
+        /// </summary>
+        /// <remarks>
+        ///     It is possible that some guilds might be unsynced if <see cref="DiscordSocketConfig.MaxWaitBetweenGuildAvailablesBeforeReady" /> was not long enough to receive all GUILD_AVAILABLES before READY.
+        /// </remarks>
         public event Func<Task> Ready
         {
             add { _readyEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -25,7 +25,7 @@ namespace Discord.WebSocket
         ///     Fired when guild data has finished downloading.
         /// </summary>
         /// <remarks>
-        ///     It is possible that some guilds might be unsynced if <see cref="DiscordSocketConfig.MaxWaitBetweenGuildAvailablesBeforeReady" /> was not long enough to receive all GUILD_AVAILABLES before READY.
+        ///     It is possible that some guilds might be unsynced if <see cref="DiscordSocketConfig.MaxWaitBetweenGuildAvailablesBeforeReady" /> was not long enough to receive all GUILD_AVAILABLEs before READY.
         /// </remarks>
         public event Func<Task> Ready
         {

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.Events.cs
@@ -25,7 +25,8 @@ namespace Discord.WebSocket
         ///     Fired when guild data has finished downloading.
         /// </summary>
         /// <remarks>
-        ///     It is possible that some guilds might be unsynced if <see cref="DiscordSocketConfig.MaxWaitBetweenGuildAvailablesBeforeReady" /> was not long enough to receive all GUILD_AVAILABLEs before READY.
+        ///     It is possible that some guilds might be unsynced if <see cref="DiscordSocketConfig.MaxWaitBetweenGuildAvailablesBeforeReady" />
+        ///     was not long enough to receive all GUILD_AVAILABLEs before READY.
         /// </remarks>
         public event Func<Task> Ready
         {

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -368,7 +368,7 @@ namespace Discord.WebSocket
         {
             var cachedGuilds = guilds.ToImmutableArray();
 
-            const short batchSize = 1000; //TODO: Gateway Intents will limit to a maximum of 1 guild_id
+            const short batchSize = 100; //TODO: Gateway Intents will limit to a maximum of 1 guild_id
             ulong[] batchIds = new ulong[Math.Min(batchSize, cachedGuilds.Length)];
             Task[] batchTasks = new Task[batchIds.Length];
             int batchCount = (cachedGuilds.Length + (batchSize - 1)) / batchSize;
@@ -376,7 +376,7 @@ namespace Discord.WebSocket
             for (int i = 0, k = 0; i < batchCount; i++)
             {
                 bool isLast = i == batchCount - 1;
-                int count = isLast ? (batchIds.Length - (batchCount - 1) * batchSize) : batchSize;
+                int count = isLast ? (cachedGuilds.Length - (batchCount - 1) * batchSize) : batchSize;
 
                 for (int j = 0; j < count; j++, k++)
                 {

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -125,6 +125,32 @@ namespace Discord.WebSocket
         public bool GuildSubscriptions { get; set; } = true;
 
         /// <summary>
+        ///     Gets or sets the maximum wait time in milliseconds between GUILD_AVAILABLE events before firing READY.
+        ///
+        ///     If zero, READY will fire as soon as it is received and all guilds will be unavailable.
+        /// </summary>
+        /// <remarks>
+        ///     <para>This property is measured in milliseconds, negative values will throw an exception.</para>
+        ///     <para>If a guild is not received before READY, it will be unavailable.</para>
+        /// </remarks>
+        /// <returns>
+        ///     The maximum wait time in milliseconds between GUILD_AVAILABLE events before firing READY.
+        /// </returns>
+        /// <exception cref="System.ArgumentException">Value must be at least 0.</exception>
+        public int MaxWaitBetweenGuildAvailablesBeforeReady {
+            get
+            {
+                return _maxWaitForGuildAvailable;
+            }
+            set
+            {
+                Preconditions.AtLeast(value, 0, nameof(MaxWaitBetweenGuildAvailablesBeforeReady));
+                _maxWaitForGuildAvailable = value;
+            }
+        }
+        private int _maxWaitForGuildAvailable = 10000;
+
+        /// <summary>
         ///     Initializes a default configuration.
         /// </summary>
         public DiscordSocketConfig()


### PR DESCRIPTION
## Summary

There were three issues related to how these were being done:
- It was possible to Ready to fire before downloading all guild data because some large guilds can take more than two seconds to be received so it will assume it's over. I was able to always reproduce this locally with Discord API (the guild) with a small bot, would take a lot more time.
- AlwaysDownloadUsers would fire one gateway request to download members per guild, making it easily reach the gateway limit of 120 requests per minute, when this request, without gateway intents, can receive an array of `guild_id`s (tested up to 200, but limited to 100 since it isn't documented).
- The wrong variable was being used to calculate `count` in `DownloadUsersAsync`, returning a negative number.

## Changes

- Add property `MaxWaitBetweenGuildAvailablesBeforeReady` to `DiscordSocketConfig` that will let the user decide how long they want to wait, zero being an option (firing READY without waiting GUILD_AVAILABLEs).
- Change default wait time to 10,000ms instead of 2,000ms (large guilds can take more time than 2 seconds) to avoid firing READY before all guild data is downloaded.
- Adjust the maximum batch size for a `Request Guild Members` gateway request (tested up to 200 and it still worked fine).
- Fixed how `count` is calculated in `DownloadUsersAsync`