### PR TITLE
Fix CI/CD

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,25 +14,20 @@ trigger:
 jobs:
 - job: Linux
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk'
-    inputs:
-      packageType: 'sdk'
-      version: '3.x'
   - template: azure/build.yml
 
 - job: Windows_build
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-latest'
   condition: ne(variables['Build.SourceBranch'], 'refs/heads/dev')
   steps:
   - template: azure/build.yml
 
 - job: Windows_deploy
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-latest'
   condition: |
       and (
         succeeded(),

--- a/azure/build.yml
+++ b/azure/build.yml
@@ -1,5 +1,10 @@
 steps:
-- script: dotnet restore --no-cache Discord.Net.sln
+- task: DotNetCoreCLI@2
+  inputs:
+     command: 'restore'
+     projects: 'Discord.Net.sln'
+     feedsToUse: 'select'
+     verbosityRestore: 'Minimal'
   displayName: Restore packages
 
 - script: dotnet build "Discord.Net.sln" --no-restore -v minimal -c $(buildConfiguration) /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)

--- a/samples/01_basic_ping_bot/01_basic_ping_bot.csproj
+++ b/samples/01_basic_ping_bot/01_basic_ping_bot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/02_commands_framework/02_commands_framework.csproj
+++ b/samples/02_commands_framework/02_commands_framework.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/03_sharded_client/03_sharded_client.csproj
+++ b/samples/03_sharded_client/03_sharded_client.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>_03_sharded_client</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`dotnet restore` on the windows agents seems to no longer include the default nuget feed, thereby failing the restore.