### PR TITLE
fix: Trim token before passing it to the authorization header

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -82,9 +82,9 @@ namespace Discord.API
         {
             return tokenType switch
             {
-                default(TokenType) => token?.TrimEnd(),
-                TokenType.Bot => $"Bot {token?.TrimEnd()}",
-                TokenType.Bearer => $"Bearer {token?.TrimEnd()}",
+                default(TokenType) => token,
+                TokenType.Bot => $"Bot {token}",
+                TokenType.Bearer => $"Bearer {token}",
                 _ => throw new ArgumentException(message: "Unknown OAuth token type.", paramName: nameof(tokenType)),
             };
         }
@@ -129,7 +129,7 @@ namespace Discord.API
                 RestClient.SetCancelToken(_loginCancelToken.Token);
 
                 AuthTokenType = tokenType;
-                AuthToken = token;
+                AuthToken = token?.TrimEnd();
                 if (tokenType != TokenType.Webhook)
                     RestClient.SetHeader("authorization", GetPrefixedToken(AuthTokenType, AuthToken));
 

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -80,17 +80,13 @@ namespace Discord.API
         /// <exception cref="ArgumentException">Unknown OAuth token type.</exception>
         internal static string GetPrefixedToken(TokenType tokenType, string token)
         {
-            switch (tokenType)
+            return tokenType switch
             {
-                case default(TokenType):
-                    return token;
-                case TokenType.Bot:
-                    return $"Bot {token}";
-                case TokenType.Bearer:
-                    return $"Bearer {token}";
-                default:
-                    throw new ArgumentException(message: "Unknown OAuth token type.", paramName: nameof(tokenType));
-            }
+                default(TokenType) => token?.TrimEnd(),
+                TokenType.Bot => $"Bot {token?.TrimEnd()}",
+                TokenType.Bearer => $"Bearer {token?.TrimEnd()}",
+                _ => throw new ArgumentException(message: "Unknown OAuth token type.", paramName: nameof(tokenType)),
+            };
         }
         internal virtual void Dispose(bool disposing)
         {


### PR DESCRIPTION
## Summary

Prevents the client from logging in successfully but throwing an exception when doing http methods that aren't GET with an `error 411: LengthRequired` that isn't intuitive to why it happened since it can occur long after the client started.

Fixes #1577 