### PR TITLE
misc: Internal change to GetOrCreateUser

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -314,11 +314,13 @@ namespace Discord.WebSocket
         ///     Clears cached users from the client.
         /// </summary>
         public void PurgeUserCache() => State.PurgeUsers();
-        internal SocketGlobalUser GetOrCreateUser(ClientState state, Discord.API.User model, bool cache)
+        internal SocketGlobalUser GetOrCreateUser(ClientState state, Discord.API.User model)
         {
-            if (cache)
-                return state.GetOrAddUser(model.Id, x => SocketGlobalUser.Create(this, state, model));
-            return state.GetUser(model.Id) ?? SocketGlobalUser.Create(this, state, model);
+            return state.GetOrAddUser(model.Id, x => SocketGlobalUser.Create(this, state, model));
+        }
+        internal SocketUser GetOrCreateTemporaryUser(ClientState state, Discord.API.User model)
+        {
+            return state.GetUser(model.Id) ?? (SocketUser)SocketUnknownUser.Create(this, state, model);
         }
         internal SocketGlobalUser GetOrCreateSelfUser(ClientState state, Discord.API.User model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -29,14 +29,14 @@ namespace Discord.WebSocket
         /// </summary>
         public new IReadOnlyCollection<SocketUser> Users => ImmutableArray.Create(Discord.CurrentUser, Recipient);
 
-        internal SocketDMChannel(DiscordSocketClient discord, ulong id, SocketGlobalUser recipient)
+        internal SocketDMChannel(DiscordSocketClient discord, ulong id, SocketUser recipient)
             : base(discord, id)
         {
             Recipient = recipient;
         }
         internal static SocketDMChannel Create(DiscordSocketClient discord, ClientState state, Model model)
         {
-            var entity = new SocketDMChannel(discord, model.Id, discord.GetOrCreateUser(state, model.Recipients.Value[0], false));
+            var entity = new SocketDMChannel(discord, model.Id, discord.GetOrCreateTemporaryUser(state, model.Recipients.Value[0]));
             entity.Update(state, model);
             return entity;
         }
@@ -46,7 +46,7 @@ namespace Discord.WebSocket
         }
         internal static SocketDMChannel Create(DiscordSocketClient discord, ClientState state, ulong channelId, API.User recipient)
         {
-            var entity = new SocketDMChannel(discord, channelId, discord.GetOrCreateUser(state, recipient, false));
+            var entity = new SocketDMChannel(discord, channelId, discord.GetOrCreateTemporaryUser(state, recipient));
             entity.Update(state, recipient);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
@@ -38,7 +38,7 @@ namespace Discord.WebSocket
         }
         internal static SocketGroupUser Create(SocketGroupChannel channel, ClientState state, Model model)
         {
-            var entity = new SocketGroupUser(channel, channel.Discord.GetOrCreateUser(state, model, true));
+            var entity = new SocketGroupUser(channel, channel.Discord.GetOrCreateUser(state, model));
             entity.Update(state, model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -116,20 +116,20 @@ namespace Discord.WebSocket
         }
         internal static SocketGuildUser Create(SocketGuild guild, ClientState state, UserModel model)
         {
-            var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model, true));
+            var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model));
             entity.Update(state, model);
             entity.UpdateRoles(new ulong[0]);
             return entity;
         }
         internal static SocketGuildUser Create(SocketGuild guild, ClientState state, MemberModel model)
         {
-            var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model.User, true));
+            var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model.User));
             entity.Update(state, model);
             return entity;
         }
         internal static SocketGuildUser Create(SocketGuild guild, ClientState state, PresenceModel model)
         {
-            var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model.User, true));
+            var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model.User));
             entity.Update(state, model, false);
             return entity;
         }


### PR DESCRIPTION
Separate the temporary (unknown) user creation part from `GetOrCreateUser` to `GetOrCreateTemporaryUser`.