### PR TITLE
Remove sync voice regions methods and properties

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -70,14 +70,6 @@ namespace Discord.WebSocket
         ///     A read-only collection of private channels that the user currently partakes in.
         /// </returns>
         public abstract IReadOnlyCollection<ISocketPrivateChannel> PrivateChannels { get; }
-        /// <summary>
-        ///     Gets a collection of available voice regions.
-        /// </summary>
-        /// <returns>
-        ///     A read-only collection of voice regions that the user has access to.
-        /// </returns>
-        [Obsolete("This property is obsolete, use the GetVoiceRegionsAsync method instead.")]
-        public abstract IReadOnlyCollection<RestVoiceRegion> VoiceRegions { get; }
 
         internal BaseSocketClient(DiscordSocketConfig config, DiscordRestApiClient client)
             : base(config, client) => BaseConfig = config;
@@ -163,16 +155,6 @@ namespace Discord.WebSocket
         ///     found.
         /// </returns>
         public abstract SocketGuild GetGuild(ulong id);
-        /// <summary>
-        ///     Gets a voice region.
-        /// </summary>
-        /// <param name="id">The identifier of the voice region (e.g. <c>eu-central</c> ).</param>
-        /// <returns>
-        ///     A REST-based voice region associated with the identifier; <c>null</c> if the voice region is not
-        ///     found.
-        /// </returns>
-        [Obsolete("This method is obsolete, use GetVoiceRegionAsync instead.")]
-        public abstract RestVoiceRegion GetVoiceRegion(string id);
         /// <summary>
         ///     Gets all voice regions.
         /// </summary>
@@ -327,10 +309,14 @@ namespace Discord.WebSocket
             => Task.FromResult<IUser>(GetUser(username, discriminator));
 
         /// <inheritdoc />
-        Task<IVoiceRegion> IDiscordClient.GetVoiceRegionAsync(string id, RequestOptions options)
-            => Task.FromResult<IVoiceRegion>(GetVoiceRegion(id));
+        async Task<IVoiceRegion> IDiscordClient.GetVoiceRegionAsync(string id, RequestOptions options)
+        {
+            return await GetVoiceRegionAsync(id).ConfigureAwait(false);
+        }
         /// <inheritdoc />
-        Task<IReadOnlyCollection<IVoiceRegion>> IDiscordClient.GetVoiceRegionsAsync(RequestOptions options)
-            => Task.FromResult<IReadOnlyCollection<IVoiceRegion>>(VoiceRegions);
+        async Task<IReadOnlyCollection<IVoiceRegion>> IDiscordClient.GetVoiceRegionsAsync(RequestOptions options)
+        {
+            return await GetVoiceRegionsAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -36,9 +36,6 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override IReadOnlyCollection<ISocketPrivateChannel> PrivateChannels => GetPrivateChannels().ToReadOnlyCollection(GetPrivateChannelCount);
         public IReadOnlyCollection<DiscordSocketClient> Shards => _shards;
-        /// <inheritdoc />
-        [Obsolete("This property is obsolete, use the GetVoiceRegionsAsync method instead.")]
-        public override IReadOnlyCollection<RestVoiceRegion> VoiceRegions => _shards[0].VoiceRegions;
 
         /// <summary>
         ///     Provides access to a REST-only client with a shared state from this client.
@@ -265,11 +262,6 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc />
-        [Obsolete("This method is obsolete, use GetVoiceRegionAsync instead.")]
-        public override RestVoiceRegion GetVoiceRegion(string id)
-            => _shards[0].GetVoiceRegion(id);
-
-        /// <inheritdoc />
         public override async ValueTask<IReadOnlyCollection<RestVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options = null)
         {
             return await _shards[0].GetVoiceRegionsAsync().ConfigureAwait(false);
@@ -432,11 +424,15 @@ namespace Discord.WebSocket
             => Task.FromResult<IUser>(GetUser(username, discriminator));
 
         /// <inheritdoc />
-        Task<IReadOnlyCollection<IVoiceRegion>> IDiscordClient.GetVoiceRegionsAsync(RequestOptions options)
-            => Task.FromResult<IReadOnlyCollection<IVoiceRegion>>(VoiceRegions);
+        async Task<IReadOnlyCollection<IVoiceRegion>> IDiscordClient.GetVoiceRegionsAsync(RequestOptions options)
+        {
+            return await GetVoiceRegionsAsync().ConfigureAwait(false);
+        }
         /// <inheritdoc />
-        Task<IVoiceRegion> IDiscordClient.GetVoiceRegionAsync(string id, RequestOptions options)
-            => Task.FromResult<IVoiceRegion>(GetVoiceRegion(id));
+        async Task<IVoiceRegion> IDiscordClient.GetVoiceRegionAsync(string id, RequestOptions options)
+        {
+            return await GetVoiceRegionAsync(id).ConfigureAwait(false);
+        }
 
         internal override void Dispose(bool disposing)
         {

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -109,9 +109,6 @@ namespace Discord.WebSocket
         /// </returns>
         public IReadOnlyCollection<SocketGroupChannel> GroupChannels
             => State.PrivateChannels.OfType<SocketGroupChannel>().ToImmutableArray();
-        /// <inheritdoc />
-        [Obsolete("This property is obsolete, use the GetVoiceRegionsAsync method instead.")]
-        public override IReadOnlyCollection<RestVoiceRegion> VoiceRegions => GetVoiceRegionsAsync().GetAwaiter().GetResult();
 
         /// <summary>
         ///     Initializes a new REST/WebSocket-based Discord client.
@@ -341,11 +338,6 @@ namespace Discord.WebSocket
         }
         internal void RemoveUser(ulong id)
             => State.RemoveUser(id);
-
-        /// <inheritdoc />
-        [Obsolete("This method is obsolete, use GetVoiceRegionAsync instead.")]
-        public override RestVoiceRegion GetVoiceRegion(string id)
-            => GetVoiceRegionAsync(id).GetAwaiter().GetResult();
 
         /// <inheritdoc />
         public override async ValueTask<IReadOnlyCollection<RestVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options = null)


### PR DESCRIPTION
## Summary

This PR will continue the removal of the sync methods and properties related to VoiceRegions since they aren't cached at the start anymore.

## Changes

- Remove `BaseSocketClient.VoiceRegions` property
- Remove `BaseSocketClient.GetVoiceRegion` method