### PR TITLE
Patch; Rest message components cannot pass through execute method

### DIFF
--- a/src/Discord.Net.Interactions/Info/Commands/ComponentCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/ComponentCommandInfo.cs
@@ -57,7 +57,7 @@ namespace Discord.Interactions
         public async Task<IResult> ExecuteAsync(IInteractionContext context, IEnumerable<CommandParameterInfo> paramList, IEnumerable<string> values,
             IServiceProvider services)
         {
-            if (context.Interaction is not SocketMessageComponent messageComponent)
+            if (context.Interaction is not IComponentInteraction messageComponent)
                 return ExecuteResult.FromError(InteractionCommandError.ParseFailed, $"Provided {nameof(IInteractionContext)} doesn't belong to a Component Command Interaction");
 
             try


### PR DESCRIPTION
Line 60 should be equal to line 42 here. Currently rest interactions cant execute the message component handlers.