### PR TITLE
Fix thread member download on thread create

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2913,6 +2913,9 @@ namespace Discord.WebSocket
             }
         }
 
+        internal bool HasGatewayIntent(GatewayIntents intents)
+            => _gatewayIntents.HasFlag(intents);
+
         private async Task GuildAvailableAsync(SocketGuild guild)
         {
             if (!guild.IsConnected)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -119,7 +119,8 @@ namespace Discord.WebSocket
 
             var thread = (SocketThreadChannel)Guild.AddOrUpdateChannel(Discord.State, model);
 
-            await thread.DownloadUsersAsync();
+            if(Discord.AlwaysDownloadUsers && Discord.HasGatewayIntent(GatewayIntents.GuildMembers))
+                await thread.DownloadUsersAsync();
 
             return thread;
         }


### PR DESCRIPTION
## Summary
This PR fixes #2065 by adding a check for the config option `AlwaysDownloadUsers` and gateway intent `GuildMembers` before calling `DownloadUsersAsync` on the thread channel.

Closes #2065