### PR TITLE
feature: Add missing properties to Guild and deprecate GuildEmbed

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -62,10 +62,20 @@ namespace Discord
         /// <param name="guildId">The guild snowflake identifier.</param>
         /// <param name="splashId">The splash icon identifier.</param>
         /// <returns>
-        ///     A URL pointing to the guild's icon.
+        ///     A URL pointing to the guild's splash.
         /// </returns>
         public static string GetGuildSplashUrl(ulong guildId, string splashId)
             => splashId != null ? $"{DiscordConfig.CDNUrl}splashes/{guildId}/{splashId}.jpg" : null;
+        /// <summary>
+        ///     Returns a guild discovery splash URL.
+        /// </summary>
+        /// <param name="guildId">The guild snowflake identifier.</param>
+        /// <param name="discoverySplashId">The discovery splash icon identifier.</param>
+        /// <returns>
+        ///     A URL pointing to the guild's discovery splash.
+        /// </returns>
+        public static string GetGuildDiscoverySplashUrl(ulong guildId, string discoverySplashId)
+            => discoverySplashId != null ? $"{DiscordConfig.CDNUrl}discovery-splashes/{guildId}/{discoverySplashId}.jpg" : null;
         /// <summary>
         ///     Returns a channel icon URL.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Guilds/GuildWidgetProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildWidgetProperties.cs
@@ -1,0 +1,21 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Provides properties that are used to modify the widget of an <see cref="IGuild" /> with the specified changes.
+    /// </summary>
+    public class GuildWidgetProperties
+    {
+        /// <summary>
+        ///     Sets whether the widget should be enabled.
+        /// </summary>
+        public Optional<bool> Enabled { get; set; }
+        /// <summary>
+        ///     Sets the channel that the invite should place its users in, if not <c>null</c>.
+        /// </summary>
+        public Optional<IChannel> Channel { get; set; }
+        /// <summary>
+        ///     Sets the channel the invite should place its users in, if not <c>null</c>.
+        /// </summary>
+        public Optional<ulong?> ChannelId { get; set; }
+    }
+}

--- a/src/Discord.Net.Core/Entities/Guilds/GuildWidgetProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildWidgetProperties.cs
@@ -10,11 +10,11 @@ namespace Discord
         /// </summary>
         public Optional<bool> Enabled { get; set; }
         /// <summary>
-        ///     Sets the channel that the invite should place its users in, if not <c>null</c>.
+        ///     Sets the channel that the invite should place its users in, if not <see langword="null" />.
         /// </summary>
         public Optional<IChannel> Channel { get; set; }
         /// <summary>
-        ///     Sets the channel the invite should place its users in, if not <c>null</c>.
+        ///     Sets the channel that the invite should place its users in, if not <see langword="null" />.
         /// </summary>
         public Optional<ulong?> ChannelId { get; set; }
     }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -23,7 +23,7 @@ namespace Discord
         ///     automatically moved to the AFK voice channel.
         /// </summary>
         /// <returns>
-        ///     An <see cref="int"/> representing the amount of time in seconds for a user to be marked as inactive
+        ///     An <see langword="int"/> representing the amount of time in seconds for a user to be marked as inactive
         ///     and moved into the AFK voice channel.
         /// </returns>
         int AFKTimeout { get; }
@@ -31,14 +31,14 @@ namespace Discord
         ///     Gets a value that indicates whether this guild is embeddable (i.e. can use widget).
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this guild can be embedded via widgets; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this guild has a widget enabled; otherwise <see langword="false" />.
         /// </returns>
         bool IsEmbeddable { get; }
         /// <summary>
         ///     Gets a value that indicates whether this guild has the widget enabled.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this guild has a widget enabled; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this guild has a widget enabled; otherwise <see langword="false" />.
         /// </returns>
         bool IsWidgetEnabled { get; }
         /// <summary>
@@ -71,42 +71,42 @@ namespace Discord
         ///     Gets the ID of this guild's icon.
         /// </summary>
         /// <returns>
-        ///     An identifier for the splash image; <c>null</c> if none is set.
+        ///     An identifier for the splash image; <see langword="null" /> if none is set.
         /// </returns>
         string IconId { get; }
         /// <summary>
         ///     Gets the URL of this guild's icon.
         /// </summary>
         /// <returns>
-        ///     A URL pointing to the guild's icon; <c>null</c> if none is set.
+        ///     A URL pointing to the guild's icon; <see langword="null" /> if none is set.
         /// </returns>
         string IconUrl { get; }
         /// <summary>
         ///     Gets the ID of this guild's splash image.
         /// </summary>
         /// <returns>
-        ///     An identifier for the splash image; <c>null</c> if none is set.
+        ///     An identifier for the splash image; <see langword="null" /> if none is set.
         /// </returns>
         string SplashId { get; }
         /// <summary>
         ///     Gets the URL of this guild's splash image.
         /// </summary>
         /// <returns>
-        ///     A URL pointing to the guild's splash image; <c>null</c> if none is set.
+        ///     A URL pointing to the guild's splash image; <see langword="null" /> if none is set.
         /// </returns>
         string SplashUrl { get; }
         /// <summary>
         ///     Gets the ID of this guild's discovery splash image.
         /// </summary>
         /// <returns>
-        ///     An identifier for the discovery splash image; <c>null</c> if none is set.
+        ///     An identifier for the discovery splash image; <see langword="null" /> if none is set.
         /// </returns>
         string DiscoverySplashId { get; }
         /// <summary>
         ///     Gets the URL of this guild's discovery splash image.
         /// </summary>
         /// <returns>
-        ///     A URL pointing to the guild's discovery splash image; <c>null</c> if none is set.
+        ///     A URL pointing to the guild's discovery splash image; <see langword="null" /> if none is set.
         /// </returns>
         string DiscoverySplashUrl { get; }
         /// <summary>
@@ -119,7 +119,7 @@ namespace Discord
         ///     This boolean is used to determine if the guild is currently connected to the WebSocket and is ready to be used/accessed.
         /// </remarks>
         /// <returns>
-        ///     <c>true</c> if this guild is currently connected and ready to be used; otherwise <c>false</c>.
+        ///     <c>true</c> if this guild is currently connected and ready to be used; otherwise <see langword="false"/>.
         /// </returns>
         bool Available { get; }
 
@@ -127,7 +127,7 @@ namespace Discord
         ///     Gets the ID of the AFK voice channel for this guild.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the AFK voice channel; <c>null</c> if
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the AFK voice channel; <see langword="null" /> if
         ///     none is set.
         /// </returns>
         ulong? AFKChannelId { get; }
@@ -142,7 +142,7 @@ namespace Discord
         ///     </note>
         /// </remarks>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the default text channel; <c>0</c> if
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the default text channel; <c>0</c> if
         ///     none can be found.
         /// </returns>
         ulong DefaultChannelId { get; }
@@ -150,55 +150,54 @@ namespace Discord
         ///     Gets the ID of the widget embed channel of this guild.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the embedded channel found within the
