### PR TITLE
fix: guild scheduled events update

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2642,7 +2642,7 @@ namespace Discord.WebSocket
                                         return;
                                     }
 
-                                    var before = guild.GetEvent(data.Id);
+                                    var before = guild.GetEvent(data.Id)?.Clone();
 
                                     var beforeCacheable = new Cacheable<SocketGuildEvent, ulong>(before, data.Id, before != null, () => Task.FromResult((SocketGuildEvent)null));
 

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuildEvent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuildEvent.cs
@@ -196,6 +196,8 @@ namespace Discord.WebSocket
         public IAsyncEnumerable<IReadOnlyCollection<RestUser>> GetUsersAsync(ulong fromUserId, Direction dir, int limit = DiscordConfig.MaxGuildEventUsersPerBatch, RequestOptions options = null)
             => GuildHelper.GetEventUsersAsync(Discord, this, fromUserId, dir, limit, options);
 
+        internal SocketGuildEvent Clone() => MemberwiseClone() as SocketGuildEvent;
+
         #region IGuildScheduledEvent
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Summary
This PR fixed the `GuildScheduledEventUpdated` event by adding a memberwise clone to the `before` entity. 