### PR TITLE
feature: MoveAsync and DisconnectAsync

### DIFF
--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -165,5 +165,14 @@ namespace Discord
         /// </returns>
         public static Task BanAsync(this IGuildUser user, int pruneDays = 0, string reason = null, RequestOptions options = null)
             => user.Guild.AddBanAsync(user, pruneDays, reason, options);
+
+
+        /// <summary>
+        /// Moves the user to the voice channel.
+        /// </summary>
+        /// <param name="user">The user to move.</param>
+        /// <param name="targetChannel">the channel where the user gets moved to.</param>
+        /// <returns>A task that represents the asynchronous operation for moving a user.</returns>
+        public static Task MoveAsync(this IGuildUser user, IVoiceChannel targetChannel) => user.ModifyAsync(x => x.Channel = new Optional<IVoiceChannel>(targetChannel));
     }
 }

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -173,6 +173,16 @@ namespace Discord
         /// <param name="user">The user to move.</param>
         /// <param name="targetChannel">the channel where the user gets moved to.</param>
         /// <returns>A task that represents the asynchronous operation for moving a user.</returns>
-        public static Task MoveAsync(this IGuildUser user, IVoiceChannel targetChannel) => user.ModifyAsync(x => x.Channel = new Optional<IVoiceChannel>(targetChannel));
+        public static Task MoveAsync(this IGuildUser user, IVoiceChannel targetChannel)
+            => user.ModifyAsync(x => x.Channel = new Optional<IVoiceChannel>(targetChannel));
+
+
+        /// <summary>
+        /// Disconnects the user from its current voice channel
+        /// </summary>
+        /// <param name="user">The user to disconnect.</param>
+        /// <returns>A task that represents the asynchronous operation for disconnecting a user.</returns>
+        public static Task DisconnectAsync(this IGuildUser user)
+            => user.ModifyAsync(x => x.Channel = new Optional<IVoiceChannel>());
     }
 }


### PR DESCRIPTION
This allows library users to move and disconnect other discord users more easily.

My reason for this change is, that this is much faster to work with and also more clearly what it does than working with `ModifyAsync`

# Changes
- **IGuildUser**: added new method `MoveAsync` (to move the user to another voice channel)
- **IGuildUser**: added new method `DisconnectAsync` (to disconnect the user from its current voice channel)