-        ///     widget settings of this guild; <c>null</c> if none is set.
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the embedded channel found within the
+        ///     widget settings of this guild; <see langword="null" /> if none is set.
         /// </returns>
         ulong? EmbedChannelId { get; }
         /// <summary>
         ///     Gets the ID of the channel assigned to the widget of this guild.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the channel assigned to the widget found
-        ///     within the widget settings of this guild; <c>null</c> if none is set.
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the channel assigned to the widget found
+        ///     within the widget settings of this guild; <see langword="null" /> if none is set.
         /// </returns>
         ulong? WidgetChannelId { get; }
         /// <summary>
         ///     Gets the ID of the channel where randomized welcome messages are sent.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the system channel where randomized
-        ///     welcome messages are sent; <c>null</c> if none is set.
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the system channel where randomized
+        ///     welcome messages are sent; <see langword="null" /> if none is set.
         /// </returns>
         ulong? SystemChannelId { get; }
         /// <summary>
         ///     Gets the ID of the channel with the rules.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the channel that contains the rules;
-        ///     <c>null</c> if none is set.
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the channel that contains the rules;
+        ///     <see langword="null" /> if none is set.
         /// </returns>
         ulong? RulesChannelId { get; }
         /// <summary>
-        ///     Gets the ID of the channel where admins and moderators of guilds with the "PUBLIC" feature
-        ///     receive notices from Discord.
+        ///     Gets the ID of the channel where admins and moderators of Community guilds receive notices from Discord.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the channel where admins and moderators
-        ///     of guilds with the "PUBLIC" feature receive notices from Discord; <c>null</c> if none is set.
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the channel where admins and moderators
+        ///     of Community guilds  receive notices from Discord; <see langword="null" /> if none is set.
         /// </returns>
         ulong? PublicUpdatesChannelId { get; }
         /// <summary>
         ///     Gets the ID of the user that owns this guild.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the user that owns this guild.
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the user that owns this guild.
         /// </returns>
         ulong OwnerId { get; }
         /// <summary>
         ///     Gets the application ID of the guild creator if it is bot-created.
         /// </summary>
         /// <returns>
-        ///     A <see cref="ulong"/> representing the snowflake identifier of the application ID that created this guild, or <c>null</c> if it was not bot-created.
+        ///     A <see langword="ulong"/> representing the snowflake identifier of the application ID that created this guild, or <see langword="null" /> if it was not bot-created.
         /// </returns>
         ulong? ApplicationId { get; }
         /// <summary>
@@ -254,21 +253,21 @@ namespace Discord
         ///     Gets the identifier for this guilds banner image.
         /// </summary>
         /// <returns>
-        ///     An identifier for the banner image; <c>null</c> if none is set.
+        ///     An identifier for the banner image; <see langword="null" /> if none is set.
         /// </returns>
         string BannerId { get; }
         /// <summary>
         ///     Gets the URL of this guild's banner image.
         /// </summary>
         /// <returns>
-        ///     A URL pointing to the guild's banner image; <c>null</c> if none is set.
+        ///     A URL pointing to the guild's banner image; <see langword="null" /> if none is set.
         /// </returns>
         string BannerUrl { get; }
         /// <summary>
         ///     Gets the code for this guild's vanity invite URL.
         /// </summary>
         /// <returns>
-        ///     A string containing the vanity invite code for this guild; <c>null</c> if none is set.
+        ///     A string containing the vanity invite code for this guild; <see langword="null" /> if none is set.
         /// </returns>
         string VanityURLCode { get; }
         /// <summary>
@@ -282,7 +281,7 @@ namespace Discord
         ///     Gets the description for the guild.
         /// </summary>
         /// <returns>
-        ///     The description for the guild; <c>null</c> if none is set.
+        ///     The description for the guild; <see langword="null" /> if none is set.
         /// </returns>
         string Description { get; }
         /// <summary>
@@ -292,7 +291,7 @@ namespace Discord
         ///     This is the number of users who have boosted this guild.
         /// </remarks>
         /// <returns>
-        ///     The number of premium subscribers of this guild.
+        ///     The number of premium subscribers of this guild; <see langword="null" /> if not available.
         /// </returns>
         int PremiumSubscriptionCount { get; }
         /// <summary>
@@ -433,7 +432,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a ban object, which
-        ///     contains the user information and the reason for the ban; <c>null</c> if the ban entry cannot be found.
+        ///     contains the user information and the reason for the ban; <see langword="null" /> if the ban entry cannot be found.
         /// </returns>
         Task<IBan> GetBanAsync(IUser user, RequestOptions options = null);
         /// <summary>
@@ -443,7 +442,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a ban object, which
-        ///     contains the user information and the reason for the ban; <c>null</c> if the ban entry cannot be found.
+        ///     contains the user information and the reason for the ban; <see langword="null" /> if the ban entry cannot be found.
         /// </returns>
         Task<IBan> GetBanAsync(ulong userId, RequestOptions options = null);
         /// <summary>
@@ -507,7 +506,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the generic channel
-        ///     associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     associated with the specified <paramref name="id"/>; <see langword="null" /> if none is found.
         /// </returns>
         Task<IGuildChannel> GetChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -528,7 +527,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel
-        ///     associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     associated with the specified <paramref name="id"/>; <see langword="null" /> if none is found.
         /// </returns>
         Task<ITextChannel> GetTextChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -559,7 +558,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the voice channel associated
-        ///     with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     with the specified <paramref name="id"/>; <see langword="null" /> if none is found.
         /// </returns>
         Task<IVoiceChannel> GetVoiceChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -569,7 +568,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the voice channel that the
-        ///     AFK users will be moved to after they have idled for too long; <c>null</c> if none is set.
+        ///     AFK users will be moved to after they have idled for too long; <see langword="null" /> if none is set.
         /// </returns>
         Task<IVoiceChannel> GetAFKChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -579,7 +578,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel where
-        ///     randomized welcome messages will be sent to; <c>null</c> if none is set.
+        ///     randomized welcome messages will be sent to; <see langword="null" /> if none is set.
         /// </returns>
         Task<ITextChannel> GetSystemChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -589,7 +588,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the first viewable text
-        ///     channel in this guild; <c>null</c> if none is found.
+        ///     channel in this guild; <see langword="null" /> if none is found.
         /// </returns>
         Task<ITextChannel> GetDefaultChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -599,7 +598,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the embed channel set
-        ///     within the server's widget settings; <c>null</c> if none is set.
+        ///     within the server's widget settings; <see langword="null" /> if none is set.
         /// </returns>
         [Obsolete("This endpoint is deprecated, use GetWidgetChannelAsync instead.")]
         Task<IGuildChannel> GetEmbedChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
@@ -610,27 +609,27 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the widget channel set
-        ///     within the server's widget settings; <c>null</c> if none is set.
+        ///     within the server's widget settings; <see langword="null" /> if none is set.
         /// </returns>
         Task<IGuildChannel> GetWidgetChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
