### PR TITLE
feature: Support to multiple files for webhooks

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
@@ -12,9 +12,8 @@ namespace Discord.API.Rest
     {
         private static JsonSerializer _serializer = new JsonSerializer { ContractResolver = new DiscordContractResolver() };
 
-        public Stream File { get; }
+        public IEnumerable<KeyValuePair<string, Stream>> Files { get; }
 
-        public Optional<string> Filename { get; set; }
         public Optional<string> Content { get; set; }
         public Optional<string> Nonce { get; set; }
         public Optional<bool> IsTTS { get; set; }
@@ -24,19 +23,23 @@ namespace Discord.API.Rest
 
         public bool IsSpoiler { get; set; } = false;
 
-        public UploadWebhookFileParams(Stream file)
+        public UploadWebhookFileParams(IEnumerable<KeyValuePair<string, Stream>> files)
         {
-            File = file;
+            Files = files;
         }
 
         public IReadOnlyDictionary<string, object> ToDictionary()
         {
             var d = new Dictionary<string, object>();
-            var filename = Filename.GetValueOrDefault("unknown.dat");
-            if (IsSpoiler && !filename.StartsWith(AttachmentExtensions.SpoilerPrefix))
-                filename = filename.Insert(0, AttachmentExtensions.SpoilerPrefix);
 
-            d["file"] = new MultipartFile(File, filename);
+            int i = 0;
+            foreach (var file in Files)
+            {
+                var filename = file.Key ?? "unknown.dat";
+                if (IsSpoiler && !filename.StartsWith(AttachmentExtensions.SpoilerPrefix))
+                    filename = filename.Insert(0, AttachmentExtensions.SpoilerPrefix);
+                d[$"file{i++}"] = new MultipartFile(file.Value, filename);
+            }
 
             var payload = new Dictionary<string, object>();
             if (Content.IsSpecified)

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -85,30 +85,93 @@ namespace Discord.Webhook
         }
         private static API.DiscordRestApiClient CreateApiClient(DiscordRestConfig config)
             => new API.DiscordRestApiClient(config.RestClientProvider, DiscordRestConfig.UserAgent);
-        /// <summary> Sends a message to the channel for this webhook. </summary>
-        /// <returns> Returns the ID of the created message. </returns>
+
+        /// <summary>
+        ///     Sends a message to the channel for this webhook.
+        /// </summary>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embeds">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/>s to be sent.</param>
+        /// <param name="username">The username the webhook will display on this message.</param>
+        /// <param name="avatarUrl">The url to the avatar the webhook will display on this message.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     Returns the ID of the created message.
+        /// </returns>
         public Task<ulong> SendMessageAsync(string text = null, bool isTTS = false, IEnumerable<Embed> embeds = null,
             string username = null, string avatarUrl = null, RequestOptions options = null)
             => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, options);
 
-        /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
-        /// <returns> Returns the ID of the created message. </returns>
+        /// <summary>
+        ///     Sends a message to the channel for this webhook with an attachment.
+        /// </summary>
+        /// <param name="filePath">The file path of the file.</param>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embeds">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/>s to be sent.</param>
+        /// <param name="username">The username the webhook will display on this message.</param>
+        /// <param name="avatarUrl">The url to the avatar the webhook will display on this message.</param>
+        /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     Returns the ID of the created message.
+        /// </returns>
         public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
             => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
-        /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
-        /// <returns> Returns the ID of the created message. </returns>
+
+        /// <summary>
+        ///     Sends a message to the channel for this webhook with an attachment.
+        /// </summary>
+        /// <param name="stream">The stream of the file to be sent.</param>
+        /// <param name="filename">The name of the file to be sent.</param>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embeds">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/>s to be sent.</param>
+        /// <param name="username">The username the webhook will display on this message.</param>
+        /// <param name="avatarUrl">The url to the avatar the webhook will display on this message.</param>
+        /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     Returns the ID of the created message.
+        /// </returns>
         public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
             => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
 
-        /// <summary> Sends a message to the channel for this webhook with multiple attachments. </summary>
-        /// <returns> Returns the ID of the created message. </returns>
+        /// <summary>
+        ///     Sends a message to the channel for this webhook with multiple attachments.
+        /// </summary>
+        /// <param name="filePaths">The <see cref="IEnumerable{T}"/> of file paths of the files.</param>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embeds">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/>s to be sent.</param>
+        /// <param name="username">The username the webhook will display on this message.</param>
+        /// <param name="avatarUrl">The url to the avatar the webhook will display on this message.</param>
+        /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     Returns the ID of the created message.
+        /// </returns>
         public Task<ulong> SendFileAsync(IEnumerable<string> filePaths, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
             => WebhookClientHelper.SendFileAsync(this, filePaths, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
-        /// <summary> Sends a message to the channel for this webhook with multiple attachments. </summary>
-        /// <returns> Returns the ID of the created message. </returns>
+
+        /// <summary>
+        ///     Sends a message to the channel for this webhook with multiple attachments.
+        /// </summary>
+        /// <param name="streams">The <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/>
+        /// that are the filename and stream for each file.</param>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embeds">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/>s to be sent.</param>
+        /// <param name="username">The username the webhook will display on this message.</param>
+        /// <param name="avatarUrl">The url to the avatar the webhook will display on this message.</param>
+        /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     Returns the ID of the created message.
+        /// </returns>
         public Task<ulong> SendFileAsync(IEnumerable<KeyValuePair<string, Stream>> streams, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
             => WebhookClientHelper.SendFileAsync(this, streams, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -102,6 +102,17 @@ namespace Discord.Webhook
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
             => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
 
+        /// <summary> Sends a message to the channel for this webhook with multiple attachments. </summary>
+        /// <returns> Returns the ID of the created message. </returns>
+        public Task<ulong> SendFileAsync(IEnumerable<string> filePaths, string text, bool isTTS = false,
+            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
+            => WebhookClientHelper.SendFileAsync(this, filePaths, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
+        /// <summary> Sends a message to the channel for this webhook with multiple attachments. </summary>
+        /// <returns> Returns the ID of the created message. </returns>
+        public Task<ulong> SendFileAsync(IEnumerable<KeyValuePair<string, Stream>> streams, string text, bool isTTS = false,
+            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
+            => WebhookClientHelper.SendFileAsync(this, streams, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
+
         /// <summary> Modifies the properties of this webhook. </summary>
         public Task ModifyWebhookAsync(Action<WebhookProperties> func, RequestOptions options = null)
             => Webhook.ModifyAsync(func, options);


### PR DESCRIPTION
## Summary

Adds the possibility to upload multiple files with a single request.
I'm not sure if this should really be added since, while it works, it isn't something official (see [https://github.com/discord/discord-api-docs/issues/1552#issuecomment-620511268](https://github.com/discord/discord-api-docs/issues/1552#issuecomment-620511268)), so I'll leave the PR here and maybe get more input about it.

Fixes #1538 

## Changes
- Add `SendFileAsync(IEnumerable<string> filePaths, string text, bool isTTS = false, IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)` to `DiscordWebhookClient`
- Add `SendFileAsync(IEnumerable<KeyValuePair<string, Stream>> streams, string text, bool isTTS = false, IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)` to `DiscordWebhookClient`