### PR TITLE
Fix: SocketGuild.HasAllMembers is false if a user left a guild

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -136,7 +136,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public string BannerUrl => CDN.GetGuildBannerUrl(Id, BannerId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>
-        public bool HasAllMembers => MemberCount >= DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
+        public bool HasAllMembers => MemberCount <= DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
         /// <summary> Indicates whether the guild cache is synced to this guild. </summary>
         public bool IsSynced => _syncPromise.Task.IsCompleted;
         public Task SyncPromise => _syncPromise.Task;

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -136,7 +136,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public string BannerUrl => CDN.GetGuildBannerUrl(Id, BannerId);
         /// <summary> Indicates whether the client has all the members downloaded to the local guild cache. </summary>
-        public bool HasAllMembers => MemberCount == DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
+        public bool HasAllMembers => MemberCount >= DownloadedMemberCount;// _downloaderPromise.Task.IsCompleted;
         /// <summary> Indicates whether the guild cache is synced to this guild. </summary>
         public bool IsSynced => _syncPromise.Task.IsCompleted;
         public Task SyncPromise => _syncPromise.Task;


### PR DESCRIPTION
SocketGuild.HasAllMembers is defined as `MemberCount == DownloadMemberCount`, but in some cases `DownloadMemberCount` is greater than `MemberCount`. For example, if a user left and the user wasn't removed from the cache.

If this occurs after this change, HasAllMembers will remain true because it is defined as `MemberCount <= DownloadMemberCount`.

This is useful for occasionally looping through guilds where HasAllMembers is false to download the users. We don't want to download users again if there are more users in the cache than in the server itself.


Footnote: I closed the first pr and someone suggested I just amend it. I checked out the pr and attempted to make another commit but got a 403. Perhaps it would work if I re-opened the pr but I didn't want to risk spamming the discord channel more. Sorry!