### PR TITLE
feature: Implemented Guildmember pending property

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -69,6 +69,11 @@ namespace Discord
         IReadOnlyCollection<ulong> RoleIds { get; }
 
         /// <summary>
+        ///     Whether the user has passed the guild's Membership Screening requirements.
+        /// </summary>
+        bool? IsPending { get; }
+
+        /// <summary>
         ///     Gets the level permissions granted to this user to a given channel.
         /// </summary>
         /// <example>

--- a/src/Discord.Net.Rest/API/Common/GuildMember.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildMember.cs
@@ -18,6 +18,8 @@ namespace Discord.API
         public Optional<bool> Deaf { get; set; }
         [JsonProperty("mute")]
         public Optional<bool> Mute { get; set; }
+        [JsonProperty("pending")]
+        public Optional<bool> Pending { get; set; }
         [JsonProperty("premium_since")]
         public Optional<DateTimeOffset?> PremiumSince { get; set; }
     }

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -29,6 +29,10 @@ namespace Discord.Rest
         public DateTimeOffset? PremiumSince => DateTimeUtils.FromTicks(_premiumSinceTicks);
         /// <inheritdoc />
         public ulong GuildId => Guild.Id;
+        /// <summary>
+        ///     Whether the user has passed the guild's Membership Screening requirements
+        /// </summary>
+        public bool? Pending { get; private set; }
 
         /// <inheritdoc />
         /// <exception cref="InvalidOperationException" accessor="get">Resolving permissions requires the parent guild to be downloaded.</exception>
@@ -73,6 +77,8 @@ namespace Discord.Rest
                 UpdateRoles(model.Roles.Value);
             if (model.PremiumSince.IsSpecified)
                 _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
+            if (model.Pending.IsSpecified)
+                Pending = model.Pending.Value;
         }
         private void UpdateRoles(ulong[] roleIds)
         {

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -29,10 +29,8 @@ namespace Discord.Rest
         public DateTimeOffset? PremiumSince => DateTimeUtils.FromTicks(_premiumSinceTicks);
         /// <inheritdoc />
         public ulong GuildId => Guild.Id;
-        /// <summary>
-        ///     Whether the user has passed the guild's Membership Screening requirements
-        /// </summary>
-        public bool? Pending { get; private set; }
+        /// <inheritdoc />
+        public bool? IsPending { get; private set; }
 
         /// <inheritdoc />
         /// <exception cref="InvalidOperationException" accessor="get">Resolving permissions requires the parent guild to be downloaded.</exception>
@@ -78,7 +76,7 @@ namespace Discord.Rest
             if (model.PremiumSince.IsSpecified)
                 _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
             if (model.Pending.IsSpecified)
-                Pending = model.Pending.Value;
+                IsPending = model.Pending.Value;
         }
         private void UpdateRoles(ulong[] roleIds)
         {

--- a/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestWebhookUser.cs
@@ -52,6 +52,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         string IGuildUser.Nickname => null;
         /// <inheritdoc />
+        bool? IGuildUser.IsPending => null;
+        /// <inheritdoc />
         GuildPermissions IGuildUser.GuildPermissions => GuildPermissions.Webhook;
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -56,6 +56,10 @@ namespace Discord.WebSocket
         public bool IsMuted => VoiceState?.IsMuted ?? false;
         /// <inheritdoc />
         public bool IsStreaming => VoiceState?.IsStreaming ?? false;
+        /// <summary>
+        ///     Whether the user has passed the guild's Membership Screening requirements
+        /// </summary>
+        public bool? Pending { get; private set; }
         /// <inheritdoc />
         public DateTimeOffset? JoinedAt => DateTimeUtils.FromTicks(_joinedAtTicks);
         /// <summary>
@@ -142,6 +146,8 @@ namespace Discord.WebSocket
                 UpdateRoles(model.Roles.Value);
             if (model.PremiumSince.IsSpecified)
                 _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
+            if (model.Pending.IsSpecified)
+                Pending = model.Pending.Value;
         }
         internal void Update(ClientState state, PresenceModel model, bool updatePresence)
         {
@@ -156,6 +162,7 @@ namespace Discord.WebSocket
                 UpdateRoles(model.Roles.Value);
             if (model.PremiumSince.IsSpecified)
                 _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
+            
         }
         private void UpdateRoles(ulong[] roleIds)
         {
@@ -203,5 +210,6 @@ namespace Discord.WebSocket
         //IVoiceState
         /// <inheritdoc />
         IVoiceChannel IVoiceState.VoiceChannel => VoiceChannel;
+        /// <inheritdoc />
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -56,10 +56,8 @@ namespace Discord.WebSocket
         public bool IsMuted => VoiceState?.IsMuted ?? false;
         /// <inheritdoc />
         public bool IsStreaming => VoiceState?.IsStreaming ?? false;
-        /// <summary>
-        ///     Whether the user has passed the guild's Membership Screening requirements
-        /// </summary>
-        public bool? Pending { get; private set; }
+        /// <inheritdoc />
+        public bool? IsPending { get; private set; }
         /// <inheritdoc />
         public DateTimeOffset? JoinedAt => DateTimeUtils.FromTicks(_joinedAtTicks);
         /// <summary>
@@ -147,7 +145,7 @@ namespace Discord.WebSocket
             if (model.PremiumSince.IsSpecified)
                 _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
             if (model.Pending.IsSpecified)
-                Pending = model.Pending.Value;
+                IsPending = model.Pending.Value;
         }
         internal void Update(ClientState state, PresenceModel model, bool updatePresence)
         {
@@ -162,7 +160,6 @@ namespace Discord.WebSocket
                 UpdateRoles(model.Roles.Value);
             if (model.PremiumSince.IsSpecified)
                 _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
-            
         }
         private void UpdateRoles(ulong[] roleIds)
         {
@@ -210,6 +207,5 @@ namespace Discord.WebSocket
         //IVoiceState
         /// <inheritdoc />
         IVoiceChannel IVoiceState.VoiceChannel => VoiceChannel;
-        /// <inheritdoc />
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -65,6 +65,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         DateTimeOffset? IGuildUser.PremiumSince => null;
         /// <inheritdoc />
+        bool? IGuildUser.IsPending => null;
+        /// <inheritdoc />
         GuildPermissions IGuildUser.GuildPermissions => GuildPermissions.Webhook;
 
         /// <inheritdoc />


### PR DESCRIPTION
# Summary

This PR implements the [Discord Guildmember Pending](https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-structure) property for whether they are yet to accept the server rules as per membership screening feature.

# Changes

- Added `pending` property to the GuildMember model.
- Added `Pending` to `SocketGuildUser` and `RestGuildUser`