### PR TITLE
feature: Send presence on Identify payload

### DIFF
--- a/src/Discord.Net.WebSocket/API/Gateway/IdentifyParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/IdentifyParams.cs
@@ -15,6 +15,8 @@ namespace Discord.API.Gateway
         public int LargeThreshold { get; set; }
         [JsonProperty("shard")]
         public Optional<int[]> ShardingParams { get; set; }
+        [JsonProperty("presence")]
+        public Optional<StatusUpdateParams> Presence { get; set; }
         [JsonProperty("guild_subscriptions")]
         public Optional<bool> GuildSubscriptions { get; set; }
         [JsonProperty("intents")]

--- a/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API.Gateway
@@ -12,7 +12,7 @@ namespace Discord.API.Gateway
         public long? IdleSince { get; set; }
         [JsonProperty("afk")]
         public bool IsAFK { get; set; }
-        [JsonProperty("game")]
-        public Game Game { get; set; }
+        [JsonProperty("activities")]
+        public Game[] Activities { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -565,6 +565,7 @@ namespace Discord.WebSocket
                                         var state = new ClientState(data.Guilds.Length, data.PrivateChannels.Length);
 
                                         var currentUser = SocketSelfUser.Create(this, state, data.User);
+                                        currentUser.Presence = new SocketPresence(Status, Activity, null, null);
                                         ApiClient.CurrentUserId = currentUser.Id;
                                         int unavailableGuilds = 0;
                                         for (int i = 0; i < data.Guilds.Length; i++)

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -59,7 +59,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override UserStatus Status { get; protected set; } = UserStatus.Online;
         /// <inheritdoc />
-        public override IActivity Activity { get; protected set; }
+        public override IActivity Activity { get => _activity.GetValueOrDefault(); protected set => _activity = Optional.Create(value); }
+        private Optional<IActivity> _activity;
 
         //From DiscordSocketConfig
         internal int TotalShards { get; private set; }
@@ -248,14 +249,11 @@ namespace Discord.WebSocket
                 else
                 {
                     await _gatewayLogger.DebugAsync("Identifying").ConfigureAwait(false);
-                    await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards, guildSubscriptions: _guildSubscriptions, gatewayIntents: _gatewayIntents).ConfigureAwait(false);
+                    await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards, guildSubscriptions: _guildSubscriptions, gatewayIntents: _gatewayIntents, presence: BuildCurrentStatus()).ConfigureAwait(false);
                 }
 
                 //Wait for READY
                 await _connection.WaitAsync().ConfigureAwait(false);
-
-                await _gatewayLogger.DebugAsync("Sending Status").ConfigureAwait(false);
-                await SendStatusAsync().ConfigureAwait(false);
             }
             finally
             {
@@ -449,28 +447,44 @@ namespace Discord.WebSocket
         {
             if (CurrentUser == null)
                 return;
+            CurrentUser.Presence = new SocketPresence(Status, Activity, null, null);
+
+            var presence = BuildCurrentStatus();
+
+            await ApiClient.SendStatusUpdateAsync(
+                presence.Item1,
+                presence.Item2,
+                presence.Item3,
+                presence.Item4).ConfigureAwait(false);
+        }
+
+        private (UserStatus, bool, long?, GameModel[]) BuildCurrentStatus()
+        {
             var status = Status;
             var statusSince = _statusSince;
-            CurrentUser.Presence = new SocketPresence(status, Activity, null, null);
+            var activity = _activity;
 
-            var gameModel = new GameModel();
+            GameModel[] gameModels = null;
             // Discord only accepts rich presence over RPC, don't even bother building a payload
-            if (Activity is RichGame)
-                throw new NotSupportedException("Outgoing Rich Presences are not supported via WebSocket.");
 
-            if (Activity != null)
+            if (activity.GetValueOrDefault() != null)
             {
+                var gameModel = new GameModel();
+                if (activity.Value is RichGame)
+                    throw new NotSupportedException("Outgoing Rich Presences are not supported via WebSocket.");
                 gameModel.Name = Activity.Name;
                 gameModel.Type = Activity.Type;
                 if (Activity is StreamingGame streamGame)
                     gameModel.StreamUrl = streamGame.Url;
+                gameModels = new[] { gameModel };
             }
+            else if (activity.IsSpecified)
+                gameModels = new GameModel[0];
 
-            await ApiClient.SendStatusUpdateAsync(
-                status,
-                status == UserStatus.AFK,
-                statusSince != null ? _statusSince.Value.ToUnixTimeMilliseconds() : (long?)null,
-                gameModel).ConfigureAwait(false);
+            return (status,
+                    status == UserStatus.AFK,
+                    statusSince != null ? _statusSince.Value.ToUnixTimeMilliseconds() : (long?)null,
+                    gameModels);
         }
 
         private async Task ProcessMessageAsync(GatewayOpCode opCode, int? seq, string type, object payload)
@@ -523,7 +537,7 @@ namespace Discord.WebSocket
                             await _shardedClient.AcquireIdentifyLockAsync(ShardId, _connection.CancelToken).ConfigureAwait(false);
                             try
                             {
-                                await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards, guildSubscriptions: _guildSubscriptions, gatewayIntents: _gatewayIntents).ConfigureAwait(false);
+                                await ApiClient.SendIdentifyAsync(shardID: ShardId, totalShards: TotalShards, guildSubscriptions: _guildSubscriptions, gatewayIntents: _gatewayIntents, presence: BuildCurrentStatus()).ConfigureAwait(false);
                             }
                             finally
                             {


### PR DESCRIPTION
## Summary

It will send the presence when identifying, removing the necessity of sending an aditional gateway request after it.
A few changes were made to be able to clear the activity when using it.

Example:
```cs
await _client.SetStatusAsync(UserStatus.DoNotDisturb);
await _client.SetActivityAsync(null);
await _client.LoginAsync(TokenType.Bot, "yourToken");
await _client.StartAsync();
```

## Changes
- Send Presence on Identify
- Remove `SendStatusAsync` on Identify
- Update Presence payload to latest

## TODO

- [X] CurrentUser.Presence should be the same