### PR TITLE
Added threads support to Webhooks 

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -841,7 +841,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}${WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}${WebhookQuery(false, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -173,10 +173,12 @@ namespace Discord.API
         private async Task LogoutInternalAsync()
         {
             //An exception here will lock the client into the unusable LoggingOut state, but that's probably fine since our client is in an undefined state too.
-            if (LoginState == LoginState.LoggedOut) return;
+            if (LoginState == LoginState.LoggedOut)
+                return;
             LoginState = LoginState.LoggingOut;
 
-            try { _loginCancelToken?.Cancel(false); }
+            try
+            { _loginCancelToken?.Cancel(false); }
             catch { }
 
             await DisconnectInternalAsync(null).ConfigureAwait(false);
@@ -398,7 +400,7 @@ namespace Discord.API
             Preconditions.AtLeast(args.Position, 0, nameof(args.Position));
             Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
 
-            if(args.Name.IsSpecified)
+            if (args.Name.IsSpecified)
                 Preconditions.AtMost(args.Name.Value.Length, 100, nameof(args.Name));
 
             options = RequestOptions.CreateOrClone(options);
@@ -414,9 +416,9 @@ namespace Discord.API
             Preconditions.AtLeast(args.Position, 0, nameof(args.Position));
             Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
 
-            if(args.Name.IsSpecified)
+            if (args.Name.IsSpecified)
                 Preconditions.AtMost(args.Name.Value.Length, 100, nameof(args.Name));
-            if(args.Topic.IsSpecified)
+            if (args.Topic.IsSpecified)
                 Preconditions.AtMost(args.Topic.Value.Length, 1024, nameof(args.Name));
 
             Preconditions.AtLeast(args.SlowModeInterval, 0, nameof(args.SlowModeInterval));
@@ -798,9 +800,11 @@ namespace Discord.API
             var ids = new BucketIds(channelId: channelId);
             return await SendJsonAsync<Message>("POST", () => $"channels/{channelId}/messages", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
+
+
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task<Message> CreateWebhookMessageAsync(ulong webhookId, CreateWebhookMessageParams args, RequestOptions options = null)
+        public async Task<Message> CreateWebhookMessageAsync(ulong webhookId, CreateWebhookMessageParams args, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -816,12 +820,19 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+
+            string threadQuery = "";
+            if (threadId.HasValue)
+            {
+                threadQuery = $"&thread_id=${threadId}";
+            }
+
+            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?{WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task ModifyWebhookMessageAsync(ulong webhookId, ulong messageId, ModifyWebhookMessageParams args, RequestOptions options = null)
+        public async Task ModifyWebhookMessageAsync(ulong webhookId, ulong messageId, ModifyWebhookMessageParams args, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -837,11 +848,11 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}${WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task DeleteWebhookMessageAsync(ulong webhookId, ulong messageId, RequestOptions options = null)
+        public async Task DeleteWebhookMessageAsync(ulong webhookId, ulong messageId, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -852,7 +863,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            await SendAsync("DELETE", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}", ids, options: options).ConfigureAwait(false);
+            await SendAsync("DELETE", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}?{WebhookQuery(false, threadId)}", ids, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
@@ -873,7 +884,7 @@ namespace Discord.API
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task<Message> UploadWebhookFileAsync(ulong webhookId, UploadWebhookFileParams args, RequestOptions options = null)
+        public async Task<Message> UploadWebhookFileAsync(ulong webhookId, UploadWebhookFileParams args, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -892,8 +903,14 @@ namespace Discord.API
                     throw new ArgumentOutOfRangeException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
             }
 
+            string threadQuery = "";
+            if (threadId.HasValue)
+            {
+                threadQuery = $"&";
+            }
+
             var ids = new BucketIds(webhookId: webhookId);
-            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?{WebhookQuery(true, threadId)}", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
         public async Task DeleteMessageAsync(ulong channelId, ulong messageId, RequestOptions options = null)
         {
@@ -1380,7 +1397,7 @@ namespace Discord.API
             if ((!args.Embeds.IsSpecified || args.Embeds.Value == null || args.Embeds.Value.Length == 0) && !args.File.IsSpecified)
                 Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
 
-            if(args.Content.IsSpecified && args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
+            if (args.Content.IsSpecified && args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
                 throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
 
             options = RequestOptions.CreateOrClone(options);
@@ -1400,7 +1417,7 @@ namespace Discord.API
                 throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
 
             options = RequestOptions.CreateOrClone(options);
-           
+
             var ids = new BucketIds();
             return await SendMultipartAsync<Message>("POST", () => $"webhooks/{CurrentApplicationId}/{token}?wait=true", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
@@ -1729,8 +1746,10 @@ namespace Discord.API
             if (args.TargetType.IsSpecified)
             {
                 Preconditions.NotEqual((int)args.TargetType.Value, (int)TargetUserType.Undefined, nameof(args.TargetType));
-                if (args.TargetType.Value == TargetUserType.Stream) Preconditions.GreaterThan(args.TargetUserId, 0, nameof(args.TargetUserId));
-                if (args.TargetType.Value == TargetUserType.EmbeddedApplication) Preconditions.GreaterThan(args.TargetApplicationId, 0, nameof(args.TargetUserId));
+                if (args.TargetType.Value == TargetUserType.Stream)
+                    Preconditions.GreaterThan(args.TargetUserId, 0, nameof(args.TargetUserId));
+                if (args.TargetType.Value == TargetUserType.EmbeddedApplication)
+                    Preconditions.GreaterThan(args.TargetApplicationId, 0, nameof(args.TargetUserId));
             }
             options = RequestOptions.CreateOrClone(options);
 
@@ -2414,6 +2433,18 @@ namespace Discord.API
 
             return (expr as MemberExpression).Member.Name;
         }
+
+        private static string WebhookQuery(bool wait = false, ulong? threadId = null)
+        {
+            List<string> querys = new List<string>() { };
+            if (wait)
+                querys.Add("wait=true");
+            if (threadId.HasValue)
+                querys.Add($"thread_id={threadId}");
+
+            return $"{string.Join("&", querys)}";
+        }
+
         #endregion
     }
 }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -173,10 +173,12 @@ namespace Discord.API
         private async Task LogoutInternalAsync()
         {
             //An exception here will lock the client into the unusable LoggingOut state, but that's probably fine since our client is in an undefined state too.
-            if (LoginState == LoginState.LoggedOut) return;
+            if (LoginState == LoginState.LoggedOut)
+                return;
             LoginState = LoginState.LoggingOut;
 
-            try { _loginCancelToken?.Cancel(false); }
+            try
+            { _loginCancelToken?.Cancel(false); }
             catch { }
 
             await DisconnectInternalAsync(null).ConfigureAwait(false);
@@ -398,7 +400,7 @@ namespace Discord.API
             Preconditions.AtLeast(args.Position, 0, nameof(args.Position));
             Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
 
-            if(args.Name.IsSpecified)
+            if (args.Name.IsSpecified)
                 Preconditions.AtMost(args.Name.Value.Length, 100, nameof(args.Name));
 
             options = RequestOptions.CreateOrClone(options);
@@ -414,9 +416,9 @@ namespace Discord.API
             Preconditions.AtLeast(args.Position, 0, nameof(args.Position));
             Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
 
-            if(args.Name.IsSpecified)
+            if (args.Name.IsSpecified)
                 Preconditions.AtMost(args.Name.Value.Length, 100, nameof(args.Name));
-            if(args.Topic.IsSpecified)
+            if (args.Topic.IsSpecified)
                 Preconditions.AtMost(args.Topic.Value.Length, 1024, nameof(args.Name));
 
             Preconditions.AtLeast(args.SlowModeInterval, 0, nameof(args.SlowModeInterval));
@@ -798,9 +800,11 @@ namespace Discord.API
             var ids = new BucketIds(channelId: channelId);
             return await SendJsonAsync<Message>("POST", () => $"channels/{channelId}/messages", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
+
+
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task<Message> CreateWebhookMessageAsync(ulong webhookId, CreateWebhookMessageParams args, RequestOptions options = null)
+        public async Task<Message> CreateWebhookMessageAsync(ulong webhookId, CreateWebhookMessageParams args, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -816,12 +820,12 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?{WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task ModifyWebhookMessageAsync(ulong webhookId, ulong messageId, ModifyWebhookMessageParams args, RequestOptions options = null)
+        public async Task ModifyWebhookMessageAsync(ulong webhookId, ulong messageId, ModifyWebhookMessageParams args, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -837,11 +841,11 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}${WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task DeleteWebhookMessageAsync(ulong webhookId, ulong messageId, RequestOptions options = null)
+        public async Task DeleteWebhookMessageAsync(ulong webhookId, ulong messageId, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -852,7 +856,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            await SendAsync("DELETE", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}", ids, options: options).ConfigureAwait(false);
+            await SendAsync("DELETE", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}?{WebhookQuery(false, threadId)}", ids, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
@@ -873,7 +877,7 @@ namespace Discord.API
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task<Message> UploadWebhookFileAsync(ulong webhookId, UploadWebhookFileParams args, RequestOptions options = null)
+        public async Task<Message> UploadWebhookFileAsync(ulong webhookId, UploadWebhookFileParams args, RequestOptions options = null, ulong? threadId = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -893,7 +897,7 @@ namespace Discord.API
             }
 
             var ids = new BucketIds(webhookId: webhookId);
-            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?{WebhookQuery(true, threadId)}", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
         public async Task DeleteMessageAsync(ulong channelId, ulong messageId, RequestOptions options = null)
         {
@@ -1380,7 +1384,7 @@ namespace Discord.API
             if ((!args.Embeds.IsSpecified || args.Embeds.Value == null || args.Embeds.Value.Length == 0) && !args.File.IsSpecified)
                 Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
 
-            if(args.Content.IsSpecified && args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
+            if (args.Content.IsSpecified && args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
                 throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
 
             options = RequestOptions.CreateOrClone(options);
@@ -1400,7 +1404,7 @@ namespace Discord.API
                 throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
 
             options = RequestOptions.CreateOrClone(options);
-           
+
             var ids = new BucketIds();
             return await SendMultipartAsync<Message>("POST", () => $"webhooks/{CurrentApplicationId}/{token}?wait=true", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
@@ -1729,8 +1733,10 @@ namespace Discord.API
             if (args.TargetType.IsSpecified)
             {
                 Preconditions.NotEqual((int)args.TargetType.Value, (int)TargetUserType.Undefined, nameof(args.TargetType));
-                if (args.TargetType.Value == TargetUserType.Stream) Preconditions.GreaterThan(args.TargetUserId, 0, nameof(args.TargetUserId));
-                if (args.TargetType.Value == TargetUserType.EmbeddedApplication) Preconditions.GreaterThan(args.TargetApplicationId, 0, nameof(args.TargetUserId));
+                if (args.TargetType.Value == TargetUserType.Stream)
+                    Preconditions.GreaterThan(args.TargetUserId, 0, nameof(args.TargetUserId));
+                if (args.TargetType.Value == TargetUserType.EmbeddedApplication)
+                    Preconditions.GreaterThan(args.TargetApplicationId, 0, nameof(args.TargetUserId));
             }
             options = RequestOptions.CreateOrClone(options);
 
@@ -2414,6 +2420,18 @@ namespace Discord.API
 
             return (expr as MemberExpression).Member.Name;
         }
+
+        private static string WebhookQuery(bool wait = false, ulong? threadId = null)
+        {
+            List<string> querys = new List<string>() { };
+            if (wait)
+                querys.Add("wait=true");
+            if (threadId.HasValue)
+                querys.Add($"thread_id={threadId}");
+
+            return $"{string.Join("&", querys)}";
+        }
+
         #endregion
     }
 }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -820,13 +820,6 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-
-            string threadQuery = "";
-            if (threadId.HasValue)
-            {
-                threadQuery = $"&thread_id=${threadId}";
-            }
-
             return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?{WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
@@ -901,12 +894,6 @@ namespace Discord.API
                     args.Content = "";
                 if (args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
                     throw new ArgumentOutOfRangeException($"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", nameof(args.Content));
-            }
-
-            string threadQuery = "";
-            if (threadId.HasValue)
-            {
-                threadQuery = $"&";
             }
 
             var ids = new BucketIds(webhookId: webhookId);

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -173,12 +173,10 @@ namespace Discord.API
         private async Task LogoutInternalAsync()
         {
             //An exception here will lock the client into the unusable LoggingOut state, but that's probably fine since our client is in an undefined state too.
-            if (LoginState == LoginState.LoggedOut)
-                return;
+            if (LoginState == LoginState.LoggedOut) return;
             LoginState = LoginState.LoggingOut;
 
-            try
-            { _loginCancelToken?.Cancel(false); }
+            try { _loginCancelToken?.Cancel(false); }
             catch { }
 
             await DisconnectInternalAsync(null).ConfigureAwait(false);
@@ -400,7 +398,7 @@ namespace Discord.API
             Preconditions.AtLeast(args.Position, 0, nameof(args.Position));
             Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
 
-            if (args.Name.IsSpecified)
+            if(args.Name.IsSpecified)
                 Preconditions.AtMost(args.Name.Value.Length, 100, nameof(args.Name));
 
             options = RequestOptions.CreateOrClone(options);
@@ -416,9 +414,9 @@ namespace Discord.API
             Preconditions.AtLeast(args.Position, 0, nameof(args.Position));
             Preconditions.NotNullOrWhitespace(args.Name, nameof(args.Name));
 
-            if (args.Name.IsSpecified)
+            if(args.Name.IsSpecified)
                 Preconditions.AtMost(args.Name.Value.Length, 100, nameof(args.Name));
-            if (args.Topic.IsSpecified)
+            if(args.Topic.IsSpecified)
                 Preconditions.AtMost(args.Topic.Value.Length, 1024, nameof(args.Name));
 
             Preconditions.AtLeast(args.SlowModeInterval, 0, nameof(args.SlowModeInterval));
@@ -800,11 +798,9 @@ namespace Discord.API
             var ids = new BucketIds(channelId: channelId);
             return await SendJsonAsync<Message>("POST", () => $"channels/{channelId}/messages", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
-
-
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task<Message> CreateWebhookMessageAsync(ulong webhookId, CreateWebhookMessageParams args, RequestOptions options = null, ulong? threadId = null)
+        public async Task<Message> CreateWebhookMessageAsync(ulong webhookId, CreateWebhookMessageParams args, RequestOptions options = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -820,12 +816,12 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?{WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            return await SendJsonAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task ModifyWebhookMessageAsync(ulong webhookId, ulong messageId, ModifyWebhookMessageParams args, RequestOptions options = null, ulong? threadId = null)
+        public async Task ModifyWebhookMessageAsync(ulong webhookId, ulong messageId, ModifyWebhookMessageParams args, RequestOptions options = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -841,11 +837,11 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}${WebhookQuery(true, threadId)}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            await SendJsonAsync<Message>("PATCH", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}", args, ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task DeleteWebhookMessageAsync(ulong webhookId, ulong messageId, RequestOptions options = null, ulong? threadId = null)
+        public async Task DeleteWebhookMessageAsync(ulong webhookId, ulong messageId, RequestOptions options = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -856,7 +852,7 @@ namespace Discord.API
             options = RequestOptions.CreateOrClone(options);
 
             var ids = new BucketIds(webhookId: webhookId);
-            await SendAsync("DELETE", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}?{WebhookQuery(false, threadId)}", ids, options: options).ConfigureAwait(false);
+            await SendAsync("DELETE", () => $"webhooks/{webhookId}/{AuthToken}/messages/{messageId}", ids, options: options).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
@@ -877,7 +873,7 @@ namespace Discord.API
 
         /// <exception cref="ArgumentOutOfRangeException">Message content is too long, length must be less or equal to <see cref="DiscordConfig.MaxMessageSize"/>.</exception>
         /// <exception cref="InvalidOperationException">This operation may only be called with a <see cref="TokenType.Webhook"/> token.</exception>
-        public async Task<Message> UploadWebhookFileAsync(ulong webhookId, UploadWebhookFileParams args, RequestOptions options = null, ulong? threadId = null)
+        public async Task<Message> UploadWebhookFileAsync(ulong webhookId, UploadWebhookFileParams args, RequestOptions options = null)
         {
             if (AuthTokenType != TokenType.Webhook)
                 throw new InvalidOperationException($"This operation may only be called with a {nameof(TokenType.Webhook)} token.");
@@ -897,7 +893,7 @@ namespace Discord.API
             }
 
             var ids = new BucketIds(webhookId: webhookId);
-            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?{WebhookQuery(true, threadId)}", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
+            return await SendMultipartAsync<Message>("POST", () => $"webhooks/{webhookId}/{AuthToken}?wait=true", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
         public async Task DeleteMessageAsync(ulong channelId, ulong messageId, RequestOptions options = null)
         {
@@ -1384,7 +1380,7 @@ namespace Discord.API
             if ((!args.Embeds.IsSpecified || args.Embeds.Value == null || args.Embeds.Value.Length == 0) && !args.File.IsSpecified)
                 Preconditions.NotNullOrEmpty(args.Content, nameof(args.Content));
 
-            if (args.Content.IsSpecified && args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
+            if(args.Content.IsSpecified && args.Content.Value?.Length > DiscordConfig.MaxMessageSize)
                 throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
 
             options = RequestOptions.CreateOrClone(options);
@@ -1404,7 +1400,7 @@ namespace Discord.API
                 throw new ArgumentException(message: $"Message content is too long, length must be less or equal to {DiscordConfig.MaxMessageSize}.", paramName: nameof(args.Content));
 
             options = RequestOptions.CreateOrClone(options);
-
+           
             var ids = new BucketIds();
             return await SendMultipartAsync<Message>("POST", () => $"webhooks/{CurrentApplicationId}/{token}?wait=true", args.ToDictionary(), ids, clientBucket: ClientBucketType.SendEdit, options: options).ConfigureAwait(false);
         }
@@ -1733,10 +1729,8 @@ namespace Discord.API
             if (args.TargetType.IsSpecified)
             {
                 Preconditions.NotEqual((int)args.TargetType.Value, (int)TargetUserType.Undefined, nameof(args.TargetType));
-                if (args.TargetType.Value == TargetUserType.Stream)
-                    Preconditions.GreaterThan(args.TargetUserId, 0, nameof(args.TargetUserId));
-                if (args.TargetType.Value == TargetUserType.EmbeddedApplication)
-                    Preconditions.GreaterThan(args.TargetApplicationId, 0, nameof(args.TargetUserId));
+                if (args.TargetType.Value == TargetUserType.Stream) Preconditions.GreaterThan(args.TargetUserId, 0, nameof(args.TargetUserId));
+                if (args.TargetType.Value == TargetUserType.EmbeddedApplication) Preconditions.GreaterThan(args.TargetApplicationId, 0, nameof(args.TargetUserId));
             }
             options = RequestOptions.CreateOrClone(options);
 
@@ -2420,18 +2414,6 @@ namespace Discord.API
 
             return (expr as MemberExpression).Member.Name;
         }
-
-        private static string WebhookQuery(bool wait = false, ulong? threadId = null)
-        {
-            List<string> querys = new List<string>() { };
-            if (wait)
-                querys.Add("wait=true");
-            if (threadId.HasValue)
-                querys.Add($"thread_id={threadId}");
-
-            return $"{string.Join("&", querys)}";
-        }
-
         #endregion
     }
 }

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -88,8 +88,8 @@ namespace Discord.Webhook
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendMessageAsync(string text = null, bool isTTS = false, IEnumerable<Embed> embeds = null,
             string username = null, string avatarUrl = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None)
-            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags);
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId);
 
         /// <summary>
         ///     Modifies a message posted using this webhook.
@@ -103,8 +103,8 @@ namespace Discord.Webhook
         /// <returns>
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
-        public Task ModifyMessageAsync(ulong messageId, Action<WebhookMessageProperties> func, RequestOptions options = null)
-            => WebhookClientHelper.ModifyMessageAsync(this, messageId, func, options);
+        public Task ModifyMessageAsync(ulong messageId, Action<WebhookMessageProperties> func, RequestOptions options = null, ulong? threadId = null)
+            => WebhookClientHelper.ModifyMessageAsync(this, messageId, func, options, threadId);
 
         /// <summary>
         ///     Deletes a message posted using this webhook.
@@ -117,43 +117,43 @@ namespace Discord.Webhook
         /// <returns>
         ///     A task that represents the asynchronous deletion operation.
         /// </returns>
-        public Task DeleteMessageAsync(ulong messageId, RequestOptions options = null)
-            => WebhookClientHelper.DeleteMessageAsync(this, messageId, options);
+        public Task DeleteMessageAsync(ulong messageId, RequestOptions options = null, ulong ? threadId = null)
+            => WebhookClientHelper.DeleteMessageAsync(this, messageId, options, threadId);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None)
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
             => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl,
-                allowedMentions, options, isSpoiler, components, flags);
+                allowedMentions, options, isSpoiler, components, flags, threadId);
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None)
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
             => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username,
-                avatarUrl, allowedMentions, options, isSpoiler, components, flags);
+                avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(FileAttachment attachment, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, 
-            MessageFlags flags = MessageFlags.None)
+            MessageFlags flags = MessageFlags.None, ulong? threadId = null)
             => WebhookClientHelper.SendFileAsync(this, attachment, text, isTTS, embeds, username,
-                avatarUrl, allowedMentions, components, options, flags);
+                avatarUrl, allowedMentions, components, options, flags, threadId);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFilesAsync(IEnumerable<FileAttachment> attachments, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, 
-            MessageFlags flags = MessageFlags.None)
+            MessageFlags flags = MessageFlags.None, ulong? threadId = null)
             => WebhookClientHelper.SendFilesAsync(this, attachments, text, isTTS, embeds, username, avatarUrl,
-                allowedMentions, components, options, flags);
+                allowedMentions, components, options, flags, threadId);
 
 
         /// <summary> Modifies the properties of this webhook. </summary>

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -88,8 +88,8 @@ namespace Discord.Webhook
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendMessageAsync(string text = null, bool isTTS = false, IEnumerable<Embed> embeds = null,
             string username = null, string avatarUrl = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
-            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId);
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None)
+            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags);
 
         /// <summary>
         ///     Modifies a message posted using this webhook.
@@ -103,8 +103,8 @@ namespace Discord.Webhook
         /// <returns>
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
-        public Task ModifyMessageAsync(ulong messageId, Action<WebhookMessageProperties> func, RequestOptions options = null, ulong? threadId = null)
-            => WebhookClientHelper.ModifyMessageAsync(this, messageId, func, options, threadId);
+        public Task ModifyMessageAsync(ulong messageId, Action<WebhookMessageProperties> func, RequestOptions options = null)
+            => WebhookClientHelper.ModifyMessageAsync(this, messageId, func, options);
 
         /// <summary>
         ///     Deletes a message posted using this webhook.
@@ -117,43 +117,43 @@ namespace Discord.Webhook
         /// <returns>
         ///     A task that represents the asynchronous deletion operation.
         /// </returns>
-        public Task DeleteMessageAsync(ulong messageId, RequestOptions options = null, ulong ? threadId = null)
-            => WebhookClientHelper.DeleteMessageAsync(this, messageId, options, threadId);
+        public Task DeleteMessageAsync(ulong messageId, RequestOptions options = null)
+            => WebhookClientHelper.DeleteMessageAsync(this, messageId, options);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None)
             => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl,
-                allowedMentions, options, isSpoiler, components, flags, threadId);
+                allowedMentions, options, isSpoiler, components, flags);
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None)
             => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username,
-                avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId);
+                avatarUrl, allowedMentions, options, isSpoiler, components, flags);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(FileAttachment attachment, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, 
-            MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageFlags flags = MessageFlags.None)
             => WebhookClientHelper.SendFileAsync(this, attachment, text, isTTS, embeds, username,
-                avatarUrl, allowedMentions, components, options, flags, threadId);
+                avatarUrl, allowedMentions, components, options, flags);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFilesAsync(IEnumerable<FileAttachment> attachments, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, 
-            MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageFlags flags = MessageFlags.None)
             => WebhookClientHelper.SendFilesAsync(this, attachments, text, isTTS, embeds, username, avatarUrl,
-                allowedMentions, components, options, flags, threadId);
+                allowedMentions, components, options, flags);
 
 
         /// <summary> Modifies the properties of this webhook. </summary>

