### PR TITLE
feature: Add missing application properties (including Teams)

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -8,6 +8,17 @@ namespace Discord
     public static class CDN
     {
         /// <summary>
+        ///     Returns a team icon URL.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="iconId">The icon identifier.</param>
+        /// <returns>
+        ///     A URL pointing to the team's icon.
+        /// </returns>
+        public static string GetTeamIconUrl(ulong teamId, string iconId)
+            => iconId != null ? $"{DiscordConfig.CDNUrl}team-icons/{teamId}/{iconId}.jpg" : null;
+
+        /// <summary>
         ///     Returns an application icon URL.
         /// </summary>
         /// <param name="appId">The application identifier.</param>

--- a/src/Discord.Net.Core/Entities/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/IApplication.cs
@@ -22,6 +22,18 @@ namespace Discord
         ///     Gets the icon URL of the application.
         /// </summary>
         string IconUrl  { get; }
+        /// <summary>
+        ///     Gets if the bot is public.
+        /// </summary>
+        bool IsBotPublic { get; }
+        /// <summary>
+        ///     Gets if the bot requires code grant.
+        /// </summary>
+        bool BotRequiresCodeGrant { get; }
+        /// <summary>
+        ///     Gets the team associated with this application if there is one.
+        /// </summary>
+        ITeam Team { get; }
 
         /// <summary>
         ///     Gets the partial user object containing info on the owner of the application.

--- a/src/Discord.Net.Core/Entities/Teams/ITeam.cs
+++ b/src/Discord.Net.Core/Entities/Teams/ITeam.cs
@@ -18,7 +18,7 @@ namespace Discord
         /// <summary>
         ///     Gets the members of this team.
         /// </summary>
-        List<ITeamMember> TeamMembers { get; }
+        IReadOnlyList<ITeamMember> TeamMembers { get; }
         /// <summary>
         ///     Gets the user identifier that owns this team.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Teams/ITeam.cs
+++ b/src/Discord.Net.Core/Entities/Teams/ITeam.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Discord
+{
+    /// <summary>
+    ///     Represents a Discord Team.
+    /// </summary>
+    public interface ITeam
+    {
+        /// <summary>
+        ///     Gets the team icon url.
+        /// </summary>
+        string IconUrl { get; }
+        /// <summary>
+        ///     Gets the team unique identifier.
+        /// </summary>
+        ulong Id { get; }
+        /// <summary>
+        ///     Gets the members of this team.
+        /// </summary>
+        List<ITeamMember> TeamMembers { get; }
+        /// <summary>
+        ///     Gets the user identifier that owns this team.
+        /// </summary>
+        ulong OwnerUserId { get; }
+    }
+}

--- a/src/Discord.Net.Core/Entities/Teams/ITeamMember.cs
+++ b/src/Discord.Net.Core/Entities/Teams/ITeamMember.cs
@@ -1,0 +1,25 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Represents a Discord Team member.
+    /// </summary>
+    public interface ITeamMember
+    {
+        /// <summary>
+        ///     Gets the membership state of this team member.
+        /// </summary>
+        MembershipState MembershipState { get; }
+        /// <summary>
+        ///     Gets the permissions of this team member.
+        /// </summary>
+        string[] Permissions { get; }
+        /// <summary>
+        ///     Gets the team unique identifier for this team member.
+        /// </summary>
+        ulong TeamId { get; }
+        /// <summary>
+        ///     Gets the Discord user of this team member.
+        /// </summary>
+        IUser User { get; }
+    }
+}

