### PR TITLE
fix: Account for team in RequireOwnerAttribute

### DIFF
--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireOwnerAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Discord.Commands
@@ -44,8 +45,10 @@ namespace Discord.Commands
             {
                 case TokenType.Bot:
                     var application = await context.Client.GetApplicationInfoAsync().ConfigureAwait(false);
-                    if (context.User.Id != application.Owner.Id)
+
+                    if (application.Team?.TeamMembers.All(t => t.User.Id != context.User.Id) ?? context.User.Id != application.Owner.Id)
                         return PreconditionResult.FromError(ErrorMessage ?? "Command can only be run by the owner of the bot.");
+
                     return PreconditionResult.FromSuccess();
                 default:
                     return PreconditionResult.FromError($"{nameof(RequireOwnerAttribute)} is not supported by this {nameof(TokenType)}.");


### PR DESCRIPTION
# Abstract

This pull request adds support for teams in the `RequireOwnerAttribute`, which currently only works when the bot's owner is a user. 

## Changes

When the `Team` property in an application isn't null, this code will check whether the user whose permissions are being checked is part of the application's team. If, however, the `Team` property is null the code will fall back to its original behavior.

# Tests

This pull request has been tested live, and [is proven to work with personal and team applications](https://storage.googleapis.com/theodoordev.appspot.com/6430b5d09255476).

# Possible Caveats:

None