### PR TITLE
fix: NullReferenceException in audit log types

### DIFF
--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
@@ -19,8 +19,14 @@ namespace Discord.Rest
 
         internal static MessagePinAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            return new MessagePinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, RestUser.Create(discord, userInfo));
+            RestUser user = null;
+            if (entry.TargetId.HasValue)
+            {
+                var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+                user = RestUser.Create(discord, userInfo);
+            }
+
+            return new MessagePinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, user);
         }
 
         /// <summary>
@@ -38,10 +44,10 @@ namespace Discord.Rest
         /// </returns>
         public ulong ChannelId { get; }
         /// <summary>
-        ///     Gets the user of the message that was pinned.
+        ///     Gets the user of the message that was pinned if available.
         /// </summary>
         /// <returns>
-        ///     A user object representing the user that created the pinned message.
+        ///     A user object representing the user that created the pinned message or <see langword="null"/>.
         /// </returns>
         public IUser Target { get; }
     }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
@@ -19,8 +19,14 @@ namespace Discord.Rest
 
         internal static MessageUnpinAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
-            var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            return new MessageUnpinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, RestUser.Create(discord, userInfo));
+            RestUser user = null;
+            if (entry.TargetId.HasValue)
+            {
+                var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
+                user = RestUser.Create(discord, userInfo);
+            }
+
+            return new MessageUnpinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, user);
         }
 
         /// <summary>
@@ -38,10 +44,10 @@ namespace Discord.Rest
         /// </returns>
         public ulong ChannelId { get; }
         /// <summary>
-        ///     Gets the user of the message that was unpinned.
+        ///     Gets the user of the message that was unpinned if available.
         /// </summary>
         /// <returns>
-        ///     A user object representing the user that created the unpinned message.
+        ///     A user object representing the user that created the unpinned message or <see langword="null"/>.
         /// </returns>
         public IUser Target { get; }
     }


### PR DESCRIPTION
`TargetId` can be null in audit logs when pinning a webhook message. This fix adds additional checks which prevent `RestUser.Create` from throwing exceptions.