### PR TITLE
[Docs] Autocomplete examples

### DIFF
--- a/docs/guides/int_framework/autocompletion.md
+++ b/docs/guides/int_framework/autocompletion.md
@@ -18,6 +18,8 @@ AutocompleteHandlers raise the `AutocompleteHandlerExecuted` event on execution.
 
 A valid AutocompleteHandlers must inherit [AutocompleteHandler] base type and implement all of its abstract methods.
 
+[!code-csharp[Autocomplete Command Example](samples/autocompletion/autocomplete-example.cs)]
+
 ### GenerateSuggestionsAsync()
 
 The Interactions Service uses this method to generate a response of an Autocomplete Interaction.

--- a/docs/guides/int_framework/samples/autocompletion/autocomplete-example.cs
+++ b/docs/guides/int_framework/samples/autocompletion/autocomplete-example.cs
@@ -1,0 +1,20 @@
+// you need to add `Autocomplete` attribute before parameter to add autocompletion to it
+[SlashCommand("command_name", "command_description")]
+public async Task ExampleCommand([Summary("parameter_name"), Autocomplete(typeof(ExampleAutocompleteHandler))] string parameterWithAutocompletion)
+    => await RespondAsync($"Your choice: {parameterWithAutocompletion}");
+
+public class ExampleAutocompleteHandler : AutocompleteHandler
+{
+    public override async Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
+    {
+        // Create a collection with suggestions for autocomplete
+        IEnumerable<AutocompleteResult> results = new[]
+        {
+            new AutocompleteResult("Name1", "value111"),
+            new AutocompleteResult("Name2", "value2")
+        };
+
+        // max - 25 suggestions at a time
+        return AutocompletionResult.FromSuccess(results.Take(25));
+    }
+}

--- a/docs/guides/int_framework/samples/autocompletion/autocomplete-example.cs
+++ b/docs/guides/int_framework/samples/autocompletion/autocomplete-example.cs
@@ -14,7 +14,7 @@ public class ExampleAutocompleteHandler : AutocompleteHandler
             new AutocompleteResult("Name2", "value2")
         };
 
-        // max - 25 suggestions at a time
+        // max - 25 suggestions at a time (API limit)
         return AutocompletionResult.FromSuccess(results.Take(25));
     }
 }

--- a/docs/guides/int_framework/samples/intro/autocomplete.cs
+++ b/docs/guides/int_framework/samples/intro/autocomplete.cs
@@ -1,9 +1,17 @@
 [AutocompleteCommand("parameter_name", "command_name")]
 public async Task Autocomplete()
 {
-    IEnumerable<AutocompleteResult> results;
+    IEnumerable<AutocompleteResult> results = new[] 
+    { 
+        new AutocompleteResult("Name1", "value1"), 
+        new AutocompleteResult("Name2", "value2") 
+    };
 
-    ...
-
-    await (Context.Interaction as SocketAutocompleteInteraction).RespondAsync(results);
+        // max - 25 suggestions at a time
+    await (Context.Interaction as SocketAutocompleteInteraction).RespondAsync(results.Take(25));
 }
+
+// you need to add `Autocomplete` attribute before parameter to add autocompletion to it
+[SlashCommand("command_name", "command_description")]
+public async Task ExampleCommand([Summary("parameter_name"), Autocomplete] string parameterWithAutocompletion)
+    => await RespondAsync($"Your choice: {parameterWithAutocompletion}");

--- a/docs/guides/int_framework/samples/intro/autocomplete.cs
+++ b/docs/guides/int_framework/samples/intro/autocomplete.cs
@@ -8,7 +8,8 @@ public async Task Autocomplete()
         new AutocompleteResult("foo", "foo_value"),
         new AutocompleteResult("bar", "bar_value"),
         new AutocompleteResult("baz", "baz_value"),
-    }.Where(x => x.Name.StartsWith(userInput)); // only send suggestions that start with user's input
+    }.Where(x => x.Name.StartsWith(userInput, StringComparison.InvariantCultureIgnoreCase)); // only send suggestions that starts with user's input; use case insensitive matching
+
 
     // max - 25 suggestions at a time
     await (Context.Interaction as SocketAutocompleteInteraction).RespondAsync(results.Take(25));

--- a/docs/guides/int_framework/samples/intro/autocomplete.cs
+++ b/docs/guides/int_framework/samples/intro/autocomplete.cs
@@ -1,13 +1,16 @@
 [AutocompleteCommand("parameter_name", "command_name")]
 public async Task Autocomplete()
 {
-    IEnumerable<AutocompleteResult> results = new[] 
-    { 
-        new AutocompleteResult("Name1", "value1"), 
-        new AutocompleteResult("Name2", "value2") 
-    };
+    string userInput = (Context.Interaction as SocketAutocompleteInteraction).Data.Current.Value.ToString();
 
-        // max - 25 suggestions at a time
+    IEnumerable<AutocompleteResult> results = new[]
+    {
+        new AutocompleteResult("foo", "foo_value"),
+        new AutocompleteResult("bar", "bar_value"),
+        new AutocompleteResult("baz", "baz_value"),
+    }.Where(x => x.Name.StartsWith(userInput)); // only send suggestions that start with user's input
+
+    // max - 25 suggestions at a time
     await (Context.Interaction as SocketAutocompleteInteraction).RespondAsync(results.Take(25));
 }
 


### PR DESCRIPTION
This PR adds example usages of autocomplete parameters to interaction framework `intro` and `auto-completion`

# Changes
- modified codeblock in interaction framework intro
- added codeblock with an example to interaction framework `Auto-Completion`