### PR TITLE
Fix: Not using the new domain name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![NuGet](https://img.shields.io/nuget/vpre/Discord.Net.svg?maxAge=2592000?style=plastic)](https://www.nuget.org/packages/Discord.Net)
 [![MyGet](https://img.shields.io/myget/discord-net/vpre/Discord.Net.svg)](https://www.myget.org/feed/Packages/discord-net)
 [![Build Status](https://dev.azure.com/discord-net/Discord.Net/_apis/build/status/discord-net.Discord.Net?branchName=dev)](https://dev.azure.com/discord-net/Discord.Net/_build/latest?definitionId=1&branchName=dev)
-[![Discord](https://discordapp.com/api/guilds/81384788765712384/widget.png)](https://discord.gg/jkrBmQR)
+[![Discord](https://discord.com/api/guilds/81384788765712384/widget.png)](https://discord.gg/jkrBmQR)
 
 An unofficial .NET API Wrapper for the Discord client (http://discordapp.com).
 

--- a/docs/_overwrites/Common/EmbedObjectBuilder.Inclusion.md
+++ b/docs/_overwrites/Common/EmbedObjectBuilder.Inclusion.md
@@ -4,10 +4,10 @@ field, and 2 normal fields using an @Discord.EmbedBuilder:
 ```cs
 var exampleAuthor = new EmbedAuthorBuilder()
         .WithName("I am a bot")
-        .WithIconUrl("https://discordapp.com/assets/e05ead6e6ebc08df9291738d0aa6986d.png");
+        .WithIconUrl("https://discord.com/assets/e05ead6e6ebc08df9291738d0aa6986d.png");
 var exampleFooter = new EmbedFooterBuilder()
         .WithText("I am a nice footer")
-        .WithIconUrl("https://discordapp.com/assets/28174a34e77bb5e5310ced9f95cb480b.png");
+        .WithIconUrl("https://discord.com/assets/28174a34e77bb5e5310ced9f95cb480b.png");
 var exampleField = new EmbedFieldBuilder()
         .WithName("Title of Another Field")
         .WithValue("I am an [example](https://example.com).")

--- a/docs/faq/basics/client-basics.md
+++ b/docs/faq/basics/client-basics.md
@@ -30,7 +30,7 @@ There are few possible reasons why this may occur.
 [TokenType]: xref:Discord.TokenType
 [827]: https://github.com/RogueException/Discord.Net/issues/827
 [958]: https://github.com/RogueException/Discord.Net/issues/958
-[Discord API Terms of Service]: https://discordapp.com/developers/docs/legal
+[Discord API Terms of Service]: https://discord.com/developers/docs/legal
 
 ## How do I do X, Y, Z when my bot connects/logs on? Why do I get a `NullReferenceException` upon calling any client methods after connect?
 

--- a/docs/faq/misc/glossary.md
+++ b/docs/faq/misc/glossary.md
@@ -19,7 +19,7 @@ channels, and are often referred to as "servers".
 * A **Channel** ([IChannel]) represents a generic channel.
 	- Example: #dotnet_discord-net
 	- See [Channel Types](#channel-types)
-	
+
 [IGuild]: xref:Discord.IGuild
 [IChannel]: xref:Discord.IChannel
 
@@ -79,4 +79,4 @@ activity for listening to a song on Spotify.
 [RichGame]: xref:Discord.RichGame
 [StreamingGame]: xref:Discord.StreamingGame
 [SpotifyGame]: xref:Discord.SpotifyGame
-[Rich Presence Intro]: https://discordapp.com/developers/docs/rich-presence/best-practices
+[Rich Presence Intro]: https://discord.com/developers/docs/rich-presence/best-practices

--- a/docs/guides/getting_started/first-bot.md
+++ b/docs/guides/getting_started/first-bot.md
@@ -31,7 +31,7 @@ the Discord Applications Portal first.
 
     ![Step 7](images/intro-public-bot.png)
 
-[Discord Applications Portal]: https://discordapp.com/developers/applications/
+[Discord Applications Portal]: https://discord.com/developers/applications/
 
 ## Adding your bot to a server
 
@@ -165,11 +165,11 @@ or any other blocking method, such as reading from the console.
 > the source code for your bot.
 >
 > In the following example, we retrieve the token from a pre-defined
-> variable, which is **NOT** secure, especially if you plan on 
+> variable, which is **NOT** secure, especially if you plan on
 > distributing the application in any shape or form.
 >
-> We recommend alternative storage such as 
-> [Environment Variables], an external configuration file, or a 
+> We recommend alternative storage such as
+> [Environment Variables], an external configuration file, or a
 > secrets manager for safe-handling of secrets.
 >
 > [Environment Variables]: https://en.wikipedia.org/wiki/Environment_variable

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,12 +11,12 @@ title: Home
 [![NuGet](https://img.shields.io/nuget/vpre/Discord.Net.svg?maxAge=2592000?style=plastic)](https://www.nuget.org/packages/Discord.Net)
 [![MyGet](https://img.shields.io/myget/discord-net/vpre/Discord.Net.svg)](https://www.myget.org/feed/Packages/discord-net)
 [![Build Status](https://dev.azure.com/discord-net/Discord.Net/_apis/build/status/discord-net.Discord.Net?branchName=dev)](https://dev.azure.com/discord-net/Discord.Net/_build/latest?definitionId=1&branchName=dev)
-[![Discord](https://discordapp.com/api/guilds/81384788765712384/widget.png)](https://discord.gg/jkrBmQR)
+[![Discord](https://discord.com/api/guilds/81384788765712384/widget.png)](https://discord.gg/jkrBmQR)
 
 ## What is Discord.Net?
 
 Discord.Net is an asynchronous, multi-platform .NET Library used to
-interface with the [Discord API](https://discordapp.com/).
+interface with the [Discord API](https://discord.com/).
 
 ## Where to begin?
 

--- a/samples/04_webhook_client/Program.cs
+++ b/samples/04_webhook_client/Program.cs
@@ -14,10 +14,10 @@ namespace _04_webhook_client
 
         public async Task MainAsync()
         {
-            // The webhook url follows the format https://discordapp.com/api/webhooks/{id}/{token}
+            // The webhook url follows the format https://discord.com/api/webhooks/{id}/{token}
             // Because anyone with the webhook URL can use your webhook
-            // you should NOT hard code the URL or ID + token into your application. 
-            using (var client = new DiscordWebhookClient("https://discordapp.com/api/webhooks/123/abc123"))
+            // you should NOT hard code the URL or ID + token into your application.
+            using (var client = new DiscordWebhookClient("https://discord.com/api/webhooks/123/abc123"))
             {
                 var embed = new EmbedBuilder
                 {
@@ -26,7 +26,7 @@ namespace _04_webhook_client
                 };
 
                 // Webhooks are able to send multiple embeds per message
-                // As such, your embeds must be passed as a collection. 
+                // As such, your embeds must be passed as a collection.
                 await client.SendMessageAsync(text: "Send a message to this webhook!", embeds: new[] { embed.Build() });
             }
         }

--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -13,7 +13,7 @@ namespace Discord
         /// <returns>
         ///     An <see cref="int"/> representing the API version that Discord.Net uses to communicate with Discord.
         ///     <para>A list of available API version can be seen on the official 
-        ///     <see href="https://discordapp.com/developers/docs/reference#api-versioning">Discord API documentation</see>
+        ///     <see href="https://discord.com/developers/docs/reference#api-versioning">Discord API documentation</see>
         ///     .</para>
         /// </returns>
         public const int APIVersion = 6;
@@ -50,7 +50,7 @@ namespace Discord
         /// <returns>
         ///     The Discord API URL using <see cref="APIVersion"/>.
         /// </returns>
-        public static readonly string APIUrl = $"https://discordapp.com/api/v{APIVersion}/";
+        public static readonly string APIUrl = $"https://discord.com/api/v{APIVersion}/";
         /// <summary> 
         ///     Returns the base Discord CDN URL. 
         /// </summary>

--- a/src/Discord.Net.Core/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/MessageExtensions.cs
@@ -17,7 +17,7 @@ namespace Discord
         public static string GetJumpUrl(this IMessage msg)
         {
             var channel = msg.Channel;
-            return $"https://discordapp.com/channels/{(channel is IDMChannel ? "@me" : $"{(channel as ITextChannel).GuildId}")}/{channel.Id}/{msg.Id}";
+            return $"https://discord.com/channels/{(channel is IDMChannel ? "@me" : $"{(channel as ITextChannel).GuildId}")}/{channel.Id}/{msg.Id}";
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Net/HttpException.cs
+++ b/src/Discord.Net.Core/Net/HttpException.cs
@@ -13,7 +13,7 @@ namespace Discord.Net
         /// </summary>
         /// <returns>
         ///     An 
-        ///     <see href="https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#http">HTTP status code</see>
+        ///     <see href="https://discord.com/developers/docs/topics/opcodes-and-status-codes#http">HTTP status code</see>
         ///     from Discord.
         /// </returns>
         public HttpStatusCode HttpCode { get; }
@@ -22,7 +22,7 @@ namespace Discord.Net
         /// </summary>
         /// <returns>
         ///     A 
-        ///     <see href="https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#json">JSON error code</see>
+        ///     <see href="https://discord.com/developers/docs/topics/opcodes-and-status-codes#json">JSON error code</see>
         ///     from Discord, or <c>null</c> if none.
         /// </returns>
         public int? DiscordCode { get; }

--- a/src/Discord.Net.Core/Net/WebSocketClosedException.cs
+++ b/src/Discord.Net.Core/Net/WebSocketClosedException.cs
@@ -11,7 +11,7 @@ namespace Discord.Net
         /// </summary>
         /// <returns>
         ///     A 
-        ///     <see href="https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes">close code</see>
+        ///     <see href="https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes">close code</see>
         ///     from Discord.
         /// </returns>
         public int CloseCode { get; }

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -87,7 +87,7 @@ namespace Discord.WebSocket
         ///     </para>
         ///     <para>
         ///         For more information, please see
-        ///         <see href="https://discordapp.com/developers/docs/topics/gateway#request-guild-members">Request Guild Members</see>
+        ///         <see href="https://discord.com/developers/docs/topics/gateway#request-guild-members">Request Guild Members</see>
         ///         on the official Discord API documentation.
         ///     </para>
         ///     <note>

--- a/test/Discord.Net.Tests.Unit/TokenUtilsTests.cs
+++ b/test/Discord.Net.Tests.Unit/TokenUtilsTests.cs
@@ -83,7 +83,7 @@ namespace Discord
         public void BotTokenDoesNotThrowExceptions(string token)
         {
             // This example token is pulled from the Discord Docs
-            // https://discordapp.com/developers/docs/reference#authentication-example-bot-token-authorization-header
+            // https://discord.com/developers/docs/reference#authentication-example-bot-token-authorization-header
             // should not throw any exception
             TokenUtils.ValidateToken(TokenType.Bot, token);
         }

--- a/test/Discord.Net.Tests/Tests.DiscordWebhookClient.cs
+++ b/test/Discord.Net.Tests/Tests.DiscordWebhookClient.cs
@@ -15,15 +15,15 @@ namespace Discord
         [InlineData("https://discord.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
             123412347732897802, "_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK")]
         // ptb, canary, etc will have slightly different urls
-        [InlineData("https://ptb.discordapp.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
+        [InlineData("https://ptb.discord.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
             123412347732897802, "_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK")]
-        [InlineData("https://canary.discordapp.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
+        [InlineData("https://canary.discord.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
             123412347732897802, "_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK")]
         // don't care about https
-        [InlineData("http://canary.discordapp.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
+        [InlineData("http://canary.discord.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
             123412347732897802, "_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK")]
         // this is the minimum that the regex cares about
-        [InlineData("discordapp.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
+        [InlineData("discord.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
             123412347732897802, "_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK")]
         public void TestWebhook_Valid(string webhookurl, ulong expectedId, string expectedToken)
         {

--- a/test/Discord.Net.Tests/Tests.DiscordWebhookClient.cs
+++ b/test/Discord.Net.Tests/Tests.DiscordWebhookClient.cs
@@ -12,7 +12,7 @@ namespace Discord
     public class DiscordWebhookClientTests
     {
         [Theory]
-        [InlineData("https://discordapp.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
+        [InlineData("https://discord.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
             123412347732897802, "_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK")]
         // ptb, canary, etc will have slightly different urls
         [InlineData("https://ptb.discordapp.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK",
@@ -48,7 +48,7 @@ namespace Discord
         [Theory]
         [InlineData("123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK")]
         // trailing slash
-        [InlineData("https://discordapp.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK/")]
+        [InlineData("https://discord.com/api/webhooks/123412347732897802/_abcde123456789-ABCDEFGHIJKLMNOP12345678-abcdefghijklmnopABCDEFGHIJK/")]
         public void TestWebhook_Invalid(string webhookurl)
         {
             Assert.Throws<ArgumentException>(() =>


### PR DESCRIPTION
### Summary
---
Changed the domain name from discordapp.com to discord.com
This change is needed because Discord is planning to require the new domain.

### Changes
---
- Changed the domain name in the code.
- Changed the domain name in the documentation.

### References
---
https://discord.com/developers/docs/reference