### PR TITLE
Fix log severity mapping for guide sample

### DIFF
--- a/docs/guides/other_libs/samples/ModifyLogMethod.cs
+++ b/docs/guides/other_libs/samples/ModifyLogMethod.cs
@@ -6,8 +6,8 @@ private static async Task LogAsync(LogMessage message)
         LogSeverity.Error => LogEventLevel.Error,
         LogSeverity.Warning => LogEventLevel.Warning,
         LogSeverity.Info => LogEventLevel.Information,
-        LogSeverity.Verbose => LogEventLevel.Debug,
-        LogSeverity.Debug => LogEventLevel.Verbose,
+        LogSeverity.Verbose => LogEventLevel.Verbose,
+        LogSeverity.Debug => LogEventLevel.Debug,
         _ => LogEventLevel.Information
     };
     Log.Write(severity, message.Exception, "[{Source}] {Message}", message.Source, message.Message);


### PR DESCRIPTION
The mapping for the SeriLog example was incorrect.  :)