### PR TITLE
Fix guild feature enum mixing ints

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/GuildFeature.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildFeature.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Discord
 {
     [Flags]
-    public enum GuildFeature
+    public enum GuildFeature : long
     {
         /// <summary>
         ///     The guild has no features.


### PR DESCRIPTION
## Summary
This PR attempts to fix #2084 by explicitly making the guild feature enum inherit long.