### PR TITLE
fix: Move and fix internal AllowedMentions object

### DIFF
--- a/src/Discord.Net.Rest/API/Common/AllowedMentions.cs
+++ b/src/Discord.Net.Rest/API/Common/AllowedMentions.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Discord.API
 {
-    public class AllowedMentions
+    internal class AllowedMentions
     {
         [JsonProperty("parse")]
         public Optional<string[]> Parse { get; set; }


### PR DESCRIPTION
This AllowedMentions class should have been internal since the start and it's currently in the wrong place.
In theory, this would be a breaking change but since we never expose any place that takes this as a parameter and it should only be used internally, I'll make an exception.