### PR TITLE
feature: Add presence specific event

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IPresence.cs
+++ b/src/Discord.Net.Core/Entities/Users/IPresence.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+using System.Collections.Generic;
 
 namespace Discord
 {
@@ -14,10 +14,10 @@ namespace Discord
         /// <summary>
         ///     Gets the set of clients where this user is currently active.
         /// </summary>
-        IImmutableSet<ClientType> ActiveClients { get; }
+        IReadOnlyCollection<ClientType> ActiveClients { get; }
         /// <summary>
         ///     Gets the list of activities that this user currently has available.
         /// </summary>
-        IImmutableList<IActivity> Activities { get; }
+        IReadOnlyCollection<IActivity> Activities { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Model = Discord.API.User;
 using EventUserModel = Discord.API.GuildScheduledEventUser;
+using System.Collections.Generic;
 
 namespace Discord.Rest
 {
@@ -41,9 +42,9 @@ namespace Discord.Rest
         /// <inheritdoc />
         public virtual UserStatus Status => UserStatus.Offline;
         /// <inheritdoc />
-        public virtual IImmutableSet<ClientType> ActiveClients => ImmutableHashSet<ClientType>.Empty;
+        public virtual IReadOnlyCollection<ClientType> ActiveClients => ImmutableHashSet<ClientType>.Empty;
         /// <inheritdoc />
-        public virtual IImmutableList<IActivity> Activities => ImmutableList<IActivity>.Empty;
+        public virtual IReadOnlyCollection<IActivity> Activities => ImmutableList<IActivity>.Empty;
         /// <inheritdoc />
         public virtual bool IsWebhook => false;
 

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -502,6 +502,18 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<SocketGroupUser, Task>> _recipientRemovedEvent = new AsyncEvent<Func<SocketGroupUser, Task>>();
         #endregion
 
+        #region Presence
+
+        /// <summary> Fired when a users presence is updated. </summary>
+        public event Func<SocketUser, SocketPresence, SocketPresence, Task> PresenceUpdated
+        {
+            add { _presenceUpdated.Add(value); }
+            remove { _presenceUpdated.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketUser, SocketPresence, SocketPresence, Task>> _presenceUpdated = new AsyncEvent<Func<SocketUser, SocketPresence, SocketPresence, Task>>();
+
+        #endregion
+
         #region Invites
         /// <summary>
         ///     Fired when an invite is created.

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Linq;
 using Model = Discord.API.User;
-using PresenceModel = Discord.API.Presence;
 
 namespace Discord.WebSocket
 {
@@ -46,11 +45,6 @@ namespace Discord.WebSocket
                 if (--_references <= 0)
                     discord.RemoveUser(Id);
             }
-        }
-
-        internal void Update(ClientState state, PresenceModel model)
-        {
-            Presence = SocketPresence.Create(model);
         }
 
         private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Global)";

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -164,8 +164,7 @@ namespace Discord.WebSocket
         {
             if (updatePresence)
             {
-                Presence = SocketPresence.Create(model);
-                GlobalUser.Update(state, model);
+                Update(model);
             }
             if (model.Nick.IsSpecified)
                 Nickname = model.Nick.Value;
@@ -174,6 +173,13 @@ namespace Discord.WebSocket
             if (model.PremiumSince.IsSpecified)
                 _premiumSinceTicks = model.PremiumSince.Value?.UtcTicks;
         }
+
+        internal override void Update(PresenceModel model)
+        {
+            Presence.Update(model);
+            GlobalUser.Update(model);
+        }
+
         private void UpdateRoles(ulong[] roleIds)
         {
             var roles = ImmutableArray.CreateBuilder<ulong>(roleIds.Length + 1);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Discord.Rest;
 using Model = Discord.API.User;
+using PresenceModel = Discord.API.Presence;
 
 namespace Discord.WebSocket
 {
@@ -40,9 +41,9 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public UserStatus Status => Presence.Status;
         /// <inheritdoc />
-        public IImmutableSet<ClientType> ActiveClients => Presence.ActiveClients ?? ImmutableHashSet<ClientType>.Empty;
+        public IReadOnlyCollection<ClientType> ActiveClients => Presence.ActiveClients ?? ImmutableHashSet<ClientType>.Empty;
         /// <inheritdoc />
-        public IImmutableList<IActivity> Activities => Presence.Activities ?? ImmutableList<IActivity>.Empty;
+        public IReadOnlyCollection<IActivity> Activities => Presence.Activities ?? ImmutableList<IActivity>.Empty;
         /// <summary>
         ///     Gets mutual guilds shared with this user.
         /// </summary>
@@ -89,6 +90,11 @@ namespace Discord.WebSocket
                 hasChanges = true;
             }
             return hasChanges;
+        }
+
+        internal virtual void Update(PresenceModel model)
+        {
+            Presence.Update(model);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR adds a `PresenceUpdated` event to the socket client. As pointed out in #1505 the guild member updated / user updated event shouldn't deal with presence as developers use those events for non presence related functions.

This PR also changes the behavior of `SocketPresence` to be more like an entity in the sense that it can be updated, this helps with memory as every time a presence was updated before it would create a new struct for it.

I've also changed the collection types from `IImmutableSet` to `IReadOnlyCollection` to follow the standard in the rest of the library.