### PR TITLE
Update summary of SocketVoiceChannel.Users

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -34,7 +34,12 @@ namespace Discord.WebSocket
         public Task SyncPermissionsAsync(RequestOptions options = null)
             => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
 
-        /// <inheritdoc />
+        /// <summary>
+        ///     Gets a collection of users that are currently connected to this voice channel.
+        /// </summary>
+        /// <returns>
+        ///     A read-only collection of users that are currently connected to this voice channel.
+        /// </returns>
         public override IReadOnlyCollection<SocketGuildUser> Users
             => Guild.Users.Where(x => x.VoiceChannel?.Id == Id).ToImmutableArray();
 


### PR DESCRIPTION
The inherited summary incorrectly stated that all users who _see_ the channel are returned when in reality only the ones _connected_ are. It's a very small non-code change and should only impact the XML-docs (and the API-docs since they're built from the XML-docs IIRC).

Hope this meager description is fine but there really isn't more to it :)

Fixes #1711