### PR TITLE
Fix context menu comand message type

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -134,7 +134,8 @@ namespace Discord.WebSocket
             if (model.Type == MessageType.Default ||
                 model.Type == MessageType.Reply ||
                 model.Type == MessageType.ApplicationCommand ||
-                model.Type == MessageType.ThreadStarterMessage)
+                model.Type == MessageType.ThreadStarterMessage ||
+                model.Type == MessageType.ContextMenuCommand)
                 return SocketUserMessage.Create(discord, state, author, channel, model);
             else
                 return SocketSystemMessage.Create(discord, state, author, channel, model);


### PR DESCRIPTION
This PR fixes a bug that causes context menu command messages to be created with the wrong message type (`SocketSystemMessage`). This caused some issues like empty properties.