-        ///     Gets the text channel where guilds with the "PUBLIC" feature can display rules and/or guidelines.
+        ///     Gets the text channel where Community guilds can display rules and/or guidelines.
         /// </summary>
         /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel
-        ///     where guilds with the "PUBLIC" feature can display rules and/or guidelines; <c>null</c> if none is set.
+        ///     where Community guilds can display rules and/or guidelines; <see langword="null" /> if none is set.
         /// </returns>
         Task<ITextChannel> GetRulesChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
-        ///     Gets the text channel channel where admins and moderators of guilds with the "PUBLIC" feature receive notices from Discord.
+        ///     Gets the text channel channel where admins and moderators of Community guilds receive notices from Discord.
         /// </summary>
         /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel channel where
-        ///     admins and moderators of guilds with the "PUBLIC" feature receive notices from Discord; <c>null</c> if none is set.
+        ///     admins and moderators of Community guilds receive notices from Discord; <see langword="null" /> if none is set.
         /// </returns>
         Task<ITextChannel> GetPublicUpdatesChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
 
@@ -701,7 +700,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the partial metadata of
-        ///     the vanity invite found within this guild; <c>null</c> if none is found.
+        ///     the vanity invite found within this guild; <see langword="null" /> if none is found.
         /// </returns>
         Task<IInviteMetadata> GetVanityInviteAsync(RequestOptions options = null);
 
@@ -710,7 +709,7 @@ namespace Discord
         /// </summary>
         /// <param name="id">The snowflake identifier for the role.</param>
         /// <returns>
-        ///     A role that is associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     A role that is associated with the specified <paramref name="id"/>; <see langword="null" /> if none is found.
         /// </returns>
         IRole GetRole(ulong id);
         /// <summary>
@@ -752,7 +751,7 @@ namespace Discord
         /// <param name="accessToken">The OAuth2 access token for the user, requested with the guilds.join scope.</param>
         /// <param name="func">The delegate containing the properties to be applied to the user upon being added to the guild.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>A guild user associated with the specified <paramref name="userId" />; <c>null</c> if the user is already in the guild.</returns>
+        /// <returns>A guild user associated with the specified <paramref name="userId" />; <see langword="null" /> if the user is already in the guild.</returns>
         Task<IGuildUser> AddGuildUserAsync(ulong userId, string accessToken, Action<AddGuildUserProperties> func = null, RequestOptions options = null);
         /// <summary>
         ///     Gets a collection of all users in this guild.
@@ -777,7 +776,7 @@ namespace Discord
         /// <remarks>
         ///     This method retrieves a user found within this guild.
         ///     <note>
-        ///         This may return <c>null</c> in the WebSocket implementation due to incomplete user collection in
+        ///         This may return <see langword="null" /> in the WebSocket implementation due to incomplete user collection in
         ///         large guilds.
         ///     </note>
         /// </remarks>
@@ -786,7 +785,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the guild user
-        ///     associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     associated with the specified <paramref name="id"/>; <see langword="null" /> if none is found.
         /// </returns>
         Task<IGuildUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -879,7 +878,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the webhook with the
-        ///     specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     specified <paramref name="id"/>; <see langword="null" /> if none is found.
         /// </returns>
         Task<IWebhook> GetWebhookAsync(ulong id, RequestOptions options = null);
         /// <summary>
@@ -899,7 +898,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the emote found with the
-        ///     specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     specified <paramref name="id"/>; <see langword="null" /> if none is found.
         /// </returns>
         Task<GuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null);
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -35,6 +35,13 @@ namespace Discord
         /// </returns>
         bool IsEmbeddable { get; }
         /// <summary>
+        ///     Gets a value that indicates whether this guild has the widget enabled.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this guild has a widget enabled; otherwise <c>false</c>.
+        /// </returns>
+        bool IsWidgetEnabled { get; }
+        /// <summary>
         ///     Gets the default message notifications for users who haven't explicitly set their notification settings.
         /// </summary>
         DefaultMessageNotifications DefaultMessageNotifications { get; }
@@ -89,6 +96,20 @@ namespace Discord
         /// </returns>
         string SplashUrl { get; }
         /// <summary>
+        ///     Gets the ID of this guild's discovery splash image.
+        /// </summary>
+        /// <returns>
+        ///     An identifier for the discovery splash image; <c>null</c> if none is set.
+        /// </returns>
+        string DiscoverySplashId { get; }
+        /// <summary>
+        ///     Gets the URL of this guild's discovery splash image.
+        /// </summary>
+        /// <returns>
+        ///     A URL pointing to the guild's discovery splash image; <c>null</c> if none is set.
+        /// </returns>
+        string DiscoverySplashUrl { get; }
+        /// <summary>
         ///     Determines if this guild is currently connected and ready to be used.
         /// </summary>
         /// <remarks>
@@ -134,6 +155,14 @@ namespace Discord
         /// </returns>
         ulong? EmbedChannelId { get; }
         /// <summary>
+        ///     Gets the ID of the channel assigned to the widget of this guild.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the channel assigned to the widget found
+        ///     within the widget settings of this guild; <c>null</c> if none is set.
+        /// </returns>
+        ulong? WidgetChannelId { get; }
+        /// <summary>
         ///     Gets the ID of the channel where randomized welcome messages are sent.
         /// </summary>
         /// <returns>
@@ -141,6 +170,23 @@ namespace Discord
         ///     welcome messages are sent; <c>null</c> if none is set.
         /// </returns>
         ulong? SystemChannelId { get; }
+        /// <summary>
+        ///     Gets the ID of the channel with the rules.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the channel that contains the rules;
+        ///     <c>null</c> if none is set.
+        /// </returns>
+        ulong? RulesChannelId { get; }
+        /// <summary>
+        ///     Gets the ID of the channel where admins and moderators of guilds with the "PUBLIC" feature
+        ///     receive notices from Discord.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier of the channel where admins and moderators
+        ///     of guilds with the "PUBLIC" feature receive notices from Discord; <c>null</c> if none is set.
+        /// </returns>
+        ulong? PublicUpdatesChannelId { get; }
         /// <summary>
         ///     Gets the ID of the user that owns this guild.
         /// </summary>
@@ -249,6 +295,47 @@ namespace Discord
         ///     The number of premium subscribers of this guild.
         /// </returns>
         int PremiumSubscriptionCount { get; }
