### PR TITLE
Fix: Sending 2 requests instead of 1 to create a Guild role.

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/CreateGuildRoleParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildRoleParams.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace Discord.API.Rest
+{
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    public class CreateGuildRoleParams
+    {
+        [JsonProperty("name")]
+        public Optional<string> Name { get; set; }
+        [JsonProperty("permissions")]
+        public Optional<ulong> Permissions { get; set; }
+        [JsonProperty("color")]
+        public Optional<uint> Color { get; set; }
+        [JsonProperty("hoist")]
+        public Optional<bool> Hoist { get; set; }
+        [JsonProperty("mentionable")]
+        public Optional<bool> Mentionable { get; set; }
+    }
+    }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1146,13 +1146,13 @@ namespace Discord.API
             var ids = new BucketIds(guildId: guildId);
             return await SendAsync<IReadOnlyCollection<Role>>("GET", () => $"guilds/{guildId}/roles", ids, options: options).ConfigureAwait(false);
         }
-        public async Task<Role> CreateGuildRoleAsync(ulong guildId, RequestOptions options = null)
+        public async Task<Role> CreateGuildRoleAsync(ulong guildId, Rest.CreateGuildRoleParams args, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(guildId: guildId);
-            return await SendAsync<Role>("POST", () => $"guilds/{guildId}/roles", ids, options: options).ConfigureAwait(false);
+            return await SendJsonAsync<Role>("POST", () => $"guilds/{guildId}/roles", args, ids, options: options).ConfigureAwait(false);
         }
         public async Task DeleteGuildRoleAsync(ulong guildId, ulong roleId, RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -264,19 +264,18 @@ namespace Discord.Rest
         {
             if (name == null) throw new ArgumentNullException(paramName: nameof(name));
 
-            var model = await client.ApiClient.CreateGuildRoleAsync(guild.Id, options).ConfigureAwait(false);
-            var role = RestRole.Create(client, guild, model);
-
-            await role.ModifyAsync(x =>
+            var createGuildRoleParams = new API.Rest.CreateGuildRoleParams
             {
-                x.Name = name;
-                x.Permissions = (permissions ?? role.Permissions);
-                x.Color = (color ?? Color.Default);
-                x.Hoist = isHoisted;
-                x.Mentionable = isMentionable;
-            }, options).ConfigureAwait(false);
+                Color = color?.RawValue ?? Optional.Create<uint>(),
+                Hoist = isHoisted,
+                Mentionable = isMentionable,
+                Name = name,
+                Permissions = permissions?.RawValue ?? Optional.Create<ulong>()
+            };
 
-            return role;
+            var model = await client.ApiClient.CreateGuildRoleAsync(guild.Id, createGuildRoleParams, options).ConfigureAwait(false);
+
+            return RestRole.Create(client, guild, model);
         }
 
         //Users


### PR DESCRIPTION
### Summary
---
The GuildHelper.CreateRoleAsync() was sending 2 requests to create a role. One to create the role, and one to modify the role after it was created. 
This can be done in one request. So i have moved it to a single request to lower the amount of requests send to the api. 
This will also solve issue [#1451](https://github.com/discord-net/Discord.Net/issues/1451) where it it was successfully creating a role, but getting stuck on the modify request.

### Changes
---
- Added API.Rest.CreateGuildRoleParams.
- Changed the API request in the DiscordRestApiClient to SendJsonAsync with the the API.Rest.CreateGuildRoleParams.
- Removed role.ModifyAsync() from GuildHelper.CreateRoleAsync().

### Refrences
---

https://discord.com/developers/docs/resources/guild#create-guild-role  