### PR TITLE
Fix crosspost ratelimits

### DIFF
--- a/src/Discord.Net.Rest/API/Common/Ratelimit.cs
+++ b/src/Discord.Net.Rest/API/Common/Ratelimit.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.API
+{
+    internal class Ratelimit
+    {
+        [JsonProperty("global")]
+        public bool Global { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
+        [JsonProperty("retry_after")]
+        public double RetryAfter { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/Net/DefaultRestClient.cs
+++ b/src/Discord.Net.Rest/Net/DefaultRestClient.cs
@@ -149,7 +149,7 @@ namespace Discord.Net.Rest
                 HttpResponseMessage response = await _client.SendAsync(request, cancelToken).ConfigureAwait(false);
 
                 var headers = response.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault(), StringComparer.OrdinalIgnoreCase);
-                var stream = !headerOnly ? await response.Content.ReadAsStreamAsync().ConfigureAwait(false) : null;
+                var stream = (!headerOnly || !response.IsSuccessStatusCode) ? await response.Content.ReadAsStreamAsync().ConfigureAwait(false) : null;
 
                 return new RestResponse(response.StatusCode, headers, stream);
             }

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -75,6 +75,7 @@ namespace Discord.Net.Queue
                         switch (response.StatusCode)
                         {
                             case (HttpStatusCode)429:
+                                info.ReadRatelimitPayload(response.Stream);
                                 if (info.IsGlobal)
                                 {
 #if DEBUG_LIMITS

--- a/src/Discord.Net.Rest/Net/RateLimitInfo.cs
+++ b/src/Discord.Net.Rest/Net/RateLimitInfo.cs
@@ -1,6 +1,10 @@
+using Discord.API;
+using Discord.Net.Rest;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 
 namespace Discord.Net
 {
@@ -25,7 +29,7 @@ namespace Discord.Net
         public DateTimeOffset? Reset { get; }
 
         /// <inheritdoc/>
-        public TimeSpan? ResetAfter { get; }
+        public TimeSpan? ResetAfter { get; private set; }
 
         /// <inheritdoc/>
         public string Bucket { get; }
@@ -55,6 +59,24 @@ namespace Discord.Net
             Bucket = headers.TryGetValue("X-RateLimit-Bucket", out temp) ? temp : null;
             Lag = headers.TryGetValue("Date", out temp) &&
                 DateTimeOffset.TryParse(temp, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ? DateTimeOffset.UtcNow - date : (TimeSpan?)null;
+        }
+
+        internal void ReadRatelimitPayload(Stream response)
+        {
+            try
+            {
+                if (response != null && response.Length != 0)
+                {
+                    using (TextReader text = new StreamReader(response))
+                    using (JsonReader reader = new JsonTextReader(text))
+                    {
+                        var ratelimit = Discord.Rest.DiscordRestClient.Serializer.Deserialize<Ratelimit>(reader);
+
+                        ResetAfter = TimeSpan.FromSeconds(ratelimit.RetryAfter);
+                    }
+                }
+            }
+            catch { }
         }
     }
 }


### PR DESCRIPTION
## Summary

Currently, there seems to be a bug with the headers returned on crosspost ratelimits, the fix for this is to read the payload of the ratelimit and trust the `retry_after` field in that.