### PR TITLE
fix: ApiClient.CurrentUser being null

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -16,7 +16,7 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the logged-in user.
         /// </summary>
-        public new RestSelfUser CurrentUser => base.CurrentUser as RestSelfUser;
+        public new RestSelfUser CurrentUser { get => base.CurrentUser as RestSelfUser; internal set => base.CurrentUser = value; }
 
         /// <inheritdoc />
         public DiscordRestClient() : this(new DiscordRestConfig()) { }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -618,6 +618,7 @@ namespace Discord.WebSocket
                                         var activities = _activity.IsSpecified ? ImmutableList.Create(_activity.Value) : null;
                                         currentUser.Presence = new SocketPresence(Status, null, activities);
                                         ApiClient.CurrentUserId = currentUser.Id;
+                                        Rest.CurrentUser = RestSelfUser.Create(this, data.User);
                                         int unavailableGuilds = 0;
                                         for (int i = 0; i < data.Guilds.Length; i++)
                                         {


### PR DESCRIPTION
Populate the rest api client for socket clients with the user from ready.