### PR TITLE
fix: Message mentions

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -39,6 +39,13 @@ namespace Discord
         /// </returns>
         bool IsSuppressed { get; }
         /// <summary>
+        ///     Gets the value that indicates whether this message mentioned everyone.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this message mentioned everyone; otherwise <c>false</c>.
+        /// </returns>
+        bool MentionedEveryone { get; }
+        /// <summary>
         ///     Gets the content for this message.
         /// </summary>
         /// <returns>

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -37,6 +37,9 @@ namespace Discord.Rest
         public virtual bool IsSuppressed => false;
         /// <inheritdoc />
         public virtual DateTimeOffset? EditedTimestamp => null;
+        /// <inheritdoc />
+        public virtual bool MentionedEveryone => false;
+
         /// <summary>
         ///     Gets a collection of the <see cref="Attachment"/>'s on the message.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -18,6 +18,8 @@ namespace Discord.Rest
         private ImmutableArray<Attachment> _attachments = ImmutableArray.Create<Attachment>();
         private ImmutableArray<Embed> _embeds = ImmutableArray.Create<Embed>();
         private ImmutableArray<ITag> _tags = ImmutableArray.Create<ITag>();
+        private ImmutableArray<ulong> _roleMentionIds = ImmutableArray.Create<ulong>();
+        private ImmutableArray<RestUser> _userMentions = ImmutableArray.Create<RestUser>();
 
         /// <inheritdoc />
         public override bool IsTTS => _isTTS;
@@ -28,15 +30,17 @@ namespace Discord.Rest
         /// <inheritdoc />
         public override DateTimeOffset? EditedTimestamp => DateTimeUtils.FromTicks(_editedTimestampTicks);
         /// <inheritdoc />
+        public override bool MentionedEveryone => _isMentioningEveryone;
+        /// <inheritdoc />
         public override IReadOnlyCollection<Attachment> Attachments => _attachments;
         /// <inheritdoc />
         public override IReadOnlyCollection<Embed> Embeds => _embeds;
         /// <inheritdoc />
         public override IReadOnlyCollection<ulong> MentionedChannelIds => MessageHelper.FilterTagsByKey(TagType.ChannelMention, _tags);
         /// <inheritdoc />
-        public override IReadOnlyCollection<ulong> MentionedRoleIds => MessageHelper.FilterTagsByKey(TagType.RoleMention, _tags);
+        public override IReadOnlyCollection<ulong> MentionedRoleIds => _roleMentionIds;
         /// <inheritdoc />
-        public override IReadOnlyCollection<RestUser> MentionedUsers => MessageHelper.FilterTagsByValue<RestUser>(TagType.UserMention, _tags);
+        public override IReadOnlyCollection<RestUser> MentionedUsers => _userMentions;
         /// <inheritdoc />
         public override IReadOnlyCollection<ITag> Tags => _tags;
 
@@ -67,6 +71,8 @@ namespace Discord.Rest
             {
                 _isSuppressed = model.Flags.Value.HasFlag(API.MessageFlags.Suppressed);
             }
+            if (model.RoleMentions.IsSpecified)
+                _roleMentionIds = model.RoleMentions.Value.ToImmutableArray();
 
             if (model.Attachments.IsSpecified)
             {
@@ -96,20 +102,19 @@ namespace Discord.Rest
                     _embeds = ImmutableArray.Create<Embed>();
             }
 
-            ImmutableArray<IUser> mentions = ImmutableArray.Create<IUser>();
             if (model.UserMentions.IsSpecified)
             {
                 var value = model.UserMentions.Value;
                 if (value.Length > 0)
                 {
-                    var newMentions = ImmutableArray.CreateBuilder<IUser>(value.Length);
+                    var newMentions = ImmutableArray.CreateBuilder<RestUser>(value.Length);
                     for (int i = 0; i < value.Length; i++)
                     {
                         var val = value[i];
                         if (val.Object != null)
                             newMentions.Add(RestUser.Create(Discord, val.Object));
                     }
-                    mentions = newMentions.ToImmutable();
+                    _userMentions = newMentions.ToImmutable();
                 }
             }
 
@@ -118,7 +123,7 @@ namespace Discord.Rest
                 var text = model.Content.Value;
                 var guildId = (Channel as IGuildChannel)?.GuildId;
                 var guild = guildId != null ? (Discord as IDiscordClient).GetGuildAsync(guildId.Value, CacheMode.CacheOnly).Result : null;
-                _tags = MessageHelper.ParseTags(text, null, guild, mentions);
+                _tags = MessageHelper.ParseTags(text, null, guild, _userMentions);
                 model.Content = text;
             }
         }

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -46,6 +46,8 @@ namespace Discord.WebSocket
         public virtual bool IsSuppressed => false;
         /// <inheritdoc />
         public virtual DateTimeOffset? EditedTimestamp => null;
+        /// <inheritdoc />
+        public virtual bool MentionedEveryone => false;
 
         /// <inheritdoc />
         public MessageActivity Activity { get; private set; }


### PR DESCRIPTION
## Summary

With AllowedMentions now, mentions shouldn't be parsed from the content but use what's directly sent in the message object.
Having a "@everyone" or "<@1271847174>" doesn't necessarily mean they were mentioned.
Fix #1617 

## Changes
- Expose `mention_everyone`
- Get mentioned roles and users from the message object instead of parsing the content