### PR TITLE
Add marshal by ref to entities

### DIFF
--- a/src/Discord.Net.Rest/Entities/RestEntity.cs
+++ b/src/Discord.Net.Rest/Entities/RestEntity.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 
 namespace Discord.Rest
 {
-    public abstract class RestEntity<T> : IEntity<T>
+    public abstract class RestEntity<T> : MarshalByRefObject, IEntity<T>
         where T : IEquatable<T>
     {
         internal BaseDiscordClient Discord { get; }

--- a/src/Discord.Net.WebSocket/Entities/SocketEntity.cs
+++ b/src/Discord.Net.WebSocket/Entities/SocketEntity.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Discord.WebSocket
 {
-    public abstract class SocketEntity<T> : IEntity<T>
+    public abstract class SocketEntity<T> : MarshalByRefObject, IEntity<T>
         where T : IEquatable<T>
     {
         internal DiscordSocketClient Discord { get; }


### PR DESCRIPTION
## Summary
This PR implements `MarshalByRefObject` to both RestEntity and SocketEntity base classes.

Closes #570

### Things to note:
Marshal by ref (from what I understand) has been replaced with [WCF](https://docs.microsoft.com/en-us/dotnet/framework/wcf/whats-wcf?redirectedfrom=MSDN) ([see this stack overflow post](https://stackoverflow.com/questions/4295894/what-is-the-major-use-of-marshalbyrefobject)), is this still useful within Discord.Net?