### PR TITLE
Add Construct Method to InteractionModuleBase and Fix NRE on User-Built Module Creation

### DIFF
--- a/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
@@ -261,19 +261,24 @@ namespace Discord.Interactions.Builders
 
         internal ModuleInfo Build (InteractionService interactionService, IServiceProvider services, ModuleInfo parent = null)
         {
-            var moduleInfo = new ModuleInfo(this, interactionService, services, parent);
-
-            IInteractionModuleBase instance = ReflectionUtils<IInteractionModuleBase>.CreateObject(TypeInfo, interactionService, services);
-            try
+            if (TypeInfo is not null && ModuleClassBuilder.IsValidModuleDefinition(TypeInfo))
             {
-                instance.OnModuleBuilding(interactionService, moduleInfo);
-            }
-            finally
-            {
-                ( instance as IDisposable )?.Dispose();
-            }
+                var instance = ReflectionUtils<IInteractionModuleBase>.CreateObject(TypeInfo, interactionService, services);
 
-            return moduleInfo;
+                try
+                {
+                    instance.Construct(this, interactionService);
+                    var moduleInfo = new ModuleInfo(this, interactionService, services, parent);
+                    instance.OnModuleBuilding(interactionService, moduleInfo);
+                    return moduleInfo;
+                }
+                finally
+                {
+                    (instance as IDisposable)?.Dispose();
+                }
+            }
+            else
+                return new(this, interactionService, services, parent);
         }
     }
 }

--- a/src/Discord.Net.Interactions/IInteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/IInteractionModuleBase.cs
@@ -38,10 +38,17 @@ namespace Discord.Interactions
         void AfterExecute (ICommandInfo command);
 
         /// <summary>
-        ///     Method body to be executed before the derived module is built.
+        ///     Method body to be executed when <see cref="Builders.ModuleBuilder.Build(InteractionService, System.IServiceProvider, ModuleInfo)"/> is called.
         /// </summary>
         /// <param name="commandService">Command Service instance that built this module.</param>
         /// <param name="module">Info class of this module.</param>
         void OnModuleBuilding (InteractionService commandService, ModuleInfo module);
+
+        /// <summary>
+        ///     Method body to be executed after the automated module creation is completed and before <see cref="Builders.ModuleBuilder.Build(InteractionService, System.IServiceProvider, ModuleInfo)"/> is called.
+        /// </summary>
+        /// <param name="builder">Builder class of this module.</param>
+        /// <param name="commandService">Command Service instance that is building this method.</param>
+        void Construct(Builders.ModuleBuilder builder, InteractionService commandService);
     }
 }

--- a/src/Discord.Net.Interactions/InteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/InteractionModuleBase.cs
@@ -29,6 +29,9 @@ namespace Discord.Interactions
         /// <inheritdoc/>
         public virtual void OnModuleBuilding (InteractionService commandService, ModuleInfo module) { }
 
+        /// <inheritdoc/>
+        public virtual void Construct (Builders.ModuleBuilder builder, InteractionService commandService) { }
+
         internal void SetContext (IInteractionContext context)
         {
             var newValue = context as T;


### PR DESCRIPTION
Adds a method called `Construct` to `IInteractionModuleBase` to allow users to manupulate the builder instance of the class dynamically and fixes #2006.