### PR TITLE
Guarding against empty descriptions in `SlashCommandBuilder`/`SlashCommandOptionBuilder`

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -166,8 +166,11 @@ namespace Discord
         {
             // Make sure the name matches the requirements from discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
+            Preconditions.NotNullOrEmpty(description, nameof(description));
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, MaxNameLength, nameof(name));
+            Preconditions.AtLeast(description.Length, 1, nameof(description));
+            Preconditions.AtMost(description.Length, MaxDescriptionLength, nameof(description));
 
             // Discord updated the docs, this regex prevents special characters like @!$%( and s p a c e s.. etc,
             // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
@@ -402,8 +405,11 @@ namespace Discord
         {
             // Make sure the name matches the requirements from discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
+            Preconditions.NotNullOrEmpty(description, nameof(description));
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, SlashCommandBuilder.MaxNameLength, nameof(name));
+            Preconditions.AtLeast(description.Length, 1, nameof(description));
+            Preconditions.AtMost(description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(description));
 
             // Discord updated the docs, this regex prevents special characters like @!$%( and s p a c e s.. etc,
             // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -164,23 +164,12 @@ namespace Discord
            string description, bool? isRequired = null, bool? isDefault = null, bool isAutocomplete = false, double? minValue = null, double? maxValue = null,
            List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
-            // Make sure the name matches the requirements from discord
-            Preconditions.NotNullOrEmpty(name, nameof(name));
-            Preconditions.NotNullOrEmpty(description, nameof(description));
-            Preconditions.AtLeast(name.Length, 1, nameof(name));
-            Preconditions.AtMost(name.Length, MaxNameLength, nameof(name));
-            Preconditions.AtLeast(description.Length, 1, nameof(description));
-            Preconditions.AtMost(description.Length, MaxDescriptionLength, nameof(description));
+            Preconditions.Options(name, description);
 
             // Discord updated the docs, this regex prevents special characters like @!$%( and s p a c e s.. etc,
             // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
             if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
                 throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(name));
-
-            // same with description
-            Preconditions.NotNullOrEmpty(description, nameof(description));
-            Preconditions.AtLeast(description.Length, 1, nameof(description));
-            Preconditions.AtMost(description.Length, MaxDescriptionLength, nameof(description));
 
             // make sure theres only one option with default set to true
             if (isDefault == true && Options?.Any(x => x.IsDefault == true) == true)
@@ -217,6 +206,7 @@ namespace Discord
                 throw new InvalidOperationException($"Cannot have more than {MaxOptionsCount} options!");
 
             Preconditions.NotNull(option, nameof(option));
+            Preconditions.Options(option.Name, option.Description); // this is a double-check when this method is called via AddOption(string name... )
 
             Options.Add(option);
             return this;
@@ -238,6 +228,9 @@ namespace Discord
 
             if (Options.Count + options.Length > MaxOptionsCount)
                 throw new ArgumentOutOfRangeException(nameof(options), $"Cannot have more than {MaxOptionsCount} options!");
+
+            foreach (var option in options)
+                Preconditions.Options(option.Name, option.Description);
 
             Options.AddRange(options);
             return this;
@@ -382,7 +375,7 @@ namespace Discord
                 MinValue = MinValue,
                 MaxValue = MaxValue
             };
-        }
+        }        
 
         /// <summary>
         ///     Adds an option to the current slash command.
@@ -403,23 +396,12 @@ namespace Discord
            string description, bool? isRequired = null, bool isDefault = false, bool isAutocomplete = false, double? minValue = null, double? maxValue = null,
            List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
-            // Make sure the name matches the requirements from discord
-            Preconditions.NotNullOrEmpty(name, nameof(name));
-            Preconditions.NotNullOrEmpty(description, nameof(description));
-            Preconditions.AtLeast(name.Length, 1, nameof(name));
-            Preconditions.AtMost(name.Length, SlashCommandBuilder.MaxNameLength, nameof(name));
-            Preconditions.AtLeast(description.Length, 1, nameof(description));
-            Preconditions.AtMost(description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(description));
+            Preconditions.Options(name, description);
 
             // Discord updated the docs, this regex prevents special characters like @!$%( and s p a c e s.. etc,
             // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
             if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
                 throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(name));
-
-            // same with description
-            Preconditions.NotNullOrEmpty(description, nameof(description));
-            Preconditions.AtLeast(description.Length, 1, nameof(description));
-            Preconditions.AtMost(description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(description));
 
             // make sure theres only one option with default set to true
             if (isDefault && Options?.Any(x => x.IsDefault == true) == true)
@@ -455,6 +437,7 @@ namespace Discord
                 throw new InvalidOperationException($"There can only be {SlashCommandBuilder.MaxOptionsCount} options per sub command group!");
 
             Preconditions.NotNull(option, nameof(option));
+            Preconditions.Options(option.Name, option.Description); // double check again
 
             Options.Add(option);
             return this;

--- a/src/Discord.Net.Core/Utils/Preconditions.cs
+++ b/src/Discord.Net.Core/Utils/Preconditions.cs
@@ -297,5 +297,20 @@ namespace Discord
             }
         }
         #endregion
+
+        #region SlashCommandOptions
+
+        public static void Options(string name, string description)
+        {
+            // Make sure the name matches the requirements from discord
+            NotNullOrEmpty(name, nameof(name));
+            NotNullOrEmpty(description, nameof(description));
+            AtLeast(name.Length, 1, nameof(name));
+            AtMost(name.Length, SlashCommandBuilder.MaxNameLength, nameof(name));
+            AtLeast(description.Length, 1, nameof(description));
+            AtMost(description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(description));
+        }
+
+        #endregion
     }
 }

