### PR TITLE
Add catch for operation canceled in connection manager

### DIFF
--- a/src/Discord.Net.WebSocket/ConnectionManager.cs
+++ b/src/Discord.Net.WebSocket/ConnectionManager.cs
@@ -78,6 +78,14 @@ namespace Discord
                             nextReconnectDelay = 1000; //Reset delay
                             await _connectionPromise.Task.ConfigureAwait(false);
                         }
+                        catch (OperationCanceledException ex)
+                        {
+                            // Added back for log out / stop to client. The connection promise would cancel and it would be logged as an error, shouldn't be the case.
+                            // ref #2026
+
+                            Cancel(); //In case this exception didn't come from another Error call
+                            await DisconnectAsync(ex, !reconnectCancelToken.IsCancellationRequested).ConfigureAwait(false);
+                        }
                         catch (Exception ex)
                         {
                             Error(ex); //In case this exception didn't come from another Error call


### PR DESCRIPTION
## Summary
This PR aims to fix #2026 by adding a catch case for `OperationCanceledException` in the connection manager.

This catch statement was removed in #1873 for deadlock reasons but I'm unable to find any regarding this catch statement.