### PR TITLE
Fix CurrentUser with ICommandContext on ShardedClient is broken

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -495,9 +495,12 @@ namespace Discord.WebSocket
             client.GuildScheduledEventUserAdd += (arg1, arg2) => _guildScheduledEventUserAdd.InvokeAsync(arg1, arg2);
             client.GuildScheduledEventUserRemove += (arg1, arg2) => _guildScheduledEventUserRemove.InvokeAsync(arg1, arg2);
         }
-#endregion
+        #endregion
 
         #region IDiscordClient
+        /// <inheritdoc />
+        ISelfUser IDiscordClient.CurrentUser => CurrentUser;
+
         /// <inheritdoc />
         async Task<IApplication> IDiscordClient.GetApplicationInfoAsync(RequestOptions options)
             => await GetApplicationInfoAsync().ConfigureAwait(false);


### PR DESCRIPTION
Fixes  #1910. As i found out while troubleshoting, down-casting a `DiscordShardedClient` into `BaseDiscordClient` and trying to get the CurrentUser property also causes the same problem but i couldnt find a clean fix which i can guarantee wouldnt have any negative side effects. So this basic fix just addresses the issue on `IDiscordClient`