### PR TITLE
New Discord Certified Moderator Flag Add

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/UserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/UserProperties.cs
@@ -67,5 +67,9 @@ namespace Discord
         ///     Flag given to users that developed bots and early verified their accounts.
         /// </summary>
         EarlyVerifiedBotDeveloper = 1 << 17,
+         /// <summary>
+        ///     Flag given to users that are discord certified moderators who has give discord's exam.
+        /// </summary>
+        DiscordCertifiedModerator = 1 << 18,
     }
 }


### PR DESCRIPTION
This pull request adds the Discord Certified Moderator badge flag to the User Flags
PR in discord-api-docs: https://github.com/discord/discord-api-docs/pull/2946

