### PR TITLE
Support Gateway Intents

### DIFF
--- a/src/Discord.Net.Core/GatewayIntents.cs
+++ b/src/Discord.Net.Core/GatewayIntents.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Discord
+{
+    [Flags]
+    public enum GatewayIntents
+    {
+        /// <summary> GUILD_CREATE, GUILD_UPDATE, GUILD_DELETE, GUILD_ROLE_CREATE, GUILD_ROLE_UPDATE, GUILD_ROLE_DELETE, CHANNEL_CREATE, CHANNEL_UPDATE, CHANNEL_DELETE, CHANNEL_PINS_UPDATE </summary>
+        GUILDS = 1 << 0,
+        /// <summary> GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE, GUILD_MEMBER_REMOVE </summary>
+        GUILD_MEMBERS = 1 << 1,
+        /// <summary> GUILD_BAN_ADD, GUILD_BAN_REMOVE </summary>
+        GUILD_BANS = 1 << 2,
+        /// <summary> GUILD_EMOJIS_UPDATE </summary>
+        GUILD_EMOJIS = 1 << 3,
+        /// <summary> GUILD_INTEGRATIONS_UPDATE </summary>
+        GUILD_INTEGRATIONS = 1 << 4,
+        /// <summary> WEBHOOKS_UPDATE </summary>
+        GUILD_WEBHOOKS = 1 << 5,
+        /// <summary> INVITE_CREATE, INVITE_DELETE </summary>
+        GUILD_INVITES = 1 << 6,
+        /// <summary> VOICE_STATE_UPDATE </summary>
+        GUILD_VOICE_STATES = 1 << 7,
+        /// <summary> PRESENCE_UPDATE </summary>
+        GUILD_PRESENCES = 1 << 8,
+        /// <summary> MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, MESSAGE_DELETE_BULK </summary>
+        GUILD_MESSAGES = 1 << 9,
+        /// <summary> MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE, MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI </summary>
+        GUILD_MESSAGE_REACTIONS = 1 << 10,
+        /// <summary> TYPING_START </summary>
+        GUILD_MESSAGE_TYPING = 1 << 11,
+        /// <summary> CHANNEL_CREATE, MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, CHANNEL_PINS_UPDATE </summary>
+        DIRECT_MESSAGES = 1 << 12,
+        /// <summary> MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE, MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI </summary>
+        DIRECT_MESSAGE_REACTIONS = 1 << 13,
+        /// <summary> TYPING_START </summary>
+        DIRECT_MESSAGE_TYPING = 1 << 14,
+    }
+}

