### PR TITLE
fix: Do not update overwrite cache locally

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -125,7 +125,6 @@ namespace Discord.WebSocket
         public virtual async Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
         {
             await ChannelHelper.AddPermissionOverwriteAsync(this, Discord, user, permissions, options).ConfigureAwait(false);
-            _overwrites = _overwrites.Add(new Overwrite(user.Id, PermissionTarget.User, new OverwritePermissions(permissions.AllowValue, permissions.DenyValue)));
         }
 
         /// <summary>
@@ -140,7 +139,6 @@ namespace Discord.WebSocket
         public virtual async Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
         {
             await ChannelHelper.AddPermissionOverwriteAsync(this, Discord, role, permissions, options).ConfigureAwait(false);
-            _overwrites = _overwrites.Add(new Overwrite(role.Id, PermissionTarget.Role, new OverwritePermissions(permissions.AllowValue, permissions.DenyValue)));
         }
         /// <summary>
         ///     Removes the permission overwrite for the given user, if one exists.
@@ -153,15 +151,6 @@ namespace Discord.WebSocket
         public virtual async Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
         {
             await ChannelHelper.RemovePermissionOverwriteAsync(this, Discord, user, options).ConfigureAwait(false);
-
-            for (int i = 0; i < _overwrites.Length; i++)
-            {
-                if (_overwrites[i].TargetId == user.Id)
-                {
-                    _overwrites = _overwrites.RemoveAt(i);
-                    return;
-                }
-            }
         }
         /// <summary>
         ///     Removes the permission overwrite for the given role, if one exists.
@@ -174,15 +163,6 @@ namespace Discord.WebSocket
         public virtual async Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
         {
             await ChannelHelper.RemovePermissionOverwriteAsync(this, Discord, role, options).ConfigureAwait(false);
-
-            for (int i = 0; i < _overwrites.Length; i++)
-            {
-                if (_overwrites[i].TargetId == role.Id)
-                {
-                    _overwrites = _overwrites.RemoveAt(i);
-                    return;
-                }
-            }
         }
 
         public new virtual SocketGuildUser GetUser(ulong id) => null;


### PR DESCRIPTION
## Summary

Updating the overwrite cache is incorrect and can cause inconsistencies as mentioned in #1612 .
Based on the general design, I decided to just remove it and wait for Discord to send the gateway event to patch it (I didn't see any place that manually updates the cache instead of waiting Discord to patch it with a gateway event, like roles, members, channels, etc).

Fixes #1612 

## Changes

- Don't update the overwrite cache manually

## Notes

Intents could potentially make channels never update (by not receiving `CHANNEL_UPDATE`s), so updating it locally could help a bit but they would never receive changes done by users or other bots, keeping the cache always outdated, so I decided to just stick with how it's done everywhere else in the lib.