### PR TITLE
Add missing methods to IComponentInteraction

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/IComponentInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/IComponentInteraction.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading.Tasks;
+
 namespace Discord
 {
     /// <summary>
@@ -6,7 +9,7 @@ namespace Discord
     public interface IComponentInteraction : IDiscordInteraction
     {
         /// <summary>
-        ///     Gets the data received with this interaction, contains the button that was clicked.
+        ///     Gets the data received with this component interaction.
         /// </summary>
         new IComponentInteractionData Data { get; }
 
@@ -14,5 +17,21 @@ namespace Discord
         ///     Gets the message that contained the trigger for this interaction.
         /// </summary>
         IUserMessage Message { get; }
+
+        /// <summary>
+        ///     Updates the message which this component resides in with the type <see cref="InteractionResponseType.UpdateMessage"/>
+        /// </summary>
+        /// <param name="func">A delegate containing the properties to modify the message with.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>A task that represents the asynchronous operation of updating the message.</returns>
+        Task UpdateAsync(Action<MessageProperties> func, RequestOptions options = null);
+
+        /// <summary>
+        ///     Defers an interaction with the response type 5 (<see cref="InteractionResponseType.DeferredChannelMessageWithSource"/>).
+        /// </summary>
+        /// <param name="ephemeral"><see langword="true"/> to defer ephemerally, otherwise <see langword="false"/>.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>A task that represents the asynchronous operation of acknowledging the interaction.</returns>
+        Task DeferLoadingAsync(bool ephemeral = false, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
@@ -492,5 +492,13 @@ namespace Discord.Rest
 
         /// <inheritdoc/>
         IUserMessage IComponentInteraction.Message => Message;
+
+        /// <inheritdoc />
+        Task IComponentInteraction.UpdateAsync(Action<MessageProperties> func, RequestOptions options)
+            => Task.FromResult(Update(func, options));
+
+        /// <inheritdoc />
+        Task IComponentInteraction.DeferLoadingAsync(bool ephemeral, RequestOptions options)
+            => Task.FromResult(DeferLoading(ephemeral, options));
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
@@ -202,12 +202,7 @@ namespace Discord.WebSocket
             HasResponded = true;
         }
 
-        /// <summary>
-        ///     Updates the message which this component resides in with the type <see cref="InteractionResponseType.UpdateMessage"/>
-        /// </summary>
-        /// <param name="func">A delegate containing the properties to modify the message with.</param>
-        /// <param name="options">The request options for this <see langword="async"/> request.</param>
-        /// <returns>A task that represents the asynchronous operation of updating the message.</returns>
+        /// <inheritdoc/>
         public async Task UpdateAsync(Action<MessageProperties> func, RequestOptions options = null)
         {
             var args = new MessageProperties();
@@ -383,14 +378,7 @@ namespace Discord.WebSocket
             return await InteractionHelper.SendFollowupAsync(Discord, args, Token, Channel, options).ConfigureAwait(false);
         }
 
-        /// <summary>
-        ///     Defers an interaction and responds with type 5 (<see cref="InteractionResponseType.DeferredChannelMessageWithSource"/>)
-        /// </summary>
-        /// <param name="ephemeral"><see langword="true"/> to send this message ephemerally, otherwise <see langword="false"/>.</param>
-        /// <param name="options">The request options for this <see langword="async"/> request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous operation of acknowledging the interaction.
-        /// </returns>
+        /// <inheritdoc/>
         public async Task DeferLoadingAsync(bool ephemeral = false, RequestOptions options = null)
         {
             if (!InteractionHelper.CanSendResponse(this))


### PR DESCRIPTION
This PR add 2 methods that are missing in `IComponentInteraction`. The lack of these methods makes it hard to properly unit test and mock component interactions.

Note: The code from the [similar PR from Labs](https://github.com/Discord-Net-Labs/Discord.Net-Labs/pull/410) is already present in this PR.