### PR TITLE
[Docs] - Updated to use async main

### DIFF
--- a/docs/guides/getting_started/first-bot.md
+++ b/docs/guides/getting_started/first-bot.md
@@ -80,15 +80,11 @@ recommended for these operations to be awaited in a
 properly established async context whenever possible.
 
 To establish an async context, we will be creating an async main method
-in your console application, and rewriting the static main method to
-invoke the new async main.
+in your console application.
 
 [!code-csharp[Async Context](samples/first-bot/async-context.cs)]
 
-As a result of this, your program will now start and immediately
-jump into an async context. This allows us to create a connection
-to Discord later on without having to worry about setting up the
-correct async implementation.
+As a result of this, your program will now start into an async context.
 
 > [!WARNING]
 > If your application throws any exceptions within an async context,

--- a/docs/guides/getting_started/samples/first-bot/async-context.cs
+++ b/docs/guides/getting_started/samples/first-bot/async-context.cs
@@ -1,7 +1,7 @@
 public class Program
 {
-	public static void Main(string[] args)
-		=> new Program().MainAsync().GetAwaiter().GetResult();
+	public static async Task Main(string[] args)
+		=> await new Program().MainAsync();
 
 	public async Task MainAsync()
 	{

--- a/docs/guides/getting_started/samples/first-bot/async-context.cs
+++ b/docs/guides/getting_started/samples/first-bot/async-context.cs
@@ -1,7 +1,6 @@
 public class Program
 {
-	public static async Task Main(string[] args)
-		=> await new Program().MainAsync();
+	public static Task Main(string[] args) => new Program().MainAsync();
 
 	public async Task MainAsync()
 	{

--- a/docs/guides/getting_started/samples/first-bot/complete.cs
+++ b/docs/guides/getting_started/samples/first-bot/complete.cs
@@ -2,8 +2,7 @@ public class Program
 {
 	private DiscordSocketClient _client;
 	
-	public static async Task Main(string[] args)
-		=> await new Program().MainAsync();
+	public static Task Main(string[] args) => new Program().MainAsync();
 
 	public async Task MainAsync()
 	{

--- a/docs/guides/getting_started/samples/first-bot/complete.cs
+++ b/docs/guides/getting_started/samples/first-bot/complete.cs
@@ -2,8 +2,8 @@ public class Program
 {
 	private DiscordSocketClient _client;
 	
-	public static void Main(string[] args)
-		=> new Program().MainAsync().GetAwaiter().GetResult();
+	public static async Task Main(string[] args)
+		=> await new Program().MainAsync();
 
 	public async Task MainAsync()
 	{

--- a/docs/guides/getting_started/samples/first-bot/structure.cs
+++ b/docs/guides/getting_started/samples/first-bot/structure.cs
@@ -10,11 +10,11 @@ using Discord.WebSocket;
 class Program
 {
     // Program entry point
-    static void Main(string[] args)
+    static async Task Main(string[] args)
     {
         // Call the Program constructor, followed by the 
         // MainAsync method and wait until it finishes (which should be never).
-        new Program().MainAsync().GetAwaiter().GetResult();
+        await new Program().MainAsync();
     }
 
     private readonly DiscordSocketClient _client;

--- a/docs/guides/getting_started/samples/first-bot/structure.cs
+++ b/docs/guides/getting_started/samples/first-bot/structure.cs
@@ -10,11 +10,11 @@ using Discord.WebSocket;
 class Program
 {
     // Program entry point
-    static async Task Main(string[] args)
+    static Task Main(string[] args)
     {
         // Call the Program constructor, followed by the 
         // MainAsync method and wait until it finishes (which should be never).
-        await new Program().MainAsync();
+        return new Program().MainAsync();
     }
 
     private readonly DiscordSocketClient _client;


### PR DESCRIPTION
Currently, we use GetAwaiter().GetResult() to run our MainAsync method.  In C# 7.1 or above, we can create an async main method:

```cs
public static async Task Main(string[] args){}
```

This way, we can simplify some things on documentation like this:

```cs
public static void Main(string[] args)
	=> new Program().MainAsync().GetAwaiter().GetResult();

public async Task MainAsync()
{
}
```
-----
After PR:

```cs
public static async TaskMain(string[] args) 
	=> await new Program().MainAsync();

public async Task MainAsync()
{
}
```

