### PR TITLE
Simplify code in Discord.DiscordComparers

### DIFF
--- a/src/Discord.Net.Core/Utils/Comparers.cs
+++ b/src/Discord.Net.Core/Utils/Comparers.cs
@@ -11,29 +11,23 @@ namespace Discord
         /// <summary>
         ///     Gets an <see cref="IEqualityComparer{T}"/> to be used to compare users.
         /// </summary>
-        public static IEqualityComparer<IUser> UserComparer => _userComparer ??= new EntityEqualityComparer<IUser, ulong>();
+        public static IEqualityComparer<IUser> UserComparer { get; } = new EntityEqualityComparer<IUser, ulong>();
         /// <summary>
         ///     Gets an <see cref="IEqualityComparer{T}"/> to be used to compare guilds.
         /// </summary>
-        public static IEqualityComparer<IGuild> GuildComparer => _guildComparer ??= new EntityEqualityComparer<IGuild, ulong>();
+        public static IEqualityComparer<IGuild> GuildComparer { get; } = new EntityEqualityComparer<IGuild, ulong>();
         /// <summary>
         ///     Gets an <see cref="IEqualityComparer{T}"/> to be used to compare channels.
         /// </summary>
-        public static IEqualityComparer<IChannel> ChannelComparer => _channelComparer ??= new EntityEqualityComparer<IChannel, ulong>();
+        public static IEqualityComparer<IChannel> ChannelComparer { get; } = new EntityEqualityComparer<IChannel, ulong>();
         /// <summary>
         ///     Gets an <see cref="IEqualityComparer{T}"/> to be used to compare roles.
         /// </summary>
-        public static IEqualityComparer<IRole> RoleComparer => _roleComparer ??= new EntityEqualityComparer<IRole, ulong>();
+        public static IEqualityComparer<IRole> RoleComparer { get; } = new EntityEqualityComparer<IRole, ulong>();
         /// <summary>
         ///     Gets an <see cref="IEqualityComparer{T}"/> to be used to compare messages.
         /// </summary>
-        public static IEqualityComparer<IMessage> MessageComparer => _messageComparer ??= new EntityEqualityComparer<IMessage, ulong>();
-
-        private static IEqualityComparer<IUser> _userComparer;
-        private static IEqualityComparer<IGuild> _guildComparer;
-        private static IEqualityComparer<IChannel> _channelComparer;
-        private static IEqualityComparer<IRole> _roleComparer;
-        private static IEqualityComparer<IMessage> _messageComparer;
+        public static IEqualityComparer<IMessage> MessageComparer { get; } = new EntityEqualityComparer<IMessage, ulong>();
 
         private sealed class EntityEqualityComparer<TEntity, TId> : EqualityComparer<TEntity>
             where TEntity : IEntity<TId>
@@ -46,7 +40,7 @@ namespace Discord
                     (null, null) => true,
                     (null, _)    => false,
                     (_, null)    => false,
-                    var (l, r)   => l.Id.Equals(r.Id)
+                    _            => x.Id.Equals(y.Id)
                 };
             }
 


### PR DESCRIPTION
This change simplifies the code by:
- Removing the need for private fields to return the privately stored comparer instances
- Removing the variable declaration in the switch statement for already existing variables