### PR TITLE
fix: Thread member update NRE

### DIFF
--- a/src/Discord.Net.Rest/API/Common/ThreadMember.cs
+++ b/src/Discord.Net.Rest/API/Common/ThreadMember.cs
@@ -14,12 +14,6 @@ namespace Discord.API
         [JsonProperty("join_timestamp")]
         public DateTimeOffset JoinTimestamp { get; set; }
 
-        [JsonProperty("presence")]
-        public Optional<Presence> Presence { get; set; }
-
-        [JsonProperty("member")]
-        public Optional<GuildMember> Member { get; set; }
-
         [JsonProperty("flags")]
         public int Flags { get; set; } // No enum type (yet?)
     }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2529,16 +2529,14 @@ namespace Discord.WebSocket
                                         {
                                             SocketGuildUser guildMember;
 
-                                            if (threadMember.Member.IsSpecified)
+                                            guildMember = guild.GetUser(threadMember.UserId.Value);
+
+                                            if(guildMember == null)
                                             {
-                                                guildMember = guild.AddOrUpdateUser(threadMember.Member.Value);
+                                                await UnknownGuildUserAsync("THREAD_MEMBERS_UPDATE", threadMember.UserId.Value, guild.Id);
                                             }
                                             else
-                                            {
-                                                guildMember = guild.GetUser(threadMember.UserId.Value);
-                                            }
-
-                                            newThreadMembers.Add(thread.AddOrUpdateThreadMember(threadMember, guildMember));
+                                                newThreadMembers.Add(thread.AddOrUpdateThreadMember(threadMember, guildMember));
                                         }
 
                                         if (newThreadMembers.Any())

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -137,16 +137,6 @@ namespace Discord.WebSocket
         internal void Update(Model model)
         {
             ThreadJoinedAt = model.JoinTimestamp;
-
-            if (model.Presence.IsSpecified)
-            {
-                GuildUser.Update(Discord.State, model.Presence.Value, true);
-            }
-
-            if (model.Member.IsSpecified)
-            {
-                GuildUser.Update(Discord.State, model.Member.Value);
-            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Summary
This PR fixes a rare NRE when thread user are updated, discord removed the `presence` and `member` field from the thread member object but occasionally discord will send these properties with null values. The library will try to use these null values for updating the corresponding entities. 