### PR TITLE
feature: Handle bidirectional usernames

### DIFF
--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -106,7 +106,7 @@ namespace Discord
         }
 
         /// <summary>
-        ///     Formats a users username + discriminator while maintaining bidirectional unicode
+        ///     Formats a user's username + discriminator while maintaining bidirectional unicode
         /// </summary>
         /// <param name="user">The user whos username and discriminator to format</param>
         /// <returns>The username + discriminator</returns>

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -104,5 +104,15 @@ namespace Discord
             var newText = Regex.Replace(text, @"(\*|_|`|~|>|\\)", "");
             return newText;
         }
+
+        /// <summary>
+        ///     Formats a users username + discriminator while maintaining bidirectional unicode
+        /// </summary>
+        /// <param name="user">The user whos username and discriminator to format</param>
+        /// <returns>The username + discriminator</returns>
+        public static string UsernameAndDiscriminator(IUser user)
+        {
+            return $"\u2066{user.Username}\u2069#{user.Discriminator}";
+        }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -128,8 +128,8 @@ namespace Discord.Rest
         /// <returns>
         ///     A string that resolves to Username#Discriminator of the user.
         /// </returns>
-        public override string ToString() => $"{Username}#{Discriminator}";
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";
+        public override string ToString() => Format.UsernameAndDiscriminator(this);
+        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this)} ({Id}{(IsBot ? ", Bot" : "")})";
         #endregion
 
         #region IUser

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -109,8 +109,8 @@ namespace Discord.WebSocket
         /// <returns>
         ///     The full name of the user.
         /// </returns>
-        public override string ToString() => $"{Username}#{Discriminator}";
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")})";
+        public override string ToString() => Format.UsernameAndDiscriminator(this);
+        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this)} ({Id}{(IsBot ? ", Bot" : "")})";
         internal SocketUser Clone() => MemberwiseClone() as SocketUser;
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes #1829 by implementing bi-directional isolation characters when concatenating the username and discriminator. 