### PR TITLE
feature: Add a OnException hook to IModuleBase

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -220,6 +220,11 @@ namespace Discord.Commands
                         return ExecuteResult.FromSuccess();
                     }
                 }
+                catch (Exception exception)
+                {
+                    instance.OnException(cmd, exception);
+                    return ExecuteResult.FromError(exception);
+                }
                 finally
                 {
                     instance.AfterExecute(cmd);

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -1,3 +1,4 @@
+using System;
 using Discord.Commands.Builders;
 
 namespace Discord.Commands
@@ -9,6 +10,8 @@ namespace Discord.Commands
         void BeforeExecute(CommandInfo command);
         
         void AfterExecute(CommandInfo command);
+
+        void OnException(CommandInfo command, Exception exception);
 
         void OnModuleBuilding(CommandService commandService, ModuleBuilder builder);
     }

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -55,6 +55,15 @@ namespace Discord.Commands
         }
 
         /// <summary>
+        ///     The method to execute when an exception is thrown
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="exception"></param>
+        protected virtual void OnException(CommandInfo command, Exception exception)
+        {
+        }
+
+        /// <summary>
         ///     The method to execute when building the module.
         /// </summary>
         /// <param name="commandService">The <see cref="CommandService"/> used to create the module.</param>
@@ -71,6 +80,7 @@ namespace Discord.Commands
         }
         void IModuleBase.BeforeExecute(CommandInfo command) => BeforeExecute(command);
         void IModuleBase.AfterExecute(CommandInfo command) => AfterExecute(command);
+        void IModuleBase.OnException(CommandInfo command, Exception exception) => OnException(command, exception);
         void IModuleBase.OnModuleBuilding(CommandService commandService, ModuleBuilder builder) => OnModuleBuilding(commandService, builder);
     }
 }


### PR DESCRIPTION
# Summary

This PR add a way to handle exceptions thrown by commands using a custom ModuleBase. The benefit of this change is that you don't have to wrap your entire command code in a try/catch block. It also fits in nicely with the `BeforeExecute` and `AfterExecute` hooks.

The change is loosely inspired by [exception filters in asp.net core](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/filters?view=aspnetcore-3.1#exception-filters)

# Changes

* Add a `OnException` hook to `IModuleBase`

