### PR TITLE
fix: add support for default avatar in WithAuthor extension.

### DIFF
--- a/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Discord
 
         /// <summary> Fills the embed author field with the provided user's full username and avatar URL. </summary>
         public static EmbedBuilder WithAuthor(this EmbedBuilder builder, IUser user) =>
-            builder.WithAuthor($"{user.Username}#{user.Discriminator}", user.GetAvatarUrl());
+            builder.WithAuthor($"{user.Username}#{user.Discriminator}", user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl());
 
         /// <summary> Converts a <see cref="EmbedType.Rich"/> <see cref="IEmbed"/> object to a <see cref="EmbedBuilder"/>. </summary>
         /// <exception cref="InvalidOperationException">The embed type is not <see cref="EmbedType.Rich"/>.</exception>


### PR DESCRIPTION
# Summary
Adds `??  user.GetDefaultAvatarUrl()` to the avatar icon field. This ensures that if the user has a default avatar that its included in the author field.

