### PR TITLE
fix: thread owner always null

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -147,6 +147,17 @@ namespace Discord.WebSocket
             return entity;
         }
 
+        internal static SocketThreadUser Create(SocketGuild guild, SocketThreadChannel thread, SocketGuildUser owner)
+        {
+            // this is used for creating the owner of the thread.
+            var entity = new SocketThreadUser(guild, thread, owner, owner.Id);
+            entity.Update(new Model
+            {
+                JoinTimestamp = thread.CreatedAt,
+            });
+            return entity;
+        }
+
         internal void Update(Model model)
         {
             ThreadJoinedAt = model.JoinTimestamp;


### PR DESCRIPTION
## Summary
This PR fixes the `SocketThreadChannel.Owner` always being null.

Closes #2143