### PR TITLE
fix: Invoke UserUpdated from GuildMemberUpdated if needed

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -903,6 +903,13 @@ namespace Discord.WebSocket
 
                                         if (user != null)
                                         {
+                                            var globalBefore = user.GlobalUser.Clone();
+                                            if (user.GlobalUser.Update(State, data.User))
+                                            {
+                                                //Global data was updated, trigger UserUpdated
+                                                await TimedInvokeAsync(_userUpdatedEvent, nameof(UserUpdated), globalBefore, user).ConfigureAwait(false);
+                                            }
+
                                             var before = user.Clone();
                                             user.Update(State, data);
                                             await TimedInvokeAsync(_guildMemberUpdatedEvent, nameof(GuildMemberUpdated), before, user).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

GuildMemberUpdated is also fired by some global changes (Username for example) that are kept in the `SocketGlobalUser` property inside the `SocketGuildUser` and since Clone is a shallow copy, it doesn't keep the old state and not possible to the user to compare before and after to know it happened.

To fix it, I just redid the same logic in `PRESENCE_UPDATE` and fired a `UserUpdated` if a global change happened in `GUILD_MEMBER_UPDATE`.

This will keep the same behavior as before but making possible to track global changes (like username changes) without `PRESENCE_UPDATE`s.

Thanks to Yeba#3517 for noticing and reporting this issue.

## Changes

- Fire UserUpdated from `GUILD_MEMBER_UPDATED` if a global change happened