### PR TITLE
feature: Support to multiple files for Webhooks

### DIFF
--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -123,14 +123,35 @@ namespace Discord.Webhook
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
-            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
-            => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler);
+            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
+            MessageComponent components = null)
+            => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl,
+                allowedMentions, options, isSpoiler, components);
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
-            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
-            => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler);
+            RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
+            MessageComponent components = null)
+            => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username,
+                avatarUrl, allowedMentions, options, isSpoiler, components);
+
+        /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
+        /// <returns> Returns the ID of the created message. </returns>
+        public Task<ulong> SendFileAsync(FileAttachment attachment, string text, bool isTTS = false,
+            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
+            RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null)
+            => WebhookClientHelper.SendFileAsync(this, attachment, text, isTTS, embeds, username,
+                avatarUrl, allowedMentions, components, options);
+
+        /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
+        /// <returns> Returns the ID of the created message. </returns>
+        public Task<ulong> SendFilesAsync(IEnumerable<FileAttachment> attachments, string text, bool isTTS = false,
+            IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
+            RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null)
+            => WebhookClientHelper.SendFilesAsync(this, attachments, text, isTTS, embeds, username, avatarUrl,
+                allowedMentions, components, options);
+
 
         /// <summary> Modifies the properties of this webhook. </summary>
         public Task ModifyWebhookAsync(Action<WebhookProperties> func, RequestOptions options = null)


### PR DESCRIPTION
## Summary
This PR is a re-implementation of #1570 with the new `files[n]` schema defined in the [Execute Webhook](https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params) request, you can read about how it works [here](https://discord.com/developers/docs/reference#uploading-files). 

The goal was to keep backwards compatibility with pre existing code as much as possible, this PR doesn't remove the older methods that take in file paths or streams, it adds 2 new ones: 
#### SendFileAsync(FileAttachment attachment, ...)
This method uses the [FileAttachment](https://github.com/discord-net/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs) struct to define the files name, description, and spoiler as well as a stream for the file content. The pro of using a struct here is it allows you to define file specifics instead of globally defining stuff like whether or not its a spoiler.

#### SendFilesAsync(IEnumerable\<FileAttachment> attachments, ...)
This method is similar to the above one except it takes a collection of files to allow multiple, this follows the current standard of the [`IMessageChannel`](https://github.com/discord-net/Discord.Net/blob/dev/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs#L173) implementation.

Fixes #1538