### PR TITLE
Fixed documentation typo's

### DIFF
--- a/docs/guides/int_basics/message-components/advanced.md
+++ b/docs/guides/int_basics/message-components/advanced.md
@@ -43,7 +43,7 @@ var components = new ComponentBuilder()
     .WithSelectMenu(menu);
 
 
-await arg.RespondAsync("On a scale of one to five, how gaming is this?", component: componBuild(), ephemeral: true);
+await arg.RespondAsync("On a scale of one to five, how gaming is this?", component: components.Build(), ephemeral: true);
 break;
 ```
 

--- a/docs/guides/int_basics/message-components/text-input.md
+++ b/docs/guides/int_basics/message-components/text-input.md
@@ -35,11 +35,11 @@ and min/max length of the input:
 var tb = new TextInputBuilder()
     .WithLabel("Labeled")
     .WithCustomId("text_input")
-	.WithStyle(TextInputStyle.Paragraph)
-	.WithMinLength(6);
-	.WithMaxLength(42)
-	.WithRequired(true)
-	.WithPlaceholder("Consider this place held.");
+    .WithStyle(TextInputStyle.Paragraph)
+    .WithMinLength(6)
+    .WithMaxLength(42)
+    .WithRequired(true)
+    .WithPlaceholder("Consider this place held.");
 ```
 
 ![more advanced text input](images/image9.png)

--- a/docs/guides/int_framework/samples/intro/context.cs
+++ b/docs/guides/int_framework/samples/intro/context.cs
@@ -1,7 +1,7 @@
 discordClient.ButtonExecuted += async (interaction) => 
 {
     var ctx = new SocketInteractionContext<SocketMessageComponent>(discordClient, interaction);
-    await _interactionService.ExecuteAsync(ctx, serviceProvider);
+    await _interactionService.ExecuteCommandAsync(ctx, serviceProvider);
 };
 
 public class MessageComponentModule : InteractionModuleBase<SocketInteractionContext<SocketMessageComponent>>


### PR DESCRIPTION
In the section **Text Input Components** there was an typo. The example code had an extra `;` where there shouldn't have been one.

The code that had the typo:

```cs
var tb = new TextInputBuilder()
    .WithLabel("Labeled")
    .WithCustomId("text_input")
    .WithStyle(TextInputStyle.Paragraph)
    .WithMinLength(6); // This ";" does not belong here.
    .WithMaxLength(42)
    .WithRequired(true)
    .WithPlaceholder("Consider this place held.");
```

Edit: I'll commit more typo's from the documentation if there are any