### PR TITLE
feature: Bring your own MessageCache

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -66,6 +66,7 @@ namespace Discord.WebSocket
         //From DiscordSocketConfig
         internal int TotalShards { get; private set; }
         internal int MessageCacheSize { get; private set; }
+        internal IMessageCache MessageCache { get; private set; }
         internal int LargeThreshold { get; private set; }
         internal ClientState State { get; private set; }
         internal UdpSocketProvider UdpSocketProvider { get; private set; }
@@ -131,6 +132,7 @@ namespace Discord.WebSocket
             ShardId = config.ShardId ?? 0;
             TotalShards = config.TotalShards ?? 1;
             MessageCacheSize = config.MessageCacheSize;
+            MessageCache = config.MessageCache;
             LargeThreshold = config.LargeThreshold;
             UdpSocketProvider = config.UdpSocketProvider;
             WebSocketProvider = config.WebSocketProvider;

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -57,6 +57,8 @@ namespace Discord.WebSocket
         /// </summary>
         public int MessageCacheSize { get; set; } = 0;
 
+        public IMessageCache MessageCache { get; set; } = null;
+
         /// <summary>
         ///     Gets or sets the max number of users a guild may have for offline users to be included in the READY
         ///     packet. The maximum value allowed is 250.

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -190,7 +190,7 @@ namespace Discord.WebSocket
         {
             WebSocketProvider = DefaultWebSocketProvider.Instance;
             UdpSocketProvider = DefaultUdpSocketProvider.Instance;
-            MessageCache = new MessageCache();
+            MessageCache = new MessageCache(MessageCacheSize);
         }
 
         internal DiscordSocketConfig Clone() => MemberwiseClone() as DiscordSocketConfig;

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -190,6 +190,7 @@ namespace Discord.WebSocket
         {
             WebSocketProvider = DefaultWebSocketProvider.Instance;
             UdpSocketProvider = DefaultUdpSocketProvider.Instance;
+            MessageCache = new MessageCache();
         }
 
         internal DiscordSocketConfig Clone() => MemberwiseClone() as DiscordSocketConfig;

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -17,6 +17,7 @@ namespace Discord.WebSocket
         ///     A read-only collection of WebSocket-based messages.
         /// </returns>
         IReadOnlyCollection<SocketMessage> CachedMessages { get; }
