### PR TITLE
feature: Add enterTyping optional parameter to CommandService.ExecuteAsync()

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -483,25 +483,27 @@ namespace Discord.Commands
         /// <param name="context">The context of the command.</param>
         /// <param name="argPos">The position of which the command starts at.</param>
         /// <param name="services">The service to be used in the command's dependency injection.</param>
+        /// <param name="enterTyping">Whether the client should enter typing state.</param>
         /// <param name="multiMatchHandling">The handling mode when multiple command matches are found.</param>
         /// <returns>
         ///     A task that represents the asynchronous execution operation. The task result contains the result of the
         ///     command execution.
         /// </returns>
-        public Task<IResult> ExecuteAsync(ICommandContext context, int argPos, IServiceProvider services, MultiMatchHandling multiMatchHandling = MultiMatchHandling.Exception)
-            => ExecuteAsync(context, context.Message.Content.Substring(argPos), services, multiMatchHandling);
+        public Task<IResult> ExecuteAsync(ICommandContext context, int argPos, IServiceProvider services, bool enterTyping = false, MultiMatchHandling multiMatchHandling = MultiMatchHandling.Exception)
+            => ExecuteAsync(context, context.Message.Content.Substring(argPos), services, enterTyping, multiMatchHandling);
         /// <summary>
         ///     Executes the command.
         /// </summary>
         /// <param name="context">The context of the command.</param>
         /// <param name="input">The command string.</param>
         /// <param name="services">The service to be used in the command's dependency injection.</param>
+        /// <param name="enterTyping">Whether the client should enter typing state.</param>
         /// <param name="multiMatchHandling">The handling mode when multiple command matches are found.</param>
         /// <returns>
         ///     A task that represents the asynchronous execution operation. The task result contains the result of the
         ///     command execution.
         /// </returns>
-        public async Task<IResult> ExecuteAsync(ICommandContext context, string input, IServiceProvider services, MultiMatchHandling multiMatchHandling = MultiMatchHandling.Exception)
+        public async Task<IResult> ExecuteAsync(ICommandContext context, string input, IServiceProvider services, bool enterTyping = false, MultiMatchHandling multiMatchHandling = MultiMatchHandling.Exception)
         {
             services = services ?? EmptyServiceProvider.Instance;
 
@@ -511,7 +513,11 @@ namespace Discord.Commands
                 await _commandExecutedEvent.InvokeAsync(Optional.Create<CommandInfo>(), context, searchResult).ConfigureAwait(false);
                 return searchResult;
             }
-                
+
+            if (enterTyping)
+            {
+                using var typing = context.Channel.EnterTypingState();
+            }
 
             var commands = searchResult.Commands;
             var preconditionResults = new Dictionary<CommandMatch, PreconditionResult>();


### PR DESCRIPTION
## Abstract
This resolves #1775 by adding an optional parameter to the `CommandService.ExecuteAsync()` method(s).

### Additions
Optional `bool enterTyping = false` parameter is added to `CommandService.ExecuteAsync()` that will allow users to specify whether or not the client should enter typing state in the channel where a valid command was invoked. The call to `context.Channel.EnterTypingState()` will return an `IDisposable` assigned to the local variable `var typing`. By declaring `var typing` with the `using` statement, the `IDisposable` will get disposed once `ExecuteAsync()` finishes running.

### Tests
This was tested with the sample `02_commands_framework`.