### PR TITLE
fix: Crosspost throwing InvalidOperationException

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/INewsChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/INewsChannel.cs
@@ -1,0 +1,9 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Represents a generic news channel in a guild that can send and receive messages.
+    /// </summary>
+    public interface INewsChannel : ITextChannel
+    {
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
@@ -12,7 +12,7 @@ namespace Discord.Rest
     ///     Represents a REST-based news channel in a guild that has the same properties as a <see cref="RestTextChannel"/>.
     /// </summary>
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class RestNewsChannel : RestTextChannel
+    public class RestNewsChannel : RestTextChannel, INewsChannel
     {
         internal RestNewsChannel(BaseDiscordClient discord, IGuild guild, ulong id)
             :base(discord, guild, id)

--- a/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestUserMessage.cs
@@ -154,10 +154,10 @@ namespace Discord.Rest
             => MentionUtils.Resolve(this, 0, userHandling, channelHandling, roleHandling, everyoneHandling, emojiHandling);
 
         /// <inheritdoc />
-        /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="RestNewsChannel"/> channel.</exception>
+        /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="INewsChannel"/> channel.</exception>
         public async Task CrosspostAsync(RequestOptions options = null)
         {
-            if (!(Channel is RestNewsChannel))
+            if (!(Channel is INewsChannel))
             {
                 throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");
             }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -15,7 +15,7 @@ namespace Discord.WebSocket
     ///     </note>
     /// </remarks>
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
-    public class SocketNewsChannel : SocketTextChannel
+    public class SocketNewsChannel : SocketTextChannel, INewsChannel
     {
         internal SocketNewsChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
             :base(discord, id, guild)

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -34,7 +34,7 @@ namespace Discord.WebSocket
                     case ICategoryChannel categoryChannel: return ChannelType.Category;
                     case IDMChannel dmChannel: return ChannelType.DM;
                     case IGroupChannel groupChannel: return ChannelType.Group;
-                    case SocketNewsChannel socketNewsChannel: return ChannelType.News;
+                    case INewsChannel socketNewsChannel: return ChannelType.News;
                     case ITextChannel textChannel: return ChannelType.Text;
                     default: throw new InvalidOperationException("Invalid channel type.");
                 }

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -34,7 +34,7 @@ namespace Discord.WebSocket
                     case ICategoryChannel categoryChannel: return ChannelType.Category;
                     case IDMChannel dmChannel: return ChannelType.DM;
                     case IGroupChannel groupChannel: return ChannelType.Group;
-                    case INewsChannel socketNewsChannel: return ChannelType.News;
+                    case INewsChannel newsChannel: return ChannelType.News;
                     case ITextChannel textChannel: return ChannelType.Text;
                     default: throw new InvalidOperationException("Invalid channel type.");
                 }

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -158,10 +158,10 @@ namespace Discord.WebSocket
             => MentionUtils.Resolve(this, 0, userHandling, channelHandling, roleHandling, everyoneHandling, emojiHandling);
 
         /// <inheritdoc />
-        /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="SocketNewsChannel"/> channel.</exception>
+        /// <exception cref="InvalidOperationException">This operation may only be called on a <see cref="INewsChannel"/> channel.</exception>
         public async Task CrosspostAsync(RequestOptions options = null)
         {
-            if (!(Channel is SocketNewsChannel))
+            if (!(Channel is INewsChannel))
             {
                 throw new InvalidOperationException("Publishing (crossposting) is only valid in news channels.");
             }


### PR DESCRIPTION
## Summary

Crossposting throws an InvalidOperationException when it's supposedly correct.
This happens because `GetMessageAsync` returns a `RestUserMessage` that checks if the channel is `RestNewsChannel`, when the client returns the channel as a `SocketNewsChannel`.

Fixes #1605 

## Changes

- Added new interface, `INewsChannel`
- Implemented the new interface in `RestNewsChannel` and `SocketNewsChannel`
- Check if the channel is a `INewsChannel` instead