### PR TITLE
return error when precondition fails

### DIFF
--- a/src/Discord.Net.Interactions/Attributes/Preconditions/RequireRoleAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/Preconditions/RequireRoleAttribute.cs
@@ -62,7 +62,7 @@ namespace Discord.Interactions
                 if (guildUser.Guild.Roles.Any(x => x.Name == RoleName))
                     return Task.FromResult(PreconditionResult.FromSuccess());
                 else
-                    Task.FromResult(PreconditionResult.FromError(ErrorMessage ?? $"User requires guild role {RoleName}."));
+                    return Task.FromResult(PreconditionResult.FromError(ErrorMessage ?? $"User requires guild role {RoleName}."));
             }
 
             return Task.FromResult(PreconditionResult.FromSuccess());


### PR DESCRIPTION
return `Task.FromResult()` when condition is false for user not having role required