### PR TITLE
feature: Decouple channel from messages

### DIFF
--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireBotPermissionAttribute.cs
@@ -71,10 +71,11 @@ namespace Discord.Commands
             if (ChannelPermission.HasValue)
             {
                 ChannelPermissions perms;
-                if (context.Channel is IGuildChannel guildChannel)
+                IMessageChannel channel = await context.Channel.GetOrDownloadAsync().ConfigureAwait(false);
+                if (channel is IGuildChannel guildChannel)
                     perms = guildUser.GetPermissions(guildChannel);
                 else
-                    perms = ChannelPermissions.All(context.Channel);
+                    perms = ChannelPermissions.All(channel);
 
                 if (!perms.Has(ChannelPermission.Value))
                     return PreconditionResult.FromError(ErrorMessage ?? $"Bot requires channel permission {ChannelPermission.Value}.");

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireContextAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireContextAttribute.cs
@@ -17,10 +17,6 @@ namespace Discord.Commands
         ///     Specifies the command to be executed within a DM.
         /// </summary>
         DM = 0x02,
-        /// <summary>
-        ///     Specifies the command to be executed within a group.
-        /// </summary>
-        Group = 0x04
     }
 
     /// <summary>
@@ -59,11 +55,9 @@ namespace Discord.Commands
             bool isValid = false;
 
             if ((Contexts & ContextType.Guild) != 0)
-                isValid = context.Channel is IGuildChannel;
+                isValid = context.GuildId != null;
             if ((Contexts & ContextType.DM) != 0)
-                isValid = isValid || context.Channel is IDMChannel;
-            if ((Contexts & ContextType.Group) != 0)
-                isValid = isValid || context.Channel is IGroupChannel;
+                isValid = context.GuildId == null;
 
             if (isValid)
                 return Task.FromResult(PreconditionResult.FromSuccess());

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireNsfwAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireNsfwAttribute.cs
@@ -36,7 +36,7 @@ namespace Discord.Commands
         /// <inheritdoc />
         public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
-            if (context.Channel is ITextChannel text && text.IsNsfw)
+            if (context.Channel.HasValue && context.Channel.Value is ITextChannel text && text.IsNsfw)
                 return Task.FromResult(PreconditionResult.FromSuccess());
             else
                 return Task.FromResult(PreconditionResult.FromError(ErrorMessage ?? "This command may only be invoked in an NSFW channel."));

--- a/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/Preconditions/RequireUserPermissionAttribute.cs
@@ -54,31 +54,32 @@ namespace Discord.Commands
         }
 
         /// <inheritdoc />
-        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+        public override async Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             var guildUser = context.User as IGuildUser;
 
             if (GuildPermission.HasValue)
             {
                 if (guildUser == null)
-                    return Task.FromResult(PreconditionResult.FromError(NotAGuildErrorMessage ?? "Command must be used in a guild channel."));                
+                    return PreconditionResult.FromError(NotAGuildErrorMessage ?? "Command must be used in a guild channel.");                
                 if (!guildUser.GuildPermissions.Has(GuildPermission.Value))
-                    return Task.FromResult(PreconditionResult.FromError(ErrorMessage ?? $"User requires guild permission {GuildPermission.Value}."));
+                    return PreconditionResult.FromError(ErrorMessage ?? $"User requires guild permission {GuildPermission.Value}.");
             }
 
             if (ChannelPermission.HasValue)
             {
                 ChannelPermissions perms;
-                if (context.Channel is IGuildChannel guildChannel)
+                IMessageChannel channel = await context.Channel.GetOrDownloadAsync().ConfigureAwait(false);
+                if (channel is IGuildChannel guildChannel)
                     perms = guildUser.GetPermissions(guildChannel);
                 else
-                    perms = ChannelPermissions.All(context.Channel);
+                    perms = ChannelPermissions.All(channel);
 
                 if (!perms.Has(ChannelPermission.Value))
-                    return Task.FromResult(PreconditionResult.FromError(ErrorMessage ?? $"User requires channel permission {ChannelPermission.Value}."));
+                    return PreconditionResult.FromError(ErrorMessage ?? $"User requires channel permission {ChannelPermission.Value}.");
             }
 
