### PR TITLE
Fix InteractionContext.Guild

### DIFF
--- a/src/Discord.Net.Interactions/InteractionContext.cs
+++ b/src/Discord.Net.Interactions/InteractionContext.cs
@@ -26,7 +26,7 @@ namespace Discord.Interactions
             Client = client;
             Interaction = interaction;
             Channel = channel;
-            Guild = (interaction as IGuildUser)?.Guild;
+            Guild = (user as IGuildUser)?.Guild;
             User = user;
             Interaction = interaction;
         }

--- a/src/Discord.Net.Interactions/InteractionContext.cs
+++ b/src/Discord.Net.Interactions/InteractionContext.cs
@@ -21,13 +21,13 @@ namespace Discord.Interactions
         /// <param name="interaction">The underlying interaction.</param>
         /// <param name="user"><see cref="IUser"/> who executed the command.</param>
         /// <param name="channel"><see cref="ISocketMessageChannel"/> the command originated from.</param>
-        public InteractionContext(IDiscordClient client, IDiscordInteraction interaction, IUser user, IMessageChannel channel = null)
+        public InteractionContext(IDiscordClient client, IDiscordInteraction interaction, IMessageChannel channel = null)
         {
             Client = client;
             Interaction = interaction;
             Channel = channel;
-            Guild = (user as IGuildUser)?.Guild;
-            User = user;
+            Guild = (interaction.User as IGuildUser)?.Guild;
+            User = interaction.User;
             Interaction = interaction;
         }
     }


### PR DESCRIPTION
Fixes #2012. Also removes the user parameter from the class ctor in favour of using the User property of IDiscordInteraction