### PR TITLE
Fix null user on interaction without bot scope

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2331,7 +2331,9 @@ namespace Discord.WebSocket
 
                                     SocketUser user = data.User.IsSpecified
                                         ? State.GetOrAddUser(data.User.Value.Id, (_) => SocketGlobalUser.Create(this, State, data.User.Value))
-                                        : guild?.AddOrUpdateUser(data.Member.Value); // null if the bot scope isn't set, so the guild cannot be retrieved.
+                                        : guild != null
+                                            ? guild.AddOrUpdateUser(data.Member.Value) // null if the bot scope isn't set, so the guild cannot be retrieved.
+                                            : State.GetOrAddUser(data.Member.Value.User.Id, (_) => SocketGlobalUser.Create(this, State, data.Member.Value.User));
 
                                     SocketChannel channel = null;
                                     if(data.ChannelId.IsSpecified)


### PR DESCRIPTION
## Summary
This PR fixes the null user property on interactions when the bot doesn't have the bot scope.