### PR TITLE
Grab correct Uses value for vanity urls

### DIFF
--- a/src/Discord.Net.Rest/API/Common/InviteVanity.cs
+++ b/src/Discord.Net.Rest/API/Common/InviteVanity.cs
@@ -6,5 +6,7 @@ namespace Discord.API
     {
         [JsonProperty("code")]
         public string Code { get; set; }
+        [JsonProperty("uses")]
+        public int Uses { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -304,6 +304,7 @@ namespace Discord.Rest
             var vanityModel = await client.ApiClient.GetVanityInviteAsync(guild.Id, options).ConfigureAwait(false);
             if (vanityModel == null) throw new InvalidOperationException("This guild does not have a vanity URL.");
             var inviteModel = await client.ApiClient.GetInviteAsync(vanityModel.Code, options).ConfigureAwait(false);
+            inviteModel.Uses = vanityModel.Uses;
             return RestInviteMetadata.Create(client, guild, null, inviteModel);
         }
 


### PR DESCRIPTION
The vanity-url endpoint returns uses, and this can be used when populating the model.