### PR TITLE
Fix NRE when adding parameters thru builders

### DIFF
--- a/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ParameterBuilder.cs
@@ -54,7 +54,7 @@ namespace Discord.Commands.Builders
             if (type.GetTypeInfo().IsValueType)
                 DefaultValue = Activator.CreateInstance(type);
             else if (type.IsArray)
-                type = ParameterType.GetElementType();
+                DefaultValue = Array.CreateInstance(type.GetElementType(), 0);
             ParameterType = type;
         }
 


### PR DESCRIPTION
## Summary
This PR fixes the NRE defined in #1839 by removing the reference to a null property and correctly setting `DefaultValue` and `ParameterType`