### PR TITLE
feature: warn on invalid gateway intents

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -184,6 +184,11 @@ namespace Discord.WebSocket
         public GatewayIntents GatewayIntents { get; set; } = GatewayIntents.AllUnprivileged;
 
         /// <summary>
+        ///     Gets or sets whether or not to log warnings related to guild intents and events.
+        /// </summary>
+        public bool LogGatewayIntentWarnings { get; set; } = true;
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="DiscordSocketConfig"/> class with the default configuration.
         /// </summary>
         public DiscordSocketConfig()


### PR DESCRIPTION
## Summary
While dnet 2.x didn't really rely on gateway intents to function, V3 will since we're explicitly using API v9. 

### Motivation
When people come to dnet 3.0 they may not know what intents are required for what events. This PR add checks and logs warnings when your either using an event without specifying the intent required for it, or specifying an intent without using its corresponding gateway events.

### Disabling the warnings
Lets say your hooking events after you log in the client and you want to remove the warnings, you can `LogGatewayIntentWarnings` to false in the config and the warnings won't log.

### Changes
- Add `LogGatewayIntentWarnings` to the config
- Add checks for `GuildPresences`, `GuildScheduledEvents`, and `GuildInvites`