+        /// <summary>
+        ///     Gets the maximum number of presences for the guild.
+        /// </summary>
+        /// <returns>
+        ///     The maximum number of presences for the guild.
+        /// </returns>
+        int? MaxPresences { get; }
+        /// <summary>
+        ///     Gets the maximum number of members for the guild.
+        /// </summary>
+        /// <returns>
+        ///     The maximum number of members for the guild.
+        /// </returns>
+        int? MaxMembers { get; }
+        /// <summary>
+        ///     Gets the maximum amount of users in a video channel.
+        /// </summary>
+        /// <returns>
+        ///     The maximum amount of users in a video channel.
+        /// </returns>
+        int? MaxVideoChannelUsers { get; }
+        /// <summary>
+        ///     Gets the approximate number of members in this guild.
+        /// </summary>
+        /// <remarks>
+        ///     Only available when getting a guild via REST when `with_counts` is true.
+        /// </remarks>
+        /// <returns>
+        ///     The approximate number of members in this guild.
+        /// </returns>
+        int? ApproximateMemberCount { get; }
+        /// <summary>
+        ///     Gets the approximate number of non-offline members in this guild.
+        /// </summary>
+        /// <remarks>
+        ///     Only available when getting a guild via REST when `with_counts` is true.
+        /// </remarks>
+        /// <returns>
+        ///     The approximate number of non-offline members in this guild.
+        /// </returns>
+        int? ApproximatePresenceCount { get; }
 
         /// <summary>
         ///     Gets the preferred locale of this guild in IETF BCP 47
@@ -285,7 +372,17 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
+        [Obsolete("This endpoint is deprecated, use ModifyWidgetAsync instead.")]
         Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null);
+        /// <summary>
+        ///     Modifies this guild's widget.
+        /// </summary>
+        /// <param name="func">The delegate containing the properties to modify the guild widget with.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyWidgetAsync(Action<GuildWidgetProperties> func, RequestOptions options = null);
         /// <summary>
         ///     Bulk-modifies the order of channels in this guild.
         /// </summary>
@@ -504,7 +601,38 @@ namespace Discord
         ///     A task that represents the asynchronous get operation. The task result contains the embed channel set
         ///     within the server's widget settings; <c>null</c> if none is set.
         /// </returns>
+        [Obsolete("This endpoint is deprecated, use GetWidgetChannelAsync instead.")]
         Task<IGuildChannel> GetEmbedChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+        /// <summary>
+        ///     Gets the widget channel (i.e. the channel set in the guild's widget settings) in this guild.
+        /// </summary>
+        /// <param name="mode">The <see cref="CacheMode" /> that determines whether the object should be fetched from cache.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains the widget channel set
+        ///     within the server's widget settings; <c>null</c> if none is set.
+        /// </returns>
+        Task<IGuildChannel> GetWidgetChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+        /// <summary>
+        ///     Gets the text channel where guilds with the "PUBLIC" feature can display rules and/or guidelines.
+        /// </summary>
+        /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains the text channel
+        ///     where guilds with the "PUBLIC" feature can display rules and/or guidelines; <c>null</c> if none is set.
+        /// </returns>
+        Task<ITextChannel> GetRulesChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+        /// <summary>
+        ///     Gets the text channel channel where admins and moderators of guilds with the "PUBLIC" feature receive notices from Discord.
+        /// </summary>
+        /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains the text channel channel where
+        ///     admins and moderators of guilds with the "PUBLIC" feature receive notices from Discord; <c>null</c> if none is set.
+        /// </returns>
+        Task<ITextChannel> GetPublicUpdatesChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
 
         /// <summary>
         ///     Creates a new text channel in this guild.

--- a/src/Discord.Net.Core/Entities/IUpdateable.cs
+++ b/src/Discord.Net.Core/Entities/IUpdateable.cs
@@ -10,6 +10,7 @@ namespace Discord
         /// <summary>
         ///     Updates this object's properties with its current state.
         /// </summary>
