### PR TITLE
Implement Name property to Teams in the Rest API

### DIFF
--- a/src/Discord.Net.Core/Entities/Teams/ITeam.cs
+++ b/src/Discord.Net.Core/Entities/Teams/ITeam.cs
@@ -20,6 +20,10 @@ namespace Discord
         /// </summary>
         IReadOnlyList<ITeamMember> TeamMembers { get; }
         /// <summary>
+        ///     Gets the name of this team.
+        /// </summary>
+        string Name { get; }
+        /// <summary>
         ///     Gets the user identifier that owns this team.
         /// </summary>
         ulong OwnerUserId { get; }

--- a/src/Discord.Net.Rest/API/Common/Team.cs
+++ b/src/Discord.Net.Rest/API/Common/Team.cs
@@ -11,6 +11,8 @@ namespace Discord.API
         public ulong Id { get; set; }
         [JsonProperty("members")]
         public TeamMember[] TeamMembers { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
         [JsonProperty("owner_user_id")]
         public ulong OwnerUserId { get; set; }
     }

--- a/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
+++ b/src/Discord.Net.Rest/Entities/Teams/RestTeam.cs
@@ -12,6 +12,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public IReadOnlyList<ITeamMember> TeamMembers { get; private set; }
         /// <inheritdoc />
+        public string Name { get; private set; }
+        /// <inheritdoc />
         public ulong OwnerUserId { get; private set; }
 
         private string _iconId;
@@ -30,6 +32,7 @@ namespace Discord.Rest
         {
             if (model.Icon.IsSpecified)
                 _iconId = model.Icon.Value;
+            Name = model.Name;
             OwnerUserId = model.OwnerUserId;
             TeamMembers = model.TeamMembers.Select(x => new RestTeamMember(Discord, x)).ToImmutableArray();
         }


### PR DESCRIPTION
# Summary
Not sure if the `Name` string property was missed when Teams initially rolled out, or if it was a recent change the APIv9, but I went ahead and added the property for the Rest Model, Rest implementation of Team, and the team contract.

# Changes
* Added `Name` string property to `Team.cs`
* Added `Name` string property to `ITeam.cs`
* Added `Name` string property to `RestTeam.cs`