### PR TITLE
Treat warnings as errors and set warning level to 5

### DIFF
--- a/src/Discord.Net.Commands/Discord.Net.Commands.csproj
+++ b/src/Discord.Net.Commands/Discord.Net.Commands.csproj
@@ -7,6 +7,8 @@
     <Description>A Discord.Net extension adding support for bot commands.</Description>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net5.0;net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <WarningLevel>5</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Commands/Results/MatchResult.cs
+++ b/src/Discord.Net.Commands/Results/MatchResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Discord.Commands
 {
@@ -12,7 +12,7 @@ namespace Discord.Commands
         /// <summary>
         ///     Gets on which pipeline stage the command may have matched or failed.
         /// </summary>
-        public IResult? Pipeline { get; }
+        public IResult Pipeline { get; }
 
         /// <inheritdoc />
         public CommandError? Error { get; }
@@ -21,7 +21,7 @@ namespace Discord.Commands
         /// <inheritdoc />
         public bool IsSuccess => !Error.HasValue;
 
-        private MatchResult(CommandMatch? match, IResult? pipeline, CommandError? error, string errorReason)
+        private MatchResult(CommandMatch? match, IResult pipeline, CommandError? error, string errorReason)
         {
             Match = match;
             Error = error;

--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -7,6 +7,8 @@
     <Description>The core components for the Discord.Net library.</Description>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net5.0;net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <WarningLevel>5</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -1173,7 +1173,6 @@ namespace Discord
         ///     in order to use this property.
         ///     </remarks>
         /// </param>
-        /// <param name="speakers">A collection of speakers for the event.</param>
         /// <param name="location">The location of the event; links are supported</param>
         /// <param name="coverImage">The optional banner image for the event.</param>
         /// <param name="options">The options to be used when sending the request.</param>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuildScheduledEvent.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildScheduledEvent.cs
@@ -89,7 +89,7 @@ namespace Discord
         ///     Gets this events banner image url.
         /// </summary>
         /// <param name="format">The format to return.</param>
-        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>The cover images url.</returns>
         string GetCoverImageUrl(ImageFormat format = ImageFormat.Auto, ushort size = 1024);
 

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionType.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionType.cs
@@ -56,7 +56,7 @@ namespace Discord
         Number = 10,
 
         /// <summary>
-        ///     A <see cref="Discord.Attachment"/>.
+        ///     A <see cref="IAttachment"/>.
         /// </summary>
         Attachment = 11
     }

--- a/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
@@ -55,7 +55,7 @@ namespace Discord
         string UserLocale { get; }
 
         /// <summary>
-        ///     Gets the preferred locale of the guild this interaction was executed in. <see cref="null"/> if not executed in a guild.
+        ///     Gets the preferred locale of the guild this interaction was executed in. <see langword="null"/> if not executed in a guild.
         /// </summary>
         /// <remarks>
         ///     Non-community guilds (With no locale setting available) will have en-US as the default value sent by Discord.

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -1194,9 +1194,9 @@ namespace Discord
         /// <summary>
         ///     Gets or sets the default value of the text input.
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="Value.Length"/> is less than 0.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><see cref="Value"/>.Length is less than 0.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <see cref="Value.Length"/> is greater than <see cref="LargestMaxLength"/> or <see cref="MaxLength"/>.
+        ///     <see cref="Value"/>.Length is greater than <see cref="LargestMaxLength"/> or <see cref="MaxLength"/>.
         /// </exception>
         public string Value
         {
@@ -1306,18 +1306,18 @@ namespace Discord
         /// <summary>
         ///     Sets the minimum length of the current builder.
         /// </summary>
-        /// <param name="placeholder">The value to set.</param>
+        /// <param name="minLength">The value to set.</param>
         /// <returns>The current builder. </returns>
         public TextInputBuilder WithMinLength(int minLength)
         {
             MinLength = minLength;
             return this;
         }
-        
+
         /// <summary>
         ///     Sets the maximum length of the current builder.
         /// </summary>
-        /// <param name="placeholder">The value to set.</param>
+        /// <param name="maxLength">The value to set.</param>
         /// <returns>The current builder. </returns>
         public TextInputBuilder WithMaxLength(int maxLength)
         {

--- a/src/Discord.Net.Core/Entities/Interactions/Modals/ModalBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Modals/ModalBuilder.cs
@@ -64,18 +64,18 @@ namespace Discord
         /// <summary>
         ///     Sets the custom id of the current modal.
         /// </summary>
-        /// <param name="title">The value to set the custom id to.</param>
+        /// <param name="customId">The value to set the custom id to.</param>
         /// <returns>The current builder.</returns>
         public ModalBuilder WithCustomId(string customId)
         {
             CustomId = customId;
             return this;
         }
-        
+
         /// <summary>
         ///     Adds a component to the current builder.
         /// </summary>
-        /// <param name="title">The component to add.</param>
+        /// <param name="component">The component to add.</param>
         /// <returns>The current builder.</returns>
         public ModalBuilder AddTextInput(TextInputBuilder component)
         {
@@ -213,7 +213,7 @@ namespace Discord
         ///     Adds a <see cref="TextInputBuilder"/> to the <see cref="ModalComponentBuilder"/> at the specific row.
         ///     If the row cannot accept the component then it will add it to a row that can.
         /// </summary>
-        /// <param name="text">The <see cref="TextInputBuilder"> to add.</param>
+        /// <param name="text">The <see cref="TextInputBuilder"/> to add.</param>
         /// <param name="row">The row to add the text input.</param>
         /// <exception cref="InvalidOperationException">There are no more rows to add a text input to.</exception>
         /// <exception cref="ArgumentException"><paramref name="row"/> must be less than <see cref="MaxActionRowCount"/>.</exception>

--- a/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
@@ -79,7 +79,7 @@ namespace Discord
         ///     Sets a timestamp how long a user should be timed out for.
         /// </summary>
         /// <remarks>
-        ///     <see cref="null"/> or a time in the past to clear a currently existing timeout.
+        ///     <see langword="null"/> or a time in the past to clear a currently existing timeout.
         /// </remarks>
         public Optional<DateTimeOffset?> TimedOutUntil { get; set; }
     }

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -104,7 +104,7 @@ namespace Discord
         ///     Gets the date and time that indicates if and for how long a user has been timed out.
         /// </summary>
         /// <remarks>
-        ///     <see cref="null"/> or a timestamp in the past if the user is not timed out.
+        ///     <see langword="null"/> or a timestamp in the past if the user is not timed out.
         /// </remarks>
         /// <returns>
         ///     A <see cref="DateTimeOffset"/> indicating how long the user will be timed out for.
@@ -116,7 +116,7 @@ namespace Discord
         /// </summary>
         /// <example>
         ///     <para>The following example checks if the current user has the ability to send a message with attachment in
-        ///     this channel; if so, uploads a file via <see cref="IMessageChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions, MessageReference)"/>.</para>
+        ///     this channel; if so, uploads a file via <see cref="IMessageChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions, MessageReference, MessageComponent, ISticker[], Embed[], MessageFlags)"/>.</para>
         /// <code language="cs">
         ///     if (currentUser?.GetPermissions(targetChannel)?.AttachFiles)
         ///         await targetChannel.SendFileAsync("fortnite.png");
@@ -151,7 +151,7 @@ namespace Discord
         ///     If the user does not have a guild avatar, this will be the user's regular avatar.
         /// </remarks>
         /// <param name="format">The format to return.</param>
-        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.
+        /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <returns>
         ///     A string representing the URL of the displayed avatar for this user. <see langword="null"/> if the user does not have an avatar in place.
         /// </returns>

--- a/src/Discord.Net.Core/Utils/UrlValidation.cs
+++ b/src/Discord.Net.Core/Utils/UrlValidation.cs
@@ -23,7 +23,7 @@ namespace Discord.Utils
 
         /// <summary>
         ///     Not full URL validation right now. Just Ensures the protocol is either http, https, or discord
-        /// <see cref="Validate(string)"/> should be used everything other than url buttons.
+        /// <see cref="Validate(string, bool)"/> should be used everything other than url buttons.
         /// </summary>
         /// <param name="url">The URL to validate before sending to discord.</param>
         /// <exception cref="InvalidOperationException">A URL must include a protocol (either http, https, or discord).</exception>

--- a/src/Discord.Net.Interactions/Attributes/AutocompleteAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/AutocompleteAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Discord.Interactions
 {
     /// <summary>
-    ///     Set the <see cref="ApplicationCommandOptionProperties.Autocomplete"/> to <see langword="true"/>.
+    ///     Set the <see cref="ApplicationCommandOptionProperties.IsAutocomplete"/> to <see langword="true"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
     public class AutocompleteAttribute : Attribute
@@ -14,7 +14,7 @@ namespace Discord.Interactions
         public Type AutocompleteHandlerType { get; }
 
         /// <summary>
-        ///     Set the <see cref="ApplicationCommandOptionProperties.Autocomplete"/> to <see langword="true"/> and define a <see cref="AutocompleteHandler"/> to handle
+        ///     Set the <see cref="ApplicationCommandOptionProperties.IsAutocomplete"/> to <see langword="true"/> and define a <see cref="AutocompleteHandler"/> to handle
         ///     Autocomplete interactions targeting the parameter this <see cref="Attribute"/> is applied to.
         /// </summary>
         /// <remarks>
@@ -29,7 +29,7 @@ namespace Discord.Interactions
         }
 
         /// <summary>
-        ///     Set the <see cref="ApplicationCommandOptionProperties.Autocomplete"/> to <see langword="true"/> without specifying a <see cref="AutocompleteHandler"/>.
+        ///     Set the <see cref="ApplicationCommandOptionProperties.IsAutocomplete"/> to <see langword="true"/> without specifying a <see cref="AutocompleteHandler"/>.
         /// </summary>
         public AutocompleteAttribute() { }
     }

--- a/src/Discord.Net.Interactions/Attributes/Modals/ModalInputAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/Modals/ModalInputAttribute.cs
@@ -21,9 +21,7 @@ namespace Discord.Interactions
         /// <summary>
         ///     Create a new <see cref="ModalInputAttribute"/>.
         /// </summary>
-        /// <param name="label">The label of the input.</param>
         /// <param name="customId">The custom id of the input.</param>
-        /// <param name="required">Whether the user is required to input a value.></param>
         protected ModalInputAttribute(string customId)
         {
             CustomId = customId;

--- a/src/Discord.Net.Interactions/Attributes/Modals/ModalTextInputAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/Modals/ModalTextInputAttribute.cs
@@ -36,7 +36,7 @@ namespace Discord.Interactions
         /// <summary>
         ///     Create a new <see cref="ModalTextInputAttribute"/>.
         /// </summary>
-        /// <param name="customId"The custom id of the text input.></param>
+        /// <param name="customId">The custom id of the text input.></param>
         /// <param name="style">The style of the text input.</param>
         /// <param name="placeholder">The placeholder of the text input.</param>
         /// <param name="minLength">The minimum length of the text input's content.</param>

--- a/src/Discord.Net.Interactions/Attributes/Preconditions/RequireUserPermissionAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/Preconditions/RequireUserPermissionAttribute.cs
@@ -29,7 +29,7 @@ namespace Discord.Interactions
         /// <remarks>
         ///     This precondition will always fail if the command is being invoked in a <see cref="IPrivateChannel"/>.
         /// </remarks>
-        /// <param name="permission">
+        /// <param name="guildPermission">
         ///     The <see cref="Discord.GuildPermission" /> that the user must have. Multiple permissions can be
         ///     specified by ORing the permissions together.
         /// </param>
@@ -41,7 +41,7 @@ namespace Discord.Interactions
         /// <summary>
         ///     Requires that the user invoking the command to have a specific <see cref="Discord.ChannelPermission"/>.
         /// </summary>
-        /// <param name="permission">
+        /// <param name="channelPermission">
         ///     The <see cref="Discord.ChannelPermission"/> that the user must have. Multiple permissions can be
         ///     specified by ORing the permissions together.
         /// </param>

--- a/src/Discord.Net.Interactions/Builders/Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Commands/SlashCommandBuilder.cs
@@ -56,7 +56,7 @@ namespace Discord.Interactions.Builders
         /// <summary>
         ///     Sets <see cref="DefaultPermission"/>.
         /// </summary>
-        /// <param name="defaultPermision">New value of the <see cref="DefaultPermission"/>.</param>
+        /// <param name="permission">New value of the <see cref="DefaultPermission"/>.</param>
         /// <returns>
         ///     The builder instance.
         /// </returns>

--- a/src/Discord.Net.Interactions/Builders/Modals/Inputs/TextInputComponentBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Modals/Inputs/TextInputComponentBuilder.cs
@@ -41,7 +41,7 @@ namespace Discord.Interactions.Builders
         /// <summary>
         ///     Sets <see cref="Style"/>.
         /// </summary>
-        /// <param name="style">New value of the <see cref="SetValue(string)"/>.</param>
+        /// <param name="style">New value of the <see cref="Style"/>.</param>
         /// <returns>
         ///     The builder instance.
         /// </returns>

--- a/src/Discord.Net.Interactions/Builders/Modals/ModalBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Modals/ModalBuilder.cs
@@ -64,7 +64,7 @@ namespace Discord.Interactions.Builders
         }
 
         /// <summary>
-        ///     Adds text components to <see cref="TextComponents"/>.
+        ///     Adds text components to <see cref="Components"/>.
         /// </summary>
         /// <param name="configure">Text Component builder factory.</param>
         /// <returns>

--- a/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
@@ -357,7 +357,8 @@ namespace Discord.Interactions.Builders
             return this;
 
         }
-        
+
+        /// <summary>
         ///     Adds a modal command builder to <see cref="ModalCommands"/>.
         /// </summary>
         /// <param name="configure"><see cref="ModalCommands"/> factory.</param>

--- a/src/Discord.Net.Interactions/Builders/Parameters/ParameterBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Parameters/ParameterBuilder.cs
@@ -122,7 +122,7 @@ namespace Discord.Interactions.Builders
         /// <summary>
         ///     Adds preconditions to <see cref="Preconditions"/>
         /// </summary>
-        /// <param name="preconditions">New attributes to be added to <see cref="Preconditions"/>.</param>
+        /// <param name="attributes">New attributes to be added to <see cref="Preconditions"/>.</param>
         /// <returns>
         ///     The builder instance.
         /// </returns>

--- a/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
+++ b/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
@@ -7,8 +7,10 @@
     <RootNamespace>Discord.Interactions</RootNamespace>
     <AssemblyName>Discord.Net.Interactions</AssemblyName>
     <Description>A Discord.Net extension adding support for Application Commands.</Description>
+    <WarningLevel>5</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />
     <ProjectReference Include="..\Discord.Net.Rest\Discord.Net.Rest.csproj" />

--- a/src/Discord.Net.Interactions/InteractionContext.cs
+++ b/src/Discord.Net.Interactions/InteractionContext.cs
@@ -24,8 +24,7 @@ namespace Discord.Interactions
         /// </summary>
         /// <param name="client">The underlying client.</param>
         /// <param name="interaction">The underlying interaction.</param>
-        /// <param name="user"><see cref="IUser"/> who executed the command.</param>
-        /// <param name="channel"><see cref="ISocketMessageChannel"/> the command originated from.</param>
+        /// <param name="channel"><see cref="IMessageChannel"/> the command originated from.</param>
         public InteractionContext(IDiscordClient client, IDiscordInteraction interaction, IMessageChannel channel = null)
         {
             Client = client;

--- a/src/Discord.Net.Interactions/InteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/InteractionModuleBase.cs
@@ -45,7 +45,7 @@ namespace Discord.Interactions
         protected virtual async Task DeferAsync(bool ephemeral = false, RequestOptions options = null) =>
             await Context.Interaction.DeferAsync(ephemeral, options).ConfigureAwait(false);
 
-        /// <inheritdoc cref="IDiscordInteraction.RespondAsync(string, Embed[], bool, bool, AllowedMentions, RequestOptions, MessageComponent, Embed)"/>
+        /// <inheritdoc cref="IDiscordInteraction.RespondAsync(string, Embed[], bool, bool, AllowedMentions, MessageComponent, Embed, RequestOptions)"/>
         protected virtual async Task RespondAsync (string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false,
             AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent components = null, Embed embed = null) =>
             await Context.Interaction.RespondAsync(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options).ConfigureAwait(false);
@@ -70,7 +70,7 @@ namespace Discord.Interactions
             AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null)
             => Context.Interaction.RespondWithFilesAsync(attachments, text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options);
 
-        /// <inheritdoc cref="IDiscordInteraction.FollowupAsync(string, Embed[], bool, bool, AllowedMentions, RequestOptions, MessageComponent, Embed)"/>
+        /// <inheritdoc cref="IDiscordInteraction.FollowupAsync(string, Embed[], bool, bool, AllowedMentions, MessageComponent, Embed, RequestOptions)"/>
         protected virtual async Task<IUserMessage> FollowupAsync (string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false,
             AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent components = null, Embed embed = null) =>
             await Context.Interaction.FollowupAsync(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options).ConfigureAwait(false);
@@ -95,7 +95,7 @@ namespace Discord.Interactions
             AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null)
             => Context.Interaction.FollowupWithFilesAsync(attachments, text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options);
 
