### PR TITLE
feature: added GetStreams to AudioClient and IAudioClient

### DIFF
--- a/src/Discord.Net.Core/Audio/IAudioClient.cs
+++ b/src/Discord.Net.Core/Audio/IAudioClient.cs
@@ -22,7 +22,7 @@ namespace Discord.Audio
         int UdpLatency { get; }
 
         /// <summary>Gets the current audio streams.</summary>
-        Dictionary<ulong, AudioInStream> GetStreams();
+        IReadOnlyDictionary<ulong, AudioInStream> GetStreams();
 
         Task StopAsync();
         Task SetSpeakingAsync(bool value);

--- a/src/Discord.Net.Core/Audio/IAudioClient.cs
+++ b/src/Discord.Net.Core/Audio/IAudioClient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Discord.Audio
@@ -19,6 +20,9 @@ namespace Discord.Audio
         int Latency { get; }
         /// <summary> Gets the estimated round-trip latency, in milliseconds, to the voice UDP server. </summary>
         int UdpLatency { get; }
+
+        /// <summary>Gets the current audio streams.</summary>
+        Dictionary<ulong, AudioInStream> GetStreams();
 
         Task StopAsync();
         Task SetSpeakingAsync(bool value);

--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -99,11 +99,16 @@ namespace Discord.Audio
             _token = token;
             await _connection.StartAsync().ConfigureAwait(false);
         }
+
+        public Dictionary<ulong, AudioInStream> GetStreams()
+        {
+            return _streams.ToDictionary(pair => pair.Key, pair => pair.Value.Reader);
+        }
+
         public async Task StopAsync()
         {
             await _connection.StopAsync().ConfigureAwait(false);
         }
-
         private async Task OnConnectingAsync()
         {
             await _audioLogger.DebugAsync("Connecting ApiClient").ConfigureAwait(false);
@@ -379,7 +384,7 @@ namespace Discord.Audio
 
         private async Task RunHeartbeatAsync(int intervalMillis, CancellationToken cancelToken)
         {
-            //TODO: Clean this up when Discord's session patch is live
+            // TODO: Clean this up when Discord's session patch is live
             try
             {
                 await _audioLogger.DebugAsync("Heartbeat Started").ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -100,7 +100,7 @@ namespace Discord.Audio
             await _connection.StartAsync().ConfigureAwait(false);
         }
 
-        public Dictionary<ulong, AudioInStream> GetStreams()
+        public IReadOnlyDictionary<ulong, AudioInStream> GetStreams()
         {
             return _streams.ToDictionary(pair => pair.Key, pair => pair.Value.Reader);
         }
@@ -109,6 +109,7 @@ namespace Discord.Audio
         {
             await _connection.StopAsync().ConfigureAwait(false);
         }
+
         private async Task OnConnectingAsync()
         {
             await _audioLogger.DebugAsync("Connecting ApiClient").ConfigureAwait(false);


### PR DESCRIPTION
# Summary
This PR aims to add a function to AudioClient to allow people to obtain a dictionary of streams that are already inside of the AudioClient, this allows people to get the streams before registering the **StreamCreated** event, and allow them to process the audio streams.

Fixes #1395

# Changes
- Add function declaration of GetStreams to IAudioClient
- Add function definition to AudioClient