--- a/src/Discord.Net.Core/GatewayIntents.cs
+++ b/src/Discord.Net.Core/GatewayIntents.cs
@@ -5,6 +5,8 @@ namespace Discord
     [Flags]
     public enum GatewayIntents
     {
+        /// <summary> This intent includes no events </summary>
+        None = 0,
         /// <summary> This intent includes GUILD_CREATE, GUILD_UPDATE, GUILD_DELETE, GUILD_ROLE_CREATE, GUILD_ROLE_UPDATE, GUILD_ROLE_DELETE, CHANNEL_CREATE, CHANNEL_UPDATE, CHANNEL_DELETE, CHANNEL_PINS_UPDATE </summary>
         Guilds = 1 << 0,
         /// <summary> This intent includes GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE, GUILD_MEMBER_REMOVE </summary>

--- a/src/Discord.Net.Core/GatewayIntents.cs
+++ b/src/Discord.Net.Core/GatewayIntents.cs
@@ -5,35 +5,35 @@ namespace Discord
     [Flags]
     public enum GatewayIntents
     {
-        /// <summary> GUILD_CREATE, GUILD_UPDATE, GUILD_DELETE, GUILD_ROLE_CREATE, GUILD_ROLE_UPDATE, GUILD_ROLE_DELETE, CHANNEL_CREATE, CHANNEL_UPDATE, CHANNEL_DELETE, CHANNEL_PINS_UPDATE </summary>
-        GUILDS = 1 << 0,
-        /// <summary> GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE, GUILD_MEMBER_REMOVE </summary>
-        GUILD_MEMBERS = 1 << 1,
-        /// <summary> GUILD_BAN_ADD, GUILD_BAN_REMOVE </summary>
-        GUILD_BANS = 1 << 2,
-        /// <summary> GUILD_EMOJIS_UPDATE </summary>
-        GUILD_EMOJIS = 1 << 3,
-        /// <summary> GUILD_INTEGRATIONS_UPDATE </summary>
-        GUILD_INTEGRATIONS = 1 << 4,
-        /// <summary> WEBHOOKS_UPDATE </summary>
-        GUILD_WEBHOOKS = 1 << 5,
-        /// <summary> INVITE_CREATE, INVITE_DELETE </summary>
-        GUILD_INVITES = 1 << 6,
-        /// <summary> VOICE_STATE_UPDATE </summary>
-        GUILD_VOICE_STATES = 1 << 7,
-        /// <summary> PRESENCE_UPDATE </summary>
-        GUILD_PRESENCES = 1 << 8,
-        /// <summary> MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, MESSAGE_DELETE_BULK </summary>
-        GUILD_MESSAGES = 1 << 9,
-        /// <summary> MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE, MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI </summary>
-        GUILD_MESSAGE_REACTIONS = 1 << 10,
-        /// <summary> TYPING_START </summary>
-        GUILD_MESSAGE_TYPING = 1 << 11,
-        /// <summary> CHANNEL_CREATE, MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, CHANNEL_PINS_UPDATE </summary>
-        DIRECT_MESSAGES = 1 << 12,
-        /// <summary> MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE, MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI </summary>
-        DIRECT_MESSAGE_REACTIONS = 1 << 13,
-        /// <summary> TYPING_START </summary>
-        DIRECT_MESSAGE_TYPING = 1 << 14,
+        /// <summary> This intent includes GUILD_CREATE, GUILD_UPDATE, GUILD_DELETE, GUILD_ROLE_CREATE, GUILD_ROLE_UPDATE, GUILD_ROLE_DELETE, CHANNEL_CREATE, CHANNEL_UPDATE, CHANNEL_DELETE, CHANNEL_PINS_UPDATE </summary>
+        Guilds = 1 << 0,
+        /// <summary> This intent includes GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE, GUILD_MEMBER_REMOVE </summary>
+        GuildMembers = 1 << 1,
+        /// <summary> This intent includes GUILD_BAN_ADD, GUILD_BAN_REMOVE </summary>
+        GuildBans = 1 << 2,
+        /// <summary> This intent includes GUILD_EMOJIS_UPDATE </summary>
+        GuildEmojis = 1 << 3,
+        /// <summary> This intent includes GUILD_INTEGRATIONS_UPDATE </summary>
+        GuildIntegrations = 1 << 4,
+        /// <summary> This intent includes WEBHOOKS_UPDATE </summary>
+        GuildWebhooks = 1 << 5,
+        /// <summary> This intent includes INVITE_CREATE, INVITE_DELETE </summary>
+        GuildInvites = 1 << 6,
+        /// <summary> This intent includes VOICE_STATE_UPDATE </summary>
+        GuildVoiceStates = 1 << 7,
+        /// <summary> This intent includes PRESENCE_UPDATE </summary>
+        GuildPresences = 1 << 8,
+        /// <summary> This intent includes MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, MESSAGE_DELETE_BULK </summary>
+        GuildMessages = 1 << 9,
+        /// <summary> This intent includes MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE, MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI </summary>
+        GuildMessageReactions = 1 << 10,
+        /// <summary> This intent includes TYPING_START </summary>
+        GuildMessageTyping = 1 << 11,
+        /// <summary> This intent includes CHANNEL_CREATE, MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, CHANNEL_PINS_UPDATE </summary>
+        DirectMessages = 1 << 12,
+        /// <summary> This intent includes MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE, MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI </summary>
+        DirectMessageReactions = 1 << 13,
+        /// <summary> This intent includes TYPING_START </summary>
+        DirectMessageTyping = 1 << 14,
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/IdentifyParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/IdentifyParams.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 using System.Collections.Generic;
 
@@ -17,5 +17,7 @@ namespace Discord.API.Gateway
         public Optional<int[]> ShardingParams { get; set; }
         [JsonProperty("guild_subscriptions")]
         public Optional<bool> GuildSubscriptions { get; set; }
+        [JsonProperty("intents")]
+        public Optional<int> Intents { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -226,7 +226,7 @@ namespace Discord.API
                 msg.ShardingParams = new int[] { shardID, totalShards };
 
             if (gatewayIntents.HasValue)
-                msg.Intents = Convert.ToInt32(gatewayIntents);
+                msg.Intents = (int)gatewayIntents.Value;
             else
                 msg.GuildSubscriptions = guildSubscriptions;
 

--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -209,7 +209,7 @@ namespace Discord.API
             await _sentGatewayMessageEvent.InvokeAsync(opCode).ConfigureAwait(false);
         }
 
-        public async Task SendIdentifyAsync(int largeThreshold = 100, int shardID = 0, int totalShards = 1, bool guildSubscriptions = true, RequestOptions options = null)
+        public async Task SendIdentifyAsync(int largeThreshold = 100, int shardID = 0, int totalShards = 1, bool guildSubscriptions = true, GatewayIntents? gatewayIntents = null, RequestOptions options = null)
         {
             options = RequestOptions.CreateOrClone(options);
             var props = new Dictionary<string, string>
@@ -220,11 +220,15 @@ namespace Discord.API
             {
                 Token = AuthToken,
                 Properties = props,
-                LargeThreshold = largeThreshold,
-                GuildSubscriptions = guildSubscriptions
+                LargeThreshold = largeThreshold
             };
             if (totalShards > 1)
                 msg.ShardingParams = new int[] { shardID, totalShards };
+
+            if (gatewayIntents.HasValue)
+                msg.Intents = Convert.ToInt32(gatewayIntents);
+            else
+                msg.GuildSubscriptions = guildSubscriptions;
 
             await SendGatewayAsync(GatewayOpCode.Identify, msg, options: options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -44,6 +44,7 @@ namespace Discord.WebSocket
         private RestApplication _applicationInfo;
         private bool _isDisposed;
         private bool _guildSubscriptions;
+        private GatewayIntents? _gatewayIntents;
 
         /// <summary>
         ///     Provides access to a REST-only client with a shared state from this client.
@@ -137,6 +138,7 @@ namespace Discord.WebSocket
             Rest = new DiscordSocketRestClient(config, ApiClient);
             _heartbeatTimes = new ConcurrentQueue<long>();
             _guildSubscriptions = config.GuildSubscriptions;
+            _gatewayIntents = config.GatewayIntents;
 
             _stateLock = new SemaphoreSlim(1, 1);
             _gatewayLogger = LogManager.CreateLogger(ShardId == 0 && TotalShards == 1 ? "Gateway" : $"Shard #{ShardId}");
@@ -242,7 +244,7 @@ namespace Discord.WebSocket
                 else
                 {
                     await _gatewayLogger.DebugAsync("Identifying").ConfigureAwait(false);
-                    await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards, guildSubscriptions: _guildSubscriptions).ConfigureAwait(false);
+                    await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards, guildSubscriptions: _guildSubscriptions, gatewayIntents: _gatewayIntents).ConfigureAwait(false);
                 }
 
                 //Wait for READY
@@ -517,7 +519,7 @@ namespace Discord.WebSocket
                             _sessionId = null;
                             _lastSeq = 0;
 
-                            await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards).ConfigureAwait(false);
+                            await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards, guildSubscriptions: _guildSubscriptions, gatewayIntents: _gatewayIntents).ConfigureAwait(false);
                         }
                         break;
                     case GatewayOpCode.Reconnect:

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -126,7 +126,7 @@ namespace Discord.WebSocket
         public bool GuildSubscriptions { get; set; } = true;
 
         /// <summary>
