### PR TITLE
Fix error with flag params.

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/UploadFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadFileParams.cs
@@ -51,7 +51,7 @@ namespace Discord.API.Rest
             if (Stickers.IsSpecified)
                 payload["sticker_ids"] = Stickers.Value;
             if (Flags.IsSpecified)
-                payload["flags"] = Flags;
+                payload["flags"] = Flags.Value;
 
             List<object> attachments = new();
 


### PR DESCRIPTION
Changed `payload["flags"] = Flags.Value;` to fix #2163.

Tested with the following cases:
1:
```
await message.Channel.SendFileAsync("Video.mp4", flags: MessageFlags.SuppressEmbeds);
```
2:
```
await message.Channel.SendFileAsync("Video.mp4");
```