### PR TITLE
fix: "Deadlock" in connecting logic

### DIFF
--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -75,11 +75,6 @@ namespace Discord
                             nextReconnectDelay = 1000; //Reset delay
                             await _connectionPromise.Task.ConfigureAwait(false);
                         }
-                        catch (OperationCanceledException ex)
-                        {
-                            Cancel(); //In case this exception didn't come from another Error call
-                            await DisconnectAsync(ex, !reconnectCancelToken.IsCancellationRequested).ConfigureAwait(false);
-                        }
                         catch (Exception ex)
                         {
                             Error(ex); //In case this exception didn't come from another Error call
@@ -143,16 +138,7 @@ namespace Discord
                     catch (OperationCanceledException) { }
                 });
 
-                try
-                {
-                    await _onConnecting().ConfigureAwait(false);
-                }
-                catch (TaskCanceledException ex)
-                {
-                    Exception innerEx = ex.InnerException ?? new OperationCanceledException("Failed to connect.");
-                    Error(innerEx);
-                    throw innerEx;
-                }
+                await _onConnecting().ConfigureAwait(false);
 
                 await _logger.InfoAsync("Connected").ConfigureAwait(false);
                 State = ConnectionState.Connected;


### PR DESCRIPTION
This is a change in a previous fix, #1580 , that could still have the same problem (when the inner exception is null).

After talking with the first dev of Discord.Net, I concluded the special handle for `OperationCanceledException` in the connection isn't needed and might cause more issues since `TaskCanceledException` inherits from it and tasks to do rest requests or promises could throw these.