### PR TITLE
Support FailIfNotExists on MessageReference

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageReference.cs
@@ -28,6 +28,12 @@ namespace Discord
         public Optional<ulong> GuildId { get; internal set; }
 
         /// <summary>
+        ///     Gets whether to error if the referenced message doesn't exist instead of sending as a normal (non-reply) message
+        ///     Defaults to true.
+        /// </summary>
+        public Optional<bool> FailIfNotExists { get; internal set; }
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="MessageReference"/> class.
         /// </summary>
         /// <param name="messageId">
@@ -39,16 +45,21 @@ namespace Discord
         /// <param name="guildId">
         ///     The ID of the guild that will be referenced. It will be validated if sent.
         /// </param>
-        public MessageReference(ulong? messageId = null, ulong? channelId = null, ulong? guildId = null)
+        /// <param name="failIfNotExists">
+        ///     Whether to error if the referenced message doesn't exist instead of sending as a normal (non-reply) message. Defaults to true.
+        /// </param>
+        public MessageReference(ulong? messageId = null, ulong? channelId = null, ulong? guildId = null, bool? failIfNotExists = null)
         {
             MessageId = messageId ?? Optional.Create<ulong>();
             InternalChannelId = channelId ?? Optional.Create<ulong>();
             GuildId = guildId ?? Optional.Create<ulong>();
+            FailIfNotExists = failIfNotExists ?? Optional.Create<bool>();
         }
 
         private string DebuggerDisplay
             => $"Channel ID: ({ChannelId}){(GuildId.IsSpecified ? $", Guild ID: ({GuildId.Value})" : "")}" +
-            $"{(MessageId.IsSpecified ? $", Message ID: ({MessageId.Value})" : "")}";
+            $"{(MessageId.IsSpecified ? $", Message ID: ({MessageId.Value})" : "")}" +
+            $"{(FailIfNotExists.IsSpecified ? $", FailIfNotExists: ({FailIfNotExists.Value})" : "")}";
 
         public override string ToString()
             => DebuggerDisplay;

--- a/src/Discord.Net.Rest/API/Common/MessageReference.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageReference.cs
@@ -12,5 +12,8 @@ namespace Discord.API
 
         [JsonProperty("guild_id")]
         public Optional<ulong> GuildId { get; set; }
+
+        [JsonProperty("fail_if_not_exists")]
+        public Optional<bool> FailIfNotExists { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -144,7 +144,8 @@ namespace Discord.Rest
                 {
                     GuildId = model.Reference.Value.GuildId,
                     InternalChannelId = model.Reference.Value.ChannelId,
-                    MessageId = model.Reference.Value.MessageId
+                    MessageId = model.Reference.Value.MessageId,
+                    FailIfNotExists = model.Reference.Value.FailIfNotExists
                 };
             }
 

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -87,6 +87,7 @@ namespace Discord.Rest
                 ChannelId = entity.InternalChannelId,
                 GuildId = entity.GuildId,
                 MessageId = entity.MessageId,
+                FailIfNotExists = entity.FailIfNotExists
             };
         }
         public static IEnumerable<string> EnumerateMentionTypes(this AllowedMentionTypes mentionTypes)

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -182,7 +182,8 @@ namespace Discord.WebSocket
                 {
                     GuildId = model.Reference.Value.GuildId,
                     InternalChannelId = model.Reference.Value.ChannelId,
-                    MessageId = model.Reference.Value.MessageId
+                    MessageId = model.Reference.Value.MessageId,
+                    FailIfNotExists = model.Reference.Value.FailIfNotExists
                 };
             }
 


### PR DESCRIPTION
Adds `FailIfNotExists` to `MessageReference`

Omission defaults to `true` per API docs. Consumers can set to `false` to change behavior to send non-replies when the message reference does not exist.

Fixes #2282
