### PR TITLE
Proposal: Make bidirectional formatting optional

### DIFF
--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -189,8 +189,13 @@ namespace Discord
         public bool UseInteractionSnowflakeDate { get; set; } = true;
 
         /// <summary>
-        ///     Gets or sets if any user's <see cref="object.ToString"/> override formats the string in respect to bidirectional unicode.
+        ///     Gets or sets if the Rest/Socket user <see cref="object.ToString"/> override formats the string in respect to bidirectional unicode.
         /// </summary>
+        /// <remarks>
+        ///     By default, the returned value will be "?Discord?#1234", to work with bidirectional usernames.
+        ///     <br/>
+        ///     If set to <see langword="false"/>, this value will be "Discord#1234".
+        /// </remarks>
         public bool FormatUsersInBidirectionalUnicode { get; set; } = true;
     }
 }

--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -187,5 +187,10 @@ namespace Discord
         ///     <b>This will still require a stable clock on your system.</b>
         /// </remarks>
         public bool UseInteractionSnowflakeDate { get; set; } = true;
+
+        /// <summary>
+        ///     Gets or sets if any user's <see cref="object.ToString"/> override formats the string in respect to bidirectional unicode.
+        /// </summary>
+        public bool FormatUsersInBidirectionalUnicode { get; set; } = true;
     }
 }

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -107,13 +107,16 @@ namespace Discord
         }
 
         /// <summary>
-        ///     Formats a user's username + discriminator while maintaining bidirectional unicode
+        ///     Formats a user's username + discriminator.
         /// </summary>
+        /// <param name="doBidirectional">To format the string in bidirectional unicode or not</param>
         /// <param name="user">The user whos username and discriminator to format</param>
         /// <returns>The username + discriminator</returns>
-        public static string UsernameAndDiscriminator(IUser user)
+        public static string UsernameAndDiscriminator(IUser user, bool doBidirectional)
         {
-            return $"\u2066{user.Username}\u2069#{user.Discriminator}";
+            return doBidirectional
+                ? $"\u2066{user.Username}\u2069#{user.Discriminator}"
+                : $"{user.Username}#{user.Discriminator}";
         }
     }
 }

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -36,6 +36,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public TokenType TokenType => ApiClient.AuthTokenType;
         internal bool UseInteractionSnowflakeDate { get; private set; }
+        internal bool FormatUsersInBidirectionalUnicode { get; private set; }
 
         /// <summary> Creates a new REST-only Discord client. </summary>
         internal BaseDiscordClient(DiscordRestConfig config, API.DiscordRestApiClient client)
@@ -49,6 +50,7 @@ namespace Discord.Rest
             _isFirstLogin = config.DisplayInitialLog;
 
             UseInteractionSnowflakeDate = config.UseInteractionSnowflakeDate;
+            FormatUsersInBidirectionalUnicode = config.FormatUsersInBidirectionalUnicode;
 
             ApiClient.RequestQueue.RateLimitTriggered += async (id, info, endpoint) =>
             {

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -16,6 +16,8 @@ namespace Discord.Rest
     public class RestUser : RestEntity<ulong>, IUser, IUpdateable
     {
         #region RestUser
+        private readonly bool _useBidirectionalUnicode;
+
         /// <inheritdoc />
         public bool IsBot { get; private set; }
         /// <inheritdoc />
@@ -51,6 +53,7 @@ namespace Discord.Rest
         internal RestUser(BaseDiscordClient discord, ulong id)
             : base(discord, id)
         {
+            _useBidirectionalUnicode = discord.FormatUsersInBidirectionalUnicode;
         }
         internal static RestUser Create(BaseDiscordClient discord, Model model)
             => Create(discord, null, model, null);
@@ -129,8 +132,10 @@ namespace Discord.Rest
         /// <returns>
         ///     A string that resolves to Username#Discriminator of the user.
         /// </returns>
-        public override string ToString() => Format.UsernameAndDiscriminator(this);
-        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this)} ({Id}{(IsBot ? ", Bot" : "")})";
+        public override string ToString()
+            => Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode);
+
+        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode)} ({Id}{(IsBot ? ", Bot" : "")})";
         #endregion
 
         #region IUser

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -16,8 +16,6 @@ namespace Discord.Rest
     public class RestUser : RestEntity<ulong>, IUser, IUpdateable
     {
         #region RestUser
-        private readonly bool _useBidirectionalUnicode;
-
         /// <inheritdoc />
         public bool IsBot { get; private set; }
         /// <inheritdoc />
@@ -53,7 +51,6 @@ namespace Discord.Rest
         internal RestUser(BaseDiscordClient discord, ulong id)
             : base(discord, id)
         {
-            _useBidirectionalUnicode = discord.FormatUsersInBidirectionalUnicode;
         }
         internal static RestUser Create(BaseDiscordClient discord, Model model)
             => Create(discord, null, model, null);
@@ -133,9 +130,9 @@ namespace Discord.Rest
         ///     A string that resolves to Username#Discriminator of the user.
         /// </returns>
         public override string ToString()
-            => Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode);
+            => Format.UsernameAndDiscriminator(this, Discord.FormatUsersInBidirectionalUnicode);
 
