### PR TITLE
Remove /users/@me call for socket and rework sharded client a bit

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -47,7 +47,7 @@ namespace Discord.WebSocket
         /// <summary>
         ///     Gets the current logged-in user.
         /// </summary>
-        public new SocketSelfUser CurrentUser { get => base.CurrentUser as SocketSelfUser; protected set => base.CurrentUser = value; }
+        public virtual new SocketSelfUser CurrentUser { get => base.CurrentUser as SocketSelfUser; protected set => base.CurrentUser = value; }
         /// <summary>
         ///     Gets a collection of guilds that the user is currently in.
         /// </summary>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -40,7 +40,9 @@ namespace Discord.WebSocket
         /// <summary>
         ///     Provides access to a REST-only client with a shared state from this client.
         /// </summary>
-        public override DiscordSocketRestClient Rest => _shards[0].Rest;
+        public override DiscordSocketRestClient Rest => _shards?[0].Rest;
+
+        public override SocketSelfUser CurrentUser { get => _shards?.FirstOrDefault(x => x.CurrentUser != null)?.CurrentUser; protected set => throw new InvalidOperationException(); }
 
         /// <summary> Creates a new REST/WebSocket Discord client. </summary>
         public DiscordShardedClient() : this(null, new DiscordSocketConfig()) { }
@@ -330,14 +332,6 @@ namespace Discord.WebSocket
                 }
                 return Task.Delay(0);
             };
-            if (isPrimary)
-            {
-                client.Ready += () =>
-                {
-                    CurrentUser = client.CurrentUser;
-                    return Task.Delay(0);
-                };
-            }
 
             client.Connected += () => _shardConnectedEvent.InvokeAsync(client);
             client.Disconnected += (exception) => _shardDisconnectedEvent.InvokeAsync(exception, client);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -196,7 +196,6 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         internal override async Task OnLoginAsync(TokenType tokenType, string token)
         {
-            await Rest.OnLoginAsync(tokenType, token);
         }
         /// <inheritdoc />
         internal override async Task OnLogoutAsync()

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -194,10 +194,6 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc />
-        internal override async Task OnLoginAsync(TokenType tokenType, string token)
-        {
-        }
-        /// <inheritdoc />
         internal override async Task OnLogoutAsync()
         {
             await StopAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary

The current user is sent on READY and there's no need to do a rest request for it (much less N of them if using a sharded client), so this call was removed from the socket client.
In a few times some shards that werent the first one would be ready faster and `DiscordShardedClient.CurrentUser` could be null, now this property will get the first not null CurrentUser from any shard.

## Changes

- Removed /users/@me rest request for socket client
- `DiscordShardedClient.Rest` might return null instead of throwing an exception if it wasnt initialized yet
- `DiscordShardedClient.CurrentUser` will get the first not null CurrentUser from any shard instead of just the "primary"