### PR TITLE
Fix browser field in identify connection properties

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -274,7 +274,7 @@ namespace Discord.API
             {
                 ["$device"] = "Discord.Net",
                 ["$os"] = Environment.OSVersion.Platform.ToString(),
-                [$"browser"] = "Discord.Net"
+                ["$browser"] = "Discord.Net"
             };
             var msg = new IdentifyParams()
             {


### PR DESCRIPTION
According to the [Discord Documentation](https://discord.com/developers/docs/topics/gateway#identify-identify-connection-properties) the Identify Connection Properties is expecting a `$browser` field, Discord.Net is instead sending `browser` as the `$` is position in a way that makes it an interpolated string rather than part of the string.