### PR TITLE
fix: Add missing AddRef and related

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -775,7 +775,8 @@ namespace Discord.WebSocket
                                 break;
                             case "GUILD_SYNC":
                                 {
-                                    await _gatewayLogger.DebugAsync("Received Dispatch (GUILD_SYNC)").ConfigureAwait(false);
+                                    await _gatewayLogger.DebugAsync("Ignored Dispatch (GUILD_SYNC)").ConfigureAwait(false);
+                                    /*await _gatewayLogger.DebugAsync("Received Dispatch (GUILD_SYNC)").ConfigureAwait(false); //TODO remove? userbot related
                                     var data = (payload as JToken).ToObject<GuildSyncEvent>(_serializer);
                                     var guild = State.GetGuild(data.Id);
                                     if (guild != null)
@@ -792,7 +793,7 @@ namespace Discord.WebSocket
                                     {
                                         await UnknownGuildAsync(type, data.Id).ConfigureAwait(false);
                                         return;
-                                    }
+                                    }*/
                                 }
                                 break;
                             case "GUILD_DELETE":


### PR DESCRIPTION
## Summary

GUILD_CREATE could have a few members inside it but it wouldn't add a reference and when purging the users, the RemoveRef would make the `ushort _references` be -1 and cause an exception.

## Changes
- AddRef for users being added by GUILD_CREATE
- Removed GUILD_SYNC since it should be a userbot event and wouldn't fit the changes.
- Reset DownloaderPromise after purge