### PR TITLE
feature: Add user public flags

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -75,6 +75,16 @@ namespace Discord
         ///     Gets the username for this user.
         /// </summary>
         string Username { get; }
+        /// <summary>
+        ///     Gets the public flags that are applied to this user's account.
+        /// </summary>
+        /// <remarks>
+        ///     This value is determined by bitwise OR-ing <see cref="UserProperties"/> values together.
+        /// </remarks>
+        /// <returns>
+        ///     The value of public flags for this user.
+        /// </returns>
+        UserProperties? PublicFlags { get; }
 
         /// <summary>
         ///     Gets the direct message channel of this user, or create one if it does not already exist.

--- a/src/Discord.Net.Core/Entities/Users/UserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/UserProperties.cs
@@ -10,32 +10,62 @@ namespace Discord
         /// </summary>
         None = 0,
         /// <summary>
-        ///     Flag given to Discord staff.
+        ///     Flag given to users who are a Discord employee.
         /// </summary>
-        Staff = 0b1,
+        Staff = 1 << 0,
         /// <summary>
-        ///     Flag given to Discord partners.
+        ///     Flag given to users who are owners of a partnered Discord server.
         /// </summary>
-        Partner = 0b10,
+        Partner = 1 << 1,
+        /// <summary>
+        ///     Flag given to users in HypeSquad events.
+        /// </summary>
+        HypeSquadEvents = 1 << 2,
         /// <summary>
         ///     Flag given to users who have participated in the bug report program.
+        ///     This flag is obsolete, use <see cref="BugHunterLevel1"/> instead.
         /// </summary>
-        BugHunter = 0b1000,
+        [Obsolete("Use BugHunterLevel1 instead.")]
+        BugHunter = 1 << 3,
+        /// <summary>
+        ///     Flag given to users who have participated in the bug report program and are level 1.
+        /// </summary>
+        BugHunterLevel1 = 1 << 3,
         /// <summary>
         ///     Flag given to users who are in the HypeSquad House of Bravery.
         /// </summary>
-        HypeSquadBravery = 0b100_0000,
+        HypeSquadBravery = 1 << 6,
         /// <summary>
         ///     Flag given to users who are in the HypeSquad House of Brilliance.
         /// </summary>
-        HypeSquadBrilliance = 0b1000_0000,
+        HypeSquadBrilliance = 1 << 7,
         /// <summary>
         ///     Flag given to users who are in the HypeSquad House of Balance.
         /// </summary>
-        HypeSquadBalance = 0b1_0000_0000,
+        HypeSquadBalance = 1 << 8,
         /// <summary>
         ///     Flag given to users who subscribed to Nitro before games were added.
         /// </summary>
-        EarlySupporter = 0b10_0000_0000,
+        EarlySupporter = 1 << 9,
+        /// <summary>
+        ///     Flag given to users who are part of a team.
+        /// </summary>
+        TeamUser = 1 << 10,
+        /// <summary>
+        ///     Flag given to users who represent Discord (System).
+        /// </summary>
+        System = 1 << 12,
+        /// <summary>
+        ///     Flag given to users who have participated in the bug report program and are level 2.
+        /// </summary>
+        BugHunterLevel2 = 1 << 14,
+        /// <summary>
+        ///     Flag given to users who are verified bots.
+        /// </summary>
+        VerifiedBot = 1 << 16,
+        /// <summary>
+        ///     Flag given to users that developed bots and early verified their accounts.
+        /// </summary>
+        EarlyVerifiedBotDeveloper = 1 << 17,
     }
 }

--- a/src/Discord.Net.Rest/API/Common/User.cs
+++ b/src/Discord.Net.Rest/API/Common/User.cs
@@ -29,5 +29,7 @@ namespace Discord.API
         public Optional<PremiumType> PremiumType { get; set; }
         [JsonProperty("locale")]
         public Optional<string> Locale { get; set; }
+        [JsonProperty("public_flags")]
+        public Optional<UserProperties> PublicFlags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -21,6 +21,8 @@ namespace Discord.Rest
         public ushort DiscriminatorValue { get; private set; }
         /// <inheritdoc />
         public string AvatarId { get; private set; }
+        /// <inheritdoc />
+        public UserProperties? PublicFlags { get; private set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -65,6 +67,8 @@ namespace Discord.Rest
                 IsBot = model.Bot.Value;
             if (model.Username.IsSpecified)
                 Username = model.Username.Value;
+            if (model.PublicFlags.IsSpecified)
+                PublicFlags = model.PublicFlags.Value;
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -26,6 +26,8 @@ namespace Discord.WebSocket
         public abstract string AvatarId { get; internal set; }
         /// <inheritdoc />
         public abstract bool IsWebhook { get; }
+        /// <inheritdoc />
+        public UserProperties? PublicFlags { get; private set; }
         internal abstract SocketGlobalUser GlobalUser { get; }
         internal abstract SocketPresence Presence { get; set; }
 
@@ -81,6 +83,11 @@ namespace Discord.WebSocket
             if (model.Username.IsSpecified && model.Username.Value != Username)
             {
                 Username = model.Username.Value;
+                hasChanges = true;
+            }
+            if (model.PublicFlags.IsSpecified && model.PublicFlags.Value != PublicFlags)
+            {
+                PublicFlags = model.PublicFlags.Value;
                 hasChanges = true;
             }
             return hasChanges;


### PR DESCRIPTION
## Summary

This PR adds the public flag property to users and the missing user flags.

## Changes

- Add `PublicFlags` property to `IUser` and childs.
- Add missing flags to `UserProperties`.
- Obsoletes `UserProperties.BugHunter` in favor of `BugHunterLevel1`.