--- a/src/Discord.Net.Core/Utils/Preconditions.cs
+++ b/src/Discord.Net.Core/Utils/Preconditions.cs
@@ -300,6 +300,8 @@ namespace Discord
 
         #region SlashCommandOptions
 
+        /// <exception cref="ArgumentNullException"><paramref name="description"/> or <paramref name="name"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="description"/> or <paramref name="name"/> are either empty or their length exceed limits.</exception>
         public static void Options(string name, string description)
         {
             // Make sure the name matches the requirements from discord


### PR DESCRIPTION
When using `SlashCommandBuilder.AddOption(string name, ApplicationCommandOptionType type, ...)`, empty `description`s are guarded against. This is not implemented when using `SlashCommandBuilder.AddOption(SlashCommandOptionBuilder option)` as well as `AddOptions(params SlashCommandOptionBuilder[] options)`. (The same goes for Instance-Methods of `SlashCommandOptionBuilder`).

This way, a `Discord.Net.HttpException` is thrown on adding a faulty command, which is kinda undescriptive:
<details>
<summary>Stacktrace</summary>

```
Discord.Net.HttpException: The server responded with error 50035: Invalid Form Body
Inner Errors:
BASE_TYPE_REQUIRED: This field is required
   at Discord.Net.Queue.RequestBucket.SendAsync(RestRequest request)
   at Discord.Net.Queue.RequestQueue.SendAsync(RestRequest request)
   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, Strin   at Discord.   at Discord.   at Discord.   at Discord.API.DiscordRes   at Discord.API.DiscordRes   at Discord.API.DiscordRestApiClient.SendInternalAsync   at Discord.API.DiscordRes   at Discord.API.DiscordRes   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method   at Discord.API.DiscordRestApiClient.Sen   at Discord.API.DiscordRes   at Discord.API.DiscordRes   at Discord.API.DiscordRestApiClient.SendInternalAsync   at Discord.API.DiscordRes   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, String endpo   at Discord.API.DiscordRestApiClient.SendInternalAsync   at Discord.   at Discord.API.DiscordRestApiClient.Sen   at Discord.API.DiscordRestApiClient.Sen   at Discord.   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method   at Discord.   at Discord.   at Discord.   at Discord.   at Discord.   at Discord.   at D   at Discord.API.DiscordRestApiClient.SendInternalAsync(String method, String endpoint, RestRequest request)
   at Discord.API.DiscordRestApiClient.SendJsonAsync[TResponse](String method, String endpoint, Object payload, BucketId bucketId, ClientBucketType clientBucket, RequestOptions options)
   at Discord.API.DiscordRestApiClient.BulkOverwriteGlobalApplicationCommandsAsync(CreateApplicationCommandParams[] commands, RequestOptions options)
   at Discord.Rest.InteractionHelper.BulkOverwriteGlobalCommandsAsync(BaseDiscordClient client, ApplicationCommandProperties[] args, RequestOptions options)
   at Discord.WebSocket.DiscordSocketClient.BulkOverwriteGlobalApplicationCommandsAsync(ApplicationCommandProperties[] properties, RequestOptions options)   at DAB.Discord.Commands.SlashCommandFactory.OverwriteCommandsAsync(DiscordSocketClient client) in C:\Users\chris\source\repos\DAB\DAB\Discord\Commands\SlashCommandFactory.cs:line 18
   at DAB.Discord.DiscordAnnouncementService.OnClientReadyAsync() in C:\Users\chris\source\repos\DAB\DAB\Discord\DiscordAnnouncementService.cs:line 89
```
</details>
<details>

<summary>Code to reproduce</summary>

```csharp
var cmd = new SlashCommandBuilder().WithName(nameof(SlashCommandType.chime))
                                        .WithDescription("modify your chime")
                                        .AddOptions(new SlashCommandOptionBuilder().WithName("clear")
                                                                                   //.WithDescription("clear your chime") // uncommenting this fixes that issue.
                                                                                   .WithType(ApplicationCommandOptionType.SubCommand),
                                                    new SlashCommandOptionBuilder().WithName("set")
                                                                                   .WithDescription("set your chime")
                                                                                   .WithType(ApplicationCommandOptionType.SubCommandGroup)
                                                                                   .AddOption(new SlashCommandOptionBuilder().WithName("url")
                                                                                                                             .WithDescription("set your chime with an url")
                                                                                                                             .WithType(ApplicationCommandOptionType.SubCommand)
                                                                                                                             .AddOption(new SlashCommandOptionBuilder().WithName("link")
                                                                                                                                                                       .WithDescription("link to audio-file")
                                                                                                                                                                       .WithType(ApplicationCommandOptionType.String)
                                                                                                                                                                       .WithRequired(true)))
                                                                                   .AddOption(new SlashCommandOptionBuilder().WithName("file")
                                                                                                                             .WithDescription("set your chime with a file")
                                                                                                                             .WithType(ApplicationCommandOptionType.SubCommand)
                                                                                                                             .AddOption(new SlashCommandOptionBuilder().WithName("attachment")
                                                                                                                                                                       .WithDescription("file with audio")
                                                                                                                                                                       .WithType(ApplicationCommandOptionType.Attachment)
                                                                                                                                                                       .WithRequired(true))))
                                        .Build();

discordSocketClient.BulkOverwriteGlobalApplicationCommandsAsync(cmd);
```

</details>

I suggest always guarding against empty `name` and `description`, and moving that Precondition to `Preconditions.cs`; Since the `HttpException` does not really tell anything by saying `BASE_TYPE_REQUIRED`.

This is possibly a breaking change since (the creation, not the application of) Options without `description` set will cause Exceptions to be thrown.

