### PR TITLE
Fix channel being null in most cases on Interactions

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
@@ -63,6 +63,11 @@ namespace Discord
         string GuildLocale { get; }
 
         /// <summary>
+        ///     Gets whether or not this interaction was executed in a dm channel.
+        /// </summary>
+        bool IsDMInteraction { get; }
+
+        /// <summary>
         ///     Responds to an Interaction with type <see cref="InteractionResponseType.ChannelMessageWithSource"/>.
         /// </summary>
         /// <param name="text">The text of the message to be sent.</param>

--- a/src/Discord.Net.Interactions/Attributes/Preconditions/RequireContextAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/Preconditions/RequireContextAttribute.cs
@@ -57,11 +57,9 @@ namespace Discord.Interactions
             bool isValid = false;
 
             if ((Contexts & ContextType.Guild) != 0)
-                isValid = context.Channel is IGuildChannel;
-            if ((Contexts & ContextType.DM) != 0)
-                isValid = isValid || context.Channel is IDMChannel;
-            if ((Contexts & ContextType.Group) != 0)
-                isValid = isValid || context.Channel is IGroupChannel;
+                isValid = !context.Interaction.IsDMInteraction;
+            if ((Contexts & ContextType.DM) != 0 && (Contexts & ContextType.Group) != 0)
+                isValid = context.Interaction.IsDMInteraction;
 
             if (isValid)
                 return Task.FromResult(PreconditionResult.FromSuccess());

--- a/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
@@ -61,6 +61,9 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public bool HasResponded { get; protected set; }
 
+        /// <inheritdoc/>
+        public bool IsDMInteraction { get; private set; }
+
         internal RestInteraction(BaseDiscordClient discord, ulong id)
             : base(discord, id)
         {
@@ -108,6 +111,8 @@ namespace Discord.Rest
 
         internal virtual async Task UpdateAsync(DiscordRestClient discord, Model model)
         {
+            IsDMInteraction = !model.GuildId.IsSpecified;
+
             Data = model.Data.IsSpecified
                 ? model.Data.Value
                 : null;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/MessageCommands/SocketMessageCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/MessageCommands/SocketMessageCommand.cs
@@ -13,8 +13,8 @@ namespace Discord.WebSocket
         /// </summary>
         public new SocketMessageCommandData Data { get; }
 
-        internal SocketMessageCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
-            : base(client, model, channel)
+        internal SocketMessageCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
+            : base(client, model, channel, user)
         {
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
@@ -27,9 +27,9 @@ namespace Discord.WebSocket
             Data = SocketMessageCommandData.Create(client, dataModel, model.Id, guildId);
         }
 
-        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
         {
-            var entity = new SocketMessageCommand(client, model, channel);
+            var entity = new SocketMessageCommand(client, model, channel, user);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/UserCommands/SocketUserCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/UserCommands/SocketUserCommand.cs
@@ -13,8 +13,8 @@ namespace Discord.WebSocket
         /// </summary>
         public new SocketUserCommandData Data { get; }
 
-        internal SocketUserCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
-            : base(client, model, channel)
+        internal SocketUserCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
+            : base(client, model, channel, user)
         {
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
@@ -27,9 +27,9 @@ namespace Discord.WebSocket
             Data = SocketUserCommandData.Create(client, dataModel, model.Id, guildId);
         }
 
-        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
         {
-            var entity = new SocketUserCommand(client, model, channel);
+            var entity = new SocketUserCommand(client, model, channel, user);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
@@ -28,8 +28,8 @@ namespace Discord.WebSocket
         private object _lock = new object();
         public override bool HasResponded { get; internal set; } = false;
 
-        internal SocketMessageComponent(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
-            : base(client, model.Id, channel)
+        internal SocketMessageComponent(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
+            : base(client, model.Id, channel, user)
         {
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
@@ -38,9 +38,9 @@ namespace Discord.WebSocket
             Data = new SocketMessageComponentData(dataModel);
         }
 
-        internal new static SocketMessageComponent Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketMessageComponent Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
         {
-            var entity = new SocketMessageComponent(client, model, channel);
+            var entity = new SocketMessageComponent(client, model, channel, user);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Modals/SocketModal.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Modals/SocketModal.cs
@@ -22,8 +22,8 @@ namespace Discord.WebSocket
         /// <value></value>
         public new SocketModalData Data { get; set; }
 
-        internal SocketModal(DiscordSocketClient client, ModelBase model, ISocketMessageChannel channel)
-             : base(client, model.Id, channel)
+        internal SocketModal(DiscordSocketClient client, ModelBase model, ISocketMessageChannel channel, SocketUser user)
+             : base(client, model.Id, channel, user)
         {
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
@@ -32,9 +32,9 @@ namespace Discord.WebSocket
             Data = new SocketModalData(dataModel);
         }
 
-        internal new static SocketModal Create(DiscordSocketClient client, ModelBase model, ISocketMessageChannel channel)
+        internal new static SocketModal Create(DiscordSocketClient client, ModelBase model, ISocketMessageChannel channel, SocketUser user)
         {
-            var entity = new SocketModal(client, model, channel);
+            var entity = new SocketModal(client, model, channel, user);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
@@ -21,8 +21,8 @@ namespace Discord.WebSocket
         public override bool HasResponded { get; internal set; }
         private object _lock = new object();
 
-        internal SocketAutocompleteInteraction(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
-            : base(client, model.Id, channel)
+        internal SocketAutocompleteInteraction(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
+            : base(client, model.Id, channel, user)
         {
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
@@ -32,9 +32,9 @@ namespace Discord.WebSocket
                 Data = new SocketAutocompleteInteractionData(dataModel);
         }
 
-        internal new static SocketAutocompleteInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketAutocompleteInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
         {
-            var entity = new SocketAutocompleteInteraction(client, model, channel);
+            var entity = new SocketAutocompleteInteraction(client, model, channel, user);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketSlashCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketSlashCommand.cs
@@ -13,8 +13,8 @@ namespace Discord.WebSocket
         /// </summary>
         public new SocketSlashCommandData Data { get; }
 
-        internal SocketSlashCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
-            : base(client, model, channel)
+        internal SocketSlashCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
+            : base(client, model, channel, user)
         {
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
@@ -27,9 +27,9 @@ namespace Discord.WebSocket
             Data = SocketSlashCommandData.Create(client, dataModel, guildId);
         }
 
-        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
         {
-            var entity = new SocketSlashCommand(client, model, channel);
+            var entity = new SocketSlashCommand(client, model, channel, user);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
@@ -35,8 +35,8 @@ namespace Discord.WebSocket
 
         private object _lock = new object();
 
-        internal SocketCommandBase(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
-            : base(client, model.Id, channel)
+        internal SocketCommandBase(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
+            : base(client, model.Id, channel, user)
         {
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
@@ -49,9 +49,9 @@ namespace Discord.WebSocket
             Data = SocketCommandBaseData.Create(client, dataModel, model.Id, guildId);
         }
 
-        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
         {
-            var entity = new SocketCommandBase(client, model, channel);
+            var entity = new SocketCommandBase(client, model, channel, user);
             entity.Update(model);
             return entity;
         }


### PR DESCRIPTION
## Summary
This PR fixes the `Channel` property on interactions being null in dms as well as exposes a method called `GetChannelAsync` that will fetch the channel from rest or the cache. 

To help on confusion or if the channel cannot be fetched, this pr also exposes a new property to `IDiscordInteraction` called `IsDMInteraction`, this can help with bots that have dm specific interactions.