### PR TITLE
fix: Limit Request Members batch size with GatewayIntents

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -370,7 +370,7 @@ namespace Discord.WebSocket
         {
             var cachedGuilds = guilds.ToImmutableArray();
 
-            const short batchSize = 100; //TODO: Gateway Intents will limit to a maximum of 1 guild_id
+            int batchSize = _gatewayIntents.HasValue ? 1 : 100;
             ulong[] batchIds = new ulong[Math.Min(batchSize, cachedGuilds.Length)];
             Task[] batchTasks = new Task[batchIds.Length];
             int batchCount = (cachedGuilds.Length + (batchSize - 1)) / batchSize;


### PR DESCRIPTION
## Summary

Gateway intents should limit the maximum guild ids in the Request Guild Members gateway request to 1.
I just need to test if it'll be needed to change the type to `ulong` instead of `IEnumerable<ulong>`.

Fixes #1646 

EDIT: Forgot to add, reference: "You will be limited to requesting 1 guild_id" at [https://discord.com/developers/docs/topics/gateway#request-guild-members](https://discord.com/developers/docs/topics/gateway#request-guild-members)

## Changes

- Change batch size to 1 if GatewayIntents are being used