--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -21,8 +21,8 @@ namespace Discord.Webhook
             return RestInternalWebhook.Create(client, model);
         }
         public static async Task<ulong> SendMessageAsync(DiscordWebhookClient client,
-            string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl, 
-            AllowedMentions allowedMentions, RequestOptions options, MessageComponent components, MessageFlags flags)
+            string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl,
+            AllowedMentions allowedMentions, RequestOptions options, MessageComponent components, MessageFlags flags, ulong? threadId = null)
         {
             var args = new CreateWebhookMessageParams
             {
@@ -44,12 +44,13 @@ namespace Discord.Webhook
 
             if (flags is not MessageFlags.None and not MessageFlags.SuppressEmbeds)
                 throw new ArgumentException("The only valid MessageFlags are SuppressEmbeds and none.", nameof(flags));
-            
-            var model = await client.ApiClient.CreateWebhookMessageAsync(client.Webhook.Id, args, options: options).ConfigureAwait(false);
+
+            var model = await client.ApiClient.CreateWebhookMessageAsync(client.Webhook.Id, args, options: options, threadId: threadId).ConfigureAwait(false);
             return model.Id;
         }
+
         public static async Task ModifyMessageAsync(DiscordWebhookClient client, ulong messageId,
-            Action<WebhookMessageProperties> func, RequestOptions options)
+            Action<WebhookMessageProperties> func, RequestOptions options, ulong? threadId)
         {
             var args = new WebhookMessageProperties();
             func(args);
@@ -94,35 +95,35 @@ namespace Discord.Webhook
                 Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() : Optional<API.ActionRowComponent[]>.Unspecified,
             };
 
