### PR TITLE
misc: VoiceRegions and related changes

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -75,6 +76,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A read-only collection of voice regions that the user has access to.
         /// </returns>
+        [Obsolete("This property is obsolete, use the GetVoiceRegionsAsync method instead.")]
         public abstract IReadOnlyCollection<RestVoiceRegion> VoiceRegions { get; }
 
         internal BaseSocketClient(DiscordSocketConfig config, DiscordRestApiClient client)
@@ -169,7 +171,26 @@ namespace Discord.WebSocket
         ///     A REST-based voice region associated with the identifier; <c>null</c> if the voice region is not
         ///     found.
         /// </returns>
+        [Obsolete("This method is obsolete, use GetVoiceRegionAsync instead.")]
         public abstract RestVoiceRegion GetVoiceRegion(string id);
+        /// <summary>
+        ///     Gets all voice regions.
+        /// </summary>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that contains a read-only collection of REST-based voice regions.
+        /// </returns>
+        public abstract ValueTask<IReadOnlyCollection<RestVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options = null);
+        /// <summary>
+        ///     Gets a voice region.
+        /// </summary>
+        /// <param name="id">The identifier of the voice region (e.g. <c>eu-central</c> ).</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that contains a REST-based voice region associated with the identifier; <c>null</c> if the
+        ///     voice region is not found.
+        /// </returns>
+        public abstract ValueTask<RestVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options = null);
         /// <inheritdoc />
         public abstract Task StartAsync();
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -37,6 +37,7 @@ namespace Discord.WebSocket
         public override IReadOnlyCollection<ISocketPrivateChannel> PrivateChannels => GetPrivateChannels().ToReadOnlyCollection(GetPrivateChannelCount);
         public IReadOnlyCollection<DiscordSocketClient> Shards => _shards;
         /// <inheritdoc />
+        [Obsolete("This property is obsolete, use the GetVoiceRegionsAsync method instead.")]
         public override IReadOnlyCollection<RestVoiceRegion> VoiceRegions => _shards[0].VoiceRegions;
 
         /// <summary>
@@ -264,8 +265,21 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc />
+        [Obsolete("This method is obsolete, use GetVoiceRegionAsync instead.")]
         public override RestVoiceRegion GetVoiceRegion(string id)
             => _shards[0].GetVoiceRegion(id);
+
+        /// <inheritdoc />
+        public override async ValueTask<IReadOnlyCollection<RestVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options = null)
+        {
+            return await _shards[0].GetVoiceRegionsAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<RestVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options = null)
+        {
+            return await _shards[0].GetVoiceRegionAsync(id, options).ConfigureAwait(false);
+        }
 
         /// <inheritdoc />
         /// <exception cref="ArgumentNullException"><paramref name="guilds"/> is <see langword="null"/></exception>

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -110,7 +110,8 @@ namespace Discord.WebSocket
         public IReadOnlyCollection<SocketGroupChannel> GroupChannels
             => State.PrivateChannels.OfType<SocketGroupChannel>().ToImmutableArray();
         /// <inheritdoc />
-        public override IReadOnlyCollection<RestVoiceRegion> VoiceRegions => _voiceRegions.ToReadOnlyCollection();
+        [Obsolete("This property is obsolete, use the GetVoiceRegionsAsync method instead.")]
+        public override IReadOnlyCollection<RestVoiceRegion> VoiceRegions => GetVoiceRegionsAsync().GetAwaiter().GetResult();
 
         /// <summary>
         ///     Initializes a new REST/WebSocket-based Discord client.
@@ -178,7 +179,6 @@ namespace Discord.WebSocket
                 return Task.Delay(0);
             };
 
-            _voiceRegions = ImmutableDictionary.Create<string, RestVoiceRegion>();
             _largeGuilds = new ConcurrentQueue<ulong>();
         }
         private static API.DiscordSocketApiClient CreateApiClient(DiscordSocketConfig config)
