### PR TITLE
fix: Possible fix to one cause of the "connection deadlock"

### DIFF
--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -141,7 +141,16 @@ namespace Discord
                     catch (OperationCanceledException) { }
                 });
 
-                await _onConnecting().ConfigureAwait(false);
+                try
+                {
+                    await _onConnecting().ConfigureAwait(false);
+                }
+                catch (TaskCanceledException ex)
+                {
+                    Exception innerEx = ex.InnerException ?? new OperationCanceledException("Failed to connect.");
+                    Error(innerEx);
+                    throw innerEx;
+                }
 
                 await _logger.InfoAsync("Connected").ConfigureAwait(false);
                 State = ConnectionState.Connected;


### PR DESCRIPTION
Firsts things first: since this issue isn't easily reproducible, I based this fix on a stacktrace provided in one issue, in this case, #1572 . So there's a few things to consider:
1) It might not fix all possible causes to the connection deadlock;
2) It might have an unintended side effect that I didn't notice/predict (I'll explain at the end).

## The issue

I read the stacktrace from #1572 again and again and came to the conclusion that what happens is due to an exception thrown from a rest request being cancelled and reaching the ConnectionManager that will permanently disconnect due to it.

It goes as this:
1) DiscordSocketClient.StartAsync
2) ConnectionManager.StartAsync
3) ConnectionManager: `await ConnectAsync(reconnectCancelToken).ConfigureAwait(false);`
4) ConnectionManager: `await _onConnecting().ConfigureAwait(false);` (that is actually DiscordSocketClient.OnConnectingAsync)
5) DiscordSocketClient: `await ApiClient.ConnectAsync().ConfigureAwait(false);`
6) DiscordSocketApiClient: ConnectAsync
7) DiscordSocketApiClient: ConnectInternalAsync
8) ConnectInternalAsync: `var gatewayResponse = await GetGatewayAsync().ConfigureAwait(false);` fails and throws a `TaskCanceledException` (could be any other rest request in DiscordSocketClient.OnConnectingAsync)
9) TaskCanceledException bubbles up until it's back to the ConnectionManager.StartAsync
10) StartAsync will finally deal with the exception, since `TaskCanceledException` inherits from `OperationCanceledException`, it'll end in this catch:
```cs
catch (OperationCanceledException ex)
{
    Cancel(); //In case this exception didn't come from another Error call
    await DisconnectAsync(ex, !reconnectCancelToken.IsCancellationRequested).ConfigureAwait(false);
}
```
This catch will cancel all tokens in `Cancel()`, including the reconnect, so it'll just Disconnect and stop there.

## Solution

I decided to try-catch the `await _onConnecting().ConfigureAwait(false);` to prevent any `TaskCanceledException` from bubbling up (and disconnecting the client permanently) and sent the inner exception instead (added a null check to prevent throwing "null", but I didn't also see a reason why that would happen, so it's there just to be safe).

Now this could cause an unintended side effect. I wasn't able to identify a method would legitly throw that specific exception, so I don't believe it'll happen but it could if I missed it, and end not disconnecting permanently the client as expected.

If anyone that has this issue recurrently could test this PR, it would be highly appreaciated, same goes if you see something I missed that could potentially cause an unintended consequence.