-            await client.ApiClient.ModifyWebhookMessageAsync(client.Webhook.Id, messageId, apiArgs, options)
+            await client.ApiClient.ModifyWebhookMessageAsync(client.Webhook.Id, messageId, apiArgs, options, threadId)
                 .ConfigureAwait(false);
         }
-        public static async Task DeleteMessageAsync(DiscordWebhookClient client, ulong messageId, RequestOptions options)
+        public static async Task DeleteMessageAsync(DiscordWebhookClient client, ulong messageId, RequestOptions options, ulong? threadId)
         {
-            await client.ApiClient.DeleteWebhookMessageAsync(client.Webhook.Id, messageId, options).ConfigureAwait(false);
+            await client.ApiClient.DeleteWebhookMessageAsync(client.Webhook.Id, messageId, options, threadId).ConfigureAwait(false);
         }
         public static async Task<ulong> SendFileAsync(DiscordWebhookClient client, string filePath, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options,
-            bool isSpoiler, MessageComponent components, MessageFlags flags = MessageFlags.None)
+            bool isSpoiler, MessageComponent components, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
         {
             string filename = Path.GetFileName(filePath);
             using (var file = File.OpenRead(filePath))
-                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler, components, flags).ConfigureAwait(false);
+                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId).ConfigureAwait(false);
         }
         public static Task<ulong> SendFileAsync(DiscordWebhookClient client, Stream stream, string filename, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options, bool isSpoiler,
-            MessageComponent components, MessageFlags flags)
-            => SendFileAsync(client, new FileAttachment(stream, filename, isSpoiler: isSpoiler), text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags);
+            MessageComponent components, MessageFlags flags, ulong? threadId)
+            => SendFileAsync(client, new FileAttachment(stream, filename, isSpoiler: isSpoiler), text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId);
 
         public static Task<ulong> SendFileAsync(DiscordWebhookClient client, FileAttachment attachment, string text, bool isTTS, 
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, 
-            MessageComponent components, RequestOptions options, MessageFlags flags)
-            => SendFilesAsync(client, new FileAttachment[] { attachment }, text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags);
+            MessageComponent components, RequestOptions options, MessageFlags flags, ulong? threadId)
+            => SendFilesAsync(client, new FileAttachment[] { attachment }, text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId);
 
         public static async Task<ulong> SendFilesAsync(DiscordWebhookClient client,
             IEnumerable<FileAttachment> attachments, string text, bool isTTS, IEnumerable<Embed> embeds, string username, 
             string avatarUrl, AllowedMentions allowedMentions, MessageComponent components, RequestOptions options,
-            MessageFlags flags)
+            MessageFlags flags, ulong? threadId)
         {
             embeds ??= Array.Empty<Embed>();
            
@@ -164,7 +165,7 @@ namespace Discord.Webhook
                 MessageComponents = components?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 Flags = flags
             };
