### PR TITLE
Add Parse & TryParse to EmbedBuilder & Add ToJsonString extension

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -164,35 +164,45 @@ namespace Discord
         /// <returns><see langword="true"/> if <paramref name="json"/> was succesfully parsed. <see langword="false"/> if not.</returns>
         public static bool TryParse(string json, out EmbedBuilder builder)
         {
-            var model = JsonConvert.DeserializeObject<Embed>(json);
-
             builder = new EmbedBuilder();
-
-            if (model is not null)
+            try
             {
-                builder = model.ToEmbedBuilder();
-                return true;
-            }
+                var model = JsonConvert.DeserializeObject<Embed>(json);
 
-            else
+                if (model is not null)
+                {
+                    builder = model.ToEmbedBuilder();
+                    return true;
+                }
                 return false;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         /// <summary>
         ///     Parses a string into an <see cref="EmbedBuilder"/>.
         /// </summary>
         /// <param name="json">The json string to parse.</param>
-        /// <returns>An <see cref="EmbedBuilder"/> with populated values from the passed <paramref name="json"/></returns>
+        /// <returns>An <see cref="EmbedBuilder"/> with populated values from the passed <paramref name="json"/>.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the string passed is not valid json.</exception>
         public static EmbedBuilder Parse(string json)
         {
-            var model = JsonConvert.DeserializeObject<Embed>(json);
+            try
+            {
+                var model = JsonConvert.DeserializeObject<Embed>(json);
 
-            if (model is not null)
-                return model.ToEmbedBuilder();
+                if (model is not null)
+                    return model.ToEmbedBuilder();
 
-            else
-                throw new JsonSerializationException("The passed json string was not able to be parsed to an embed.");
+                return new EmbedBuilder();
+            }
+            catch
+            {
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Discord.Utils;
+using Newtonsoft.Json;
 
 namespace Discord
 {
@@ -153,6 +154,45 @@ namespace Discord
 
                 return titleLength + authorLength + descriptionLength + footerLength + fieldSum;
             }
+        }
+
+        /// <summary>
+        ///     Tries to parse a string into an <see cref="EmbedBuilder"/>. 
+        /// </summary>
+        /// <param name="json">The json string to parse.</param>
+        /// <param name="builder">The <see cref="EmbedBuilder"/> with populated values. An empty instance if method returns <see langword="false"/>.</param>
+        /// <returns><see langword="true"/> if <paramref name="json"/> was succesfully parsed. <see langword="false"/> if not.</returns>
+        public static bool TryParse(string json, out EmbedBuilder builder)
+        {
+            var model = JsonConvert.DeserializeObject<Embed>(json);
+
+            builder = new EmbedBuilder();
+
+            if (model is not null)
+            {
+                builder = model.ToEmbedBuilder();
+                return true;
+            }
+
+            else
+                return false;
+        }
+
+        /// <summary>
+        ///     Parses a string into an <see cref="EmbedBuilder"/>.
+        /// </summary>
+        /// <param name="json">The json string to parse.</param>
+        /// <returns>An <see cref="EmbedBuilder"/> with populated values from the passed <paramref name="json"/></returns>
+        /// <exception cref="InvalidOperationException">Thrown if the string passed is not valid json.</exception>
+        public static EmbedBuilder Parse(string json)
+        {
+            var model = JsonConvert.DeserializeObject<Embed>(json);
+
+            if (model is not null)
+                return model.ToEmbedBuilder();
+
+            else
+                throw new JsonSerializationException("The passed json string was not able to be parsed to an embed.");
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Extensions/StringExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/StringExtensions.cs
@@ -40,7 +40,7 @@ namespace Discord.Rest
         /// </remarks>
         /// <param name="embed">The embed to format as Json <see langword="string"/>.</param>
         /// <param name="formatting">The formatting in which the Json will be returned.</param>
-        /// <returns>A Json <see langword="string"/> containing the data from the <paramref name="builder"/>.</returns>
+        /// <returns>A Json <see langword="string"/> containing the data from the <paramref name="embed"/>.</returns>
         public static string ToJsonString(this Embed embed, Formatting formatting = Formatting.Indented)
             => JsonConvert.SerializeObject(embed.ToModel(), formatting, _settings.Value);
     }

--- a/src/Discord.Net.Rest/Extensions/StringExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/StringExtensions.cs
@@ -1,0 +1,31 @@
+using Discord.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Responsible for formatting certain entities as json string, to reuse later on.
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        ///     Gets a Json formatted <see langword="string"/> from an <see cref="EmbedBuilder"/> to reuse.
+        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embeds.
+        /// </summary>
+        /// <param name="builder">The builder to format as Json <see langword="string"/>.</param>
+        /// <param name="formatting">The formatting in which the Json will be returned.</param>
+        /// <returns>A Json <see langword="string"/> containing the data from the <paramref name="builder"/>.</returns>
+        public static string ToJsonString(this EmbedBuilder builder, Formatting formatting = Formatting.Indented)
+            => ToJsonString(builder.Build(), formatting);
+
+        /// <summary>
+        ///     Gets a Json formatted <see langword="string"/> from an <see cref="Embed"/> to reuse.
+        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
+        /// </summary>
+        /// <param name="embed">The embed to format as Json <see langword="string"/>.</param>
+        /// <param name="formatting">The formatting in which the Json will be returned.</param>
+        /// <returns>A Json <see langword="string"/> containing the data from the <paramref name="builder"/>.</returns>
+        public static string ToJsonString(this Embed embed, Formatting formatting = Formatting.Indented)
+            => JsonConvert.SerializeObject(embed.ToModel(), formatting, new EmbedTypeConverter());
+    }
+}

