### PR TITLE
Set Stream.Position in FileAttachment-ctor to 0

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
@@ -32,6 +32,11 @@ namespace Discord
             FileName = fileName;
             Description = description;
             Stream = stream;
+            try
+            {
+                Stream.Position = 0;
+            }
+            catch { }
             IsSpoiler = isSpoiler;
         }
 


### PR DESCRIPTION
Calling `SendFileAsync(Stream stream, string fileName)` with a `MemoryStream` causes the uploaded file to be empty:

![grafik](https://user-images.githubusercontent.com/47949835/151369286-0271aaf3-b832-4040-a610-1f1a3ef21c36.png)

In my application, I am saving an image-object's data to a newly created MemoryStream. Thus, the streams' position is at its end.
Setting the position to zero before calling SendFileAsync solves this issue, however I still suggest to add these five lines to the `FileAttachment` ctor, so others do not need to debug this.

The only issue that could arise from this is if the actual data to be sent is somehow at a position > 0 && < stream.Length, but I can't imagine a usecase for that?