### PR TITLE
fix: Connection deadlock when waiting to Send and Disconnect

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -188,9 +188,9 @@ namespace Discord.API
             catch { }
 
             if (ex is GatewayReconnectException)
-                await WebSocketClient.DisconnectAsync(4000);
+                await WebSocketClient.DisconnectAsync(4000).ConfigureAwait(false);
             else
-            await WebSocketClient.DisconnectAsync().ConfigureAwait(false);
+                await WebSocketClient.DisconnectAsync().ConfigureAwait(false);
 
             ConnectionState = ConnectionState.Disconnected;
         }


### PR DESCRIPTION
A deadlock would happen when disconnecting from the gateway in some specific cases.

This one was caused because the disconnection awaits the gateway processing to end and in some cases the event received and being processed could fire a gateway request in response, that also uses the same lock as connecting and disconnecting.

Bit tricky but simple to reproduce with a fake gateway server that always respond with an invalid session.

A case where this is 'easily' reproducible is:
1- Receives invalid session, waiting identify semaphore (gateway task running/processing) to send identify/resume
2- Timeout happens, disconnect is called that gets the connection _lock and wait the gateway task to end
3- Identify semaphore releases
5- Identify is a gateway request, so it calls Send that tries to get the _lock
6- Deadlock happens, disconnect waiting on the processing to end but processing is waiting on disconnect to send

I also did a few other changes that I believe might help not encountering other deadlocks.
