### PR TITLE
Introduce optional API calling to RestInteraction

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -32,9 +32,15 @@ namespace Discord.Rest
         ///     Initializes a new <see cref="DiscordRestClient"/> with the provided configuration.
         /// </summary>
         /// <param name="config">The configuration to be used with the client.</param>
-        public DiscordRestClient(DiscordRestConfig config) : base(config, CreateApiClient(config)) { }
+        public DiscordRestClient(DiscordRestConfig config) : base(config, CreateApiClient(config))
+        {
+            APIOnInteractionCreation = config.APIOnRestInteractionCreation;
+        }
         // used for socket client rest access
-        internal DiscordRestClient(DiscordRestConfig config, API.DiscordRestApiClient api) : base(config, api) { }
+        internal DiscordRestClient(DiscordRestConfig config, API.DiscordRestApiClient api) : base(config, api)
+        {
+            APIOnInteractionCreation = config.APIOnRestInteractionCreation;
+        }
 
         private static API.DiscordRestApiClient CreateApiClient(DiscordRestConfig config)
             => new API.DiscordRestApiClient(config.RestClientProvider, DiscordRestConfig.UserAgent, serializer: Serializer, useSystemClock: config.UseSystemClock, defaultRatelimitCallback: config.DefaultRatelimitCallback);
@@ -81,6 +87,8 @@ namespace Discord.Rest
         }
 
         #region Rest interactions
+
+        internal readonly bool APIOnInteractionCreation;
 
         public bool IsValidHttpInteraction(string publicKey, string signature, string timestamp, string body)
             => IsValidHttpInteraction(publicKey, signature, timestamp, Encoding.UTF8.GetBytes(body));

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -121,7 +121,7 @@ namespace Discord.Rest
         ///     A <see cref="RestInteraction"/> that represents the incoming http interaction.
         /// </returns>
         /// <exception cref="BadSignatureException">Thrown when the signature doesn't match the public key.</exception>
-        public Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, string body, bool? doApiCallOnCreation = null)
+        public Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, string body, Func<InteractionType, bool> doApiCallOnCreation = null)
             => ParseHttpInteractionAsync(publicKey, signature, timestamp, Encoding.UTF8.GetBytes(body), doApiCallOnCreation);
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Discord.Rest
         ///     A <see cref="RestInteraction"/> that represents the incoming http interaction.
         /// </returns>
         /// <exception cref="BadSignatureException">Thrown when the signature doesn't match the public key.</exception>
-        public async Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, byte[] body, bool? doApiCallOnCreation = null)
+        public async Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, byte[] body, Func<InteractionType, bool> doApiCallOnCreation = null)
         {
             if (!IsValidHttpInteraction(publicKey, signature, timestamp, body))
             {
@@ -146,7 +146,7 @@ namespace Discord.Rest
             using (var jsonReader = new JsonTextReader(textReader))
             {
                 var model = Serializer.Deserialize<API.Interaction>(jsonReader);
-                return await RestInteraction.CreateAsync(this, model, doApiCallOnCreation ?? _apiOnCreation);
+                return await RestInteraction.CreateAsync(this, model, doApiCallOnCreation != null ? doApiCallOnCreation(model.Type) : _apiOnCreation);
             }
         }
 

--- a/src/Discord.Net.Rest/DiscordRestConfig.cs
+++ b/src/Discord.Net.Rest/DiscordRestConfig.cs
@@ -9,5 +9,7 @@ namespace Discord.Rest
     {
         /// <summary> Gets or sets the provider used to generate new REST connections. </summary>
         public RestClientProvider RestClientProvider { get; set; } = DefaultRestClientProvider.Instance;
+
+        public bool APIOnRestInteractionCreation { get; set; } = true;
     }
 }

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBase.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBase.cs
@@ -39,16 +39,16 @@ namespace Discord.Rest
         {
         }
 
