### PR TITLE
Fixed documentation typo

### DIFF
--- a/docs/guides/int_framework/samples/postexecution/error_review.cs
+++ b/docs/guides/int_framework/samples/postexecution/error_review.cs
@@ -16,7 +16,7 @@ async Task SlashCommandExecuted(SlashCommandInfo arg1, Discord.IInteractionConte
                 await arg2.Interaction.RespondAsync("Invalid number or arguments");
                 break;
             case InteractionCommandError.Exception:
-                await arg2.Interaction.RespondAsync("Command exception:{arg3.ErrorReason}");
+                await arg2.Interaction.RespondAsync($"Command exception: {arg3.ErrorReason}");
                 break;
             case InteractionCommandError.Unsuccessful:
                 await arg2.Interaction.RespondAsync("Command could not be executed");


### PR DESCRIPTION
`await arg2.Interaction.RespondAsync("Command exception: {arg3.ErrorReason}");` would never have showed the `ErrorReason` because a `$` was missing before the string.