@@ -204,13 +204,6 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         internal override async Task OnLoginAsync(TokenType tokenType, string token)
         {
-            if (_parentClient == null)
-            {
-                var voiceRegions = await ApiClient.GetVoiceRegionsAsync(new RequestOptions { IgnoreState = true, RetryMode = RetryMode.AlwaysRetry }).ConfigureAwait(false);
-                _voiceRegions = voiceRegions.Select(x => RestVoiceRegion.Create(this, x)).ToImmutableDictionary(x => x.Id);
-            }
-            else
-                _voiceRegions = _parentClient._voiceRegions;
             await Rest.OnLoginAsync(tokenType, token);
         }
         /// <inheritdoc />
@@ -218,7 +211,7 @@ namespace Discord.WebSocket
         {
             await StopAsync().ConfigureAwait(false);
             _applicationInfo = null;
-            _voiceRegions = ImmutableDictionary.Create<string, RestVoiceRegion>();
+            _voiceRegions = null;
             await Rest.OnLogoutAsync();
         }
 
@@ -350,11 +343,39 @@ namespace Discord.WebSocket
             => State.RemoveUser(id);
 
         /// <inheritdoc />
+        [Obsolete("This method is obsolete, use GetVoiceRegionAsync instead.")]
         public override RestVoiceRegion GetVoiceRegion(string id)
+            => GetVoiceRegionAsync(id).GetAwaiter().GetResult();
+
+        /// <inheritdoc />
+        public override async ValueTask<IReadOnlyCollection<RestVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options = null)
         {
-            if (_voiceRegions.TryGetValue(id, out RestVoiceRegion region))
-                return region;
-            return null;
+            if (_parentClient == null)
+            {
+                if (_voiceRegions == null)
+                {
+                    options = RequestOptions.CreateOrClone(options);
+                    options.IgnoreState = true;
+                    var voiceRegions = await ApiClient.GetVoiceRegionsAsync(options).ConfigureAwait(false);
+                    _voiceRegions = voiceRegions.Select(x => RestVoiceRegion.Create(this, x)).ToImmutableDictionary(x => x.Id);
+                }
+                return _voiceRegions.ToReadOnlyCollection();
+            }
+            return await _parentClient.GetVoiceRegionsAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<RestVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options = null)
+        {
+            if (_parentClient == null)
+            {
+                if (_voiceRegions == null)
+                    await GetVoiceRegionsAsync().ConfigureAwait(false);
+                if (_voiceRegions.TryGetValue(id, out RestVoiceRegion region))
+                    return region;
+                return null;
+            }
+            return await _parentClient.GetVoiceRegionAsync(id, options).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -2120,11 +2141,11 @@ namespace Discord.WebSocket
             => Task.FromResult<IUser>(GetUser(username, discriminator));
 
         /// <inheritdoc />
-        Task<IReadOnlyCollection<IVoiceRegion>> IDiscordClient.GetVoiceRegionsAsync(RequestOptions options)
-            => Task.FromResult<IReadOnlyCollection<IVoiceRegion>>(VoiceRegions);
+        async Task<IReadOnlyCollection<IVoiceRegion>> IDiscordClient.GetVoiceRegionsAsync(RequestOptions options)
+            => await GetVoiceRegionsAsync(options).ConfigureAwait(false);
         /// <inheritdoc />
-        Task<IVoiceRegion> IDiscordClient.GetVoiceRegionAsync(string id, RequestOptions options)
-            => Task.FromResult<IVoiceRegion>(GetVoiceRegion(id));
+        async Task<IVoiceRegion> IDiscordClient.GetVoiceRegionAsync(string id, RequestOptions options)
+            => await GetVoiceRegionAsync(id, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task IDiscordClient.StartAsync()


### PR DESCRIPTION
## Summary

This PR aims to remove the startup call to `voice/regions` that might be unnecessary and change it to a "Lazy" approach.
Because of this change, the synchronous methods and properties were "obsolete'd" since a rest request might be needed.

Voice regions will still be cached after the first call is done to get the voice regions.

## Changes
- `BaseSocketClient.VoiceRegions` property is now obsolete.
- `BaseSocketClient.GetVoiceRegion` method is now obsolete.
- Add `ValueTask<IReadOnlyCollection<RestVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options = null)` to `BaseSocketClient` and derived classes.
- Add `ValueTask<RestVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options = null)` to `BaseSocketClient` and derived classes.

## Considerations

I'm a bit unsure if the almost negligible difference between `Task` and `ValueTask` is enough to warrant it since all calls done after the first should complete synchronously.