### PR TITLE
misc: Change ratelimit messages

### DIFF
--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -46,12 +46,12 @@ namespace Discord.Rest
             _restLogger = LogManager.CreateLogger("Rest");
             _isFirstLogin = config.DisplayInitialLog;
 
-            ApiClient.RequestQueue.RateLimitTriggered += async (id, info) =>
+            ApiClient.RequestQueue.RateLimitTriggered += async (id, info, endpoint) =>
             {
                 if (info == null)
-                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {endpoint} {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
                 else
-                    await _restLogger.WarningAsync($"Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.WarningAsync($"Rate limit triggered: {endpoint} {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
             };
             ApiClient.SentRequest += async (method, endpoint, millis) => await _restLogger.VerboseAsync($"{method} {endpoint}: {millis} ms").ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
@@ -12,7 +12,7 @@ namespace Discord.Net.Queue
 {
     internal class RequestQueue : IDisposable
     {
-        public event Func<BucketId, RateLimitInfo?, Task> RateLimitTriggered;
+        public event Func<BucketId, RateLimitInfo?, string, Task> RateLimitTriggered;
 
         private readonly ConcurrentDictionary<BucketId, object> _buckets;
         private readonly SemaphoreSlim _tokenLock;
@@ -121,9 +121,9 @@ namespace Discord.Net.Queue
             }
             return (RequestBucket)obj;
         }
-        internal async Task RaiseRateLimitTriggered(BucketId bucketId, RateLimitInfo? info)
+        internal async Task RaiseRateLimitTriggered(BucketId bucketId, RateLimitInfo? info, string endpoint)
         {
-            await RateLimitTriggered(bucketId, info).ConfigureAwait(false);
+            await RateLimitTriggered(bucketId, info, endpoint).ConfigureAwait(false);
         }
         internal (RequestBucket, BucketId) UpdateBucketHash(BucketId id, string discordHash)
         {

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -84,7 +84,7 @@ namespace Discord.Net.Queue
 #endif
                                     UpdateRateLimit(id, request, info, true);
                                 }
-                                await _queue.RaiseRateLimitTriggered(Id, info).ConfigureAwait(false);
+                                await _queue.RaiseRateLimitTriggered(Id, info, $"{request.Method} {request.Endpoint}").ConfigureAwait(false);
                                 continue; //Retry
                             case HttpStatusCode.BadGateway: //502
 #if DEBUG_LIMITS
@@ -187,7 +187,7 @@ namespace Discord.Net.Queue
                     if (!isRateLimited)
                     {
                         isRateLimited = true;
-                        await _queue.RaiseRateLimitTriggered(Id, null).ConfigureAwait(false);
+                        await _queue.RaiseRateLimitTriggered(Id, null, $"{request.Method} {request.Endpoint}").ConfigureAwait(false);
                     }
 
                     ThrowRetryLimit(request);

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -74,12 +74,12 @@ namespace Discord.Webhook
 
             _restLogger = LogManager.CreateLogger("Rest");
 
-            ApiClient.RequestQueue.RateLimitTriggered += async (id, info) =>
+            ApiClient.RequestQueue.RateLimitTriggered += async (id, info, endpoint) =>
             {
                 if (info == null)
-                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {endpoint} {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
                 else
-                    await _restLogger.WarningAsync($"Rate limit triggered: {id?.ToString() ?? "null"}").ConfigureAwait(false);
+                    await _restLogger.WarningAsync($"Rate limit triggered: {endpoint} {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
             };
             ApiClient.SentRequest += async (method, endpoint, millis) => await _restLogger.VerboseAsync($"{method} {endpoint}: {millis} ms").ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary 

Understanding and fixing possible ratelimit issues were made a lot harder with the implementation of the ratelimit buckets that aggregate several endpoints, this change should make things a lot simpler by exposing the endpoint that triggered it as well (easier to find what method is causing it).

Now both will have the same pattern as: `HttpMethod Endpoint`, hash buckets will include their hash as: `(Bucket: BucketHash)`.
Example: `POST channels/47129545317947324/messages (Bucket: 80c17d2f203122d936070c88c8d10f33)`

## Changes

- Restructure ratelimit message by adding the endpoint