### PR TITLE
Fix: sharded client logout throws

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -178,7 +178,6 @@ namespace Discord.WebSocket
                     await _shards[i].LogoutAsync();
             }
 
-            CurrentUser = null;
             if (_automaticShards)
             {
                 _shardIds = new int[0];


### PR DESCRIPTION
## Summary
This PR fixes the attempt to set the shared clients `CurrentUser` property, the property doesn't implement a setter so this throws an exception.