-            var msg = await client.ApiClient.UploadWebhookFileAsync(client.Webhook.Id, args, options).ConfigureAwait(false);
+            var msg = await client.ApiClient.UploadWebhookFileAsync(client.Webhook.Id, args, options, threadId).ConfigureAwait(false);
             return msg.Id;
         }
 

--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -21,8 +21,8 @@ namespace Discord.Webhook
             return RestInternalWebhook.Create(client, model);
         }
         public static async Task<ulong> SendMessageAsync(DiscordWebhookClient client,
-            string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl,
-            AllowedMentions allowedMentions, RequestOptions options, MessageComponent components, MessageFlags flags, ulong? threadId = null)
+            string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl, 
+            AllowedMentions allowedMentions, RequestOptions options, MessageComponent components, MessageFlags flags)
         {
             var args = new CreateWebhookMessageParams
             {
@@ -44,13 +44,12 @@ namespace Discord.Webhook
 
             if (flags is not MessageFlags.None and not MessageFlags.SuppressEmbeds)
                 throw new ArgumentException("The only valid MessageFlags are SuppressEmbeds and none.", nameof(flags));
-
-            var model = await client.ApiClient.CreateWebhookMessageAsync(client.Webhook.Id, args, options: options, threadId: threadId).ConfigureAwait(false);
+            
+            var model = await client.ApiClient.CreateWebhookMessageAsync(client.Webhook.Id, args, options: options).ConfigureAwait(false);
             return model.Id;
         }
-
         public static async Task ModifyMessageAsync(DiscordWebhookClient client, ulong messageId,
-            Action<WebhookMessageProperties> func, RequestOptions options, ulong? threadId)
+            Action<WebhookMessageProperties> func, RequestOptions options)
         {
             var args = new WebhookMessageProperties();
             func(args);
@@ -95,35 +94,35 @@ namespace Discord.Webhook
                 Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() : Optional<API.ActionRowComponent[]>.Unspecified,
             };
 
