### PR TITLE
feature: Add role tags

### DIFF
--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -65,6 +65,13 @@ namespace Discord
         ///     An <see cref="int"/> representing the position of the role in the role list of the guild.
         /// </returns>
         int Position { get; }
+        /// <summary>
+        ///     Gets the tags related to this role.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="RoleTags"/> object containing all tags related to this role.
+        /// </returns>
+        RoleTags Tags { get; }
 
         /// <summary>
         ///     Modifies this role.

--- a/src/Discord.Net.Core/Entities/Roles/RoleTags.cs
+++ b/src/Discord.Net.Core/Entities/Roles/RoleTags.cs
@@ -1,0 +1,40 @@
+namespace Discord
+{
+    /// <summary>
+    ///     Provides tags related to a discord role.
+    /// </summary>
+    public class RoleTags
+    {
+        /// <summary>
+        ///     Gets the identifier of the bot that this role belongs to, if it does.
+        /// </summary>
+        /// <returns>
+        ///     A <see langword="ulong"/> if this role belongs to a bot; otherwise
+        ///     <see langword="null"/>.
+        /// </returns>
+        public ulong? BotId { get; }
+        /// <summary>
+        ///     Gets the identifier of the integration that this role belongs to, if it does.
+        /// </summary>
+        /// <returns>
+        ///     A <see langword="ulong"/> if this role belongs to an integration; otherwise
+        ///     <see langword="null"/>.
+        /// </returns>
+        public ulong? IntegrationId { get; }
+        /// <summary>
+        ///     Gets if this role is the guild's premium subscriber (booster) role.
+        /// </summary>
+        /// <returns>
+        ///     <see langword="true"/> if this role is the guild's premium subscriber role;
+        ///     otherwise <see langword="false"/>.
+        /// </returns>
+        public bool IsPremiumSubscriberRole { get; }
+
+        internal RoleTags(ulong? botId, ulong? integrationId, bool isPremiumSubscriber)
+        {
+            BotId = botId;
+            IntegrationId = integrationId;
+            IsPremiumSubscriberRole = isPremiumSubscriber;
+        }
+    }
+}

--- a/src/Discord.Net.Rest/API/Common/Role.cs
+++ b/src/Discord.Net.Rest/API/Common/Role.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS1591
+#pragma warning disable CS1591
 using Newtonsoft.Json;
 
 namespace Discord.API
@@ -21,5 +21,7 @@ namespace Discord.API
         public ulong Permissions { get; set; }
         [JsonProperty("managed")]
         public bool Managed { get; set; }
+        [JsonProperty("tags")]
+        public Optional<RoleTags> Tags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/RoleTags.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleTags.cs
@@ -1,0 +1,15 @@
+#pragma warning disable CS1591
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class RoleTags
+    {
+        [JsonProperty("bot_id")]
+        public Optional<ulong> BotId { get; set; }
+        [JsonProperty("integration_id")]
+        public Optional<ulong> IntegrationId { get; set; }
+        [JsonProperty("premium_subscriber")]
+        public Optional<bool?> IsPremiumSubscriber { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -26,6 +26,8 @@ namespace Discord.Rest
         public GuildPermissions Permissions { get; private set; }
         /// <inheritdoc />
         public int Position { get; private set; }
+        /// <inheritdoc />
+        public RoleTags Tags { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -56,6 +58,8 @@ namespace Discord.Rest
             Position = model.Position;
             Color = new Color(model.Color);
             Permissions = new GuildPermissions(model.Permissions);
+            if (model.Tags.IsSpecified)
+                Tags = model.Tags.Value.ToEntity();
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -34,6 +34,13 @@ namespace Discord.Rest
                 model.Thumbnail.IsSpecified ? model.Thumbnail.Value.ToEntity() : (EmbedThumbnail?)null,
                 model.Fields.IsSpecified ? model.Fields.Value.Select(x => x.ToEntity()).ToImmutableArray() : ImmutableArray.Create<EmbedField>());
         }
+        public static RoleTags ToEntity(this API.RoleTags model)
+        {
+            return new RoleTags(
+                model.BotId.IsSpecified ? model.BotId.Value : null,
+                model.IntegrationId.IsSpecified ? model.IntegrationId.Value : null,
+                model.IsPremiumSubscriber.IsSpecified ? true : false);
+        }
         public static API.Embed ToModel(this Embed entity)
         {
             if (entity == null) return null;

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -36,6 +36,8 @@ namespace Discord.WebSocket
         public GuildPermissions Permissions { get; private set; }
         /// <inheritdoc />
         public int Position { get; private set; }
+        /// <inheritdoc />
+        public RoleTags Tags { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -71,6 +73,8 @@ namespace Discord.WebSocket
             Position = model.Position;
             Color = new Color(model.Color);
             Permissions = new GuildPermissions(model.Permissions);
+            if (model.Tags.IsSpecified)
+                Tags = model.Tags.Value.ToEntity();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

This PR will add a missing feature to roles, their tags.
It'll be possible to know if a role belongs to a bot, application, or if it's the booster role.

## Changes

- Add new classes `API.RoleTags` and `RoleTags`.
- Add RoleTags properties to `IRole`, `SocketRole`, and `RestRole`.