### PR TITLE
misc: Add remark regarding CustomStatus as the activity

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -209,6 +209,12 @@ namespace Discord.WebSocket
         /// <param name="name">The name of the game.</param>
         /// <param name="streamUrl">If streaming, the URL of the stream. Must be a valid Twitch URL.</param>
         /// <param name="type">The type of the game.</param>
+        /// <remarks>
+        ///     <note type="warning">
+        ///         Bot accounts cannot use <see cref="ActivityType.CustomStatus"/> as their activity
+        ///         and it will have no effect.
+        ///     </note>
+        /// </remarks>
         /// <returns>
         ///     A task that represents the asynchronous set operation.
         /// </returns>
@@ -220,6 +226,10 @@ namespace Discord.WebSocket
         ///     This method sets the <paramref name="activity"/> of the user. 
         ///     <note type="note">
         ///         Discord will only accept setting of name and the type of activity.
+        ///     </note>
+        ///     <note type="warning">
+        ///         Bot accounts cannot use <see cref="ActivityType.CustomStatus"/> as their activity
+        ///         and it will have no effect.
         ///     </note>
         ///     <note type="warning">
         ///         Rich Presence cannot be set via this method or client. Rich Presence is strictly limited to RPC

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -211,8 +211,8 @@ namespace Discord.WebSocket
         /// <param name="type">The type of the game.</param>
         /// <remarks>
         ///     <note type="warning">
-        ///         Bot accounts cannot use <see cref="ActivityType.CustomStatus"/> as their activity
-        ///         and it will have no effect.
+        ///         Bot accounts cannot set <see cref="ActivityType.CustomStatus"/> as their activity
+        ///         type and it will have no effect.
         ///     </note>
         /// </remarks>
         /// <returns>
@@ -228,8 +228,8 @@ namespace Discord.WebSocket
         ///         Discord will only accept setting of name and the type of activity.
         ///     </note>
         ///     <note type="warning">
-        ///         Bot accounts cannot use <see cref="ActivityType.CustomStatus"/> as their activity
-        ///         and it will have no effect.
+        ///         Bot accounts cannot set <see cref="ActivityType.CustomStatus"/> as their activity
+        ///         type and it will have no effect.
         ///     </note>
         ///     <note type="warning">
         ///         Rich Presence cannot be set via this method or client. Rich Presence is strictly limited to RPC

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -450,6 +450,8 @@ namespace Discord.WebSocket
         /// </example>
         public override async Task SetGameAsync(string name, string streamUrl = null, ActivityType type = ActivityType.Playing)
         {
+            if (type == ActivityType.CustomStatus)
+                throw new InvalidOperationException("Only user accounts can use CustomStatus as their activity.");
             if (!string.IsNullOrEmpty(streamUrl))
                 Activity = new StreamingGame(name, streamUrl);
             else if (!string.IsNullOrEmpty(name))

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -450,8 +450,6 @@ namespace Discord.WebSocket
         /// </example>
         public override async Task SetGameAsync(string name, string streamUrl = null, ActivityType type = ActivityType.Playing)
         {
-            if (type == ActivityType.CustomStatus)
-                throw new InvalidOperationException("Only user accounts can use CustomStatus as their activity.");
             if (!string.IsNullOrEmpty(streamUrl))
                 Activity = new StreamingGame(name, streamUrl);
             else if (!string.IsNullOrEmpty(name))


### PR DESCRIPTION
This will add a remark to `SetGameAsync` and `SetActivityAsync` regarding trying to set `ActivityType.CustomStatus` as the bot activity. It was made like this to not introduce a breaking change.