-        ///    Gets or sets gateway intents to limit what events are sent from Discord. Allows for more granular control than the 'GuildSubscriptions' property.
+        ///    Gets or sets gateway intents to limit what events are sent from Discord. Allows for more granular control than the <see cref="GuildSubscriptions"/> property.
         /// </summary>
         /// <remarks>
         ///     For more information, please see

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -121,6 +121,7 @@ namespace Discord.WebSocket
 
         /// <summary>
         ///     Gets or sets enabling dispatching of guild subscription events e.g. presence and typing events.
+        ///     This is not used if <see cref="GatewayIntents"/> are provided.
         /// </summary>
         public bool GuildSubscriptions { get; set; } = true;
 

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -125,6 +125,16 @@ namespace Discord.WebSocket
         public bool GuildSubscriptions { get; set; } = true;
 
         /// <summary>
+        ///    Gets or sets gateway intents to limit what events are sent from Discord. Allows for more granular control than the 'GuildSubscriptions' property.
+        /// </summary>
+        /// <remarks>
+        ///     For more information, please see
+        ///     <see href="https://discord.com/developers/docs/topics/gateway#gateway-intents">GatewayIntents</see>
+        ///     on the official Discord API documentation.
+        /// </remarks>
+        public GatewayIntents? GatewayIntents { get; set; }
+
+        /// <summary>
         ///     Initializes a default configuration.
         /// </summary>
         public DiscordSocketConfig()


### PR DESCRIPTION
Allows supplying gateway intents through DiscordSocketConfig which will be passed through the IDENTIFY payload, in order to choose what gateway events you want to receive.