### PR TITLE
fix: Check 404 and return null for GetBanAsync

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -874,8 +874,12 @@ namespace Discord.API
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
             options = RequestOptions.CreateOrClone(options);
 
-            var ids = new BucketIds(guildId: guildId);
-            return await SendAsync<Ban>("GET", () => $"guilds/{guildId}/bans/{userId}", ids, options: options).ConfigureAwait(false);
+            try
+            {
+                var ids = new BucketIds(guildId: guildId);
+                return await SendAsync<Ban>("GET", () => $"guilds/{guildId}/bans/{userId}", ids, options: options).ConfigureAwait(false);
+            }
+            catch (HttpException ex) when (ex.HttpCode == HttpStatusCode.NotFound) { return null; }
         }
         /// <exception cref="ArgumentException">
         /// <paramref name="guildId"/> and <paramref name="userId"/> must not be equal to zero.

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -132,7 +132,7 @@ namespace Discord.Rest
         public static async Task<RestBan> GetBanAsync(IGuild guild, BaseDiscordClient client, ulong userId, RequestOptions options)
         {
             var model = await client.ApiClient.GetGuildBanAsync(guild.Id, userId, options).ConfigureAwait(false);
-            return RestBan.Create(client, model);
+            return model == null ? null : RestBan.Create(client, model);
         }
 
         public static async Task AddBanAsync(IGuild guild, BaseDiscordClient client,


### PR DESCRIPTION
## Summary

Check if the http code is 404 and return null when that's the case.
Fixes #1613 

## Changes

- Check the HttpCode and return null instead of throwing an exception, following the docs description for the method