### PR TITLE
Fixed overlooked code error.

### DIFF
--- a/samples/03_sharded_client/Modules/PublicModule.cs
+++ b/samples/03_sharded_client/Modules/PublicModule.cs
@@ -9,7 +9,7 @@ namespace _03_sharded_client.Modules
         [Command("info")]
         public async Task InfoAsync()
         {
-            var msg = $@"Hi {Context.User}! There are currently {Context.Client.Shards} shards!
+            var msg = $@"Hi {Context.User}! There are currently {Context.Client.Shards.Count} shards!
                 This guild is being served by shard number {Context.Client.GetShardFor(Context.Guild).ShardId}";
             await ReplyAsync(msg);
         }


### PR DESCRIPTION
Just a very simple change to address an overlooked error in example code for sharded clients.

The code previously was not displaying the count of shards available
![image](https://user-images.githubusercontent.com/16710818/112132200-b73a1f80-8ba0-11eb-88e5-893569656e03.png)

The changed version now shows the correct number of running shards.
![image](https://user-images.githubusercontent.com/16710818/112132269-ca4cef80-8ba0-11eb-8a36-c6228009f0f3.png)
