### PR TITLE
fix: stream access exception when ratelimited

### DIFF
--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -75,7 +75,6 @@ namespace Discord.Net.Queue
                         switch (response.StatusCode)
                         {
                             case (HttpStatusCode)429:
-                                info.ReadRatelimitPayload(response.Stream);
                                 if (info.IsGlobal)
                                 {
 #if DEBUG_LIMITS


### PR DESCRIPTION
## Summary
This PR removes the pre #2110 code for ratelimit body reading.