-            return Task.FromResult(PreconditionResult.FromSuccess());
+            return PreconditionResult.FromSuccess();
         }
     }
 }

--- a/src/Discord.Net.Commands/CommandContext.cs
+++ b/src/Discord.Net.Commands/CommandContext.cs
@@ -8,24 +8,27 @@ namespace Discord.Commands
         /// <inheritdoc/>
         public IGuild Guild { get; }
         /// <inheritdoc/>
-        public IMessageChannel Channel { get; }
+        public ulong? GuildId { get; }
+        /// <inheritdoc/>
+        public Cacheable<IMessageChannel, ulong> Channel { get; }
         /// <inheritdoc/>
         public IUser User { get; }
         /// <inheritdoc/>
         public IUserMessage Message { get; }
 
         /// <summary> Indicates whether the channel that the command is executed in is a private channel. </summary>
-        public bool IsPrivate => Channel is IPrivateChannel;
+        public bool IsPrivate => GuildId == null;
 
         /// <summary>
         ///     Initializes a new <see cref="CommandContext" /> class with the provided client and message.
         /// </summary>
         /// <param name="client">The underlying client.</param>
         /// <param name="msg">The underlying message.</param>
-        public CommandContext(IDiscordClient client, IUserMessage msg)
+        public CommandContext(IDiscordClient client, IUserMessage msg, IGuild guild)
         {
             Client = client;
-            Guild = (msg.Channel as IGuildChannel)?.Guild;
+            GuildId = msg.GuildId;
+            Guild = guild;
             Channel = msg.Channel;
             User = msg.Author;
             Message = msg;

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -36,9 +36,9 @@ namespace Discord.Commands
         ///     If <c>null</c>, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
-        protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null)
+        protected virtual async Task<IUserMessage> ReplyAsync(string message = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, RequestOptions options = null)
         {
-            return await Context.Channel.SendMessageAsync(message, isTTS, embed, options, allowedMentions, messageReference).ConfigureAwait(false);
+            return await Context.Client.SendMessageAsync(Context.Channel.Id, message, isTTS, embed, allowedMentions, messageReference, options).ConfigureAwait(false);
         }
         /// <summary>
         ///     The method to execute before executing the command.

--- a/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/MessageTypeReader.cs
@@ -17,7 +17,7 @@ namespace Discord.Commands
             //By Id (1.0)
             if (ulong.TryParse(input, NumberStyles.None, CultureInfo.InvariantCulture, out ulong id))
             {
-                if (await context.Channel.GetMessageAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) is T msg)
+                if (context.Channel.HasValue && await context.Channel.Value.GetMessageAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) is T msg)
                     return TypeReaderResult.FromSuccess(msg);
             }
 

--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -18,7 +18,9 @@ namespace Discord.Commands
         public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
             var results = new Dictionary<ulong, TypeReaderValue>();
-            IAsyncEnumerable<IUser> channelUsers = context.Channel.GetUsersAsync(CacheMode.CacheOnly).Flatten(); // it's better
+            IAsyncEnumerable<IUser> channelUsers = context.Channel.HasValue
+                ? context.Channel.Value.GetUsersAsync(CacheMode.CacheOnly).Flatten()
+                : AsyncEnumerable.Empty<IUser>();
             IReadOnlyCollection<IGuildUser> guildUsers = ImmutableArray.Create<IGuildUser>();
 
             if (context.Guild != null)
@@ -29,8 +31,8 @@ namespace Discord.Commands
             {
                 if (context.Guild != null)
                     AddResult(results, await context.Guild.GetUserAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) as T, 1.00f);
-                else
-                    AddResult(results, await context.Channel.GetUserAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) as T, 1.00f);
+                else if (context.Channel.HasValue)
+                    AddResult(results, await context.Channel.Value.GetUserAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) as T, 1.00f);
             }
 
             //By Id (0.9)
@@ -38,8 +40,8 @@ namespace Discord.Commands
             {
                 if (context.Guild != null)
                     AddResult(results, await context.Guild.GetUserAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) as T, 0.90f);
