### PR TITLE
feature: Add GetUsersAsync to SocketGuild

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -683,6 +683,9 @@ namespace Discord
         /// <summary>
         ///     Downloads all users for this guild if the current list is incomplete.
         /// </summary>
+        /// <remarks>
+        ///     This method downloads all users found within this guild throught the Gateway and caches them.
+        /// </remarks>
         /// <returns>
         ///     A task that represents the asynchronous download operation.
         /// </returns>

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -834,7 +834,11 @@ namespace Discord.WebSocket
         ///     users found within this guild.
         /// </returns>
         public IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> GetUsersAsync(RequestOptions options = null)
-            => GuildHelper.GetUsersAsync(this, Discord, null, null, options);
+        {
+            if (HasAllMembers)
+                return ImmutableArray.Create(Users).ToAsyncEnumerable<IReadOnlyCollection<IGuildUser>>();
+            return GuildHelper.GetUsersAsync(this, Discord, null, null, options);
+        }
 
         /// <inheritdoc />
         public async Task DownloadUsersAsync()
@@ -1202,7 +1206,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IGuildUser>> IGuild.GetUsersAsync(CacheMode mode, RequestOptions options)
         {
-            if (mode == CacheMode.AllowDownload)
+            if (mode == CacheMode.AllowDownload && !HasAllMembers)
                 return (await GetUsersAsync(options).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
             else
                 return Users;

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -821,6 +821,21 @@ namespace Discord.WebSocket
             }
         }
 
+        /// <summary>
+        ///     Gets a collection of all users in this guild.
+        /// </summary>
+        /// <remarks>
+        ///     <para>This method retrieves all users found within this guild throught REST.</para>
+        ///     <para>Users returned by this method are not cached.</para>
+        /// </remarks>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains a collection of guild
+        ///     users found within this guild.
+        /// </returns>
+        public IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> GetUsersAsync(RequestOptions options = null)
+            => GuildHelper.GetUsersAsync(this, Discord, null, null, options);
+
         /// <inheritdoc />
         public async Task DownloadUsersAsync()
         {
@@ -1185,8 +1200,13 @@ namespace Discord.WebSocket
             => await CreateRoleAsync(name, permissions, color, isHoisted, isMentionable, options).ConfigureAwait(false);
 
         /// <inheritdoc />
-        Task<IReadOnlyCollection<IGuildUser>> IGuild.GetUsersAsync(CacheMode mode, RequestOptions options)
-            => Task.FromResult<IReadOnlyCollection<IGuildUser>>(Users);
+        async Task<IReadOnlyCollection<IGuildUser>> IGuild.GetUsersAsync(CacheMode mode, RequestOptions options)
+        {
+            if (mode == CacheMode.AllowDownload)
+                return (await GetUsersAsync(options).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
+            else
+                return ImmutableArray.Create<IGuildUser>();
+        }
 
         /// <inheritdoc />
         async Task<IGuildUser> IGuild.AddGuildUserAsync(ulong userId, string accessToken, Action<AddGuildUserProperties> func, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1205,7 +1205,7 @@ namespace Discord.WebSocket
             if (mode == CacheMode.AllowDownload)
                 return (await GetUsersAsync(options).FlattenAsync().ConfigureAwait(false)).ToImmutableArray();
             else
-                return ImmutableArray.Create<IGuildUser>();
+                return Users;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

This will add the possibility to get the guild members throught REST, following the same standard as socket channels for messages.

There's a few reasons I believe this should be added:
- There's no way to get all members throught REST without having a `RestGuild`.
- The REST ratelimit is a lot higher than Gateway (better for small guilds with just a few thousands members or less).
- Doesn't keep users cached (vs downloading then purging).

## Changes

- Add `GetUsersAsync` to `SocketGuild`
- Add remark to `DownloadUsersAsync` for a better description of how it does