-        /// <inheritdoc cref="IMessageChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions, MessageReference, MessageComponent, ISticker[], Embed[])"/>
+        /// <inheritdoc cref="IMessageChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions, MessageReference, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
         protected virtual async Task<IUserMessage> ReplyAsync (string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null,
             AllowedMentions allowedMentions = null, MessageReference messageReference = null, MessageComponent components = null) =>
             await Context.Channel.SendMessageAsync(text, false, embed, options, allowedMentions, messageReference, components).ConfigureAwait(false);
@@ -118,9 +118,9 @@ namespace Discord.Interactions
         /// <inheritdoc cref="IDiscordInteraction.RespondWithModalAsync(Modal, RequestOptions)"/>
         protected virtual async Task RespondWithModalAsync(Modal modal, RequestOptions options = null) => await Context.Interaction.RespondWithModalAsync(modal);
         
-        /// <inheritdoc cref="IDiscordInteractionExtentions.RespondWithModalAsync(IDiscordInteraction, IModal, RequestOptions)"/>
-        protected virtual async Task RespondWithModalAsync<T>(string customId, RequestOptions options = null) where T : class, IModal
-            => await Context.Interaction.RespondWithModalAsync<T>(customId, options);
+        /// <inheritdoc cref="IDiscordInteractionExtentions.RespondWithModalAsync{T}(IDiscordInteraction, string, RequestOptions, Action{ModalBuilder})"/>
+        protected virtual async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null) where TModal : class, IModal
+            => await Context.Interaction.RespondWithModalAsync<TModal>(customId, options);
 
         //IInteractionModuleBase
 

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -421,7 +421,7 @@ namespace Discord.Interactions
         /// </summary>
         /// <remarks>
         ///     Commands will be registered as standalone commands, if you want the <see cref="GroupAttribute"/> to take effect,