-                else
-                    AddResult(results, await context.Channel.GetUserAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) as T, 0.90f);
+                else if (context.Channel.HasValue)
+                    AddResult(results, await context.Channel.Value.GetUserAsync(id, CacheMode.CacheOnly).ConfigureAwait(false) as T, 0.90f);
             }
 
             //By Username + Discriminator (0.7-0.85)

--- a/src/Discord.Net.Core/Commands/ICommandContext.cs
+++ b/src/Discord.Net.Core/Commands/ICommandContext.cs
@@ -14,9 +14,14 @@ namespace Discord.Commands
         /// </summary>
         IGuild Guild { get; }
         /// <summary>
-        ///     Gets the <see cref="IMessageChannel" /> that the command is executed in.
+        ///     Gets the guild id that the command is executed in if it was in one.
         /// </summary>
-        IMessageChannel Channel { get; }
+        ulong? GuildId { get; }
+        /// <summary>
+        ///     Gets the <see cref="IMessageChannel" /> that the command is executed in if cached;
+        ///     otherwise just the channel id.
+        /// </summary>
+        Cacheable<IMessageChannel, ulong> Channel { get; }
         /// <summary>
         ///     Gets the <see cref="IUser" /> who executed the command.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -66,11 +66,15 @@ namespace Discord
         ///     Time of when the message was last edited; <c>null</c> if the message is never edited.
         /// </returns>
         DateTimeOffset? EditedTimestamp { get; }
-        
+
         /// <summary>
         ///     Gets the source channel of the message.
         /// </summary>
-        IMessageChannel Channel { get; }
+        Cacheable<IMessageChannel, ulong> Channel { get; }
+        /// <summary>
+        ///     Gets the source guild id of the message if it was sent in one.
+        /// </summary>
+        ulong? GuildId { get; }
         /// <summary>
         ///     Gets the author of this message.
         /// </summary>
@@ -171,7 +175,7 @@ namespace Discord
         ///     A read-only collection of sticker objects.
         /// </returns>
         IReadOnlyCollection<ISticker> Stickers { get; }
-        
+
         /// <summary>
         ///     Gets the flags related to this message.
         /// </summary>

--- a/src/Discord.Net.Core/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/MessageExtensions.cs
@@ -17,7 +17,7 @@ namespace Discord
         public static string GetJumpUrl(this IMessage msg)
         {
             var channel = msg.Channel;
-            return $"https://discord.com/channels/{(channel is IDMChannel ? "@me" : $"{(channel as ITextChannel).GuildId}")}/{channel.Id}/{msg.Id}";
+            return $"https://discord.com/channels/{(msg.GuildId.HasValue ? $"{msg.GuildId}" : "@me")}/{channel.Id}/{msg.Id}";
         }
 
         /// <summary>
@@ -89,7 +89,8 @@ namespace Discord
         /// </returns>
         public static async Task<IUserMessage> ReplyAsync(this IUserMessage msg, string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, RequestOptions options = null)
         {
-            return await msg.Channel.SendMessageAsync(text, isTTS, embed, options, allowedMentions, new MessageReference(messageId: msg.Id)).ConfigureAwait(false);
+            IMessageChannel channel = await msg.Channel.GetOrDownloadAsync().ConfigureAwait(false);
+            return await channel.SendMessageAsync(text, isTTS, embed, options, allowedMentions, new MessageReference(messageId: msg.Id)).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Core/IDiscordClient.cs
+++ b/src/Discord.Net.Core/IDiscordClient.cs
@@ -284,5 +284,24 @@ namespace Discord
         ///     that represents the gateway information related to the bot.
         /// </returns>
         Task<BotGateway> GetBotGatewayAsync(RequestOptions options = null);
+
+        /// <summary>
+        ///     Sends a message to a channel.
+        /// </summary>
+        /// <param name="channelId">The channel to send the message.</param>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
+        /// <param name="messageReference">The reference for this message.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous send operation for delivering the message. The task result
+        ///     contains the sent message.
+        /// </returns>
+        Task<IUserMessage> SendMessageAsync(ulong channelId, string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Examples/WebSocket/BaseSocketClient.Events.Examples.cs
+++ b/src/Discord.Net.Examples/WebSocket/BaseSocketClient.Events.Examples.cs
@@ -84,12 +84,12 @@ namespace Discord.Net.Examples.WebSocket
             // check if the message is a user message as opposed to a system message (e.g. Clyde, pins, etc.)
             if (!(message is SocketUserMessage userMessage)) return Task.CompletedTask;
             // check if the message origin is a guild message channel
-            if (!(userMessage.Channel is SocketTextChannel textChannel)) return Task.CompletedTask;
+            if (userMessage.GuildId == null) return Task.CompletedTask;
             // check if the target user was mentioned
             var targetUsers = userMessage.MentionedUsers.Where(x => _targetUserIds.Contains(x.Id));
             foreach (var targetUser in targetUsers)
                 Console.WriteLine(
-                    $"{targetUser} was mentioned in the message '{message.Content}' by {message.Author} in {textChannel.Name}.");
+                    $"{targetUser} was mentioned in the message '{message.Content}' by {message.Author} in {MentionUtils.MentionChannel(message.Channel.Id)}.");
             return Task.CompletedTask;
         }
 

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -217,6 +217,10 @@ namespace Discord.Rest
             => Task.FromResult<IWebhook>(null);
 
         /// <inheritdoc />
