### PR TITLE
[Doc] Fix TextCommands reference in first-bot.md

### DIFF
--- a/docs/guides/getting_started/first-bot.md
+++ b/docs/guides/getting_started/first-bot.md
@@ -202,7 +202,7 @@ online in Discord.
 
 To create commands for your bot, you may choose from a variety of
 command processors available. Throughout the guides, we will be using
-the one that Discord.Net ships with. @Guides.Commands.Intro will
+the one that Discord.Net ships with. @Guides.TextCommands.Intro will
 guide you through how to setup a program that is ready for
 [CommandService].
 


### PR DESCRIPTION
The doc `first-bot.md` is referencing another doc whose uid seems have been changed from `Guides.Commands.Intro` into `Guides.TextCommands.Intro`.
> https://discordnet.dev/guides/getting_started/first-bot.html#:~:text=%40Guides.Commands.Intro