### PR TITLE
(4.x) Rewrite RestInteraction to not force API calls.

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -113,7 +113,7 @@ namespace Discord.Rest
         ///     A <see cref="RestInteraction"/> that represents the incoming http interaction.
         /// </returns>
         /// <exception cref="BadSignatureException">Thrown when the signature doesn't match the public key.</exception>
-        public Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, string body)
+        public RestInteraction ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, string body)
             => ParseHttpInteractionAsync(publicKey, signature, timestamp, Encoding.UTF8.GetBytes(body));
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Discord.Rest
         ///     A <see cref="RestInteraction"/> that represents the incoming http interaction.
         /// </returns>
         /// <exception cref="BadSignatureException">Thrown when the signature doesn't match the public key.</exception>
-        public async Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, byte[] body)
+        public RestInteraction ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, byte[] body)
         {
             if (!IsValidHttpInteraction(publicKey, signature, timestamp, body))
             {
@@ -138,7 +138,7 @@ namespace Discord.Rest
             using (var jsonReader = new JsonTextReader(textReader))
             {
                 var model = Serializer.Deserialize<API.Interaction>(jsonReader);
-                return await RestInteraction.CreateAsync(this, model);
+                return RestInteraction.Create(this, model);
             }
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBase.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBase.cs
@@ -39,16 +39,16 @@ namespace Discord.Rest
         {
         }
 
-        internal new static async Task<RestCommandBase> CreateAsync(DiscordRestClient client, Model model)
+        internal new static RestCommandBase Create(DiscordRestClient client, Model model)
         {
             var entity = new RestCommandBase(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            entity.Update(client, model);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override void Update(DiscordRestClient client, Model model)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            base.Update(client, model);
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBaseData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBaseData.cs
@@ -27,20 +27,20 @@ namespace Discord.Rest
         {
         }
 
-        internal static async Task<RestCommandBaseData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal static RestCommandBaseData Create(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
         {
             var entity = new RestCommandBaseData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            entity.Update(client, model, guild, channel);
             return entity;
         }
 
-        internal virtual async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal virtual void Update(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
         {
             Name = model.Name;
             if (model.Resolved.IsSpecified && ResolvableData == null)
             {
                 ResolvableData = new RestResolvableData<Model>();
-                await ResolvableData.PopulateAsync(client, guild, channel, model).ConfigureAwait(false);
+                ResolvableData.PopulateAsync(client, guild, channel, model).ConfigureAwait(false);
             }
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommand.cs
@@ -20,22 +20,22 @@ namespace Discord.Rest
             
         }
 
-        internal new static async Task<RestMessageCommand> CreateAsync(DiscordRestClient client, Model model)
+        internal new static RestMessageCommand Create(DiscordRestClient client, Model model)
         {
             var entity = new RestMessageCommand(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            entity.Update(client, model);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override void Update(DiscordRestClient client, Model model)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            base.Update(client, model);
 
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
                 : null;
             
-            Data = await RestMessageCommandData.CreateAsync(client, dataModel, Guild, Channel).ConfigureAwait(false);
+            Data = RestMessageCommandData.Create(client, dataModel, Guild, Channel);
         }
 
         //IMessageCommandInteraction

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommandData.cs
@@ -28,10 +28,10 @@ namespace Discord.Rest
         internal RestMessageCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal new static async Task<RestMessageCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal new static RestMessageCommandData Create(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
         {
             var entity = new RestMessageCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            entity.Update(client, model, guild, channel);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
@@ -23,22 +23,22 @@ namespace Discord.Rest
         {
         }
 
-        internal new static async Task<RestUserCommand> CreateAsync(DiscordRestClient client, Model model)
+        internal new static RestUserCommand Create(DiscordRestClient client, Model model)
         {
             var entity = new RestUserCommand(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            entity.Update(client, model);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override void Update(DiscordRestClient client, Model model)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            base.Update(client, model);
 
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
                 : null;
 
-            Data = await RestUserCommandData.CreateAsync(client, dataModel, Guild, Channel).ConfigureAwait(false);
+            Data = RestUserCommandData.Create(client, dataModel, Guild, Channel);
         }
 
         //IUserCommandInteractionData

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommandData.cs
@@ -26,10 +26,10 @@ namespace Discord.Rest
         internal RestUserCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal new static async Task<RestUserCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal new static RestUserCommandData Create(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
         {
             var entity = new RestUserCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            entity.Update(client, model, guild, channel);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
@@ -37,15 +37,15 @@ namespace Discord.Rest
             Data = new RestMessageComponentData(dataModel);
         }
 
-        internal new static async Task<RestMessageComponent> CreateAsync(DiscordRestClient client, Model model)
+        internal new static RestMessageComponent Create(DiscordRestClient client, Model model)
         {
             var entity = new RestMessageComponent(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            entity.Update(client, model);
             return entity;
         }
-        internal override async Task UpdateAsync(DiscordRestClient discord, Model model)
+        internal override void Update(DiscordRestClient discord, Model model)
         {
-            await base.UpdateAsync(discord, model).ConfigureAwait(false);
+            base.Update(discord, model);
 
             if (model.Message.IsSpecified && model.ChannelId.IsSpecified)
             {

--- a/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
@@ -26,10 +26,10 @@ namespace Discord.Rest
             Data = new RestModalData(dataModel);
         }
 
-        internal new static async Task<RestModal> CreateAsync(DiscordRestClient client, ModelBase model)
+        internal new static RestModal Create(DiscordRestClient client, ModelBase model)
         {
             var entity = new RestModal(client, model);
-            await entity.UpdateAsync(client, model);
+            entity.Update(client, model);
             return entity;
         }
         

--- a/src/Discord.Net.Rest/Entities/Interactions/RestPingInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestPingInteraction.cs
@@ -18,10 +18,10 @@ namespace Discord.Rest
         {
         }
 
-        internal static new async Task<RestPingInteraction> CreateAsync(DiscordRestClient client, Model model)
+        internal static new RestPingInteraction Create(DiscordRestClient client, Model model)
         {
             var entity = new RestPingInteraction(client, model.Id);
-            await entity.UpdateAsync(client, model);
+            entity.Update(client, model);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
@@ -32,10 +32,10 @@ namespace Discord.Rest
                 Data = new RestAutocompleteInteractionData(dataModel);
         }
 
-        internal new static async Task<RestAutocompleteInteraction> CreateAsync(DiscordRestClient client, Model model)
+        internal new static RestAutocompleteInteraction Create(DiscordRestClient client, Model model)
         {
             var entity = new RestAutocompleteInteraction(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            entity.Update(client, model);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
@@ -23,22 +23,22 @@ namespace Discord.Rest
         {   
         }
 
-        internal new static async Task<RestSlashCommand> CreateAsync(DiscordRestClient client, Model model)
+        internal new static RestSlashCommand Create(DiscordRestClient client, Model model)
         {
             var entity = new RestSlashCommand(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            entity.Update(client, model);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override void Update(DiscordRestClient client, Model model)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            base.Update(client, model);
 
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
                 : null;
 
-            Data = await RestSlashCommandData.CreateAsync(client, dataModel, Guild, Channel).ConfigureAwait(false);
+            Data = RestSlashCommandData.Create(client, dataModel, Guild, Channel);
         }
 
         //ISlashCommandInteraction

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommandData.cs
@@ -14,15 +14,15 @@ namespace Discord.Rest
         internal RestSlashCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal static new async Task<RestSlashCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal static new RestSlashCommandData Create(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
         {
             var entity = new RestSlashCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            entity.Update(client, model, guild, channel);
             return entity;
         }
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal override void Update(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
         {
-            await base.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            base.Update(client, model, guild, channel);
 
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(x => new RestSlashCommandDataOption(this, x)).ToImmutableArray()


### PR DESCRIPTION
### Issue:

In current behavior, `RestInteraction` makes API calls to get the `Channel` & `Guild` of the user invoking the interaction. This behavior is forced, the result of which is that some interactions will be missed if they often occur, due to having to wait on rate limits before the interaction can even be responded to or deferred.

### Goal:

The goal of this PR is to make these properties initialize lazily, and only get called if they are required, from the users' side. Additional configuration may be obligated to allow or disallow the `Data` of interactions that require guild or channel parameters. Additionally, we can also populate this data when the getter is called.

Due to no longer requiring these 2 async calls, nothing but 1 call in the entire interaction creation process is required to be async any longer, and the sync creation behavior of other entities can be followed.

### Breaking changes:

Parsing http interactions is no longer async because of the above, which is breaking. Additionally, the lazy values currently used may need to become AsyncLazy or Lazy<Task<T>> thanks to them being async. This means the properties cannot call to the value directly, and these may need to change in signature as well.