### PR TITLE
fix: Session invalidation on GWv6 when updating the status

### DIFF
--- a/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
@@ -12,7 +12,7 @@ namespace Discord.API.Gateway
         public long? IdleSince { get; set; }
         [JsonProperty("afk")]
         public bool IsAFK { get; set; }
-        [JsonProperty("activities")]
-        public Game[] Activities { get; set; }
+        [JsonProperty("game")]
+        public Game Game { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -216,7 +216,7 @@ namespace Discord.API
             await _sentGatewayMessageEvent.InvokeAsync(opCode).ConfigureAwait(false);
         }
 
-        public async Task SendIdentifyAsync(int largeThreshold = 100, int shardID = 0, int totalShards = 1, bool guildSubscriptions = true, GatewayIntents? gatewayIntents = null, (UserStatus, bool, long?, GameModel[])? presence = null, RequestOptions options = null)
+        public async Task SendIdentifyAsync(int largeThreshold = 100, int shardID = 0, int totalShards = 1, bool guildSubscriptions = true, GatewayIntents? gatewayIntents = null, (UserStatus, bool, long?, GameModel)? presence = null, RequestOptions options = null)
         {
             options = RequestOptions.CreateOrClone(options);
             var props = new Dictionary<string, string>
@@ -246,7 +246,7 @@ namespace Discord.API
                     Status = presence.Value.Item1,
                     IsAFK = presence.Value.Item2,
                     IdleSince = presence.Value.Item3,
-                    Activities = presence.Value.Item4
+                    Game = presence.Value.Item4,
                 };
             }
 
@@ -268,7 +268,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
             await SendGatewayAsync(GatewayOpCode.Heartbeat, lastSeq, options: options).ConfigureAwait(false);
         }
-        public async Task SendStatusUpdateAsync(UserStatus status, bool isAFK, long? since, GameModel[] game, RequestOptions options = null)
+        public async Task SendStatusUpdateAsync(UserStatus status, bool isAFK, long? since, GameModel game, RequestOptions options = null)
         {
             options = RequestOptions.CreateOrClone(options);
             var args = new StatusUpdateParams
@@ -276,7 +276,7 @@ namespace Discord.API
                 Status = status,
                 IdleSince = since,
                 IsAFK = isAFK,
-                Activities = game
+                Game = game
             };
             options.BucketId = GatewayBucket.Get(GatewayBucketType.PresenceUpdate).Id;
             await SendGatewayAsync(GatewayOpCode.StatusUpdate, args, options: options).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

Updating the status would invalidate the session after a few seconds.
`activities` might be only accepted on the Update Status request in GWv8 but v6 would accept the same on Identify.

Fixes #1701 

## Changes
- Revert `activities` to `game`
- Add possibility to not send presence on identify