### PR TITLE
Add null check to AllowedMentions.ToModel()

### DIFF
--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -70,6 +70,7 @@ namespace Discord.Rest
         }
         public static API.AllowedMentions ToModel(this AllowedMentions entity)
         {
+            if (entity == null) return null;
             return new API.AllowedMentions()
             {
                 Parse = entity.AllowedTypes?.EnumerateMentionTypes().ToArray(),


### PR DESCRIPTION
This PR adds a null check to `AllowedMentions.ToModel()`, fixing the nullrefs when setting the `AllowedMentions` parameter to null in `IUserMessage.ModifyAsync()`, `IMessageChannel.ModifyMessageAsync()` and `DiscordWebhookClient.ModifyMessageAsync()`.