### PR TITLE
Fix ThreadMember null ref

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -123,8 +123,8 @@ namespace Discord.WebSocket
 
         private SocketGuildUser GuildUser { get; set; }
 
-        internal SocketThreadUser(SocketGuild guild, SocketThreadChannel thread, SocketGuildUser member)
-            : base(guild.Discord, member.Id)
+        internal SocketThreadUser(SocketGuild guild, SocketThreadChannel thread, SocketGuildUser member, ulong userId)
+            : base(guild.Discord, userId)
         {
             Thread = thread;
             Guild = guild;
@@ -133,7 +133,7 @@ namespace Discord.WebSocket
 
         internal static SocketThreadUser Create(SocketGuild guild, SocketThreadChannel thread, Model model, SocketGuildUser member)
         {
-            var entity = new SocketThreadUser(guild, thread, member);
+            var entity = new SocketThreadUser(guild, thread, member, model.UserId.Value);
             entity.Update(model);
             return entity;
         }


### PR DESCRIPTION
## Summary
This PR fixes a NullReferenceException in the constructor of the `SocketThreadUser` class, the constructor didn't account for non-cached guild members and was attempting to access the user id of a null member.