--- a/src/Discord.Net.Core/Entities/Teams/MembershipState.cs
+++ b/src/Discord.Net.Core/Entities/Teams/MembershipState.cs
@@ -1,0 +1,11 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Represents the membership state of a team member.
+    /// </summary>
+    public enum MembershipState
+    {
+        Invited,
+        Accepted,
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/Application.cs
+++ b/src/Discord.Net.Rest/API/Common/Application.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -15,6 +15,12 @@ namespace Discord.API
         public ulong Id { get; set; }
         [JsonProperty("icon")]
         public string Icon { get; set; }
+        [JsonProperty("bot_public")]
+        public bool IsBotPublic { get; set; }
+        [JsonProperty("bot_require_code_grant")]
+        public bool BotRequiresCodeGrant { get; set; }
+        [JsonProperty("team")]
+        public Optional<Team> Team { get; set; }
 
         [JsonProperty("flags"), Int53]
         public Optional<ulong> Flags { get; set; }

--- a/src/Discord.Net.Rest/API/Common/MembershipState.cs
+++ b/src/Discord.Net.Rest/API/Common/MembershipState.cs
@@ -1,0 +1,9 @@
+namespace Discord.API
+{
+    internal enum MembershipState
+    {
+        None = 0,
+        Invited = 1,
+        Accepted = 2,
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/Team.cs
+++ b/src/Discord.Net.Rest/API/Common/Team.cs
@@ -1,0 +1,17 @@
+#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class Team
+    {
+        [JsonProperty("icon")]
+        public Optional<string> Icon { get; set; }
+        [JsonProperty("id")]
+        public ulong Id { get; set; }
+        [JsonProperty("members")]
+        public TeamMember[] TeamMembers { get; set; }
+        [JsonProperty("owner_user_id")]
+        public ulong OwnerUserId { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/TeamMember.cs
+++ b/src/Discord.Net.Rest/API/Common/TeamMember.cs
@@ -1,0 +1,17 @@
+#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class TeamMember
+    {
+        [JsonProperty("membership_state")]
+        public MembershipState MembershipState { get; set; }
+        [JsonProperty("permissions")]
+        public string[] Permissions { get; set; }
+        [JsonProperty("team_id")]
+        public ulong TeamId { get; set; }
+        [JsonProperty("user")]
+        public User User { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/RestApplication.cs
+++ b/src/Discord.Net.Rest/Entities/RestApplication.cs
@@ -21,6 +21,12 @@ namespace Discord.Rest
         public string[] RPCOrigins { get; private set; }
         /// <inheritdoc />
         public ulong Flags { get; private set; }
+        /// <inheritdoc />
+        public bool IsBotPublic { get; private set; }
+        /// <inheritdoc />
+        public bool BotRequiresCodeGrant { get; private set; }
+        /// <inheritdoc />
+        public ITeam Team { get; private set; }
 
         /// <inheritdoc />
         public IUser Owner { get; private set; }
@@ -46,11 +52,15 @@ namespace Discord.Rest
             RPCOrigins = model.RPCOrigins;
             Name = model.Name;
             _iconId = model.Icon;
+            IsBotPublic = model.IsBotPublic;
+            BotRequiresCodeGrant = model.BotRequiresCodeGrant;
 
             if (model.Flags.IsSpecified)
                 Flags = model.Flags.Value; //TODO: Do we still need this?
             if (model.Owner.IsSpecified)
                 Owner = RestUser.Create(Discord, model.Owner.Value);
+            if (model.Team.IsSpecified)
+                Team = RestTeam.Create(Discord, model.Team.Value);
         }
 
         /// <exception cref="InvalidOperationException">Unable to update this object from a different application token.</exception>

--- a/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
+++ b/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Model = Discord.API.Team;
 
@@ -9,7 +10,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string IconUrl => _iconId != null ? CDN.GetTeamIconUrl(Id, _iconId) : null;
         /// <inheritdoc />
-        public List<ITeamMember> TeamMembers { get; private set; }
+        public IReadOnlyList<ITeamMember> TeamMembers { get; private set; }
         /// <inheritdoc />
         public ulong OwnerUserId { get; private set; }
 
@@ -30,7 +31,7 @@ namespace Discord.Rest
             if (model.Icon.IsSpecified)
                 _iconId = model.Icon.Value;
             OwnerUserId = model.OwnerUserId;
-            TeamMembers = model.TeamMembers.Select(x => new RestTeamMember(Discord, x)).ToList<ITeamMember>();
+            TeamMembers = model.TeamMembers.Select(x => new RestTeamMember(Discord, x)).ToImmutableList();
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
+++ b/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
@@ -31,7 +31,7 @@ namespace Discord.Rest
             if (model.Icon.IsSpecified)
                 _iconId = model.Icon.Value;
             OwnerUserId = model.OwnerUserId;
-            TeamMembers = model.TeamMembers.Select(x => new RestTeamMember(Discord, x)).ToImmutableList();
+            TeamMembers = model.TeamMembers.Select(x => new RestTeamMember(Discord, x)).ToImmutableArray();
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
+++ b/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using Model = Discord.API.Team;
+
+namespace Discord.Rest
+{
+    public class RestTeam : RestEntity<ulong>, ITeam
+    {
+        /// <inheritdoc />
+        public string IconUrl => _iconId != null ? CDN.GetTeamIconUrl(Id, _iconId) : null;
+        /// <inheritdoc />
+        public List<ITeamMember> TeamMembers { get; private set; }
+        /// <inheritdoc />
+        public ulong OwnerUserId { get; private set; }
+
+        private string _iconId;
+
+        internal RestTeam(BaseDiscordClient discord, ulong id)
+            : base(discord, id)
+        {
+        }
+        internal static RestTeam Create(BaseDiscordClient discord, Model model)
+        {
+            var entity = new RestTeam(discord, model.Id);
+            entity.Update(model);
+            return entity;
+        }
+        internal virtual void Update(Model model)
+        {
+            if (model.Icon.IsSpecified)
+                _iconId = model.Icon.Value;
+            OwnerUserId = model.OwnerUserId;
+            TeamMembers = model.TeamMembers.Select(x => new RestTeamMember(Discord, x)).ToList<ITeamMember>();
+        }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Teams/RestTeamMember.cs
+++ b/src/Discord.Net.Rest/Entities/Teams/RestTeamMember.cs
@@ -1,0 +1,30 @@
+using System;
+using Model = Discord.API.TeamMember;
+
+namespace Discord.Rest
+{
+    public class RestTeamMember : ITeamMember
+    {
+        /// <inheritdoc />
+        public MembershipState MembershipState { get; }
+        /// <inheritdoc />
+        public string[] Permissions { get; }
+        /// <inheritdoc />
+        public ulong TeamId { get; }
+        /// <inheritdoc />
+        public IUser User { get; }
+
+        internal RestTeamMember(BaseDiscordClient discord, Model model)
+        {
+            MembershipState = model.MembershipState switch
+            {
+                API.MembershipState.Invited => MembershipState.Invited,
+                API.MembershipState.Accepted => MembershipState.Accepted,
+                _ => throw new InvalidOperationException("Invalid membership state"),
+            };
+            Permissions = model.Permissions;
+            TeamId = model.TeamId;
+            User = RestUser.Create(discord, model.User);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This will add some missing properties related to bots to `IApplication`: `IsBotPublic`, `BotRequiresCodeGrant`, and `Team`.
Fixes #1591 

## Changes

- Add `CDN.GetTeamIconUrl`.
- Add `IApplication` (and `RestApplication`) properties:  `IsBotPublic`, `BotRequiresCodeGrant` and `Team`.
- Add team related api classes: `Team`, `TeamMember`, `API.MembershipState`
- Add team related interfaces: `ITeam`, `ITeamMember`
- Add team related classes: `RestTeam`, `RestTeamMember`, `Rest.MembershipState`