-            await client.ApiClient.ModifyWebhookMessageAsync(client.Webhook.Id, messageId, apiArgs, options, threadId)
+            await client.ApiClient.ModifyWebhookMessageAsync(client.Webhook.Id, messageId, apiArgs, options)
                 .ConfigureAwait(false);
         }
-        public static async Task DeleteMessageAsync(DiscordWebhookClient client, ulong messageId, RequestOptions options, ulong? threadId)
+        public static async Task DeleteMessageAsync(DiscordWebhookClient client, ulong messageId, RequestOptions options)
         {
-            await client.ApiClient.DeleteWebhookMessageAsync(client.Webhook.Id, messageId, options, threadId).ConfigureAwait(false);
+            await client.ApiClient.DeleteWebhookMessageAsync(client.Webhook.Id, messageId, options).ConfigureAwait(false);
         }
         public static async Task<ulong> SendFileAsync(DiscordWebhookClient client, string filePath, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options,
-            bool isSpoiler, MessageComponent components, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            bool isSpoiler, MessageComponent components, MessageFlags flags = MessageFlags.None)
         {
             string filename = Path.GetFileName(filePath);
             using (var file = File.OpenRead(filePath))
-                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId).ConfigureAwait(false);
+                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler, components, flags).ConfigureAwait(false);
         }
         public static Task<ulong> SendFileAsync(DiscordWebhookClient client, Stream stream, string filename, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options, bool isSpoiler,
-            MessageComponent components, MessageFlags flags, ulong? threadId)
-            => SendFileAsync(client, new FileAttachment(stream, filename, isSpoiler: isSpoiler), text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId);
+            MessageComponent components, MessageFlags flags)
+            => SendFileAsync(client, new FileAttachment(stream, filename, isSpoiler: isSpoiler), text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags);
 
         public static Task<ulong> SendFileAsync(DiscordWebhookClient client, FileAttachment attachment, string text, bool isTTS, 
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, 
-            MessageComponent components, RequestOptions options, MessageFlags flags, ulong? threadId)
-            => SendFilesAsync(client, new FileAttachment[] { attachment }, text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId);
+            MessageComponent components, RequestOptions options, MessageFlags flags)
+            => SendFilesAsync(client, new FileAttachment[] { attachment }, text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags);
 
         public static async Task<ulong> SendFilesAsync(DiscordWebhookClient client,
             IEnumerable<FileAttachment> attachments, string text, bool isTTS, IEnumerable<Embed> embeds, string username, 
             string avatarUrl, AllowedMentions allowedMentions, MessageComponent components, RequestOptions options,
-            MessageFlags flags, ulong? threadId)
+            MessageFlags flags)
         {
             embeds ??= Array.Empty<Embed>();
            
@@ -165,7 +164,7 @@ namespace Discord.Webhook
                 MessageComponents = components?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 Flags = flags
             };
-            var msg = await client.ApiClient.UploadWebhookFileAsync(client.Webhook.Id, args, options, threadId).ConfigureAwait(false);
+            var msg = await client.ApiClient.UploadWebhookFileAsync(client.Webhook.Id, args, options).ConfigureAwait(false);
             return msg.Id;
         }
 


### PR DESCRIPTION
Currently webhooks cannot send messages into threads

I have made a solution to this by allowing a user to pass the thread id into pre existing methods
none of the code should have breaking changes

I have added thread support to the following:
UploadWebhookFileAsync
DeleteWebhookMessageAsync
ModifyWebhookMessageAsync
CreateWebhookMessageAsync

this is my first pr for anything so i dont really know what im doing.
Haven't unit tested as i have never done it before.
Works perfect on my build