-        internal new static async Task<RestCommandBase> CreateAsync(DiscordRestClient client, Model model)
+        internal new static async Task<RestCommandBase> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestCommandBase(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override async Task UpdateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            await base.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBaseData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBaseData.cs
@@ -27,20 +27,20 @@ namespace Discord.Rest
         {
         }
 
-        internal static async Task<RestCommandBaseData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal static async Task<RestCommandBaseData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestCommandBaseData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
 
-        internal virtual async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal virtual async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
         {
             Name = model.Name;
             if (model.Resolved.IsSpecified && ResolvableData == null)
             {
                 ResolvableData = new RestResolvableData<Model>();
-                await ResolvableData.PopulateAsync(client, guild, channel, model).ConfigureAwait(false);
+                await ResolvableData.PopulateAsync(client, guild, channel, model, doApiCall).ConfigureAwait(false);
             }
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestResolvableData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestResolvableData.cs
@@ -38,15 +38,26 @@ namespace Discord.Rest
 
             if (resolved.Channels.IsSpecified)
             {
-                var channels = await guild.GetChannelsAsync().ConfigureAwait(false);
+                var channels = discord.APIOnInteractionCreation ? await guild.GetChannelsAsync().ConfigureAwait(false) : null;
 
                 foreach (var channelModel in resolved.Channels.Value)
                 {
-                    var restChannel = channels.FirstOrDefault(x => x.Id == channelModel.Value.Id);
+                    if (channels != null)
+                    {
+                        var guildChannel = channels.FirstOrDefault(x => x.Id == channelModel.Value.Id);
 
-                    restChannel.Update(channelModel.Value);
+                        guildChannel.Update(channelModel.Value);
 
-                    Channels.Add(ulong.Parse(channelModel.Key), restChannel);
+                        Channels.Add(ulong.Parse(channelModel.Key), guildChannel);
+                    }
+                    else
+                    {
+                        var restChannel = RestChannel.Create(discord, channelModel.Value);
+
+                        restChannel.Update(channelModel.Value);
+
+                        Channels.Add(ulong.Parse(channelModel.Key), restChannel);
+                    }
                 }
             }
 
@@ -76,7 +87,10 @@ namespace Discord.Rest
             {
                 foreach (var msg in resolved.Messages.Value)
                 {
-                    channel ??= (IRestMessageChannel)(Channels.FirstOrDefault(x => x.Key == msg.Value.ChannelId).Value ?? await discord.GetChannelAsync(msg.Value.ChannelId).ConfigureAwait(false));
+                    channel ??= (IRestMessageChannel)(Channels.FirstOrDefault(x => x.Key == msg.Value.ChannelId).Value
+                        ?? (discord.APIOnInteractionCreation
+                        ? await discord.GetChannelAsync(msg.Value.ChannelId).ConfigureAwait(false)
+                        : null));
 
                     RestUser author;
 

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestResolvableData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestResolvableData.cs
@@ -22,7 +22,7 @@ namespace Discord.Rest
         internal readonly Dictionary<ulong, Attachment> Attachments
             = new Dictionary<ulong, Attachment>();
 
-        internal async Task PopulateAsync(DiscordRestClient discord, RestGuild guild, IRestMessageChannel channel, T model)
+        internal async Task PopulateAsync(DiscordRestClient discord, RestGuild guild, IRestMessageChannel channel, T model, bool doApiCall)
         {
             var resolved = model.Resolved.Value;
 
@@ -38,7 +38,7 @@ namespace Discord.Rest
 
             if (resolved.Channels.IsSpecified)
             {
-                var channels = discord.APIOnInteractionCreation ? await guild.GetChannelsAsync().ConfigureAwait(false) : null;
+                var channels = doApiCall ? await guild.GetChannelsAsync().ConfigureAwait(false) : null;
 
                 foreach (var channelModel in resolved.Channels.Value)
                 {
@@ -88,7 +88,7 @@ namespace Discord.Rest
                 foreach (var msg in resolved.Messages.Value)
                 {
                     channel ??= (IRestMessageChannel)(Channels.FirstOrDefault(x => x.Key == msg.Value.ChannelId).Value
-                        ?? (discord.APIOnInteractionCreation
+                        ?? (doApiCall
                         ? await discord.GetChannelAsync(msg.Value.ChannelId).ConfigureAwait(false)
                         : null));
 

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommand.cs
@@ -20,22 +20,22 @@ namespace Discord.Rest
             
         }
 
-        internal new static async Task<RestMessageCommand> CreateAsync(DiscordRestClient client, Model model)
+        internal new static async Task<RestMessageCommand> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestMessageCommand(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override async Task UpdateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            await base.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
 
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
                 : null;
             
-            Data = await RestMessageCommandData.CreateAsync(client, dataModel, Guild, Channel).ConfigureAwait(false);
+            Data = await RestMessageCommandData.CreateAsync(client, dataModel, Guild, Channel, doApiCall).ConfigureAwait(false);
         }
 
         //IMessageCommandInteraction

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommandData.cs
@@ -23,15 +23,15 @@ namespace Discord.Rest
         ///     <b>Note</b> Not implemented for <see cref="RestMessageCommandData"/>
         /// </remarks>
         public override IReadOnlyCollection<IApplicationCommandInteractionDataOption> Options
-            => throw new System.NotImplementedException();
+            => throw new NotImplementedException();
 
         internal RestMessageCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal new static async Task<RestMessageCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal new static async Task<RestMessageCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestMessageCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
@@ -32,7 +32,7 @@ namespace Discord.Rest
 
         internal override async Task UpdateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            await base.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
 
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
@@ -23,14 +23,14 @@ namespace Discord.Rest
         {
         }
 
-        internal new static async Task<RestUserCommand> CreateAsync(DiscordRestClient client, Model model)
+        internal new static async Task<RestUserCommand> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestUserCommand(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override async Task UpdateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             await base.UpdateAsync(client, model).ConfigureAwait(false);
 
@@ -38,7 +38,7 @@ namespace Discord.Rest
                 ? (DataModel)model.Data.Value
                 : null;
 
-            Data = await RestUserCommandData.CreateAsync(client, dataModel, Guild, Channel).ConfigureAwait(false);
+            Data = await RestUserCommandData.CreateAsync(client, dataModel, Guild, Channel, doApiCall).ConfigureAwait(false);
         }
 
         //IUserCommandInteractionData

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommandData.cs
@@ -26,10 +26,10 @@ namespace Discord.Rest
         internal RestUserCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal new static async Task<RestUserCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal new static async Task<RestUserCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestUserCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
@@ -37,15 +37,15 @@ namespace Discord.Rest
             Data = new RestMessageComponentData(dataModel);
         }
 
-        internal new static async Task<RestMessageComponent> CreateAsync(DiscordRestClient client, Model model)
+        internal new static async Task<RestMessageComponent> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestMessageComponent(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
             return entity;
         }
-        internal override async Task UpdateAsync(DiscordRestClient discord, Model model)
+        internal override async Task UpdateAsync(DiscordRestClient discord, Model model, bool doApiCall)
         {
-            await base.UpdateAsync(discord, model).ConfigureAwait(false);
+            await base.UpdateAsync(discord, model, doApiCall).ConfigureAwait(false);
 
             if (model.Message.IsSpecified && model.ChannelId.IsSpecified)
             {

--- a/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
@@ -26,10 +26,10 @@ namespace Discord.Rest
             Data = new RestModalData(dataModel);
         }
 
-        internal new static async Task<RestModal> CreateAsync(DiscordRestClient client, ModelBase model)
+        internal new static async Task<RestModal> CreateAsync(DiscordRestClient client, ModelBase model, bool doApiCall)
         {
             var entity = new RestModal(client, model);
-            await entity.UpdateAsync(client, model);
+            await entity.UpdateAsync(client, model, doApiCall);
             return entity;
         }
         

--- a/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
@@ -168,7 +168,7 @@ namespace Discord.Rest
             {
                 if (model.Member.IsSpecified && model.GuildId.IsSpecified)
                 {
-                    User = RestGuildUser.Create(Discord, Guild, model.Member.Value);
+                    User = RestGuildUser.Create(Discord, Guild, model.Member.Value, (Guild is null) ? model.GuildId.Value : null);
                 }
                 else
                 {

--- a/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
@@ -100,11 +100,11 @@ namespace Discord.Rest
                 : DateTime.UtcNow;
         }
 
-        internal static async Task<RestInteraction> CreateAsync(DiscordRestClient client, Model model)
+        internal static async Task<RestInteraction> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             if(model.Type == InteractionType.Ping)
             {
-                return await RestPingInteraction.CreateAsync(client, model);
+                return await RestPingInteraction.CreateAsync(client, model, doApiCall);
             }
 
             if (model.Type == InteractionType.ApplicationCommand)
@@ -118,26 +118,26 @@ namespace Discord.Rest
 
                 return dataModel.Type switch
                 {
-                    ApplicationCommandType.Slash => await RestSlashCommand.CreateAsync(client, model).ConfigureAwait(false),
-                    ApplicationCommandType.Message => await RestMessageCommand.CreateAsync(client, model).ConfigureAwait(false),
-                    ApplicationCommandType.User => await RestUserCommand.CreateAsync(client, model).ConfigureAwait(false),
+                    ApplicationCommandType.Slash => await RestSlashCommand.CreateAsync(client, model, doApiCall).ConfigureAwait(false),
+                    ApplicationCommandType.Message => await RestMessageCommand.CreateAsync(client, model, doApiCall).ConfigureAwait(false),
+                    ApplicationCommandType.User => await RestUserCommand.CreateAsync(client, model, doApiCall).ConfigureAwait(false),
                     _ => null
                 };
             }
 
             if (model.Type == InteractionType.MessageComponent)
-                return await RestMessageComponent.CreateAsync(client, model).ConfigureAwait(false);
+                return await RestMessageComponent.CreateAsync(client, model, doApiCall).ConfigureAwait(false);
 
             if (model.Type == InteractionType.ApplicationCommandAutocomplete)
-                return await RestAutocompleteInteraction.CreateAsync(client, model).ConfigureAwait(false);
+                return await RestAutocompleteInteraction.CreateAsync(client, model, doApiCall).ConfigureAwait(false);
 
             if (model.Type == InteractionType.ModalSubmit)
-                return await RestModal.CreateAsync(client, model).ConfigureAwait(false);
+                return await RestModal.CreateAsync(client, model, doApiCall).ConfigureAwait(false);
 
             return null;
         }
 
-        internal virtual async Task UpdateAsync(DiscordRestClient discord, Model model)
+        internal virtual async Task UpdateAsync(DiscordRestClient discord, Model model, bool doApiCall)
         {
             IsDMInteraction = !model.GuildId.IsSpecified;
 
@@ -151,7 +151,7 @@ namespace Discord.Rest
             if (Guild == null && model.GuildId.IsSpecified)
             {
                 GuildId = model.GuildId.Value;
-                if (discord.APIOnInteractionCreation)
+                if (doApiCall)
                     Guild = await discord.GetGuildAsync(model.GuildId.Value);
                 else
                     Guild = null;
@@ -174,7 +174,7 @@ namespace Discord.Rest
                 try
                 {
                     ChannelId = model.ChannelId.Value;
-                    if (discord.APIOnInteractionCreation)
+                    if (doApiCall)
                         Channel = (IRestMessageChannel)await discord.GetChannelAsync(model.ChannelId.Value);
                     else
                         Channel = null;
@@ -200,9 +200,6 @@ namespace Discord.Rest
 
             return json.ToString();
         }
-
-        public async Task<RestGuild> GetGuildAsync()
-            => await 
 
         /// <inheritdoc/>
         public abstract string Defer(bool ephemeral = false, RequestOptions options = null);

--- a/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
@@ -31,6 +31,10 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the user who invoked the interaction.
         /// </summary>
+        /// <remarks>
+        ///     If this user is an <see cref="RestGuildUser"/> and <see cref="DiscordRestConfig.APIOnRestInteractionCreation"/> is set to false,
+        ///     <see cref="RestGuildUser.Guild"/> will return <see langword="null"/>
+        /// </remarks>
         public RestUser User { get; private set; }
 
         /// <inheritdoc/>
@@ -51,11 +55,17 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the channel that this interaction was executed in.
         /// </summary>
+        /// <remarks>
+        ///     <see langword="null"/> if <see cref="DiscordRestConfig.APIOnRestInteractionCreation"/> is set to false.
+        /// </remarks>
         public IRestMessageChannel Channel { get; private set; }
 
         /// <summary>
-        ///     Gets the guild this interaction was executed in.
+        ///     Gets the guild this interaction was executed in if applicable.
         /// </summary>
+        /// <remarks>
+        ///     <see langword="null"/> if <see cref="DiscordRestConfig.APIOnRestInteractionCreation"/> is set to false.
+        /// </remarks>
         public RestGuild Guild { get; private set; }
 
         /// <inheritdoc/>
@@ -122,7 +132,10 @@ namespace Discord.Rest
 
             if(Guild == null && model.GuildId.IsSpecified)
             {
-                Guild = await discord.GetGuildAsync(model.GuildId.Value);
+                if (discord.APIOnInteractionCreation)
+                    Guild = await discord.GetGuildAsync(model.GuildId.Value);
+                else
+                    Guild = null;
             }
 
             if (User == null)
@@ -141,7 +154,10 @@ namespace Discord.Rest
             {
                 try
                 {
-                    Channel = (IRestMessageChannel)await discord.GetChannelAsync(model.ChannelId.Value);
+                    if (discord.APIOnInteractionCreation)
+                        Channel = (IRestMessageChannel)await discord.GetChannelAsync(model.ChannelId.Value);
+                    else
+                        Channel = null;
                 }
                 catch(HttpException x) when(x.DiscordCode == DiscordErrorCode.MissingPermissions) { } // ignore
             }

--- a/src/Discord.Net.Rest/Entities/Interactions/RestPingInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestPingInteraction.cs
@@ -18,10 +18,10 @@ namespace Discord.Rest
         {
         }
 
-        internal static new async Task<RestPingInteraction> CreateAsync(DiscordRestClient client, Model model)
+        internal static new async Task<RestPingInteraction> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestPingInteraction(client, model.Id);
-            await entity.UpdateAsync(client, model);
+            await entity.UpdateAsync(client, model, doApiCall);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
@@ -32,10 +32,10 @@ namespace Discord.Rest
                 Data = new RestAutocompleteInteractionData(dataModel);
         }
 
-        internal new static async Task<RestAutocompleteInteraction> CreateAsync(DiscordRestClient client, Model model)
+        internal new static async Task<RestAutocompleteInteraction> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestAutocompleteInteraction(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
@@ -23,22 +23,22 @@ namespace Discord.Rest
         {   
         }
 
-        internal new static async Task<RestSlashCommand> CreateAsync(DiscordRestClient client, Model model)
+        internal new static async Task<RestSlashCommand> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestSlashCommand(client, model);
             await entity.UpdateAsync(client, model).ConfigureAwait(false);
             return entity;
         }
 
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model)
+        internal override async Task UpdateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
-            await base.UpdateAsync(client, model).ConfigureAwait(false);
+            await base.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
 
             var dataModel = model.Data.IsSpecified
                 ? (DataModel)model.Data.Value
                 : null;
 
-            Data = await RestSlashCommandData.CreateAsync(client, dataModel, Guild, Channel).ConfigureAwait(false);
+            Data = await RestSlashCommandData.CreateAsync(client, dataModel, Guild, Channel, doApiCall).ConfigureAwait(false);
         }
 
         //ISlashCommandInteraction

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
@@ -26,7 +26,7 @@ namespace Discord.Rest
         internal new static async Task<RestSlashCommand> CreateAsync(DiscordRestClient client, Model model, bool doApiCall)
         {
             var entity = new RestSlashCommand(client, model);
-            await entity.UpdateAsync(client, model).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, doApiCall).ConfigureAwait(false);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommandData.cs
@@ -14,15 +14,15 @@ namespace Discord.Rest
         internal RestSlashCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal static new async Task<RestSlashCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal static new async Task<RestSlashCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestSlashCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel)
+        internal override async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
         {
-            await base.UpdateAsync(client, model, guild, channel).ConfigureAwait(false);
+            await base.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
 
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(x => new RestSlashCommandDataOption(this, x)).ToImmutableArray()

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -35,7 +35,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public DateTimeOffset? PremiumSince => DateTimeUtils.FromTicks(_premiumSinceTicks);
         /// <inheritdoc />
-        public ulong GuildId => Guild.Id;
+        public ulong GuildId { get; }
         /// <inheritdoc />
         public bool? IsPending { get; private set; }
         /// <inheritdoc />
@@ -80,14 +80,16 @@ namespace Discord.Rest
         /// <inheritdoc />
         public DateTimeOffset? JoinedAt => DateTimeUtils.FromTicks(_joinedAtTicks);
 
-        internal RestGuildUser(BaseDiscordClient discord, IGuild guild, ulong id)
+        internal RestGuildUser(BaseDiscordClient discord, IGuild guild, ulong id, ulong? guildId = null)
             : base(discord, id)
         {
-            Guild = guild;
+            if (guild is not null)
+                Guild = guild;
+            GuildId = guildId ?? Guild.Id;
         }
-        internal static RestGuildUser Create(BaseDiscordClient discord, IGuild guild, Model model)
+        internal static RestGuildUser Create(BaseDiscordClient discord, IGuild guild, Model model, ulong? guildId = null)
         {
-            var entity = new RestGuildUser(discord, guild, model.User.Id);
+            var entity = new RestGuildUser(discord, guild, model.User.Id, guildId);
             entity.Update(model);
             return entity;
         }
@@ -116,7 +118,7 @@ namespace Discord.Rest
         private void UpdateRoles(ulong[] roleIds)
         {
             var roles = ImmutableArray.CreateBuilder<ulong>(roleIds.Length + 1);
-            roles.Add(Guild.Id);
+            roles.Add(GuildId);
             for (int i = 0; i < roleIds.Length; i++)
                 roles.Add(roleIds[i]);
             _roleIds = roles.ToImmutable();


### PR DESCRIPTION
In a previous PR (#2276) I opted to implement a number of breaking changes to achieve the same result as in this PR. After serious revision, I decided to completely revert this approach and start over. Considering the amount of data passed over interactions, even partial objects are enough to populate interactions enough to be functional, even for the interaction service.

### Changes

This PR does **not** break anything for users that plan on keeping this behavior. A new configuration option has been introduced at Rest level to allow users to disable API calls on interaction creation. 

The properties `Channel` and `Guild` will be null as a result of the above, and some values from app-command `Data` will not be fully populated. There is no way around this, even if we turn the properties lazy. These calls were forced on creation, there would be no point to lazy calling because it would be done directly. `ChannelId` and `GuildId` have been introduced to be able to manually make API calls if desired.