### PR TITLE
feature: Add missing create/modify channel properties

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Discord
 {
     /// <summary>
@@ -30,5 +32,9 @@ namespace Discord
         ///     is set.
         /// </remarks>
         public Optional<ulong?> CategoryId { get; set; }
+        /// <summary>
+        ///     Gets or sets the permission overwrites for this channel.
+        /// </summary>
+        public Optional<IEnumerable<Overwrite>> PermissionOverwrites { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
@@ -14,12 +14,16 @@ namespace Discord.API.Rest
         public Optional<ulong?> CategoryId { get; set; }
         [JsonProperty("position")]
         public Optional<int> Position { get; set; }
+        [JsonProperty("permission_overwrites")]
+        public Optional<Overwrite[]> Overwrites { get; set; }
 
         //Text channels
         [JsonProperty("topic")]
         public Optional<string> Topic { get; set; }
         [JsonProperty("nsfw")]
         public Optional<bool> IsNsfw { get; set; }
+        [JsonProperty("rate_limit_per_user")]
+        public Optional<int> SlowModeInterval { get; set; }
 
         //Voice channels
         [JsonProperty("bitrate")]

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -46,6 +46,15 @@ namespace Discord.Rest
                 Topic = args.Topic,
                 IsNsfw = args.IsNsfw,
                 SlowModeInterval = args.SlowModeInterval,
+                Overwrites = args.PermissionOverwrites.IsSpecified
+                    ? args.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                    {
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue,
+                        Deny = overwrite.Permissions.DenyValue
+                    }).ToArray()
+                    : Optional.Create<API.Overwrite[]>(),
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }
@@ -413,7 +422,8 @@ namespace Discord.Rest
             var apiArgs = new ModifyGuildChannelParams
             {
                 Overwrites = category.PermissionOverwrites
-                    .Select(overwrite => new API.Overwrite{
+                    .Select(overwrite => new API.Overwrite
+                    {
                         TargetId = overwrite.TargetId,
                         TargetType = overwrite.TargetType,
                         Allow = overwrite.Permissions.AllowValue,

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -176,7 +176,17 @@ namespace Discord.Rest
                 CategoryId = props.CategoryId,
                 Topic = props.Topic,
                 IsNsfw = props.IsNsfw,
-                Position = props.Position
+                Position = props.Position,
+                SlowModeInterval = props.SlowModeInterval,
+                Overwrites = props.PermissionOverwrites.IsSpecified
+                    ? props.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                    {
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue,
+                        Deny = overwrite.Permissions.DenyValue
+                    }).ToArray()
+                    : Optional.Create<API.Overwrite[]>(),
             };
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
             return RestTextChannel.Create(client, guild, model);
@@ -195,7 +205,16 @@ namespace Discord.Rest
                 CategoryId = props.CategoryId,
                 Bitrate = props.Bitrate,
                 UserLimit = props.UserLimit,
-                Position = props.Position
+                Position = props.Position,
+                Overwrites = props.PermissionOverwrites.IsSpecified
+                    ? props.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                    {
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue,
+                        Deny = overwrite.Permissions.DenyValue
+                    }).ToArray()
+                    : Optional.Create<API.Overwrite[]>(),
             };
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
             return RestVoiceChannel.Create(client, guild, model);
@@ -211,7 +230,16 @@ namespace Discord.Rest
 
             var args = new CreateGuildChannelParams(name, ChannelType.Category)
             {
-                Position = props.Position
+                Position = props.Position,
+                Overwrites = props.PermissionOverwrites.IsSpecified
+                    ? props.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                    {
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue,
+                        Deny = overwrite.Permissions.DenyValue
+                    }).ToArray()
+                    : Optional.Create<API.Overwrite[]>(),
             };
 
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

Add a missing property when creating and modifying channels, `PermissionOverwrites`, and pass `SlowModeInterval` when creating a channel.

## Changes

- Add `GuildChannelProperties.PermissionOverwrites`
- Add `CreateGuildChannelParams.SlowModeInterval`
- Add `CreateGuildChannelParams.PermissionOverwrites`