### PR TITLE
fix: Fix audio dispose

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/Streams/BufferedWriteStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/BufferedWriteStream.cs
@@ -61,14 +61,17 @@ namespace Discord.Audio.Streams
 
             _task = Run();
         }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
                 _disposeTokenSource?.Cancel();
                 _disposeTokenSource?.Dispose();
+                _cancelTokenSource?.Cancel();
                 _cancelTokenSource?.Dispose();
                 _queueLock?.Dispose();
+                _next.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/src/Discord.Net.WebSocket/Audio/Streams/OpusDecodeStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/OpusDecodeStream.cs
@@ -68,10 +68,12 @@ namespace Discord.Audio.Streams
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
+            {
                 _decoder.Dispose();
+                _next.Dispose();
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Audio/Streams/OpusEncodeStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/OpusEncodeStream.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -89,10 +89,12 @@ namespace Discord.Audio.Streams
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-
             if (disposing)
+            {
                 _encoder.Dispose();
+                _next.Dispose();
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Audio/Streams/RTPReadStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/RTPReadStream.cs
@@ -76,5 +76,12 @@ namespace Discord.Audio.Streams
                 (buffer[extensionOffset + 3]);
             return extensionOffset + 4 + (extensionLength * 4);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _next.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/Discord.Net.WebSocket/Audio/Streams/RTPWriteStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/RTPWriteStream.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -68,6 +68,13 @@ namespace Discord.Audio.Streams
         public override async Task ClearAsync(CancellationToken cancelToken)
         {
             await _next.ClearAsync(cancelToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _next.Dispose();
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Audio/Streams/SodiumDecryptStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/SodiumDecryptStream.cs
@@ -44,5 +44,12 @@ namespace Discord.Audio.Streams
         {
             await _next.ClearAsync(cancelToken).ConfigureAwait(false);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _next.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/Discord.Net.WebSocket/Audio/Streams/SodiumEncryptStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/SodiumEncryptStream.cs
@@ -60,5 +60,12 @@ namespace Discord.Audio.Streams
         {
             await _next.ClearAsync(cancelToken).ConfigureAwait(false);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _next.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }


### PR DESCRIPTION
## Summary

The audio streams weren't disposing the others so only one in the chain would be disposed, this would leave a stream open and trying "to shutdown" all audio.

If another stream was created, they would spam send speaking (one trying to enable and one trying to disable) causing a ratelimit and session invalidation.

It would be good to a few more people to test it to be sure I didn't miss anything.

Fixes #1274

## Changes

- Call Dispose on the `_next` stream