-        ///     use <see cref="AddModulesToGuildAsync(IGuild, ModuleInfo[])"/>. Registering a commands without group names might cause the command traversal to fail.
+        ///     use <see cref="AddModulesToGuildAsync(IGuild, bool, ModuleInfo[])"/>. Registering a commands without group names might cause the command traversal to fail.
         /// </remarks>
         /// <param name="guild">The target guild.</param>
         /// <param name="commands">Commands to be registered to Discord.</param>
@@ -517,7 +517,7 @@ namespace Discord.Interactions
         /// </summary>
         /// <remarks>
         ///     Commands will be registered as standalone commands, if you want the <see cref="GroupAttribute"/> to take effect,
-        ///     use <see cref="AddModulesToGuildAsync(IGuild, ModuleInfo[])"/>. Registering a commands without group names might cause the command traversal to fail.
+        ///     use <see cref="AddModulesToGuildAsync(IGuild, bool, ModuleInfo[])"/>. Registering a commands without group names might cause the command traversal to fail.
         /// </remarks>
         /// <param name="commands">Commands to be registered to Discord.</param>
         /// <returns>
@@ -960,7 +960,7 @@ namespace Discord.Interactions
         ///     Removes a type reader for the given type.
         /// </summary>
         /// <remarks>
-        ///     Removing a <see cref="TypeReader"/> from the <see cref="CommandService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
+        ///     Removing a <see cref="TypeReader"/> from the <see cref="InteractionService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
         ///     You need to reload the modules for the changes to take effect.
         /// </remarks>
         /// <param name="type">The type to remove the reader from.</param>
