### PR TITLE
Resolve NRE at get audit for Deleted User#....

### DIFF
--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BanAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BanAuditLogData.cs
@@ -18,12 +18,15 @@ namespace Discord.Rest
         internal static BanAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
             var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            return new BanAuditLogData(RestUser.Create(discord, userInfo));
+            return new BanAuditLogData((userInfo != null) ? RestUser.Create(discord, userInfo) : null);
         }
 
         /// <summary>
         ///     Gets the user that was banned.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user object representing the banned user.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BotAddAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/BotAddAuditLogData.cs
@@ -18,12 +18,15 @@ namespace Discord.Rest
         internal static BotAddAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
             var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            return new BotAddAuditLogData(RestUser.Create(discord, userInfo));
+            return new BotAddAuditLogData((userInfo != null) ? RestUser.Create(discord, userInfo) : null);
         }
 
         /// <summary>
         ///     Gets the bot that was added.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the bot is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user object representing the bot.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
@@ -45,7 +45,7 @@ namespace Discord.Rest
             {
                 var inviterId = inviterIdModel.NewValue.ToObject<ulong>(discord.ApiClient.Serializer);
                 var inviterInfo = log.Users.FirstOrDefault(x => x.Id == inviterId);
-                inviter = RestUser.Create(discord, inviterInfo);
+                inviter = (inviterInfo != null) ? RestUser.Create(discord, inviterInfo) : null;
             }
 
             return new InviteCreateAuditLogData(maxAge, code, temporary, inviter, channelId, uses, maxUses);
@@ -76,6 +76,9 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the user that created this invite if available.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user that created this invite or <see langword="null"/>.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
@@ -45,7 +45,7 @@ namespace Discord.Rest
             {
                 var inviterId = inviterIdModel.OldValue.ToObject<ulong>(discord.ApiClient.Serializer);
                 var inviterInfo = log.Users.FirstOrDefault(x => x.Id == inviterId);
-                inviter = RestUser.Create(discord, inviterInfo);
+                inviter = (inviterInfo != null) ? RestUser.Create(discord, inviterInfo) : null;
             }
 
             return new InviteDeleteAuditLogData(maxAge, code, temporary, inviter, channelId, uses, maxUses);
@@ -76,6 +76,9 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the user that created this invite if available.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user that created this invite or <see langword="null"/>.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/KickAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/KickAuditLogData.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
@@ -18,12 +18,15 @@ namespace Discord.Rest
         internal static KickAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
             var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            return new KickAuditLogData(RestUser.Create(discord, userInfo));
+            return new KickAuditLogData((userInfo != null) ? RestUser.Create(discord, userInfo) : null);
         }
 
         /// <summary>
         ///     Gets the user that was kicked.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user object representing the kicked user.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleAuditLogData.cs
@@ -27,7 +27,7 @@ namespace Discord.Rest
                 .ToList();
 
             var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            var user = RestUser.Create(discord, userInfo);
+            RestUser user = (userInfo != null) ? RestUser.Create(discord, userInfo) : null;
 
             return new MemberRoleAuditLogData(roleInfos.ToReadOnlyCollection(), user);
         }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberUpdateAuditLogData.cs
@@ -33,7 +33,7 @@ namespace Discord.Rest
                 newMute = muteModel?.NewValue?.ToObject<bool>(discord.ApiClient.Serializer);
 
             var targetInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            var user = RestUser.Create(discord, targetInfo);
+            RestUser user = (targetInfo != null) ? RestUser.Create(discord, targetInfo) : null;
 
             var before = new MemberInfo(oldNick, oldDeaf, oldMute);
             var after = new MemberInfo(newNick, newDeaf, newMute);
@@ -44,6 +44,9 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the user that the changes were performed on.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user object representing the user who the changes were performed on.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageDeleteAuditLogData.cs
@@ -2,6 +2,7 @@ using System.Linq;
 
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
+using System;
 
 namespace Discord.Rest
 {
@@ -20,7 +21,7 @@ namespace Discord.Rest
         internal static MessageDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
             var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            return new MessageDeleteAuditLogData(entry.Options.ChannelId.Value, entry.Options.Count.Value, RestUser.Create(discord, userInfo));
+            return new MessageDeleteAuditLogData(entry.Options.ChannelId.Value, entry.Options.Count.Value, userInfo != null ? RestUser.Create(discord, userInfo) : null);
         }
 
         /// <summary>
@@ -41,6 +42,9 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the user of the messages that were deleted.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user object representing the user that created the deleted messages.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessagePinAuditLogData.cs
@@ -23,7 +23,7 @@ namespace Discord.Rest
             if (entry.TargetId.HasValue)
             {
                 var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-                user = RestUser.Create(discord, userInfo);
+                user = (userInfo != null) ? RestUser.Create(discord, userInfo) : null;
             }
 
             return new MessagePinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, user);
@@ -46,6 +46,9 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the user of the message that was pinned if available.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user object representing the user that created the pinned message or <see langword="null"/>.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MessageUnpinAuditLogData.cs
@@ -23,7 +23,7 @@ namespace Discord.Rest
             if (entry.TargetId.HasValue)
             {
                 var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-                user = RestUser.Create(discord, userInfo);
+                user = (userInfo != null) ? RestUser.Create(discord, userInfo) : null;
             }
 
             return new MessageUnpinAuditLogData(entry.Options.MessageId.Value, entry.Options.ChannelId.Value, user);
@@ -46,6 +46,9 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the user of the message that was unpinned if available.
         /// </summary>
+        /// <remarks>
+        ///     Will be <see langword="null"/> if the user is a 'Deleted User#....' because Discord does send user data for deleted users.
+        /// </remarks>
         /// <returns>
         ///     A user object representing the user that created the unpinned message or <see langword="null"/>.
         /// </returns>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/UnbanAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/UnbanAuditLogData.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
@@ -18,7 +18,7 @@ namespace Discord.Rest
         internal static UnbanAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
         {
             var userInfo = log.Users.FirstOrDefault(x => x.Id == entry.TargetId);
-            return new UnbanAuditLogData(RestUser.Create(discord, userInfo));
+            return new UnbanAuditLogData((userInfo != null) ? RestUser.Create(discord, userInfo) : null);
         }
 
         /// <summary>


### PR DESCRIPTION
Thanks to Discord not sending any user data of deleted users, there is no way to create a `RestUser` for the `IUser` property of user-bound audit entries. Property will be set to null so no internal NRE is thrown when attempting to call `GetAuditLogsAsync`. Fixes #2303.
