### PR TITLE
fix: Fire GuildMemberUpdated without cached user

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -347,6 +347,7 @@ namespace Discord.WebSocket
         }
         internal readonly AsyncEvent<Func<SocketUser, SocketUser, Task>> _userUpdatedEvent = new AsyncEvent<Func<SocketUser, SocketUser, Task>>();
         /// <summary> Fired when a guild member is updated, or a member presence is updated. </summary>
+        /// <remarks> The first user (state before) might be null if they weren't in the cache. </remarks>
         public event Func<SocketGuildUser, SocketGuildUser, Task> GuildMemberUpdated {
             add { _guildMemberUpdatedEvent.Add(value); }
             remove { _guildMemberUpdatedEvent.Remove(value); }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -960,11 +960,8 @@ namespace Discord.WebSocket
                                         }
                                         else
                                         {
-                                            if (!guild.HasAllMembers)
-                                                await IncompleteGuildUserAsync(type, data.User.Id, data.GuildId).ConfigureAwait(false);
-                                            else
-                                                await UnknownGuildUserAsync(type, data.User.Id, data.GuildId).ConfigureAwait(false);
-                                            return;
+                                            user = guild.AddOrUpdateUser(data);
+                                            await TimedInvokeAsync(_guildMemberUpdatedEvent, nameof(GuildMemberUpdated), null, user).ConfigureAwait(false);
                                         }
                                     }
                                     else


### PR DESCRIPTION
## Summary

This change will make the event `GuildMemberUpdated` be triggered even when there's no cached version of the user.
The before state will be null.

## Changes

- Fire `GuildMemberUpdated` with before as null when the user isn't cached