### PR TITLE
feature: get private methods(backward compatibility)

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -136,7 +136,7 @@ namespace Discord.Commands
                 builder.Name = typeInfo.Name;
 
             // Get all methods (including from inherited members), that are valid commands
-            var validCommands = typeInfo.GetMethods().Where(IsValidCommandDefinition);
+            var validCommands = typeInfo.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(IsValidCommandDefinition);
 
             foreach (var method in validCommands)
             {


### PR DESCRIPTION
Breaking change fix. At the moment if a command contains private method it is not going to be handled. This change will fix this.
Improvement of: https://github.com/discord-net/Discord.Net/pull/1521