### PR TITLE
Feature: attachment description and content type

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
@@ -7,13 +7,29 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
+    /// <summary>
+    ///     Represents an outgoing file attachment used to send a file to discord.
+    /// </summary>
     public struct FileAttachment : IDisposable
     {
+        /// <summary>
+        ///     Gets or sets the filename.
+        /// </summary>
         public string FileName { get; set; }
+        /// <summary>
+        ///     Gets or sets the description of the file.
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        ///     Gets or sets whether this file should be marked as a spoiler.
+        /// </summary>
         public bool IsSpoiler { get; set; }
 
 #pragma warning disable IDISP008
+        /// <summary>
+        ///     Gets the stream containing the file content.
+        /// </summary>
         public Stream Stream { get; }
 #pragma warning restore IDISP008 
 

--- a/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
@@ -62,5 +62,13 @@ namespace Discord
         ///     <see langword="true"/> if the attachment is ephemeral; otherwise <see langword="false"/>.
         /// </returns>
         bool Ephemeral { get; }
+        /// <summary>
+        ///     Gets the description of the attachment; or <see langword="null"/> if there is none set.
+        /// </summary>
+        string Description { get; }
+        /// <summary>
+        ///     Gets the media's <see href="https://en.wikipedia.org/wiki/Media_type">MIME type</see> if present; otherwise <see langword="null"/>.
+        /// </summary>
+        string ContentType { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Messages/Attachment.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/Attachment.cs
@@ -23,8 +23,13 @@ namespace Discord
         public int? Width { get; }
         /// <inheritdoc />
         public bool Ephemeral { get; }
+        /// <inheritdoc />
+        public string Description { get; }
+        /// <inheritdoc />
+        public string ContentType { get; }
 
-        internal Attachment(ulong id, string filename, string url, string proxyUrl, int size, int? height, int? width, bool? ephemeral)
+        internal Attachment(ulong id, string filename, string url, string proxyUrl, int size, int? height, int? width,
+            bool? ephemeral, string description, string contentType)
         {
             Id = id;
             Filename = filename;
@@ -34,13 +39,16 @@ namespace Discord
             Height = height;
             Width = width;
             Ephemeral = ephemeral.GetValueOrDefault(false);
+            Description = description;
+            ContentType = contentType;
         }
         internal static Attachment Create(Model model)
         {
             return new Attachment(model.Id, model.Filename, model.Url, model.ProxyUrl, model.Size,
                 model.Height.IsSpecified ? model.Height.Value : (int?)null,
                 model.Width.IsSpecified ? model.Width.Value : (int?)null,
-                model.Ephemeral.ToNullable());
+                model.Ephemeral.ToNullable(), model.Description.GetValueOrDefault(),
+                model.ContentType.GetValueOrDefault());
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
This PR implements the `description` and `content_type` fields to the base `Attachment/IAttachment` models.

Closes #2177 
