### PR TITLE
Fix SocketGuild not returning the AudioClient

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1781,7 +1781,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         ulong? IGuild.AFKChannelId => AFKChannelId;
         /// <inheritdoc />
-        IAudioClient IGuild.AudioClient => null;
+        IAudioClient IGuild.AudioClient => AudioClient;
         /// <inheritdoc />
         bool IGuild.Available => true;
         /// <inheritdoc />


### PR DESCRIPTION
This PR fixes an issue where the SocketGuild always returns null for IGuild.AudioClient.