### PR TITLE
fix: Cancel reconnection when 4014

### DIFF
--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -44,6 +44,8 @@ namespace Discord
                     var ex2 = ex as WebSocketClosedException;
                     if (ex2?.CloseCode == 4006)
                         CriticalError(new Exception("WebSocket session expired", ex));
+                    if (ex2?.CloseCode == 4014)
+                        CriticalError(new Exception("WebSocket connection was closed", ex));
                     else
                         Error(new Exception("WebSocket connection was closed", ex));
                 }

--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -44,7 +44,7 @@ namespace Discord
                     var ex2 = ex as WebSocketClosedException;
                     if (ex2?.CloseCode == 4006)
                         CriticalError(new Exception("WebSocket session expired", ex));
-                    if (ex2?.CloseCode == 4014)
+                    else if (ex2?.CloseCode == 4014)
                         CriticalError(new Exception("WebSocket connection was closed", ex));
                     else
                         Error(new Exception("WebSocket connection was closed", ex));


### PR DESCRIPTION
Stop the client from trying to reconnect when it receives a 4014: Disallowed intent(s).
Fixes #1600 