### PR TITLE
Fix Channel Types Attribute

### DIFF
--- a/src/Discord.Net.Interactions/TypeConverters/DefaultEntityTypeConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/DefaultEntityTypeConverter.cs
@@ -72,7 +72,8 @@ namespace Discord.Interactions
 
         public override void Write (ApplicationCommandOptionProperties properties, IParameterInfo parameter)
         {
-            properties.ChannelTypes = _channelTypes;
+            if (_channelTypes is not null)
+                properties.ChannelTypes = _channelTypes;
         }
     }
 

--- a/src/Discord.Net.Interactions/TypeConverters/DefaultEntityTypeConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/DefaultEntityTypeConverter.cs
@@ -72,7 +72,8 @@ namespace Discord.Interactions
 
         public override void Write (ApplicationCommandOptionProperties properties, IParameterInfo parameter)
         {
-            properties.ChannelTypes = _channelTypes;
+            if (_channelTypes is not null)
+                properties.ChannelTypes.AddRange(_channelTypes);
         }
     }
 


### PR DESCRIPTION
Default Channel TypeConverter overwrites the values inserted by [ChannelTypeAttribute], this PR fixes the issue. Closes #2047.