### PR TITLE
fix: Create DM channel with id and author alone

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1280,7 +1280,7 @@ namespace Discord.WebSocket
                                         {
                                             var dm = SocketDMChannel.Create(this, State, data.ChannelId, data.Author.Value);
                                             channel = dm;
-                                            State.AddChannel(channel as SocketChannel);
+                                            State.AddChannel(dm);
                                             dm.Recipient.GlobalUser.DMChannel = dm;
                                         }
                                         else

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -49,6 +49,16 @@ namespace Discord.WebSocket
         {
             Recipient.Update(state, model.Recipients.Value[0]);
         }
+        internal static SocketDMChannel Create(DiscordSocketClient discord, ClientState state, ulong channelId, API.User recipient)
+        {
+            var entity = new SocketDMChannel(discord, channelId, discord.GetOrCreateUser(state, recipient));
+            entity.Update(state, recipient);
+            return entity;
+        }
+        internal void Update(ClientState state, API.User recipient)
+        {
+            Recipient.Update(state, recipient);
+        }
 
         /// <inheritdoc />
         public Task CloseAsync(RequestOptions options = null)


### PR DESCRIPTION
## Summary

GW v8 stopped sending CHANNEL_CREATEs for DMs so Discord.Net didn't have a cached channel and would ignore it as an unknown channel.
This PR will add the possibility to create DM channels with the channel id and author alone and cache this instead when receiving a MESSAGE_CREATE.
It will assume if no channel is found and there's no guild id specified, it must be a direct message. The only way I could see this not working would be for group channels that bots can't be a part of.