### PR TITLE
Add return statement to precondition handling

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -557,6 +557,7 @@ namespace Discord.Commands
             if (matchResult.Pipeline is PreconditionResult preconditionResult)
             {
                 await _commandExecutedEvent.InvokeAsync(matchResult.Match.Value.Command, context, preconditionResult).ConfigureAwait(false);
+                return preconditionResult;
             }
 
             return matchResult;


### PR DESCRIPTION
Adds a return statement to the Discord.Commands' command handling method to return the failed `PreconditionResult` instead of `MatchResult`, which shouldn't be exposed to the user in this case.

Waiting for @MrCakeSlayer.