### PR TITLE
Fix Serilog Level Mapping

### DIFF
--- a/docs/guides/other_libs/samples/ModifyLogMethod.cs
+++ b/docs/guides/other_libs/samples/ModifyLogMethod.cs
@@ -6,8 +6,8 @@ private static async Task LogAsync(LogMessage message)
         LogSeverity.Error => LogEventLevel.Error,
         LogSeverity.Warning => LogEventLevel.Warning,
         LogSeverity.Info => LogEventLevel.Information,
-        LogSeverity.Verbose => LogEventLevel.Verbose,
-        LogSeverity.Debug => LogEventLevel.Debug,
+        LogSeverity.Verbose => LogEventLevel.Debug,
+        LogSeverity.Debug => LogEventLevel.Verbose,
         _ => LogEventLevel.Information
     };
     Log.Write(severity, message.Exception, "[{Source}] {Message}", message.Source, message.Message);


### PR DESCRIPTION
`LogEventLevel.Verbose` is actually more verbose than `LogEventLevel.Debug` in Serilog so the mapping is more correct this way, see also
https://github.com/serilog/serilog/blob/e1cdad57d96dc1d5eb2c1077a2d918965e82488d/src/Serilog/Events/LogEventLevel.cs#L22-L32