### PR TITLE
feature: Add "View Guild Insights" permission

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -51,6 +51,10 @@ namespace Discord
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
         ManageGuild         = 0x00_00_00_20,
+        /// <summary>
+        ///     Allows for viewing of guild insights
+        /// </summary>
+        ViewGuildInsights = 0x00_08_00_00,
 
         // Text
 		/// <summary>

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -34,7 +34,7 @@ namespace Discord
         public bool AddReactions => Permissions.GetValue(RawValue, GuildPermission.AddReactions);
         /// <summary> If <c>true</c>, a user may view the audit log. </summary>
         public bool ViewAuditLog => Permissions.GetValue(RawValue, GuildPermission.ViewAuditLog);
-
+        /// <summary> If <c>true</c>, a user may view the guild insights. </summary>
         public bool ViewGuildInsights => Permissions.GetValue(RawValue, GuildPermission.ViewGuildInsights);
 
         /// <summary> If True, a user may join channels. </summary>

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -12,7 +12,7 @@ namespace Discord
         /// <summary> Gets a <see cref="GuildPermissions"/> that grants all guild permissions for webhook users. </summary>
         public static readonly GuildPermissions Webhook = new GuildPermissions(0b00000_0000000_0001101100000_000000);
         /// <summary> Gets a <see cref="GuildPermissions"/> that grants all guild permissions. </summary>
-        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111110_1111111111111_111111);
+        public static readonly GuildPermissions All = new GuildPermissions(0b11111_1111111_1111111111111_111111);
 
         /// <summary> Gets a packed value representing all the permissions in this <see cref="GuildPermissions"/>. </summary>
         public ulong RawValue { get; }
@@ -34,6 +34,8 @@ namespace Discord
         public bool AddReactions => Permissions.GetValue(RawValue, GuildPermission.AddReactions);
         /// <summary> If <c>true</c>, a user may view the audit log. </summary>
         public bool ViewAuditLog => Permissions.GetValue(RawValue, GuildPermission.ViewAuditLog);
+
+        public bool ViewGuildInsights => Permissions.GetValue(RawValue, GuildPermission.ViewGuildInsights);
 
         /// <summary> If True, a user may join channels. </summary>
         [Obsolete("Use ViewChannel instead.")]
@@ -97,6 +99,7 @@ namespace Discord
             bool? manageGuild = null,
             bool? addReactions = null,
             bool? viewAuditLog = null,
+            bool? viewGuildInsights = null,
             bool? viewChannel = null,
             bool? sendMessages = null,
             bool? sendTTSMessages = null,
@@ -130,6 +133,7 @@ namespace Discord
             Permissions.SetValue(ref value, manageGuild, GuildPermission.ManageGuild);
             Permissions.SetValue(ref value, addReactions, GuildPermission.AddReactions);
             Permissions.SetValue(ref value, viewAuditLog, GuildPermission.ViewAuditLog);
+            Permissions.SetValue(ref value, viewGuildInsights, GuildPermission.ViewGuildInsights);
             Permissions.SetValue(ref value, viewChannel, GuildPermission.ViewChannel);
             Permissions.SetValue(ref value, sendMessages, GuildPermission.SendMessages);
             Permissions.SetValue(ref value, sendTTSMessages, GuildPermission.SendTTSMessages);
@@ -166,6 +170,7 @@ namespace Discord
             bool manageGuild = false,
             bool addReactions = false,
             bool viewAuditLog = false,
+            bool viewGuildInsights = false,
             bool viewChannel = false,
             bool sendMessages = false,
             bool sendTTSMessages = false,
@@ -198,6 +203,7 @@ namespace Discord
                 manageGuild: manageGuild,
                 addReactions: addReactions,
                 viewAuditLog: viewAuditLog,
+                viewGuildInsights: viewGuildInsights,
                 viewChannel: viewChannel,
                 sendMessages: sendMessages,
                 sendTTSMessages: sendTTSMessages,
@@ -231,6 +237,7 @@ namespace Discord
             bool? manageGuild = null,
             bool? addReactions = null,
             bool? viewAuditLog = null,
+            bool? viewGuildInsights = null,
             bool? viewChannel = null,
             bool? sendMessages = null,
             bool? sendTTSMessages = null,
@@ -254,7 +261,7 @@ namespace Discord
             bool? manageWebhooks = null,
             bool? manageEmojis = null)
             => new GuildPermissions(RawValue, createInstantInvite, kickMembers, banMembers, administrator, manageChannels, manageGuild, addReactions,
-                viewAuditLog, viewChannel, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
+                viewAuditLog, viewGuildInsights, viewChannel, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
                 readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers,
                 useVoiceActivation, prioritySpeaker, stream, changeNickname, manageNicknames, manageRoles, manageWebhooks, manageEmojis);
 

--- a/test/Discord.Net.Tests.Unit/GuildPermissionsTests.cs
+++ b/test/Discord.Net.Tests.Unit/GuildPermissionsTests.cs
@@ -69,6 +69,7 @@ namespace Discord
             AssertFlag(() => new GuildPermissions(manageGuild: true), GuildPermission.ManageGuild);
             AssertFlag(() => new GuildPermissions(addReactions: true), GuildPermission.AddReactions);
             AssertFlag(() => new GuildPermissions(viewAuditLog: true), GuildPermission.ViewAuditLog);
+            AssertFlag(() => new GuildPermissions(viewGuildInsights: true), GuildPermission.ViewGuildInsights);
             AssertFlag(() => new GuildPermissions(viewChannel: true), GuildPermission.ViewChannel);
             AssertFlag(() => new GuildPermissions(sendMessages: true), GuildPermission.SendMessages);
             AssertFlag(() => new GuildPermissions(sendTTSMessages: true), GuildPermission.SendTTSMessages);
@@ -141,6 +142,7 @@ namespace Discord
             AssertUtil(GuildPermission.ManageGuild, x => x.ManageGuild, (p, enable) => p.Modify(manageGuild: enable));
             AssertUtil(GuildPermission.AddReactions, x => x.AddReactions, (p, enable) => p.Modify(addReactions: enable));
             AssertUtil(GuildPermission.ViewAuditLog, x => x.ViewAuditLog, (p, enable) => p.Modify(viewAuditLog: enable));
+            AssertUtil(GuildPermission.ViewGuildInsights, x => x.ViewGuildInsights, (p, enable) => p.Modify(viewGuildInsights: enable));
             AssertUtil(GuildPermission.ViewChannel, x => x.ViewChannel, (p, enable) => p.Modify(viewChannel: enable));
             AssertUtil(GuildPermission.SendMessages, x => x.SendMessages, (p, enable) => p.Modify(sendMessages: enable));
             AssertUtil(GuildPermission.SendTTSMessages, x => x.SendTTSMessages, (p, enable) => p.Modify(sendTTSMessages: enable));


### PR DESCRIPTION
# Summary
Adding "View Guild Insights" permission into Guild Permission. It enables user with this permission to view "Server Insights" from that server.

## Changes
- Added ViewGuildInsights value (0x00080000) to GuildPermission
- Added ViewGuildInsights property to GuildPermissions