### PR TITLE
Fix message events for DMs

### DIFF
--- a/src/Discord.Net.Examples/WebSocket/BaseSocketClient.Events.Examples.cs
+++ b/src/Discord.Net.Examples/WebSocket/BaseSocketClient.Events.Examples.cs
@@ -15,7 +15,7 @@ namespace Discord.Net.Examples.WebSocket
             => client.ReactionAdded += HandleReactionAddedAsync;
 
         public async Task HandleReactionAddedAsync(Cacheable<IUserMessage, ulong> cachedMessage,
-            Cacheable<ISocketMessageChannel, ulong> originChannel, SocketReaction reaction)
+            Cacheable<IMessageChannel, ulong> originChannel, SocketReaction reaction)
         {
             var message = await cachedMessage.GetOrDownloadAsync();
             if (message != null && reaction.User.IsSpecified)
@@ -100,12 +100,12 @@ namespace Discord.Net.Examples.WebSocket
         public void HookMessageDeleted(BaseSocketClient client)
             => client.MessageDeleted += HandleMessageDelete;
 
-        public async Task HandleMessageDelete(Cacheable<IMessage, ulong> cachedMessage, Cacheable<ISocketMessageChannel, ulong> cachedChannel)
+        public async Task HandleMessageDelete(Cacheable<IMessage, ulong> cachedMessage, Cacheable<IMessageChannel, ulong> cachedChannel)
         {
             // check if the message exists in cache; if not, we cannot report what was removed
             if (!cachedMessage.HasValue) return;
             // gets or downloads the channel if it's not in the cache
-            ISocketMessageChannel channel = await cachedChannel.GetOrDownloadAsync();
+            IMessageChannel channel = await cachedChannel.GetOrDownloadAsync();
             var message = cachedMessage.Value;
             Console.WriteLine(
                 $"A message ({message.Id}) from {message.Author} was removed from the channel {channel.Name} ({channel.Id}):"

--- a/src/Discord.Net.Examples/WebSocket/BaseSocketClient.Events.Examples.cs
+++ b/src/Discord.Net.Examples/WebSocket/BaseSocketClient.Events.Examples.cs
@@ -15,7 +15,7 @@ namespace Discord.Net.Examples.WebSocket
             => client.ReactionAdded += HandleReactionAddedAsync;
 
         public async Task HandleReactionAddedAsync(Cacheable<IUserMessage, ulong> cachedMessage,
-            ISocketMessageChannel originChannel, SocketReaction reaction)
+            Cacheable<ISocketMessageChannel, ulong> originChannel, SocketReaction reaction)
         {
             var message = await cachedMessage.GetOrDownloadAsync();
             if (message != null && reaction.User.IsSpecified)
@@ -100,16 +100,17 @@ namespace Discord.Net.Examples.WebSocket
         public void HookMessageDeleted(BaseSocketClient client)
             => client.MessageDeleted += HandleMessageDelete;
 
-        public Task HandleMessageDelete(Cacheable<IMessage, ulong> cachedMessage, ISocketMessageChannel channel)
+        public async Task HandleMessageDelete(Cacheable<IMessage, ulong> cachedMessage, Cacheable<ISocketMessageChannel, ulong> cachedChannel)
         {
             // check if the message exists in cache; if not, we cannot report what was removed
-            if (!cachedMessage.HasValue) return Task.CompletedTask;
+            if (!cachedMessage.HasValue) return;
+            // gets or downloads the channel if it's not in the cache
+            ISocketMessageChannel channel = await cachedChannel.GetOrDownloadAsync();
             var message = cachedMessage.Value;
             Console.WriteLine(
                 $"A message ({message.Id}) from {message.Author} was removed from the channel {channel.Name} ({channel.Id}):"
                 + Environment.NewLine
                 + message.Content);
-            return Task.CompletedTask;
         }
 
         #endregion

--- a/src/Discord.Net.WebSocket/API/Gateway/Reaction.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/Reaction.cs
@@ -10,6 +10,8 @@ namespace Discord.API.Gateway
         public ulong MessageId { get; set; }
         [JsonProperty("channel_id")]
         public ulong ChannelId { get; set; }
+        [JsonProperty("guild_id")]
+        public Optional<ulong> GuildId { get; set; }
         [JsonProperty("emoji")]
         public Emoji Emoji { get; set; }
         [JsonProperty("member")]

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -182,11 +182,11 @@ namespace Discord.WebSocket
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         /// </remarks>
-        public event Func<Cacheable<IMessage, ulong>, SocketMessage, IMessageChannel, Task> MessageUpdated {
+        public event Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task> MessageUpdated {
             add { _messageUpdatedEvent.Add(value); }
             remove { _messageUpdatedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, IMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, IMessageChannel, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>>();
         /// <summary> Fired when a reaction is added to a message. </summary>
         /// <remarks>
         ///     <para>

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -124,11 +124,11 @@ namespace Discord.WebSocket
         ///     <code language="cs" region="MessageDeleted"
         ///           source="..\Discord.Net.Examples\WebSocket\BaseSocketClient.Events.Examples.cs" />
         /// </example>
-        public event Func<Cacheable<IMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task> MessageDeleted {
+        public event Func<Cacheable<IMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task> MessageDeleted {
             add { _messageDeletedEvent.Add(value); }
             remove { _messageDeletedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task>>();
         /// <summary> Fired when multiple messages are bulk deleted. </summary>
         /// <remarks>
         ///     <note>
@@ -155,12 +155,12 @@ namespace Discord.WebSocket
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         /// </remarks>
-        public event Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<ISocketMessageChannel, ulong>, Task> MessagesBulkDeleted
+        public event Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<IMessageChannel, ulong>, Task> MessagesBulkDeleted
         {
             add { _messagesBulkDeletedEvent.Add(value); }
             remove { _messagesBulkDeletedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<ISocketMessageChannel, ulong>, Task>> _messagesBulkDeletedEvent = new AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
+        internal readonly AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<IMessageChannel, ulong>, Task>> _messagesBulkDeletedEvent = new AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<IMessageChannel, ulong>, Task>>();
         /// <summary> Fired when a message is updated. </summary>
         /// <remarks>
         ///     <para>
@@ -182,11 +182,11 @@ namespace Discord.WebSocket
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         /// </remarks>
-        public event Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task> MessageUpdated {
+        public event Func<Cacheable<IMessage, ulong>, SocketMessage, IMessageChannel, Task> MessageUpdated {
             add { _messageUpdatedEvent.Add(value); }
             remove { _messageUpdatedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, ISocketMessageChannel, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, IMessageChannel, Task>> _messageUpdatedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, SocketMessage, IMessageChannel, Task>>();
         /// <summary> Fired when a reaction is added to a message. </summary>
         /// <remarks>
         ///     <para>
@@ -217,23 +217,23 @@ namespace Discord.WebSocket
         ///     <code language="cs" region="ReactionAdded"
         ///           source="..\Discord.Net.Examples\WebSocket\BaseSocketClient.Events.Examples.cs"/>
         /// </example>
-        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task> ReactionAdded {
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task> ReactionAdded {
             add { _reactionAddedEvent.Add(value); }
             remove { _reactionAddedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task>>();
         /// <summary> Fired when a reaction is removed from a message. </summary>
-        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task> ReactionRemoved {
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task> ReactionRemoved {
             add { _reactionRemovedEvent.Add(value); }
             remove { _reactionRemovedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task>>();
         /// <summary> Fired when all reactions to a message are cleared. </summary>
-        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task> ReactionsCleared {
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task> ReactionsCleared {
             add { _reactionsClearedEvent.Add(value); }
             remove { _reactionsClearedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task>>();
         /// <summary>
         ///     Fired when all reactions to a message with a specific emote are removed.
         /// </summary>
@@ -250,12 +250,12 @@ namespace Discord.WebSocket
         ///         The emoji that all reactions had and were removed will be passed into the <see cref="IEmote"/> parameter.
         ///     </para>
         /// </remarks>
-        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, IEmote, Task> ReactionsRemovedForEmote
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, IEmote, Task> ReactionsRemovedForEmote
         {
             add { _reactionsRemovedForEmoteEvent.Add(value); }
             remove { _reactionsRemovedForEmoteEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, IEmote, Task>> _reactionsRemovedForEmoteEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, IEmote, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, IEmote, Task>> _reactionsRemovedForEmoteEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, IEmote, Task>>();
 
         //Roles
         /// <summary> Fired when a role is created. </summary>
@@ -372,11 +372,11 @@ namespace Discord.WebSocket
         }
         internal readonly AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>> _selfUpdatedEvent = new AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>>();
         /// <summary> Fired when a user starts typing. </summary>
-        public event Func<Cacheable<IUser, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task> UserIsTyping {
+        public event Func<Cacheable<IUser, ulong>, Cacheable<IMessageChannel, ulong>, Task> UserIsTyping {
             add { _userIsTypingEvent.Add(value); }
             remove { _userIsTypingEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUser, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>> _userIsTypingEvent = new AsyncEvent<Func<Cacheable<IUser, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUser, ulong>, Cacheable<IMessageChannel, ulong>, Task>> _userIsTypingEvent = new AsyncEvent<Func<Cacheable<IUser, ulong>, Cacheable<IMessageChannel, ulong>, Task>>();
         /// <summary> Fired when a user joins a group channel. </summary>
         public event Func<SocketGroupUser, Task> RecipientAdded {
             add { _recipientAddedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -124,11 +124,11 @@ namespace Discord.WebSocket
         ///     <code language="cs" region="MessageDeleted"
         ///           source="..\Discord.Net.Examples\WebSocket\BaseSocketClient.Events.Examples.cs" />
         /// </example>
-        public event Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task> MessageDeleted {
+        public event Func<Cacheable<IMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task> MessageDeleted {
             add { _messageDeletedEvent.Add(value); }
             remove { _messageDeletedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, ISocketMessageChannel, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>> _messageDeletedEvent = new AsyncEvent<Func<Cacheable<IMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
         /// <summary> Fired when multiple messages are bulk deleted. </summary>
         /// <remarks>
         ///     <note>
@@ -155,12 +155,12 @@ namespace Discord.WebSocket
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         /// </remarks>
-        public event Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, ISocketMessageChannel, Task> MessagesBulkDeleted
+        public event Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<ISocketMessageChannel, ulong>, Task> MessagesBulkDeleted
         {
             add { _messagesBulkDeletedEvent.Add(value); }
             remove { _messagesBulkDeletedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, ISocketMessageChannel, Task>> _messagesBulkDeletedEvent = new AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, ISocketMessageChannel, Task>>();
+        internal readonly AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<ISocketMessageChannel, ulong>, Task>> _messagesBulkDeletedEvent = new AsyncEvent<Func<IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
         /// <summary> Fired when a message is updated. </summary>
         /// <remarks>
         ///     <para>
@@ -217,23 +217,23 @@ namespace Discord.WebSocket
         ///     <code language="cs" region="ReactionAdded"
         ///           source="..\Discord.Net.Examples\WebSocket\BaseSocketClient.Events.Examples.cs"/>
         /// </example>
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionAdded {
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task> ReactionAdded {
             add { _reactionAddedEvent.Add(value); }
             remove { _reactionAddedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>> _reactionAddedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>>();
         /// <summary> Fired when a reaction is removed from a message. </summary>
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task> ReactionRemoved {
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task> ReactionRemoved {
             add { _reactionRemovedEvent.Add(value); }
             remove { _reactionRemovedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>> _reactionRemovedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, SocketReaction, Task>>();
         /// <summary> Fired when all reactions to a message are cleared. </summary>
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task> ReactionsCleared {
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task> ReactionsCleared {
             add { _reactionsClearedEvent.Add(value); }
             remove { _reactionsClearedEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>> _reactionsClearedEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
         /// <summary>
         ///     Fired when all reactions to a message with a specific emote are removed.
         /// </summary>
@@ -250,12 +250,12 @@ namespace Discord.WebSocket
         ///         The emoji that all reactions had and were removed will be passed into the <see cref="IEmote"/> parameter.
         ///     </para>
         /// </remarks>
-        public event Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, IEmote, Task> ReactionsRemovedForEmote
+        public event Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, IEmote, Task> ReactionsRemovedForEmote
         {
             add { _reactionsRemovedForEmoteEvent.Add(value); }
             remove { _reactionsRemovedForEmoteEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, IEmote, Task>> _reactionsRemovedForEmoteEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, ISocketMessageChannel, IEmote, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, IEmote, Task>> _reactionsRemovedForEmoteEvent = new AsyncEvent<Func<Cacheable<IUserMessage, ulong>, Cacheable<ISocketMessageChannel, ulong>, IEmote, Task>>();
 
         //Roles
         /// <summary> Fired when a role is created. </summary>
@@ -372,11 +372,11 @@ namespace Discord.WebSocket
         }
         internal readonly AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>> _selfUpdatedEvent = new AsyncEvent<Func<SocketSelfUser, SocketSelfUser, Task>>();
         /// <summary> Fired when a user starts typing. </summary>
-        public event Func<SocketUser, ISocketMessageChannel, Task> UserIsTyping {
+        public event Func<Cacheable<IUser, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task> UserIsTyping {
             add { _userIsTypingEvent.Add(value); }
             remove { _userIsTypingEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>> _userIsTypingEvent = new AsyncEvent<Func<SocketUser, ISocketMessageChannel, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<IUser, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>> _userIsTypingEvent = new AsyncEvent<Func<Cacheable<IUser, ulong>, Cacheable<ISocketMessageChannel, ulong>, Task>>();
         /// <summary> Fired when a user joins a group channel. </summary>
         public event Func<SocketGroupUser, Task> RecipientAdded {
             add { _recipientAddedEvent.Add(value); }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1418,7 +1418,7 @@ namespace Discord.WebSocket
                                     if (channel != null)
                                         msg = SocketChannelHelper.RemoveMessage(channel, this, data.Id);
                                     var cacheableMsg = new Cacheable<IMessage, ulong>(msg, data.Id, msg != null, () => Task.FromResult((IMessage)null));
-                                    var cacheableChannel = new Cacheable<ISocketMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.Id).ConfigureAwait(false) as ISocketMessageChannel);
+                                    var cacheableChannel = new Cacheable<IMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as IMessageChannel);
 
                                     await TimedInvokeAsync(_messageDeletedEvent, nameof(MessageDeleted), cacheableMsg, cacheableChannel).ConfigureAwait(false);
                                 }
@@ -1430,9 +1430,11 @@ namespace Discord.WebSocket
                                     var data = (payload as JToken).ToObject<API.Gateway.Reaction>(_serializer);
                                     var channel = GetChannel(data.ChannelId) as ISocketMessageChannel;
 
-                                    var cachedMsg = channel.GetCachedMessage(data.MessageId) as SocketUserMessage;
+                                    var cachedMsg = channel?.GetCachedMessage(data.MessageId) as SocketUserMessage;
                                     bool isMsgCached = cachedMsg != null;
-                                    var user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
+                                    IUser user = null;
+                                    if (channel != null)
+                                        user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
 
                                     var optionalMsg = !isMsgCached
                                         ? Optional.Create<SocketUserMessage>()
@@ -1445,12 +1447,14 @@ namespace Discord.WebSocket
                                         if (guild != null)
                                             user = guild.AddOrUpdateUser(data.Member.Value);
                                     }
+                                    else
+                                        user = GetUser(data.UserId);
 
                                     var optionalUser = user is null
                                         ? Optional.Create<IUser>()
                                         : Optional.Create(user);
 
-                                    var cacheableChannel = new Cacheable<ISocketMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as ISocketMessageChannel);
+                                    var cacheableChannel = new Cacheable<IMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as IMessageChannel);
                                     var cacheableMsg = new Cacheable<IUserMessage, ulong>(cachedMsg, data.MessageId, isMsgCached, async () =>
                                     {
                                         var channelObj = await cacheableChannel.GetOrDownloadAsync().ConfigureAwait(false);
@@ -1470,9 +1474,13 @@ namespace Discord.WebSocket
                                     var data = (payload as JToken).ToObject<API.Gateway.Reaction>(_serializer);
                                     var channel = GetChannel(data.ChannelId) as ISocketMessageChannel;
 
-                                    var cachedMsg = channel.GetCachedMessage(data.MessageId) as SocketUserMessage;
+                                    var cachedMsg = channel?.GetCachedMessage(data.MessageId) as SocketUserMessage;
                                     bool isMsgCached = cachedMsg != null;
-                                    var user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
+                                    IUser user = null;
+                                    if (channel != null)
+                                        user = await channel.GetUserAsync(data.UserId, CacheMode.CacheOnly).ConfigureAwait(false);
+                                    else if (!data.GuildId.IsSpecified)
+                                        user = GetUser(data.UserId);
 
                                     var optionalMsg = !isMsgCached
                                         ? Optional.Create<SocketUserMessage>()
@@ -1482,7 +1490,7 @@ namespace Discord.WebSocket
                                         ? Optional.Create<IUser>()
                                         : Optional.Create(user);
 
-                                    var cacheableChannel = new Cacheable<ISocketMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as ISocketMessageChannel);
+                                    var cacheableChannel = new Cacheable<IMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as IMessageChannel);
                                     var cacheableMsg = new Cacheable<IUserMessage, ulong>(cachedMsg, data.MessageId, isMsgCached, async () =>
                                     {
                                         var channelObj = await cacheableChannel.GetOrDownloadAsync().ConfigureAwait(false);
@@ -1502,8 +1510,8 @@ namespace Discord.WebSocket
                                     var data = (payload as JToken).ToObject<RemoveAllReactionsEvent>(_serializer);
                                     var channel = GetChannel(data.ChannelId) as ISocketMessageChannel;
 
-                                    var cacheableChannel = new Cacheable<ISocketMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as ISocketMessageChannel);
-                                    var cachedMsg = channel.GetCachedMessage(data.MessageId) as SocketUserMessage;
+                                    var cacheableChannel = new Cacheable<IMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as IMessageChannel);
+                                    var cachedMsg = channel?.GetCachedMessage(data.MessageId) as SocketUserMessage;
                                     bool isMsgCached = cachedMsg != null;
                                     var cacheableMsg = new Cacheable<IUserMessage, ulong>(cachedMsg, data.MessageId, isMsgCached, async () =>
                                     {
@@ -1523,14 +1531,14 @@ namespace Discord.WebSocket
                                     var data = (payload as JToken).ToObject<API.Gateway.RemoveAllReactionsForEmoteEvent>(_serializer);
                                     var channel = GetChannel(data.ChannelId) as ISocketMessageChannel;
 
-                                    var cachedMsg = channel.GetCachedMessage(data.MessageId) as SocketUserMessage;
+                                    var cachedMsg = channel?.GetCachedMessage(data.MessageId) as SocketUserMessage;
                                     bool isMsgCached = cachedMsg != null;
 
                                     var optionalMsg = !isMsgCached
                                         ? Optional.Create<SocketUserMessage>()
                                         : Optional.Create(cachedMsg);
 
-                                    var cacheableChannel = new Cacheable<ISocketMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as ISocketMessageChannel);
+                                    var cacheableChannel = new Cacheable<IMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as IMessageChannel);
                                     var cacheableMsg = new Cacheable<IUserMessage, ulong>(cachedMsg, data.MessageId, isMsgCached, async () =>
                                     {
                                         var channelObj = await cacheableChannel.GetOrDownloadAsync().ConfigureAwait(false);
@@ -1557,7 +1565,7 @@ namespace Discord.WebSocket
                                         return;
                                     }
 
-                                    var cacheableChannel = new Cacheable<ISocketMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as ISocketMessageChannel);
+                                    var cacheableChannel = new Cacheable<IMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as IMessageChannel);
                                     var cacheableList = new List<Cacheable<IMessage, ulong>>(data.Ids.Length);
                                     foreach (ulong id in data.Ids)
                                     {
@@ -1647,7 +1655,7 @@ namespace Discord.WebSocket
                                         return;
                                     }
 
-                                    var cacheableChannel = new Cacheable<ISocketMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as ISocketMessageChannel);
+                                    var cacheableChannel = new Cacheable<IMessageChannel, ulong>(channel, data.ChannelId, channel != null, async () => await GetChannelAsync(data.ChannelId).ConfigureAwait(false) as IMessageChannel);
 
                                     var user = (channel as SocketChannel)?.GetUser(data.UserId);
                                     if (user == null)

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -112,22 +112,6 @@ namespace Discord.WebSocket
         public int? HandlerTimeout { get; set; } = 3000;
 
         /// <summary>
-        ///     Gets or sets the behavior for <see cref="BaseSocketClient.MessageDeleted"/> on bulk deletes.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        ///     If <c>true</c>, the <see cref="BaseSocketClient.MessageDeleted"/> event will not be raised for bulk
-        ///     deletes, and only the <see cref="BaseSocketClient.MessagesBulkDeleted"/> will be raised. If <c>false</c>
-        ///     , both events will be raised.
-        /// </para>
-        /// <para>
-        ///     If unset, both events will be raised, but a warning will be raised the first time a bulk delete event is
-        ///     received.
-        /// </para>
-        /// </remarks>
-        public bool? ExclusiveBulkDelete { get; set; } = null;
-
-        /// <summary>
         ///     Gets or sets the maximum identify concurrency.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Summary

DM channels aren't cached anymore and won't be found, causing several message events to not fire.

## Changes

### Properties
- Removed `DiscordSocketConfig.ExclusiveBulkDelete`, now each is their own event and bulk won't be redirected to single

### Methods
- Added `DiscordSocketClient.GetChannelAsync`
- Added `DiscordSocketClient.GetUserAsync`
- Changed `IDiscordClient.GetChannelAsync` in `DiscordSocketClient` to fallback to rest if it's not in cache
- Changed `IDiscordClient.GetUserAsync` in `DiscordSocketClient` to fallback to rest if it's not in cache

### Events
- Changed event signature for `MessageDeleted`:
Old: `Cacheable<IMessage, ulong>, ISocketMessageChannel, Task`
New: `Cacheable<IMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task`
- Changed event signature for `MessagesBulkDeleted`:
Old: `IReadOnlyCollection<Cacheable<IMessage, ulong>>, ISocketMessageChannel, Task`
New: `IReadOnlyCollection<Cacheable<IMessage, ulong>>, Cacheable<IMessageChannel, ulong>, Task`
- Changed event signature for `ReactionAdded`:
Old: `Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task`
New: `Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task`
- Changed event signature for `ReactionRemoved`:
Old: `Cacheable<IUserMessage, ulong>, ISocketMessageChannel, SocketReaction, Task`
New: `Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, SocketReaction, Task`
- Changed event signature for `ReactionsCleared`:
Old: `Cacheable<IUserMessage, ulong>, ISocketMessageChannel, Task`
New: `Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, Task`
- Changed event signature for `ReactionsRemovedForEmote`:
Old: `Cacheable<IUserMessage, ulong>, ISocketMessageChannel, IEmote, Task`
New: `Cacheable<IUserMessage, ulong>, Cacheable<IMessageChannel, ulong>, IEmote, Task`
- Changed event signature for `UserIsTyping`:
Old: `SocketUser, ISocketMessageChannel, Task`
New: `Cacheable<IUser, ulong>, Cacheable<IMessageChannel, ulong>, Task`

## Todo

- [X] MessageUpdated
- [X] MessageDeleted
- [X] MessageBulkDeleted
- [X] ReactionAdded
- [X] ReactionRemoved
- [X] ReactionsCleared
- [X] ReactionsRemovedForEmote
- [X] UserIsTyping