+        IMessageCache MessageCache { get; }
 
         /// <summary>
         ///     Sends a message to this message channel.

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
@@ -8,7 +8,7 @@ namespace Discord.WebSocket
 {
     internal static class SocketChannelHelper
     {
-        public static IAsyncEnumerable<IReadOnlyCollection<IMessage>> GetMessagesAsync(ISocketMessageChannel channel, DiscordSocketClient discord, MessageCache messages,
+        public static IAsyncEnumerable<IReadOnlyCollection<IMessage>> GetMessagesAsync(ISocketMessageChannel channel, DiscordSocketClient discord, IMessageCache messages,
             ulong? fromMessageId, Direction dir, int limit, CacheMode mode, RequestOptions options)
         {
             if (dir == Direction.After && fromMessageId == null)
@@ -54,7 +54,7 @@ namespace Discord.WebSocket
                 return ChannelHelper.GetMessagesAsync(channel, discord, fromMessageId, dir, limit, options);
             }
         }
-        public static IReadOnlyCollection<SocketMessage> GetCachedMessages(ISocketMessageChannel channel, DiscordSocketClient discord, MessageCache messages,
+        public static IReadOnlyCollection<SocketMessage> GetCachedMessages(ISocketMessageChannel channel, DiscordSocketClient discord, IMessageCache messages,
             ulong? fromMessageId, Direction dir, int limit)
         {
             if (messages != null) //Cache enabled

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -16,7 +16,7 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketDMChannel : SocketChannel, IDMChannel, ISocketPrivateChannel, ISocketMessageChannel
     {
-        private readonly MessageCache _messages;
+        private readonly IMessageCache _messages;
 
         /// <summary>
         ///     Gets the recipient of the channel.

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -36,8 +36,7 @@ namespace Discord.WebSocket
         {
             Recipient = recipient;
             recipient.GlobalUser.AddRef();
-            if (Discord.MessageCacheSize > 0)
-                _messages = new MessageCache(Discord);
+            _messages = discord.MessageCache.CreateMessageCache(discord);
         }
         internal static SocketDMChannel Create(DiscordSocketClient discord, ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -25,7 +25,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public IReadOnlyCollection<SocketMessage> CachedMessages => _messages?.Messages ?? ImmutableArray.Create<SocketMessage>();
-
+        public IMessageCache MessageCache => _messages;
         /// <summary>
         ///     Gets a collection that is the current logged-in user and the recipient.
         /// </summary>
@@ -36,7 +36,7 @@ namespace Discord.WebSocket
         {
             Recipient = recipient;
             recipient.GlobalUser.AddRef();
-            _messages = discord.MessageCache.CreateMessageCache();
+            _messages = discord.MessageCache.CreateMessageCache(discord.MessageCacheSize);
         }
         internal static SocketDMChannel Create(DiscordSocketClient discord, ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -36,7 +36,7 @@ namespace Discord.WebSocket
         {
             Recipient = recipient;
             recipient.GlobalUser.AddRef();
-            _messages = discord.MessageCache.CreateMessageCache(discord);
+            _messages = discord.MessageCache.CreateMessageCache();
         }
         internal static SocketDMChannel Create(DiscordSocketClient discord, ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -20,7 +20,7 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketGroupChannel : SocketChannel, IGroupChannel, ISocketPrivateChannel, ISocketMessageChannel, ISocketAudioChannel
     {
-        private readonly MessageCache _messages;
+        private readonly IMessageCache _messages;
         private readonly ConcurrentDictionary<ulong, SocketVoiceState> _voiceStates;
 
         private string _iconId;

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -38,8 +38,7 @@ namespace Discord.WebSocket
         internal SocketGroupChannel(DiscordSocketClient discord, ulong id)
             : base(discord, id)
         {
-            if (Discord.MessageCacheSize > 0)
-                _messages = new MessageCache(Discord);
+            _messages = discord.MessageCache.CreateMessageCache(discord);
             _voiceStates = new ConcurrentDictionary<ulong, SocketVoiceState>(ConcurrentHashSet.DefaultConcurrencyLevel, 5);
             _users = new ConcurrentDictionary<ulong, SocketGroupUser>(ConcurrentHashSet.DefaultConcurrencyLevel, 5);
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -31,6 +31,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public IReadOnlyCollection<SocketMessage> CachedMessages => _messages?.Messages ?? ImmutableArray.Create<SocketMessage>();
+        public IMessageCache MessageCache => _messages;
         public new IReadOnlyCollection<SocketGroupUser> Users => _users.ToReadOnlyCollection();
         public IReadOnlyCollection<SocketGroupUser> Recipients
             => _users.Select(x => x.Value).Where(x => x.Id != Discord.CurrentUser.Id).ToReadOnlyCollection(() => _users.Count - 1);
@@ -38,7 +39,7 @@ namespace Discord.WebSocket
         internal SocketGroupChannel(DiscordSocketClient discord, ulong id)
             : base(discord, id)
         {
-            _messages = discord.MessageCache.CreateMessageCache();
+            _messages = discord.MessageCache.CreateMessageCache(discord.MessageCacheSize);
             _voiceStates = new ConcurrentDictionary<ulong, SocketVoiceState>(ConcurrentHashSet.DefaultConcurrencyLevel, 5);
             _users = new ConcurrentDictionary<ulong, SocketGroupUser>(ConcurrentHashSet.DefaultConcurrencyLevel, 5);
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -38,7 +38,7 @@ namespace Discord.WebSocket
         internal SocketGroupChannel(DiscordSocketClient discord, ulong id)
             : base(discord, id)
         {
-            _messages = discord.MessageCache.CreateMessageCache(discord);
+            _messages = discord.MessageCache.CreateMessageCache();
             _voiceStates = new ConcurrentDictionary<ulong, SocketVoiceState>(ConcurrentHashSet.DefaultConcurrencyLevel, 5);
             _users = new ConcurrentDictionary<ulong, SocketGroupUser>(ConcurrentHashSet.DefaultConcurrencyLevel, 5);
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -54,7 +54,7 @@ namespace Discord.WebSocket
             : base(discord, id, guild)
         {
             if (Discord.MessageCacheSize > 0)
-                _messages = new MessageCache(Discord);
+                _messages = discord.MessageCache.CreateMessageCache(discord);
         }
         internal new static SocketTextChannel Create(SocketGuild guild, ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -16,7 +16,7 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketTextChannel : SocketGuildChannel, ITextChannel, ISocketMessageChannel
     {
-        private readonly MessageCache _messages;
+        private readonly IMessageCache _messages;
 
         /// <inheritdoc />
         public string Topic { get; private set; }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -44,6 +44,7 @@ namespace Discord.WebSocket
         public string Mention => MentionUtils.MentionChannel(Id);
         /// <inheritdoc />
         public IReadOnlyCollection<SocketMessage> CachedMessages => _messages?.Messages ?? ImmutableArray.Create<SocketMessage>();
+        public IMessageCache MessageCache => _messages;
         /// <inheritdoc />
         public override IReadOnlyCollection<SocketGuildUser> Users
             => Guild.Users.Where(x => Permissions.GetValue(
@@ -54,7 +55,7 @@ namespace Discord.WebSocket
             : base(discord, id, guild)
         {
             if (Discord.MessageCacheSize > 0)
-                _messages = discord.MessageCache.CreateMessageCache();
+                _messages = discord.MessageCache.CreateMessageCache(discord.MessageCacheSize);
         }
         internal new static SocketTextChannel Create(SocketGuild guild, ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -54,7 +54,7 @@ namespace Discord.WebSocket
             : base(discord, id, guild)
         {
             if (Discord.MessageCacheSize > 0)
-                _messages = discord.MessageCache.CreateMessageCache(discord);
+                _messages = discord.MessageCache.CreateMessageCache();
         }
         internal new static SocketTextChannel Create(SocketGuild guild, ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
@@ -5,7 +5,7 @@ namespace Discord
 {
     public interface IMessageCache
     {
-        public IMessageCache CreateMessageCache(DiscordSocketClient discord);
+        public IMessageCache CreateMessageCache();
 
         public IReadOnlyCollection<SocketMessage> Messages { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
@@ -3,8 +3,10 @@ using Discord.WebSocket;
 
 namespace Discord
 {
-    internal interface IMessageCache
+    public interface IMessageCache
     {
+        public IMessageCache CreateMessageCache(DiscordSocketClient discord);
+
         public IReadOnlyCollection<SocketMessage> Messages { get; }
 
         public void Add(SocketMessage message);

--- a/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
@@ -5,7 +5,7 @@ namespace Discord
 {
     public interface IMessageCache
     {
-        public IMessageCache CreateMessageCache();
+        public IMessageCache CreateMessageCache(int size);
 
         public IReadOnlyCollection<SocketMessage> Messages { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/IMessageCache.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Discord.WebSocket;
+
+namespace Discord
+{
+    internal interface IMessageCache
+    {
+        public IReadOnlyCollection<SocketMessage> Messages { get; }
+
+        public void Add(SocketMessage message);
+
+        public SocketMessage Remove(ulong id);
+
+        public SocketMessage Get(ulong id);
+
+        public IReadOnlyCollection<SocketMessage> GetMany(ulong? fromMessageId, Direction dir, int limit);
+    }
+}

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -14,10 +14,7 @@ namespace Discord.WebSocket
 
         public IReadOnlyCollection<SocketMessage> Messages => _messages.ToReadOnlyCollection();
 
-        public IMessageCache CreateMessageCache(DiscordSocketClient discord)
-        {
-            return new MessageCache(discord);
-        }
+        public IMessageCache CreateMessageCache(DiscordSocketClient discord) => new MessageCache(discord);
 
         public MessageCache(DiscordSocketClient discord)
         {

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -14,11 +14,11 @@ namespace Discord.WebSocket
 
         public IReadOnlyCollection<SocketMessage> Messages => _messages.ToReadOnlyCollection();
 
-        public IMessageCache CreateMessageCache() => new MessageCache();
+        public IMessageCache CreateMessageCache(int size) => new MessageCache(size);
 
-        public MessageCache()
+        public MessageCache(int size)
         {
-            _size = 50; // todo: get this from the existing DiscordSocketConfig value.
+            _size = size;
             _messages = new ConcurrentDictionary<ulong, SocketMessage>(ConcurrentHashSet.DefaultConcurrencyLevel, (int)(_size * 1.05));
             _orderedMessages = new ConcurrentQueue<ulong>();
         }

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -6,13 +6,18 @@ using System.Linq;
 
 namespace Discord.WebSocket
 {
-    internal class MessageCache : IMessageCache
+    public class MessageCache : IMessageCache
     {
         private readonly ConcurrentDictionary<ulong, SocketMessage> _messages;
         private readonly ConcurrentQueue<ulong> _orderedMessages;
         private readonly int _size;
 
         public IReadOnlyCollection<SocketMessage> Messages => _messages.ToReadOnlyCollection();
+
+        public IMessageCache CreateMessageCache(DiscordSocketClient discord)
+        {
+            return new MessageCache(discord);
+        }
 
         public MessageCache(DiscordSocketClient discord)
         {

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Discord.WebSocket
 {
-    internal class MessageCache
+    internal class MessageCache : IMessageCache
     {
         private readonly ConcurrentDictionary<ulong, SocketMessage> _messages;
         private readonly ConcurrentQueue<ulong> _orderedMessages;

--- a/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/MessageCache.cs
@@ -14,11 +14,11 @@ namespace Discord.WebSocket
 
         public IReadOnlyCollection<SocketMessage> Messages => _messages.ToReadOnlyCollection();
 
-        public IMessageCache CreateMessageCache(DiscordSocketClient discord) => new MessageCache(discord);
+        public IMessageCache CreateMessageCache() => new MessageCache();
 
-        public MessageCache(DiscordSocketClient discord)
+        public MessageCache()
         {
-            _size = discord.MessageCacheSize;
+            _size = 50; // todo: get this from the existing DiscordSocketConfig value.
             _messages = new ConcurrentDictionary<ulong, SocketMessage>(ConcurrentHashSet.DefaultConcurrencyLevel, (int)(_size * 1.05));
             _orderedMessages = new ConcurrentQueue<ulong>();
         }


### PR DESCRIPTION
This change will allow library users to create their own implementation of the MessageCache through the DiscordSocketConfig.

My use case is to disable the caching of new messages, and instead only cache messages which my bot is likely to request again in the future. Instead of implementing this functionality directly, it was recommended that I allow the library users to bring their own MessageCache which I agree makes much more sense.

I've not worked much with interfaces and abstract classes before, so please inform me of any changes I could make to keep this change consistent with other parts of the library and working properly.