+        /// <param name="options">The options to be used when sending the request.</param>
         Task UpdateAsync(RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -69,7 +69,7 @@ namespace Discord.API
         [JsonProperty("max_members")]
         public Optional<int> MaxMembers { get; set; }
         [JsonProperty("premium_subscription_count")]
-        public int? PremiumSubscriptionCount { get; set; }
+        public Optional<int> PremiumSubscriptionCount { get; set; }
         [JsonProperty("preferred_locale")]
         public string PreferredLocale { get; set; }
         [JsonProperty("public_updates_channel_id")]

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -13,6 +13,8 @@ namespace Discord.API
         public string Icon { get; set; }
         [JsonProperty("splash")]
         public string Splash { get; set; }
+        [JsonProperty("discovery_splash")]
+        public string DiscoverySplash { get; set; }
         [JsonProperty("owner_id")]
         public ulong OwnerId { get; set; }
         [JsonProperty("region")]
@@ -22,9 +24,9 @@ namespace Discord.API
         [JsonProperty("afk_timeout")]
         public int AFKTimeout { get; set; }
         [JsonProperty("embed_enabled")]
-        public bool EmbedEnabled { get; set; }
+        public Optional<bool> EmbedEnabled { get; set; }
         [JsonProperty("embed_channel_id")]
-        public ulong? EmbedChannelId { get; set; }
+        public Optional<ulong?> EmbedChannelId { get; set; }
         [JsonProperty("verification_level")]
         public VerificationLevel VerificationLevel { get; set; }
         [JsonProperty("default_message_notifications")]
@@ -43,6 +45,10 @@ namespace Discord.API
         public MfaLevel MfaLevel { get; set; }
         [JsonProperty("application_id")]
         public ulong? ApplicationId { get; set; }
+        [JsonProperty("widget_enabled")]
+        public Optional<bool> WidgetEnabled { get; set; }
+        [JsonProperty("widget_channel_id")]
+        public Optional<ulong?> WidgetChannelId { get; set; }
         [JsonProperty("system_channel_id")]
         public ulong? SystemChannelId { get; set; }
         [JsonProperty("premium_tier")]
@@ -56,9 +62,23 @@ namespace Discord.API
         // this value is inverted, flags set will turn OFF features
         [JsonProperty("system_channel_flags")]
         public SystemChannelMessageDeny SystemChannelFlags { get; set; }
+        [JsonProperty("rules_channel_id")]
+        public ulong? RulesChannelId { get; set; }
+        [JsonProperty("max_presences")]
+        public Optional<int?> MaxPresences { get; set; }
+        [JsonProperty("max_members")]
+        public Optional<int> MaxMembers { get; set; }
         [JsonProperty("premium_subscription_count")]
         public int? PremiumSubscriptionCount { get; set; }
         [JsonProperty("preferred_locale")]
         public string PreferredLocale { get; set; }
+        [JsonProperty("public_updates_channel_id")]
+        public ulong? PublicUpdatesChannelId { get; set; }
+        [JsonProperty("max_video_channel_users")]
+        public Optional<int> MaxVideoChannelUsers { get; set; }
+        [JsonProperty("approximate_member_count")]
+        public Optional<int> ApproximateMemberCount { get; set; }
+        [JsonProperty("approximate_presence_count")]
+        public Optional<int> ApproximatePresenceCount { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildWidget.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildWidget.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Discord.API
 {
-    internal class GuildEmbed
+    internal class GuildWidget
     {
         [JsonProperty("enabled")]
         public bool Enabled { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildWidgetParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildWidgetParams.cs
@@ -1,0 +1,14 @@
+#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Discord.API.Rest
+{
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    internal class ModifyGuildWidgetParams
+    {        
+        [JsonProperty("enabled")]
+        public Optional<bool> Enabled { get; set; }
+        [JsonProperty("channel")]
+        public Optional<ulong?> ChannelId { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -62,9 +62,9 @@ namespace Discord.Rest
         }
         
         public static async Task<RestGuild> GetGuildAsync(BaseDiscordClient client,
-            ulong id, RequestOptions options)
+            ulong id, bool withCounts, RequestOptions options)
         {
-            var model = await client.ApiClient.GetGuildAsync(id, options).ConfigureAwait(false);
+            var model = await client.ApiClient.GetGuildAsync(id, withCounts, options).ConfigureAwait(false);
             if (model != null)
                 return RestGuild.Create(client, model);
             return null;
@@ -75,6 +75,14 @@ namespace Discord.Rest
             var model = await client.ApiClient.GetGuildEmbedAsync(id, options).ConfigureAwait(false);
             if (model != null)
                 return RestGuildEmbed.Create(model);
+            return null;
+        }
+        public static async Task<RestGuildWidget?> GetGuildWidgetAsync(BaseDiscordClient client,
+            ulong id, RequestOptions options)
+        {
+            var model = await client.ApiClient.GetGuildWidgetAsync(id, options).ConfigureAwait(false);
+            if (model != null)
+                return RestGuildWidget.Create(model);
             return null;
         }
         public static IAsyncEnumerable<IReadOnlyCollection<RestUserGuild>> GetGuildSummariesAsync(BaseDiscordClient client, 
@@ -106,13 +114,13 @@ namespace Discord.Rest
                 count: limit
             );
         }
-        public static async Task<IReadOnlyCollection<RestGuild>> GetGuildsAsync(BaseDiscordClient client, RequestOptions options)
+        public static async Task<IReadOnlyCollection<RestGuild>> GetGuildsAsync(BaseDiscordClient client, bool withCounts, RequestOptions options)
         {
             var summaryModels = await GetGuildSummariesAsync(client, null, null, options).FlattenAsync().ConfigureAwait(false);
             var guilds = ImmutableArray.CreateBuilder<RestGuild>();
             foreach (var summaryModel in summaryModels)
             {
-                var guildModel = await client.ApiClient.GetGuildAsync(summaryModel.Id).ConfigureAwait(false);
+                var guildModel = await client.ApiClient.GetGuildAsync(summaryModel.Id, withCounts).ConfigureAwait(false);
                 if (guildModel != null)
                     guilds.Add(RestGuild.Create(client, guildModel));
             }
@@ -140,7 +148,7 @@ namespace Discord.Rest
         public static async Task<RestGuildUser> GetGuildUserAsync(BaseDiscordClient client,
             ulong guildId, ulong id, RequestOptions options)
         {
-            var guild = await GetGuildAsync(client, guildId, options).ConfigureAwait(false);
+            var guild = await GetGuildAsync(client, guildId, false, options).ConfigureAwait(false);
             if (guild == null)
                 return null;
 

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -789,7 +789,7 @@ namespace Discord.API
         }
 
         //Guilds
-        public async Task<Guild> GetGuildAsync(ulong guildId, RequestOptions options = null)
+        public async Task<Guild> GetGuildAsync(ulong guildId, bool withCounts, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             options = RequestOptions.CreateOrClone(options);
@@ -797,7 +797,7 @@ namespace Discord.API
             try
             {
                 var ids = new BucketIds(guildId: guildId);
-                return await SendAsync<Guild>("GET", () => $"guilds/{guildId}", ids, options: options).ConfigureAwait(false);
+                return await SendAsync<Guild>("GET", () => $"guilds/{guildId}?with_counts={(withCounts ? "true" : "false")}", ids, options: options).ConfigureAwait(false);
             }
             catch (HttpException ex) when (ex.HttpCode == HttpStatusCode.NotFound) { return null; }
         }
@@ -933,6 +933,32 @@ namespace Discord.API
 
             var ids = new BucketIds(guildId: guildId);
             return await SendJsonAsync<GuildEmbed>("PATCH", () => $"guilds/{guildId}/embed", args, ids, options: options).ConfigureAwait(false);
+        }
+
+        //Guild Widget
+        /// <exception cref="ArgumentException"><paramref name="guildId"/> must not be equal to zero.</exception>
+        public async Task<GuildWidget> GetGuildWidgetAsync(ulong guildId, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            options = RequestOptions.CreateOrClone(options);
+
+            try
+            {
+                var ids = new BucketIds(guildId: guildId);
+                return await SendAsync<GuildWidget>("GET", () => $"guilds/{guildId}/widget", ids, options: options).ConfigureAwait(false);
+            }
+            catch (HttpException ex) when (ex.HttpCode == HttpStatusCode.NotFound) { return null; }
+        }
+        /// <exception cref="ArgumentException"><paramref name="guildId"/> must not be equal to zero.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="args"/> must not be <see langword="null"/>.</exception>
+        public async Task<GuildWidget> ModifyGuildWidgetAsync(ulong guildId, Rest.ModifyGuildWidgetParams args, RequestOptions options = null)
+        {
+            Preconditions.NotNull(args, nameof(args));
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            options = RequestOptions.CreateOrClone(options);
+
+            var ids = new BucketIds(guildId: guildId);
+            return await SendJsonAsync<GuildWidget>("PATCH", () => $"guilds/{guildId}/widget", args, ids, options: options).ConfigureAwait(false);
         }
 
         //Guild Integrations

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -76,15 +77,22 @@ namespace Discord.Rest
             => ClientHelper.GetInviteAsync(this, inviteId, options);
 
         public Task<RestGuild> GetGuildAsync(ulong id, RequestOptions options = null)
-            => ClientHelper.GetGuildAsync(this, id, options);
+            => ClientHelper.GetGuildAsync(this, id, false, options);
+        public Task<RestGuild> GetGuildAsync(ulong id, bool withCounts, RequestOptions options = null)
+            => ClientHelper.GetGuildAsync(this, id, withCounts, options);
+        [Obsolete("This endpoint is deprecated, use GetGuildWidgetAsync instead.")]
         public Task<RestGuildEmbed?> GetGuildEmbedAsync(ulong id, RequestOptions options = null)
             => ClientHelper.GetGuildEmbedAsync(this, id, options);
+        public Task<RestGuildWidget?> GetGuildWidgetAsync(ulong id, RequestOptions options = null)
+            => ClientHelper.GetGuildWidgetAsync(this, id, options);
         public IAsyncEnumerable<IReadOnlyCollection<RestUserGuild>> GetGuildSummariesAsync(RequestOptions options = null)
             => ClientHelper.GetGuildSummariesAsync(this, null, null, options);
         public IAsyncEnumerable<IReadOnlyCollection<RestUserGuild>> GetGuildSummariesAsync(ulong fromGuildId, int limit, RequestOptions options = null)
             => ClientHelper.GetGuildSummariesAsync(this, fromGuildId, limit, options);
         public Task<IReadOnlyCollection<RestGuild>> GetGuildsAsync(RequestOptions options = null)
-            => ClientHelper.GetGuildsAsync(this, options);
+            => ClientHelper.GetGuildsAsync(this, false, options);
+        public Task<IReadOnlyCollection<RestGuild>> GetGuildsAsync(bool withCounts, RequestOptions options = null)
+            => ClientHelper.GetGuildsAsync(this, withCounts, options);
         public Task<RestGuild> CreateGuildAsync(string name, IVoiceRegion region, Stream jpegIcon = null, RequestOptions options = null)
             => ClientHelper.CreateGuildAsync(this, name, region, jpegIcon, options);
 

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using EmbedModel = Discord.API.GuildEmbed;
+using WidgetModel = Discord.API.GuildWidget;
 using Model = Discord.API.Guild;
 using RoleModel = Discord.API.Role;
 using ImageModel = Discord.API.Image;
@@ -98,6 +99,27 @@ namespace Discord.Rest
                 apiArgs.ChannelId = args.ChannelId.Value;
 
             return await client.ApiClient.ModifyGuildEmbedAsync(guild.Id, apiArgs, options).ConfigureAwait(false);
+        }
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        public static async Task<WidgetModel> ModifyWidgetAsync(IGuild guild, BaseDiscordClient client,
+            Action<GuildWidgetProperties> func, RequestOptions options)
+        {
+            if (func == null)
+                throw new ArgumentNullException(nameof(func));
+
+            var args = new GuildWidgetProperties();
+            func(args);
+            var apiArgs = new API.Rest.ModifyGuildWidgetParams
+            {
+                Enabled = args.Enabled
+            };
+
+            if (args.Channel.IsSpecified)
+                apiArgs.ChannelId = args.Channel.Value?.Id;
+            else if (args.ChannelId.IsSpecified)
+                apiArgs.ChannelId = args.ChannelId.Value;
+
+            return await client.ApiClient.ModifyGuildWidgetAsync(guild.Id, apiArgs, options).ConfigureAwait(false);
         }
         public static async Task ReorderChannelsAsync(IGuild guild, BaseDiscordClient client,
             IEnumerable<ReorderChannelProperties> args, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -161,7 +161,8 @@ namespace Discord.Rest
             BannerId = model.Banner;
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
-            PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
+            if (model.PremiumSubscriptionCount.IsSpecified)
+                PremiumSubscriptionCount = model.PremiumSubscriptionCount.Value;
             if (model.MaxPresences.IsSpecified)
                 MaxPresences = model.MaxPresences.Value ?? 25000;
             if (model.MaxMembers.IsSpecified)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -235,7 +235,7 @@ namespace Discord.Rest
             => GuildHelper.DeleteAsync(this, Discord, options);
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         public async Task ModifyAsync(Action<GuildProperties> func, RequestOptions options = null)
         {
             var model = await GuildHelper.ModifyAsync(this, Discord, func, options).ConfigureAwait(false);
@@ -243,7 +243,7 @@ namespace Discord.Rest
         }
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         [Obsolete("This endpoint is deprecated, use ModifyWidgetAsync instead.")]
         public async Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null)
         {
@@ -252,7 +252,7 @@ namespace Discord.Rest
         }
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         public async Task ModifyWidgetAsync(Action<GuildWidgetProperties> func, RequestOptions options = null)
         {
             var model = await GuildHelper.ModifyWidgetAsync(this, Discord, func, options).ConfigureAwait(false);
@@ -260,7 +260,7 @@ namespace Discord.Rest
         }
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="args" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="args" /> is <see langword="null"/>.</exception>
         public async Task ReorderChannelsAsync(IEnumerable<ReorderChannelProperties> args, RequestOptions options = null)
         {
             var arr = args.ToArray();
@@ -301,7 +301,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a ban object, which
-        ///     contains the user information and the reason for the ban; <c>null</c> if the ban entry cannot be found.
+        ///     contains the user information and the reason for the ban; <see langword="null"/> if the ban entry cannot be found.
         /// </returns>
         public Task<RestBan> GetBanAsync(IUser user, RequestOptions options = null)
             => GuildHelper.GetBanAsync(this, Discord, user.Id, options);
@@ -312,7 +312,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a ban object, which
-        ///     contains the user information and the reason for the ban; <c>null</c> if the ban entry cannot be found.
+        ///     contains the user information and the reason for the ban; <see langword="null"/> if the ban entry cannot be found.
         /// </returns>
         public Task<RestBan> GetBanAsync(ulong userId, RequestOptions options = null)
             => GuildHelper.GetBanAsync(this, Discord, userId, options);
@@ -350,7 +350,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the generic channel
-        ///     associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public Task<RestGuildChannel> GetChannelAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetChannelAsync(this, Discord, id, options);
@@ -362,7 +362,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel
-        ///     associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public async Task<RestTextChannel> GetTextChannelAsync(ulong id, RequestOptions options = null)
         {
@@ -391,7 +391,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the voice channel associated
-        ///     with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public async Task<RestVoiceChannel> GetVoiceChannelAsync(ulong id, RequestOptions options = null)
         {
@@ -433,7 +433,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the voice channel that the
-        ///     AFK users will be moved to after they have idled for too long; <c>null</c> if none is set.
+        ///     AFK users will be moved to after they have idled for too long; <see langword="null"/> if none is set.
         /// </returns>
         public async Task<RestVoiceChannel> GetAFKChannelAsync(RequestOptions options = null)
         {
@@ -452,7 +452,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the first viewable text
-        ///     channel in this guild; <c>null</c> if none is found.
+        ///     channel in this guild; <see langword="null"/> if none is found.
         /// </returns>
         public async Task<RestTextChannel> GetDefaultChannelAsync(RequestOptions options = null)
         {
@@ -470,7 +470,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the embed channel set
-        ///     within the server's widget settings; <c>null</c> if none is set.
+        ///     within the server's widget settings; <see langword="null"/> if none is set.
         /// </returns>
         [Obsolete("This endpoint is deprecated, use GetWidgetChannelAsync instead.")]
         public async Task<RestGuildChannel> GetEmbedChannelAsync(RequestOptions options = null)
@@ -487,7 +487,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the widget channel set
-        ///     within the server's widget settings; <c>null</c> if none is set.
+        ///     within the server's widget settings; <see langword="null"/> if none is set.
         /// </returns>
         public async Task<RestGuildChannel> GetWidgetChannelAsync(RequestOptions options = null)
         {
@@ -503,7 +503,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel
-        ///     where guild notices such as welcome messages and boost events are poste; <c>null</c> if none is found.
+        ///     where guild notices such as welcome messages and boost events are poste; <see langword="null"/> if none is found.
         /// </returns>
         public async Task<RestTextChannel> GetSystemChannelAsync(RequestOptions options = null)
         {
@@ -517,12 +517,12 @@ namespace Discord.Rest
         }
 
         /// <summary>
-        ///     Gets the text channel where guilds with the "PUBLIC" feature can display rules and/or guidelines.
+        ///     Gets the text channel where Community guilds can display rules and/or guidelines.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel
-        ///     where guilds with the "PUBLIC" feature can display rules and/or guidelines; <c>null</c> if none is set.
+        ///     where Community guilds can display rules and/or guidelines; <see langword="null"/> if none is set.
         /// </returns>
         public async Task<RestTextChannel> GetRulesChannelAsync(RequestOptions options = null)
         {
@@ -536,12 +536,12 @@ namespace Discord.Rest
         }
 
         /// <summary>
-        ///     Gets the text channel channel where admins and moderators of guilds with the "PUBLIC" feature receive notices from Discord.
+        ///     Gets the text channel channel where admins and moderators of Community guilds receive notices from Discord.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the text channel channel where
-        ///     admins and moderators of guilds with the "PUBLIC" feature receive notices from Discord; <c>null</c> if none is set.
+        ///     admins and moderators of Community guilds receive notices from Discord; <see langword="null"/> if none is set.
         /// </returns>
         public async Task<RestTextChannel> GetPublicUpdatesChannelAsync(RequestOptions options = null)
         {
@@ -585,7 +585,7 @@ namespace Discord.Rest
         /// <param name="name">The name of the new channel.</param>
         /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name" /> is <see langword="null"/>.</exception>
         /// <returns>
         ///     The created voice channel.
         /// </returns>
@@ -597,7 +597,7 @@ namespace Discord.Rest
         /// <param name="name">The name of the new channel.</param>
         /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="name" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name" /> is <see langword="null"/>.</exception>
         /// <returns>
         ///     The created category channel.
         /// </returns>
@@ -648,7 +648,7 @@ namespace Discord.Rest
         /// </summary>
         /// <param name="id">The snowflake identifier for the role.</param>
         /// <returns>
-        ///     A role that is associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     A role that is associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public RestRole GetRole(ulong id)
         {
@@ -712,7 +712,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the guild user
-        ///     associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public Task<RestGuildUser> GetUserAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetUserAsync(this, Discord, id, options);
@@ -802,7 +802,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the webhook with the
-        ///     specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetWebhookAsync(this, Discord, id, options);
@@ -835,7 +835,7 @@ namespace Discord.Rest
         public Task<GuildEmote> CreateEmoteAsync(string name, Image image, Optional<IEnumerable<IRole>> roles = default(Optional<IEnumerable<IRole>>), RequestOptions options = null)
             => GuildHelper.CreateEmoteAsync(this, Discord, name, image, roles, options);
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         public Task<GuildEmote> ModifyEmoteAsync(GuildEmote emote, Action<EmoteProperties> func, RequestOptions options = null)
             => GuildHelper.ModifyEmoteAsync(this, Discord, emote.Id, func, options);
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuildWidget.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuildWidget.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+using Model = Discord.API.GuildWidget;
+
+namespace Discord.Rest
+{
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
+    public struct RestGuildWidget
+    {
+        public bool IsEnabled { get; private set; }
+        public ulong? ChannelId { get; private set; }
+
+        internal RestGuildWidget(bool isEnabled, ulong? channelId)
+        {
+            ChannelId = channelId;
+            IsEnabled = isEnabled;
+        }
+        internal static RestGuildWidget Create(Model model)
+        {
+            return new RestGuildWidget(model.Enabled, model.ChannelId);
+        }
+
+        public override string ToString() => ChannelId?.ToString() ?? "Unknown";
+        private string DebuggerDisplay => $"{ChannelId} ({(IsEnabled ? "Enabled" : "Disabled")})";
+    }
+}

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -448,7 +448,8 @@ namespace Discord.WebSocket
             BannerId = model.Banner;
             SystemChannelFlags = model.SystemChannelFlags;
             Description = model.Description;
-            PremiumSubscriptionCount = model.PremiumSubscriptionCount.GetValueOrDefault();
+            if (model.PremiumSubscriptionCount.IsSpecified)
+                PremiumSubscriptionCount = model.PremiumSubscriptionCount.Value;
             if (model.MaxPresences.IsSpecified)
                 MaxPresences = model.MaxPresences.Value ?? 25000;
             if (model.MaxMembers.IsSpecified)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -167,7 +167,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <returns>
         ///     A <see cref="SocketVoiceChannel" /> that the AFK users will be moved to after they have idled for too
-        ///     long; <c>null</c> if none is set.
+        ///     long; <see langword="null"/> if none is set.
         /// </returns>
         public SocketVoiceChannel AFKChannel
         {
@@ -181,7 +181,7 @@ namespace Discord.WebSocket
         ///     Gets the embed channel (i.e. the channel set in the guild's widget settings) in this guild.
         /// </summary>
         /// <returns>
-        ///     A channel set within the server's widget settings; <c>null</c> if none is set.
+        ///     A channel set within the server's widget settings; <see langword="null"/> if none is set.
         /// </returns>
         [Obsolete("This property is deprecated, use WidgetChannel instead.")]
         public SocketGuildChannel EmbedChannel
@@ -196,7 +196,7 @@ namespace Discord.WebSocket
         ///     Gets the widget channel (i.e. the channel set in the guild's widget settings) in this guild.
         /// </summary>
         /// <returns>
-        ///     A channel set within the server's widget settings; <c>null</c> if none is set.
+        ///     A channel set within the server's widget settings; <see langword="null"/> if none is set.
         /// </returns>
         public SocketGuildChannel WidgetChannel
         {
@@ -210,7 +210,7 @@ namespace Discord.WebSocket
         ///     Gets the system channel where randomized welcome messages are sent in this guild.
         /// </summary>
         /// <returns>
-        ///     A text channel where randomized welcome messages will be sent to; <c>null</c> if none is set.
+        ///     A text channel where randomized welcome messages will be sent to; <see langword="null"/> if none is set.
         /// </returns>
         public SocketTextChannel SystemChannel
         {
@@ -224,7 +224,7 @@ namespace Discord.WebSocket
         ///     Gets the channel with the guild rules.
         /// </summary>
         /// <returns>
-        ///     A text channel with the guild rules; <c>null</c> if none is set.
+        ///     A text channel with the guild rules; <see langword="null"/> if none is set.
         /// </returns>
         public SocketTextChannel RulesChannel
         {
@@ -235,12 +235,12 @@ namespace Discord.WebSocket
             }
         }
         /// <summary>
-        ///     Gets the channel where admins and moderators of guilds with the "PUBLIC"
-        ///     feature receive notices from Discord.
+        ///     Gets the channel where admins and moderators of Community guilds receive
+        ///     notices from Discord.
         /// </summary>
         /// <returns>
-        ///     A text channel where admins and moderators of guilds with the "PUBLIC"
-        ///     feature receive notices from Discord; <c>null</c> if none is set.
+        ///     A text channel where admins and moderators of Community guilds receive
+        ///     notices from Discord; <see langword="null"/> if none is set.
         /// </returns>
         public SocketTextChannel PublicUpdatesChannel
         {
@@ -523,17 +523,17 @@ namespace Discord.WebSocket
             => GuildHelper.DeleteAsync(this, Discord, options);
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         public Task ModifyAsync(Action<GuildProperties> func, RequestOptions options = null)
             => GuildHelper.ModifyAsync(this, Discord, func, options);
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         [Obsolete("This endpoint is deprecated, use ModifyWidgetAsync instead.")]
         public Task ModifyEmbedAsync(Action<GuildEmbedProperties> func, RequestOptions options = null)
             => GuildHelper.ModifyEmbedAsync(this, Discord, func, options);
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         public Task ModifyWidgetAsync(Action<GuildWidgetProperties> func, RequestOptions options = null)
             => GuildHelper.ModifyWidgetAsync(this, Discord, func, options);
         /// <inheritdoc />
@@ -566,7 +566,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a ban object, which
-        ///     contains the user information and the reason for the ban; <c>null</c> if the ban entry cannot be found.
+        ///     contains the user information and the reason for the ban; <see langword="null"/> if the ban entry cannot be found.
         /// </returns>
         public Task<RestBan> GetBanAsync(IUser user, RequestOptions options = null)
             => GuildHelper.GetBanAsync(this, Discord, user.Id, options);
@@ -577,7 +577,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a ban object, which
-        ///     contains the user information and the reason for the ban; <c>null</c> if the ban entry cannot be found.
+        ///     contains the user information and the reason for the ban; <see langword="null"/> if the ban entry cannot be found.
         /// </returns>
         public Task<RestBan> GetBanAsync(ulong userId, RequestOptions options = null)
             => GuildHelper.GetBanAsync(this, Discord, userId, options);
@@ -602,7 +602,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="id">The snowflake identifier for the channel.</param>
         /// <returns>
-        ///     A generic channel associated with the specified <paramref name="id" />; <c>null</c> if none is found.
+        ///     A generic channel associated with the specified <paramref name="id" />; <see langword="null"/> if none is found.
         /// </returns>
         public SocketGuildChannel GetChannel(ulong id)
         {
@@ -616,7 +616,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="id">The snowflake identifier for the text channel.</param>
         /// <returns>
-        ///     A text channel associated with the specified <paramref name="id" />; <c>null</c> if none is found.
+        ///     A text channel associated with the specified <paramref name="id" />; <see langword="null"/> if none is found.
         /// </returns>
         public SocketTextChannel GetTextChannel(ulong id)
             => GetChannel(id) as SocketTextChannel;
@@ -625,7 +625,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="id">The snowflake identifier for the voice channel.</param>
         /// <returns>
-        ///     A voice channel associated with the specified <paramref name="id" />; <c>null</c> if none is found.
+        ///     A voice channel associated with the specified <paramref name="id" />; <see langword="null"/> if none is found.
         /// </returns>
         public SocketVoiceChannel GetVoiceChannel(ulong id)
             => GetChannel(id) as SocketVoiceChannel;
@@ -634,7 +634,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="id">The snowflake identifier for the category channel.</param>
         /// <returns>
-        ///     A category channel associated with the specified <paramref name="id" />; <c>null</c> if none is found.
+        ///     A category channel associated with the specified <paramref name="id" />; <see langword="null"/> if none is found.
         /// </returns>
         public SocketCategoryChannel GetCategoryChannel(ulong id)
             => GetChannel(id) as SocketCategoryChannel;
@@ -670,7 +670,7 @@ namespace Discord.WebSocket
         /// <param name="name">The new name for the voice channel.</param>
         /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     voice channel.
@@ -683,7 +683,7 @@ namespace Discord.WebSocket
         /// <param name="name">The new name for the category.</param>
         /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     category channel.
@@ -747,7 +747,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the partial metadata of
-        ///     the vanity invite found within this guild; <c>null</c> if none is found.
+        ///     the vanity invite found within this guild; <see langword="null"/> if none is found.
         /// </returns>
         public Task<RestInviteMetadata> GetVanityInviteAsync(RequestOptions options = null)
             => GuildHelper.GetVanityInviteAsync(this, Discord, options);
@@ -758,7 +758,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="id">The snowflake identifier for the role.</param>
         /// <returns>
-        ///     A role that is associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     A role that is associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public SocketRole GetRole(ulong id)
         {
@@ -780,7 +780,7 @@ namespace Discord.WebSocket
         /// <param name="isHoisted">Whether the role is separated from others on the sidebar.</param>
         /// <param name="isMentionable">Whether the role can be mentioned.</param>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
@@ -812,13 +812,13 @@ namespace Discord.WebSocket
         /// <remarks>
         ///     This method retrieves a user found within this guild.
         ///     <note>
-        ///         This may return <c>null</c> in the WebSocket implementation due to incomplete user collection in
+        ///         This may return <see langword="null"/> in the WebSocket implementation due to incomplete user collection in
         ///         large guilds.
         ///     </note>
         /// </remarks>
         /// <param name="id">The snowflake identifier of the user.</param>
         /// <returns>
-        ///     A guild user associated with the specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     A guild user associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public SocketGuildUser GetUser(ulong id)
         {
@@ -972,7 +972,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the webhook with the
-        ///     specified <paramref name="id"/>; <c>null</c> if none is found.
+        ///     specified <paramref name="id"/>; <see langword="null"/> if none is found.
         /// </returns>
         public Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => GuildHelper.GetWebhookAsync(this, Discord, id, options);
@@ -995,7 +995,7 @@ namespace Discord.WebSocket
         public Task<GuildEmote> CreateEmoteAsync(string name, Image image, Optional<IEnumerable<IRole>> roles = default(Optional<IEnumerable<IRole>>), RequestOptions options = null)
             => GuildHelper.CreateEmoteAsync(this, Discord, name, image, roles, options);
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         public Task<GuildEmote> ModifyEmoteAsync(GuildEmote emote, Action<EmoteProperties> func, RequestOptions options = null)
             => GuildHelper.ModifyEmoteAsync(this, Discord, emote.Id, func, options);
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

Add missing properties to Guild classes, related methods, and deprecate GuildEmbed endpoints in favor of GuildWidget.

## Changes

- Add missing guild properties and respective methods to guild classes: `discovery_splash`, `widget_enabled`, `widget_channel_id`, `rules_channel_id`, `max_presences`, `max_members`, `public_updates_channel_id`, `max_video_channel_users`, `approximate_member_count`, `approximate_presence_count`
- Update guild properties: `embed_enabled`, `embed_channel_id`
- Add `GetGuildDiscoverySplashUrl` to `CDN`
- Add classes related to the guild widget
- Add `withCounts` parameter to `GetGuild(s)Async`
- Make GuildEmbed related methods obsolete with a message redirecting to widget ones