@@ -973,7 +973,7 @@ namespace Discord.Interactions
         ///     Removes a generic type reader from the type <typeparamref name="T"/>.
         /// </summary>
         /// <remarks>
-        ///     Removing a <see cref="TypeReader"/> from the <see cref="CommandService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
+        ///     Removing a <see cref="TypeReader"/> from the <see cref="InteractionService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
         ///     You need to reload the modules for the changes to take effect.
         /// </remarks>
         /// <typeparam name="T">The type to remove the readers from.</typeparam>
@@ -986,7 +986,7 @@ namespace Discord.Interactions
         ///     Removes a generic type reader from the given type.
         /// </summary>
         /// <remarks>
-        ///     Removing a <see cref="TypeReader"/> from the <see cref="CommandService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
+        ///     Removing a <see cref="TypeReader"/> from the <see cref="InteractionService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
         ///     You need to reload the modules for the changes to take effect.
         /// </remarks>
         /// <param name="type">The type to remove the reader from.</param>
@@ -999,7 +999,7 @@ namespace Discord.Interactions
         ///     Serialize an object using a <see cref="TypeReader"/> into a <see cref="string"/> to be placed in a Component CustomId.
         /// </summary>
         /// <remarks>
-        ///     Removing a <see cref="TypeReader"/> from the <see cref="CommandService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
+        ///     Removing a <see cref="TypeReader"/> from the <see cref="InteractionService"/> will not dereference the <see cref="TypeReader"/> from the loaded module/command instances.
         ///     You need to reload the modules for the changes to take effect.
         /// </remarks>
         /// <typeparam name="T">Type of the object to be serialized.</typeparam>