-        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode)} ({Id}{(IsBot ? ", Bot" : "")})";
+        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this, Discord.FormatUsersInBidirectionalUnicode)} ({Id}{(IsBot ? ", Bot" : "")})";
         #endregion
 
         #region IUser

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -17,6 +17,7 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public abstract class SocketUser : SocketEntity<ulong>, IUser
     {
+        private readonly bool _useBidirectionalUnicode;
         /// <inheritdoc />
         public abstract bool IsBot { get; internal set; }
         /// <inheritdoc />
@@ -56,6 +57,7 @@ namespace Discord.WebSocket
         internal SocketUser(DiscordSocketClient discord, ulong id)
             : base(discord, id)
         {
+            _useBidirectionalUnicode = discord.FormatUsersInBidirectionalUnicode;
         }
         internal virtual bool Update(ClientState state, Model model)
         {
@@ -117,8 +119,8 @@ namespace Discord.WebSocket
         /// <returns>
         ///     The full name of the user.
         /// </returns>
-        public override string ToString() => Format.UsernameAndDiscriminator(this);
-        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this)} ({Id}{(IsBot ? ", Bot" : "")})";
+        public override string ToString() => Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode);
+        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode)} ({Id}{(IsBot ? ", Bot" : "")})";
         internal SocketUser Clone() => MemberwiseClone() as SocketUser;
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -17,7 +17,6 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public abstract class SocketUser : SocketEntity<ulong>, IUser
     {
-        private readonly bool _useBidirectionalUnicode;
         /// <inheritdoc />
         public abstract bool IsBot { get; internal set; }
         /// <inheritdoc />
@@ -57,7 +56,6 @@ namespace Discord.WebSocket
         internal SocketUser(DiscordSocketClient discord, ulong id)
             : base(discord, id)
         {
-            _useBidirectionalUnicode = discord.FormatUsersInBidirectionalUnicode;
         }
         internal virtual bool Update(ClientState state, Model model)
         {
@@ -119,8 +117,8 @@ namespace Discord.WebSocket
         /// <returns>
         ///     The full name of the user.
         /// </returns>
-        public override string ToString() => Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode);
-        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this, _useBidirectionalUnicode)} ({Id}{(IsBot ? ", Bot" : "")})";
+        public override string ToString() => Format.UsernameAndDiscriminator(this, Discord.FormatUsersInBidirectionalUnicode);
+        private string DebuggerDisplay => $"{Format.UsernameAndDiscriminator(this, Discord.FormatUsersInBidirectionalUnicode)} ({Id}{(IsBot ? ", Bot" : "")})";
         internal SocketUser Clone() => MemberwiseClone() as SocketUser;
     }
 }


### PR DESCRIPTION
This PR will attempt to not introduce a major change, while making it optional for users to have the user's `.ToString()` method formatted as `"?Rozen?#4334"` or `"Rozen#4334"`. By default the behavior will remain the same as it is right now.

This value will be configurable through `DiscordConfig.FormatUsersInBidirectionalUnicode`. If users may want old behavior, this can be set to false.