+        Task<IUserMessage> IDiscordClient.SendMessageAsync(ulong channelId, string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, MessageReference messageReference, RequestOptions options)
+            => Task.FromResult<IUserMessage>(null);
+
+        /// <inheritdoc />
         Task IDiscordClient.StartAsync()
             => Task.Delay(0);
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -114,10 +114,35 @@ namespace Discord.Rest
             => MessageHelper.RemoveAllReactionsAsync(channelId, messageId, this, options);
         public Task RemoveAllReactionsForEmoteAsync(ulong channelId, ulong messageId, IEmote emote, RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsForEmoteAsync(channelId, messageId, emote, this, options);
+
+        /// <summary>
+        ///     Sends a message to a channel.
+        /// </summary>
+        /// <param name="channelId">The channel to send the message.</param>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
+        /// <param name="messageReference">The reference for this message.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous send operation for delivering the message. The task result
+        ///     contains the sent message.
+        /// </returns>
+        public Task<RestUserMessage> SendMessageAsync(ulong channelId, string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(channelId, this, text, isTTS, embed, allowedMentions, messageReference, options ?? RequestOptions.Default);
+
         //IDiscordClient
         /// <inheritdoc />
         async Task<IApplication> IDiscordClient.GetApplicationInfoAsync(RequestOptions options)
             => await GetApplicationInfoAsync(options).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        async Task<IUserMessage> IDiscordClient.SendMessageAsync(ulong channelId, string message, bool isTTS, Embed embed, AllowedMentions allowedMentions, MessageReference messageReference, RequestOptions options)
+            => await SendMessageAsync(channelId, message, isTTS, embed, allowedMentions, messageReference, options ?? RequestOptions.Default).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IChannel> IDiscordClient.GetChannelAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -223,7 +223,34 @@ namespace Discord.Rest
 
             var args = new CreateMessageParams(text) { IsTTS = isTTS, Embed = embed?.ToModel(), AllowedMentions = allowedMentions?.ToModel(), MessageReference = messageReference?.ToModel() };
             var model = await client.ApiClient.CreateMessageAsync(channel.Id, args, options).ConfigureAwait(false);
-            return RestUserMessage.Create(client, channel, client.CurrentUser, model);
+            return (RestUserMessage)RestMessage.Create(client, channel, client.CurrentUser, model);
+        }
+        /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
+        public static async Task<RestUserMessage> SendMessageAsync(ulong channelId, BaseDiscordClient client,
+            string text, bool isTTS, Embed embed, AllowedMentions allowedMentions, MessageReference messageReference, RequestOptions options)
+        {
+            Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
+            Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
+
+            // check that user flag and user Id list are exclusive, same with role flag and role Id list
+            if (allowedMentions != null && allowedMentions.AllowedTypes.HasValue)
+            {
+                if (allowedMentions.AllowedTypes.Value.HasFlag(AllowedMentionTypes.Users) &&
+                    allowedMentions.UserIds != null && allowedMentions.UserIds.Count > 0)
+                {
+                    throw new ArgumentException("The Users flag is mutually exclusive with the list of User Ids.", nameof(allowedMentions));
+                }
+
+                if (allowedMentions.AllowedTypes.Value.HasFlag(AllowedMentionTypes.Roles) &&
+                    allowedMentions.RoleIds != null && allowedMentions.RoleIds.Count > 0)
+                {
+                    throw new ArgumentException("The Roles flag is mutually exclusive with the list of Role Ids.", nameof(allowedMentions));
+                }
+            }
+
+            var args = new CreateMessageParams(text) { IsTTS = isTTS, Embed = embed?.ToModel(), AllowedMentions = allowedMentions?.ToModel(), MessageReference = messageReference?.ToModel() };
+            var model = await client.ApiClient.CreateMessageAsync(channelId, args, options).ConfigureAwait(false);
+            return (RestUserMessage)RestMessage.Create(client, null, client.CurrentUser, model);
         }
 
         /// <exception cref="ArgumentException">
@@ -283,14 +310,14 @@ namespace Discord.Rest
 
             var args = new UploadFileParams(stream) { Filename = filename, Content = text, IsTTS = isTTS, Embed = embed?.ToModel() ?? Optional<API.Embed>.Unspecified, AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified, MessageReference = messageReference?.ToModel() ?? Optional<API.MessageReference>.Unspecified, IsSpoiler = isSpoiler };
             var model = await client.ApiClient.UploadFileAsync(channel.Id, args, options).ConfigureAwait(false);
-            return RestUserMessage.Create(client, channel, client.CurrentUser, model);
+            return (RestUserMessage)RestMessage.Create(client, channel, client.CurrentUser, model);
         }
 
         public static async Task<RestUserMessage> ModifyMessageAsync(IMessageChannel channel, ulong messageId, Action<MessageProperties> func,
             BaseDiscordClient client, RequestOptions options)
         {
             var msgModel = await MessageHelper.ModifyAsync(channel.Id, messageId, client, func, options).ConfigureAwait(false);
-            return RestUserMessage.Create(client, channel, msgModel.Author.IsSpecified ? RestUser.Create(client, msgModel.Author.Value) : client.CurrentUser, msgModel);
+            return (RestUserMessage)RestMessage.Create(client, channel, msgModel.Author.IsSpecified ? RestUser.Create(client, msgModel.Author.Value) : client.CurrentUser, msgModel);
         }
 
         public static Task DeleteMessageAsync(IMessageChannel channel, ulong messageId, BaseDiscordClient client,

--- a/src/Discord.Net.Rest/Entities/Messages/RestSystemMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestSystemMessage.cs
@@ -9,11 +9,11 @@ namespace Discord.Rest
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class RestSystemMessage : RestMessage, ISystemMessage
     {
-        internal RestSystemMessage(BaseDiscordClient discord, ulong id, IMessageChannel channel, IUser author)
+        internal RestSystemMessage(BaseDiscordClient discord, ulong id, Cacheable<IMessageChannel, ulong> channel, IUser author)
             : base(discord, id, channel, author, MessageSource.System)
         {
         }
-        internal new static RestSystemMessage Create(BaseDiscordClient discord, IMessageChannel channel, IUser author, Model model)
+        internal static RestSystemMessage Create(BaseDiscordClient discord, Cacheable<IMessageChannel, ulong> channel, IUser author, Model model)
         {
             var entity = new RestSystemMessage(discord, model.Id, channel, author);
             entity.Update(model);

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -268,11 +268,34 @@ namespace Discord.WebSocket
         /// </returns>
         public Task<RestInviteMetadata> GetInviteAsync(string inviteId, RequestOptions options = null)
             => ClientHelper.GetInviteAsync(this, inviteId, options ?? RequestOptions.Default);
-        
+        /// <summary>
+        ///     Sends a message to a channel.
+        /// </summary>
+        /// <param name="channelId">The channel to send the message.</param>
+        /// <param name="text">The message to be sent.</param>
+        /// <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
+        /// <param name="embed">The <see cref="Discord.EmbedType.Rich"/> <see cref="Embed"/> to be sent.</param>
+        /// <param name="allowedMentions">
+        ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
+        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        /// </param>
+        /// <param name="messageReference">The reference for this message.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous send operation for delivering the message. The task result
+        ///     contains the sent message.
+        /// </returns>
+        public Task<RestUserMessage> SendMessageAsync(ulong channelId, string text = null, bool isTTS = false, Embed embed = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, RequestOptions options = null)
+            => ChannelHelper.SendMessageAsync(channelId, this, text, isTTS, embed, allowedMentions, messageReference, options ?? RequestOptions.Default);
+
         // IDiscordClient
         /// <inheritdoc />
         async Task<IApplication> IDiscordClient.GetApplicationInfoAsync(RequestOptions options)
             => await GetApplicationInfoAsync(options).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        async Task<IUserMessage> IDiscordClient.SendMessageAsync(ulong channelId, string message, bool isTTS, Embed embed, AllowedMentions allowedMentions, MessageReference messageReference, RequestOptions options)
+            => await SendMessageAsync(channelId, message, isTTS, embed, allowedMentions, messageReference, options ?? RequestOptions.Default).ConfigureAwait(false);
 
         /// <inheritdoc />
         Task<IChannel> IDiscordClient.GetChannelAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Commands/ShardedCommandContext.cs
+++ b/src/Discord.Net.WebSocket/Commands/ShardedCommandContext.cs
@@ -9,7 +9,7 @@ namespace Discord.Commands
         public new DiscordShardedClient Client { get; }
 
         public ShardedCommandContext(DiscordShardedClient client, SocketUserMessage msg)
-            : base(client.GetShard(GetShardId(client, (msg.Channel as SocketGuildChannel)?.Guild)), msg)
+            : base(client.GetShardFor(msg.GuildId ?? 0), msg)
         {
             Client = client;
         }

--- a/src/Discord.Net.WebSocket/Commands/SocketCommandContext.cs
+++ b/src/Discord.Net.WebSocket/Commands/SocketCommandContext.cs
@@ -15,10 +15,10 @@ namespace Discord.Commands
         ///     Gets the <see cref="SocketGuild" /> that the command is executed in.
         /// </summary>
         public SocketGuild Guild { get; }
-        /// <summary>
-        ///     Gets the <see cref="ISocketMessageChannel" /> that the command is executed in.
-        /// </summary>
-        public ISocketMessageChannel Channel { get; }
+        /// <inheritdoc/>
+        public ulong? GuildId { get; }
+        /// <inheritdoc/>
+        public Cacheable<IMessageChannel, ulong> Channel { get; }
         /// <summary>
         ///     Gets the <see cref="SocketUser" /> who executed the command.
         /// </summary>
@@ -31,7 +31,7 @@ namespace Discord.Commands
         /// <summary>
         ///     Indicates whether the channel that the command is executed in is a private channel.
         /// </summary>
-        public bool IsPrivate => Channel is IPrivateChannel;
+        public bool IsPrivate => GuildId == null;
 
         /// <summary>
         ///     Initializes a new <see cref="SocketCommandContext" /> class with the provided client and message.
@@ -41,7 +41,9 @@ namespace Discord.Commands
         public SocketCommandContext(DiscordSocketClient client, SocketUserMessage msg)
         {
             Client = client;
-            Guild = (msg.Channel as SocketGuildChannel)?.Guild;
+            GuildId = msg.GuildId;
+            if (msg.GuildId != null)
+                Guild = client.GetGuild(msg.GuildId.Value);
             Channel = msg.Channel;
             User = msg.Author;
             Message = msg;
@@ -53,7 +55,7 @@ namespace Discord.Commands
         /// <inheritdoc/>
         IGuild ICommandContext.Guild => Guild;
         /// <inheritdoc/>
-        IMessageChannel ICommandContext.Channel => Channel;
+        Cacheable<IMessageChannel, ulong> ICommandContext.Channel => Channel;
         /// <inheritdoc/>
         IUser ICommandContext.User => User;
         /// <inheritdoc/>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -179,11 +179,11 @@ namespace Discord.WebSocket
                 return _shards[id];
             return null;
         }
-        private int GetShardIdFor(ulong guildId)
+        public int GetShardIdFor(ulong guildId)
             => (int)((guildId >> 22) % (uint)_totalShards);
         public int GetShardIdFor(IGuild guild)
             => GetShardIdFor(guild?.Id ?? 0);
-        private DiscordSocketClient GetShardFor(ulong guildId)
+        public DiscordSocketClient GetShardFor(ulong guildId)
             => GetShard(GetShardIdFor(guildId));
         public DiscordSocketClient GetShardFor(IGuild guild)
             => GetShardFor(guild?.Id ?? 0);

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketSystemMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketSystemMessage.cs
@@ -9,11 +9,11 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class SocketSystemMessage : SocketMessage, ISystemMessage
     {
-        internal SocketSystemMessage(DiscordSocketClient discord, ulong id, ISocketMessageChannel channel, SocketUser author)
+        internal SocketSystemMessage(DiscordSocketClient discord, ulong id, Cacheable<IMessageChannel, ulong> channel, SocketUser author)
             : base(discord, id, channel, author, MessageSource.System)
         {
         }
-        internal new static SocketSystemMessage Create(DiscordSocketClient discord, ClientState state, SocketUser author, ISocketMessageChannel channel, Model model)
+        internal static SocketSystemMessage Create(DiscordSocketClient discord, ClientState state, SocketUser author, Cacheable<IMessageChannel, ulong> channel, Model model)
         {
             var entity = new SocketSystemMessage(discord, model.Id, channel, author);
             entity.Update(state, model);


### PR DESCRIPTION
With the arrival of Threads, some messages would be ignored as no known channel was found, I thought about two ways to fix this:
- Add threads to the cache
- Make possible to process messages without an attached channel

Since the first would make the library even more reliant on the cache, I decided to go with the 2nd, but this also comes with a heavy cost as the assumption of the channel being there is widely used internally as well, so I had to do several changes that might require a lot of changes by who's using the library.

Even now that channels are decoupled, the currently only known channel that could be missing are Threads (other guild channels are always cached and dms are created on the fly with only the user).

This is the first step on implementing threads for discord.net and this change will, at least, let bots process messages sent in those.

I'll leave this PR open for a few days so if anyone is interested, they can review or give feedback.

### Possible changes before merging
- Add a better way to send messages without the channel instead of `context.Client.SendMessageAsync(channelId, ...`

## Changes

Changes done to the interface will also propagate to classes that implement them, obviously.

- **IDiscordClient**: added a new method, `SendMessageAsync` (to send messages without the channel object, required for `ReplyAsync`)
- **DiscordShardedClient**: `GetShardFor` and `GetShardIdFor` overloads for ids are now public
- **ICommandContext**:
Added a `GuildId` property as `ulong?`
Changed the `Channel` property from `IMessageChannel` to `Cacheable<IMessageChannel, ulong>`
`IsPrivate` now checks for the presence of a guild id instead of channel type
- **IMessage**:
Added a `GuildId` property as `ulong?`
Changed the `Channel` property from `IMessageChannel` to `Cacheable<IMessageChannel, ulong>`
- **ModuleBase**: reorderer the parameters so RequestOptions is the last
- **ContextType.Group**: removed since bots cant be in groups and it's impossible to know the difference between a dm and a group, I decide to remove it entirely to not need to download the channel
- **RequireBotPermissionAttribute**: now can download the channel to retrieve the permissions
- **RequireUserPermissionAttribute**: now can download the channel to retrieve the permissions
- **RequireNsfwAttribute**: now can download the channel to check for the property
- **RequireContextAttribute**: will use the presence of `GuildId` instead of channel type
- **MessageExtensions.GetJumpUrl**: will use the presence of `GuildId` instead of channel type
- **MessageTypeReader**: will ignore channels that aren't cached as their message won't be as well
- **UserTypeReader**: won't use the channel if not present

The example for the MessageReceived event was updated to not rely on the channel being present.