--- a/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
@@ -87,12 +87,12 @@ namespace Discord.Interactions
                 await InteractionService._restResponseCallback(Context, payload).ConfigureAwait(false);
         }
 
-        protected override async Task RespondWithModalAsync<T>(string customId, RequestOptions options = null)
+        protected override async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null)
         {
             if (Context.Interaction is not RestInteraction restInteraction)
                 throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
 
-            var payload = restInteraction.RespondWithModal<T>(customId, options);
+            var payload = restInteraction.RespondWithModal<TModal>(customId, options);
 
             if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
                 await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);

--- a/src/Discord.Net.Interactions/Results/TypeConverterResult.cs
+++ b/src/Discord.Net.Interactions/Results/TypeConverterResult.cs
@@ -3,7 +3,7 @@ using System;
 namespace Discord.Interactions
 {
     /// <summary>
-    ///     Represents a result type for <see cref="TypeConverter.ReadAsync(IInteractionContext, WebSocket.SocketSlashCommandDataOption, IServiceProvider)"/>.
+    ///     Represents a result type for <see cref="TypeConverter.ReadAsync(IInteractionContext, IApplicationCommandInteractionDataOption, IServiceProvider)"/>.
     /// </summary>
     public struct TypeConverterResult : IResult
     {

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -7,6 +7,8 @@
     <Description>A core Discord.Net library containing the REST client and models.</Description>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net5.0;net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <WarningLevel>5</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -1161,7 +1161,6 @@ namespace Discord.Rest
         ///     in order to use this property.
         ///     </remarks>
         /// </param>
-        /// <param name="speakers">A collection of speakers for the event.</param>
         /// <param name="location">The location of the event; links are supported</param>
         /// <param name="coverImage">The optional banner image for the event.</param>
         /// <param name="options">The options to be used when sending the request.</param>

--- a/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
@@ -333,7 +333,6 @@ namespace Discord.Rest
             => await FollowupWithFilesAsync(attachments, text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options).ConfigureAwait(false);
         /// <inheritdoc/>
         Task IDiscordInteraction.RespondWithFilesAsync(IEnumerable<FileAttachment> attachments, string text, Embed[] embeds, bool isTTS, bool ephemeral, AllowedMentions allowedMentions, MessageComponent components, Embed embed, RequestOptions options) => throw new NotSupportedException("REST-Based interactions don't support files.");
-        /// <inheritdoc/>
 #if NETCOREAPP3_0_OR_GREATER != true
         /// <inheritdoc/>
         Task IDiscordInteraction.RespondWithFileAsync(Stream fileStream, string fileName, string text, Embed[] embeds, bool isTTS, bool ephemeral, AllowedMentions allowedMentions, MessageComponent components, Embed embed, RequestOptions options) => throw new NotSupportedException("REST-Based interactions don't support files.");

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -25,7 +25,7 @@ namespace Discord.Rest
         public string Name { get; private set; }
         /// <inheritdoc />
         public string Icon { get; private set; }
-        /// <inheritdoc>/>
+        /// <inheritdoc />
         public Emoji Emoji { get; private set; }
         /// <inheritdoc />
         public GuildPermissions Permissions { get; private set; }

--- a/src/Discord.Net.Rest/Net/ED25519/CryptoBytes.cs
+++ b/src/Discord.Net.Rest/Net/ED25519/CryptoBytes.cs
@@ -243,7 +243,7 @@ namespace Discord.Net.ED25519
         /// <summary>
         /// // Decode a base58-encoded string into byte array
         /// </summary>
-        /// <param name="strBase58">Base58 data string</param>
+        /// <param name="input">Base58 data string</param>
         /// <returns>Byte array</returns>
         public static byte[] Base58Decode(string input)
         {

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
@@ -60,14 +60,9 @@ namespace Discord.Net.Queue
                 _clearToken?.Cancel();
                 _clearToken?.Dispose();
                 _clearToken = new CancellationTokenSource();
-                if (_parentToken != null)
-                {
-                    _requestCancelTokenSource?.Dispose();
-                    _requestCancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_clearToken.Token, _parentToken);
-                    _requestCancelToken = _requestCancelTokenSource.Token;
-                }
-                else
-                    _requestCancelToken = _clearToken.Token;
+                _requestCancelTokenSource?.Dispose();
+                _requestCancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_clearToken.Token, _parentToken);
+                _requestCancelToken = _requestCancelTokenSource.Token;
             }
             finally { _tokenLock.Release(); }
         }

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
@@ -8,6 +8,8 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net5.0;net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <WarningLevel>5</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1291,7 +1291,6 @@ namespace Discord.WebSocket
         ///     in order to use this property.
         ///     </remarks>
         /// </param>
-        /// <param name="speakers">A collection of speakers for the event.</param>
         /// <param name="location">The location of the event; links are supported</param>
         /// <param name="coverImage">The optional banner image for the event.</param>
         /// <param name="options">The options to be used when sending the request.</param>

--- a/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
+++ b/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>Discord.Webhook</RootNamespace>
     <Description>A core Discord.Net library containing the Webhook client and models.</Description>
     <TargetFrameworks>net6.0;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <WarningLevel>5</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />


### PR DESCRIPTION
## Summary
This PR sets the warning level to five and treats warnings as errors. The motivation behind this is to make our codebase more consistent and to help remove invalid summaries or small warnings.