### PR TITLE
Make DefaultChannel exclude threads

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -169,7 +169,7 @@ namespace Discord.WebSocket
         ///     A <see cref="SocketTextChannel"/> representing the first viewable channel that the user has access to.
         /// </returns>
         public SocketTextChannel DefaultChannel => TextChannels
-            .Where(c => CurrentUser.GetPermissions(c).ViewChannel)
+            .Where(c => CurrentUser.GetPermissions(c).ViewChannel && c is not IThreadChannel)
             .OrderBy(c => c.Position)
             .FirstOrDefault();
         /// <summary>


### PR DESCRIPTION
## Summary
Thread channels have a position of 0 (default int) and we're included when trying to get the `DefaultChannel` on a socket guild. This PR removes thread channels from the `DefaultChannel` selector.