### PR TITLE
Fix ModifyAsync

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -42,12 +42,11 @@ namespace Discord.Rest
             bool hasEmbeds = embed.IsSpecified && embed.Value != null || embeds.IsSpecified && embeds.Value?.Length > 0;
             bool hasComponents = args.Components.IsSpecified && args.Components.Value != null;
             bool hasAttachments = args.Attachments.IsSpecified;
+            bool hasFlags = args.Flags.IsSpecified;
 
             // No content needed if modifying flags
-            if ((!hasComponents && !hasText && !hasEmbeds && !hasAttachments) && !args.Flags.IsSpecified)
-            {
+            if ((!hasComponents && !hasText && !hasEmbeds && !hasAttachments) && !hasFlags)
                 Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
-            }
 
             if (args.AllowedMentions.IsSpecified)
             {

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -43,8 +43,11 @@ namespace Discord.Rest
             bool hasComponents = args.Components.IsSpecified && args.Components.Value != null;
             bool hasAttachments = args.Attachments.IsSpecified;
 
-            if (!hasComponents && !hasText && !hasEmbeds && !hasAttachments)
+            // No content needed if modifying flags
+            if ((!hasComponents && !hasText && !hasEmbeds && !hasAttachments) && !args.Flags.IsSpecified)
+            {
                 Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
+            }
 
             if (args.AllowedMentions.IsSpecified)
             {


### PR DESCRIPTION
Fixes an issue that causes `Argument cannot be blank. (Parameter 'Content')` when only modifying a message's flags.
Fixes #2020 