--- a/src/Discord.Net.Rest/Extensions/StringExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/StringExtensions.cs
@@ -1,5 +1,7 @@
 using Discord.Net.Converters;
 using Newtonsoft.Json;
+using System.Linq;
+using System;
 
 namespace Discord.Rest
 {
@@ -8,6 +10,16 @@ namespace Discord.Rest
     /// </summary>
     public static class StringExtensions
     {
+        private static Lazy<JsonSerializerSettings> _settings = new(() =>
+        {
+            var serializer = new JsonSerializerSettings()
+            {
+                ContractResolver = new DiscordContractResolver()
+            };
+            serializer.Converters.Add(new EmbedTypeConverter());
+            return serializer;
+        });
+
         /// <summary>
         ///     Gets a Json formatted <see langword="string"/> from an <see cref="EmbedBuilder"/>.
         /// </summary>
@@ -30,6 +42,6 @@ namespace Discord.Rest
         /// <param name="formatting">The formatting in which the Json will be returned.</param>
         /// <returns>A Json <see langword="string"/> containing the data from the <paramref name="builder"/>.</returns>
         public static string ToJsonString(this Embed embed, Formatting formatting = Formatting.Indented)
-            => JsonConvert.SerializeObject(embed.ToModel(), formatting, new EmbedTypeConverter());
+            => JsonConvert.SerializeObject(embed.ToModel(), formatting, _settings.Value);
     }
 }

--- a/src/Discord.Net.Rest/Extensions/StringExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/StringExtensions.cs
@@ -4,14 +4,16 @@ using Newtonsoft.Json;
 namespace Discord.Rest
 {
     /// <summary>
-    ///     Responsible for formatting certain entities as json string, to reuse later on.
+    ///     Responsible for formatting certain entities as Json <see langword="string"/>, to reuse later on.
     /// </summary>
     public static class StringExtensions
     {
         /// <summary>
-        ///     Gets a Json formatted <see langword="string"/> from an <see cref="EmbedBuilder"/> to reuse.
-        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embeds.
+        ///     Gets a Json formatted <see langword="string"/> from an <see cref="EmbedBuilder"/>.
         /// </summary>
+        /// <remarks>
+        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
+        /// </remarks>
         /// <param name="builder">The builder to format as Json <see langword="string"/>.</param>
         /// <param name="formatting">The formatting in which the Json will be returned.</param>
         /// <returns>A Json <see langword="string"/> containing the data from the <paramref name="builder"/>.</returns>
@@ -19,9 +21,11 @@ namespace Discord.Rest
             => ToJsonString(builder.Build(), formatting);
 
         /// <summary>
-        ///     Gets a Json formatted <see langword="string"/> from an <see cref="Embed"/> to reuse.
-        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
+        ///     Gets a Json formatted <see langword="string"/> from an <see cref="Embed"/>.
         /// </summary>
+        /// <remarks>
+        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
+        /// </remarks>
         /// <param name="embed">The embed to format as Json <see langword="string"/>.</param>
         /// <param name="formatting">The formatting in which the Json will be returned.</param>
         /// <returns>A Json <see langword="string"/> containing the data from the <paramref name="builder"/>.</returns>


### PR DESCRIPTION
Introduces a method that allows users to parse embedbuilders directly from text. (json). Also adds ToJsonString methods to the Rest package to serialize as string.