### PR TITLE
fix: InvalidOperationException at MESSAGE_CREATE

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -140,7 +140,7 @@ namespace Discord.WebSocket
                 Activity = new MessageActivity()
                 {
                     Type = model.Activity.Value.Type.Value,
-                    PartyId = model.Activity.Value.PartyId.Value
+                    PartyId = model.Activity.Value.PartyId.GetValueOrDefault()
                 };
             }
 


### PR DESCRIPTION
## Summary

If PartyId isn't present, Discord.Net will throw an InvalidOperationException and not raise `MessageReceived`.
Got this a few times with my bot, stacktrace:
```
System.InvalidOperationException: This property has no value set.
   at Discord.Optional`1.get_Value() in ...\Discord.Net\src\Discord.Net.Core\Utils\Optional.cs:line 20
   at Discord.WebSocket.SocketMessage.Update(ClientState state, Message model) in ...\Discord.Net\src\Discord.Net.WebSocket\Entities\Messages\SocketMessage.cs:line 157
   at Discord.WebSocket.SocketUserMessage.Update(ClientState state, Message model) in ...\Discord.Net\src\Discord.Net.WebSocket\Entities\Messages\SocketUserMessage.cs:line 58
   at Discord.WebSocket.SocketUserMessage.Create(DiscordSocketClient discord, ClientState state, SocketUser author, ISocketMessageChannel channel, Message model) in ...\Discord.Net\src\Discord.Net.WebSocket\Entities\Messages\SocketUserMessage.cs:line 53
   at Discord.WebSocket.DiscordSocketClient.ProcessMessageAsync(GatewayOpCode opCode, Nullable`1 seq, String type, Object payload) in ...\Discord.Net\src\Discord.Net.WebSocket\DiscordSocketClient.cs:line 1210
```

After looking all properties, this is the only one that could be blamed and was already fixed for `RestMessage`s, see #1337 

## Changes

- `Value` to `GetValueOrDefault()` for `PartyId`