### PR TITLE
fix: Add AllowedMentions to webhooks

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest
@@ -19,6 +19,8 @@ namespace Discord.API.Rest
         public Optional<string> Username { get; set; }
         [JsonProperty("avatar_url")]
         public Optional<string> AvatarUrl { get; set; }
+        [JsonProperty("allowed_mentions")]
+        public Optional<AllowedMentions> AllowedMentions { get; set; }
 
         public CreateWebhookMessageParams(string content)
         {

--- a/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
@@ -21,6 +21,7 @@ namespace Discord.API.Rest
         public Optional<string> Username { get; set; }
         public Optional<string> AvatarUrl { get; set; }
         public Optional<Embed[]> Embeds { get; set; }
+        public Optional<AllowedMentions> AllowedMentions { get; set; }
 
         public bool IsSpoiler { get; set; } = false;
 
@@ -51,6 +52,8 @@ namespace Discord.API.Rest
                 payload["avatar_url"] = AvatarUrl.Value;
             if (Embeds.IsSpecified)
                 payload["embeds"] = Embeds.Value;
+            if (AllowedMentions.IsSpecified)
+                payload["allowed_mentions"] = AllowedMentions.Value;
 
             var json = new StringBuilder();
             using (var text = new StringWriter(json))

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -88,19 +88,21 @@ namespace Discord.Webhook
         /// <summary> Sends a message to the channel for this webhook. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendMessageAsync(string text = null, bool isTTS = false, IEnumerable<Embed> embeds = null,
-            string username = null, string avatarUrl = null, RequestOptions options = null)
-            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, options);
+            string username = null, string avatarUrl = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
+            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
-            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
-            => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
+            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
+            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler);
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
-            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null, RequestOptions options = null, bool isSpoiler = false)
-            => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username, avatarUrl, options, isSpoiler);
+            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
+            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler);
 
         /// <summary> Modifies the properties of this webhook. </summary>
         public Task ModifyWebhookAsync(Action<WebhookProperties> func, RequestOptions options = null)

--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -21,7 +21,7 @@ namespace Discord.Webhook
             return RestInternalWebhook.Create(client, model);
         }
         public static async Task<ulong> SendMessageAsync(DiscordWebhookClient client, 
-            string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl, RequestOptions options)
+            string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options)
         {
             var args = new CreateWebhookMessageParams(text) { IsTTS = isTTS };
             if (embeds != null)
@@ -30,19 +30,21 @@ namespace Discord.Webhook
                 args.Username = username;
             if (avatarUrl != null)
                 args.AvatarUrl = avatarUrl;
+            if (allowedMentions != null)
+                args.AllowedMentions = allowedMentions.ToModel();
 
             var model = await client.ApiClient.CreateWebhookMessageAsync(client.Webhook.Id, args, options: options).ConfigureAwait(false);
             return model.Id;
         }
         public static async Task<ulong> SendFileAsync(DiscordWebhookClient client, string filePath, string text, bool isTTS, 
-            IEnumerable<Embed> embeds, string username, string avatarUrl, RequestOptions options, bool isSpoiler)
+            IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options, bool isSpoiler)
         {
             string filename = Path.GetFileName(filePath);
             using (var file = File.OpenRead(filePath))
-                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, options, isSpoiler).ConfigureAwait(false);
+                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler).ConfigureAwait(false);
         }
         public static async Task<ulong> SendFileAsync(DiscordWebhookClient client, Stream stream, string filename, string text, bool isTTS,
-            IEnumerable<Embed> embeds, string username, string avatarUrl, RequestOptions options, bool isSpoiler)
+            IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options, bool isSpoiler)
         {
             var args = new UploadWebhookFileParams(stream) { Filename = filename, Content = text, IsTTS = isTTS, IsSpoiler = isSpoiler };
             if (username != null)
@@ -51,6 +53,8 @@ namespace Discord.Webhook
                 args.AvatarUrl = avatarUrl;
             if (embeds != null)
                 args.Embeds = embeds.Select(x => x.ToModel()).ToArray();
+            if(allowedMentions != null)
+                args.AllowedMentions = allowedMentions.ToModel();
             var msg = await client.ApiClient.UploadWebhookFileAsync(client.Webhook.Id, args, options).ConfigureAwait(false);
             return msg.Id;
         }


### PR DESCRIPTION
## Summary

Add missing `AllowedMentions` parameter to webhook methods.
Fixes #1601 

## Changes

- Add AllowedMentions to `DiscordWebhookClient#SendMessageAsync`
- Add AllowedMentions to `DiscordWebhookClient#SendFileAsync`