### PR TITLE
Feature: Add missing property to MESSAGE_REACTION_ADD event

### DIFF
--- a/src/Discord.Net.WebSocket/API/Gateway/Reaction.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/Reaction.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Discord.API.Gateway
 {
@@ -12,5 +12,7 @@ namespace Discord.API.Gateway
         public ulong ChannelId { get; set; }
         [JsonProperty("emoji")]
         public Emoji Emoji { get; set; }
+        [JsonProperty("member")]
+        public Optional<GuildMember> Member { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1384,6 +1384,14 @@ namespace Discord.WebSocket
                                             ? Optional.Create<SocketUserMessage>()
                                             : Optional.Create(cachedMsg);
 
+                                        if (data.Member.IsSpecified)
+                                        {
+                                            var guild = (channel as SocketGuildChannel)?.Guild;
+                                            
+                                            if (guild != null)
+                                                user = guild.AddOrUpdateUser(data.Member.Value);
+                                        }
+
                                         var optionalUser = user is null
                                             ? Optional.Create<IUser>()
                                             : Optional.Create(user);


### PR DESCRIPTION
# Description

This pull request adds a missing property for the MESSAGE_REACTION_ADD event

## Changes 

I have added the member property to the reaction event, I made it optional because I saw that it's also used in the MESSAGE_REACTION_REMOVE but in that event is not present. In the DiscordSocketClient I added some lines that checks if the member property is present and if yes use it instead of the user in the cache

```diff
Reaction.cs

+++ [JsonProperty("member")]
+++ public Optional<GuildMember> Member { get; set; }
```

## Motivation

Uses the member property when present in the event instead of rely on the cache

## Breaking changes

No breaking changes
