### PR TITLE
Bump version to 3.0.0-dev

### DIFF
--- a/Discord.Net.targets
+++ b/Discord.Net.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <VersionPrefix>2.4.0</VersionPrefix>
-        <VersionSuffix></VersionSuffix>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>dev</VersionSuffix>
         <LangVersion>latest</LangVersion>
         <Authors>Discord.Net Contributors</Authors>
         <PackageTags>discord;discordapp</PackageTags>

--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Discord.Net</id>
-    <version>2.4.0$suffix$</version>
+    <version>3.0.0-dev$suffix$</version>
     <title>Discord.Net</title>
     <authors>Discord.Net Contributors</authors>
     <owners>foxbot</owners>
@@ -14,25 +14,25 @@
     <iconUrl>https://github.com/RogueException/Discord.Net/raw/dev/docs/marketing/logo/PackageLogo.png</iconUrl>
     <dependencies>
         <group targetFramework="net461">
-            <dependency id="Discord.Net.Core" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="2.4.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Rest" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Commands" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="3.0.0-dev$suffix$" />
         </group>       
         <group targetFramework="netstandard2.0">
-            <dependency id="Discord.Net.Core" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="2.4.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Rest" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Commands" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="3.0.0-dev$suffix$" />
         </group>
 		<group targetFramework="netstandard2.1">
-            <dependency id="Discord.Net.Core" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="2.4.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="2.4.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Rest" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.WebSocket" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Commands" version="3.0.0-dev$suffix$" />
+            <dependency id="Discord.Net.Webhook" version="3.0.0-dev$suffix$" />
         </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This PR will bump the dev version to 3.0, the idea in this release is to clean up the old code and remove obsolete methods while bringing the gateway version to latest (depending on when I finish doing the changes, it will be 8 or 9).