### PR TITLE
Update max embed description length to 4096

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -27,7 +27,7 @@ namespace Discord
         /// <summary> 
         ///     Returns the maximum length of description allowed by Discord. 
         /// </summary>
-        public const int MaxDescriptionLength = 2048;
+        public const int MaxDescriptionLength = 4096;
         /// <summary> 
         ///     Returns the maximum length of total characters allowed by Discord. 
         /// </summary>

--- a/test/Discord.Net.Tests.Unit/EmbedBuilderTests.cs
+++ b/test/Discord.Net.Tests.Unit/EmbedBuilderTests.cs
@@ -126,7 +126,7 @@ namespace Discord
         {
             IEnumerable<string> GetInvalid()
             {
-                yield return new string('a', 2049);
+                yield return new string('a', 4097);
             }
             foreach (var description in GetInvalid())
             {
@@ -149,7 +149,7 @@ namespace Discord
             {
                 yield return string.Empty;
                 yield return null;
-                yield return new string('a', 2048);
+                yield return new string('a', 4096);
             }
             foreach (var description in GetValid())
             {


### PR DESCRIPTION
Discord has upped the character limit in embeds to 4096:
![image](https://user-images.githubusercontent.com/9088316/124396815-2ed52a00-dd0c-11eb-8a65-5510ec04a8de.png)

This PR fixes #1881.