### PR TITLE
Implementation of ValidateAndGetBestMatch

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -514,16 +514,16 @@ namespace Discord.Commands
             {
                 await _commandExecutedEvent.InvokeAsync(Optional.Create<CommandInfo>(), context, searchResult).ConfigureAwait(false);
             }
-            else if(validationResult is not ParseResult parseResult)
-            {
-                await _commandExecutedEvent.InvokeAsync(commandMatch.Value.Command,context,validationResult).ConfigureAwait(false);
-            }
-            else
+            else if(validationResult is ParseResult parseResult)
             {
                 var result = await commandMatch.Value.Command.ExecuteAsync(context, parseResult, services).ConfigureAwait(false);
                 if (!result.IsSuccess && !(result is RuntimeResult || result is ExecuteResult)) // succesful results raise the event in CommandInfo#ExecuteInternalAsync (have to raise it there b/c deffered execution)
                     await _commandExecutedEvent.InvokeAsync(commandMatch.Value.Command, context, result);
                 return result;
+            }
+            else
+            {
+                await _commandExecutedEvent.InvokeAsync(commandMatch.Value.Command, context, validationResult).ConfigureAwait(false);
             }
             return validationResult;
         }

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -517,13 +517,13 @@ namespace Discord.Commands
 
             if (validationResult is MatchResult matchResult)
             {
-                return await handleCommandPipeline(matchResult, context, services);
+                return await HandleCommandPipeline(matchResult, context, services);
             }
 
             return validationResult;
         }
 
-        private async Task<IResult> handleCommandPipeline(MatchResult matchResult, ICommandContext context, IServiceProvider services)
+        private async Task<IResult> HandleCommandPipeline(MatchResult matchResult, ICommandContext context, IServiceProvider services)
         {
             if (!matchResult.IsSuccess)
                 return matchResult;

--- a/src/Discord.Net.Commands/Results/MatchResult.cs
+++ b/src/Discord.Net.Commands/Results/MatchResult.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace Discord.Commands
+{
+    public class MatchResult : IResult
+    {
+        /// <summary>
+        ///     Gets the command that may have matched during the command execution.
+        /// </summary>
+        public CommandMatch? Match { get; }
+
+        /// <summary>
+        ///     Gets on which pipeline stage the command may have matched or failed.
+        /// </summary>
+        public IResult? Pipeline { get; }
+
+        /// <inheritdoc />
+        public CommandError? Error { get; }
+        /// <inheritdoc />
+        public string ErrorReason { get; }
+        /// <inheritdoc />
+        public bool IsSuccess => !Error.HasValue;
+
+        private MatchResult(CommandMatch? match, IResult? pipeline, CommandError? error, string errorReason)
+        {
+            Match = match;
+            Error = error;
+            Pipeline = pipeline;
+            ErrorReason = errorReason;
+        }
+
+        public static MatchResult FromSuccess(CommandMatch match, IResult pipeline)
+            => new MatchResult(match,pipeline,null, null);
+        public static MatchResult FromError(CommandError error, string reason)
+            => new MatchResult(null,null,error, reason);
+        public static MatchResult FromError(Exception ex)
+            => FromError(CommandError.Exception, ex.Message);
+        public static MatchResult FromError(IResult result)
+            => new MatchResult(null, null,result.Error, result.ErrorReason);
+        public static MatchResult FromError(IResult pipeline, CommandError error, string reason)
+            => new MatchResult(null, pipeline, error, reason);
+
+        public override string ToString() => IsSuccess ? "Success" : $"{Error}: {ErrorReason}";
+        private string DebuggerDisplay => IsSuccess ? "Success" : $"{Error}: {ErrorReason}";
+
+    }
+}


### PR DESCRIPTION
As discussed on #1699 this pr comes with a rewrite of the logic on `CommandService#ExecuteAsync`, splitting it into two functions.    
  
`ExecuteAsync` - will continue to do the `Search-Verify-Match-Execute` loop as it did before.  
  
`ValidateAndGetBestMatch` - Verifies from a set of commands (`SearchResult`) with the specified `ICommandContext`, `IServiceProvider` and `MultiMatchHandling` which command is the optimal one, using the previously established classification and ranking systems. 

Breaking Changes
---
None.

Focus
---
Code cleanup and creation of an new public api.