### PR TITLE
fix: Voice overwrites and CategoryId remarks

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
@@ -28,7 +28,7 @@ namespace Discord
         /// </summary>
         /// <remarks>
         ///     Setting this value to a category's snowflake identifier will change or set this channel's parent to the
-        ///     specified channel; setting this value to <c>0</c> will detach this channel from its parent if one
+        ///     specified channel; setting this value to <see langword="null"/> will detach this channel from its parent if one
         ///     is set.
         /// </remarks>
         public Optional<ulong?> CategoryId { get; set; }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -28,7 +28,16 @@ namespace Discord.Rest
             {
                 Name = args.Name,
                 Position = args.Position,
-                CategoryId = args.CategoryId
+                CategoryId = args.CategoryId,
+                Overwrites = args.PermissionOverwrites.IsSpecified
+                    ? args.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                    {
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue,
+                        Deny = overwrite.Permissions.DenyValue
+                    }).ToArray()
+                    : Optional.Create<API.Overwrite[]>(),
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -70,7 +70,16 @@ namespace Discord.Rest
                 Name = args.Name,
                 Position = args.Position,
                 CategoryId = args.CategoryId,
-                UserLimit = args.UserLimit.IsSpecified ? (args.UserLimit.Value ?? 0) : Optional.Create<int>()
+                UserLimit = args.UserLimit.IsSpecified ? (args.UserLimit.Value ?? 0) : Optional.Create<int>(),
+                Overwrites = args.PermissionOverwrites.IsSpecified
+                    ? args.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                    {
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue,
+                        Deny = overwrite.Permissions.DenyValue
+                    }).ToArray()
+                    : Optional.Create<API.Overwrite[]>(),
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary

Missed the overwrites for voice channels when modifying them and changed the category id remark since zero will return a bad request.