### PR TITLE
fix: Audit log UserId can be null

### DIFF
--- a/src/Discord.Net.Rest/API/Common/AuditLogEntry.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogEntry.cs
@@ -7,7 +7,7 @@ namespace Discord.API
         [JsonProperty("target_id")]
         public ulong? TargetId { get; set; }
         [JsonProperty("user_id")]
-        public ulong UserId { get; set; }
+        public ulong? UserId { get; set; }
 
         [JsonProperty("changes")]
         public AuditLogChange[] Changes { get; set; }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/RestAuditLogEntry.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/RestAuditLogEntry.cs
@@ -22,7 +22,7 @@ namespace Discord.Rest
 
         internal static RestAuditLogEntry Create(BaseDiscordClient discord, Model fullLog, EntryModel model)
         {
-            var userInfo = fullLog.Users.FirstOrDefault(x => x.Id == model.UserId);
+            var userInfo = model.UserId != null ? fullLog.Users.FirstOrDefault(x => x.Id == model.UserId) : null;
             IUser user = null;
             if (userInfo != null)
                 user = RestUser.Create(discord, userInfo);


### PR DESCRIPTION
It's possible for the UserId to be null in a few cases (like a webhook deleting itself).