### PR TITLE
(4.x) Tackle warnings, errors & messages in source at large scale

### DIFF
--- a/samples/InteractionFramework/InteractionHandler.cs
+++ b/samples/InteractionFramework/InteractionHandler.cs
@@ -37,7 +37,10 @@ namespace InteractionFramework
         }
 
         private async Task LogAsync(LogMessage log)
-            => Console.WriteLine(log);
+        {
+            Console.WriteLine(log);
+            await Task.CompletedTask;
+        }
 
         private async Task ReadyAsync()
         {

--- a/samples/InteractionFramework/Modules/ExampleModule.cs
+++ b/samples/InteractionFramework/Modules/ExampleModule.cs
@@ -12,7 +12,7 @@ namespace InteractionFramework.Modules
         // Dependencies can be accessed through Property injection, public properties with public setters will be set by the service provider
         public InteractionService Commands { get; set; }
 
-        private InteractionHandler _handler;
+        private readonly InteractionHandler _handler;
 
         // Constructor injection is also a valid way to access the dependencies
         public ExampleModule(InteractionHandler handler)
@@ -63,7 +63,7 @@ namespace InteractionFramework.Modules
         [ComponentInteraction("roleSelect")]
         public async Task RoleSelect(string[] selections)
         {
-            throw new NotImplementedException();
+            await DeferAsync();
         }
 
         // With the Attribute DoUserCheck you can make sure that only the user this button targets can click it. This is defined by the first wildcard: *.

--- a/samples/InteractionFramework/Program.cs
+++ b/samples/InteractionFramework/Program.cs
@@ -60,7 +60,10 @@ namespace InteractionFramework
         }
 
         private async Task LogAsync(LogMessage message)
-            => Console.WriteLine(message.ToString());
+        {
+            Console.WriteLine(message.ToString());
+            await Task.CompletedTask;
+        }
 
         public static bool IsDebug()
         {

--- a/samples/TextCommandFramework/Program.cs
+++ b/samples/TextCommandFramework/Program.cs
@@ -22,7 +22,7 @@ namespace TextCommandFramework
     {
         // There is no need to implement IDisposable like before as we are
         // using dependency injection, which handles calling Dispose for us.
-        static void Main(string[] args)
+        static void Main(string[] _)
             => new Program().MainAsync().GetAwaiter().GetResult();
 
         public async Task MainAsync()
@@ -31,23 +31,22 @@ namespace TextCommandFramework
             // when you are finished using it, at the end of your app's lifetime.
             // If you use another dependency injection framework, you should inspect
             // its documentation for the best way to do this.
-            using (var services = ConfigureServices())
-            {
-                var client = services.GetRequiredService<DiscordSocketClient>();
+            using var services = ConfigureServices();
 
-                client.Log += LogAsync;
-                services.GetRequiredService<CommandService>().Log += LogAsync;
+            var client = services.GetRequiredService<DiscordSocketClient>();
 
-                // Tokens should be considered secret data and never hard-coded.
-                // We can read from the environment variable to avoid hard coding.
-                await client.LoginAsync(TokenType.Bot, Environment.GetEnvironmentVariable("token"));
-                await client.StartAsync();
+            client.Log += LogAsync;
+            services.GetRequiredService<CommandService>().Log += LogAsync;
 
-                // Here we initialize the logic required to register our commands.
-                await services.GetRequiredService<CommandHandlingService>().InitializeAsync();
+            // Tokens should be considered secret data and never hard-coded.
+            // We can read from the environment variable to avoid hard coding.
+            await client.LoginAsync(TokenType.Bot, Environment.GetEnvironmentVariable("token"));
+            await client.StartAsync();
 
-                await Task.Delay(Timeout.Infinite);
-            }
+            // Here we initialize the logic required to register our commands.
+            await services.GetRequiredService<CommandHandlingService>().InitializeAsync();
+
+            await Task.Delay(Timeout.Infinite);
         }
 
         private Task LogAsync(LogMessage log)
@@ -57,7 +56,7 @@ namespace TextCommandFramework
             return Task.CompletedTask;
         }
 
-        private ServiceProvider ConfigureServices()
+        private static ServiceProvider ConfigureServices()
         {
             return new ServiceCollection()
                 .AddSingleton<DiscordSocketClient>()

--- a/samples/TextCommandFramework/Services/CommandHandlingService.cs
+++ b/samples/TextCommandFramework/Services/CommandHandlingService.cs
@@ -58,7 +58,7 @@ namespace TextCommandFramework.Services
             // we will handle the result in CommandExecutedAsync,
         }
 
-        public async Task CommandExecutedAsync(Optional<CommandInfo> command, ICommandContext context, IResult result)
+        public static async Task CommandExecutedAsync(Optional<CommandInfo> command, ICommandContext context, IResult result)
         {
             // command is unspecified when there was a search failure (command not found); we don't care about these errors
             if (!command.IsSpecified)

--- a/samples/WebhookClient/Program.cs
+++ b/samples/WebhookClient/Program.cs
@@ -9,26 +9,22 @@ namespace WebHookClient
     // To a channel specific URL to send a message to that channel.
     class Program
     {
-        static void Main(string[] args)
-            => new Program().MainAsync().GetAwaiter().GetResult();
-
-        public async Task MainAsync()
+        async static Task Main(string[] _)
         {
             // The webhook url follows the format https://discord.com/api/webhooks/{id}/{token}
             // Because anyone with the webhook URL can use your webhook
             // you should NOT hard code the URL or ID + token into your application.
-            using (var client = new DiscordWebhookClient("https://discord.com/api/webhooks/123/abc123"))
-            {
-                var embed = new EmbedBuilder
-                {
-                    Title = "Test Embed",
-                    Description = "Test Description"
-                };
+            using var client = new DiscordWebhookClient("https://discord.com/api/webhooks/123/abc123");
 
-                // Webhooks are able to send multiple embeds per message
-                // As such, your embeds must be passed as a collection.
-                await client.SendMessageAsync(text: "Send a message to this webhook!", embeds: new[] { embed.Build() });
-            }
+            var embed = new EmbedBuilder
+            {
+                Title = "Test Embed",
+                Description = "Test Description"
+            };
+
+            // Webhooks are able to send multiple embeds per message
+            // As such, your embeds must be passed as a collection.
+            await client.SendMessageAsync(text: "Send a message to this webhook!", embeds: new[] { embed.Build() });
         }
     }
 }

--- a/src/Discord.Net.Analyzers/GuildAccessAnalyzer.cs
+++ b/src/Discord.Net.Analyzers/GuildAccessAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Discord.Analyzers
         private const string Description = "Accessing 'Context.Guild' in a command without limiting the command to run only in guilds.";
         private const string Category = "API Usage";
 
-        private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static DiagnosticDescriptor Rule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -503,18 +503,10 @@ namespace Discord.Commands
         /// <param name="argPos">The position of which the command starts at.</param>
         /// <returns>The result containing the matching commands.</returns>
         public SearchResult Search(ICommandContext context, int argPos)
-            => Search(context.Message.Content.Substring(argPos));
-        /// <summary>
-        ///     Searches for the command.
-        /// </summary>
-        /// <param name="context">The context of the command.</param>
-        /// <param name="input">The command string.</param>
-        /// <returns>The result containing the matching commands.</returns>
-        public SearchResult Search(ICommandContext context, string input)
-            => Search(input);
+            => Search(context.Message.Content[argPos..]);
         public SearchResult Search(string input)
         {
-            string searchInput = _caseSensitive ? input : input.ToLowerInvariant();
+            var searchInput = _caseSensitive ? input : input.ToLowerInvariant();
             var matches = _map.GetCommands(searchInput).OrderByDescending(x => x.Command.Priority).ToImmutableArray();
 
             if (matches.Length > 0)

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -43,7 +43,7 @@ namespace Discord
         {
             if (avatarId == null)
                 return null;
-            string extension = FormatToExtension(format, avatarId);
+            var extension = FormatToExtension(format, avatarId);
             return $"{DiscordConfig.CDNUrl}avatars/{userId}/{avatarId}.{extension}?size={size}";
         }
 
@@ -51,7 +51,7 @@ namespace Discord
         {
             if (avatarId == null)
                 return null;
-            string extension = FormatToExtension(format, avatarId);
+            var extension = FormatToExtension(format, avatarId);
             return $"{DiscordConfig.CDNUrl}guilds/{guildId}/users/{userId}/avatars/{avatarId}.{extension}?size={size}";
         }
 
@@ -69,7 +69,7 @@ namespace Discord
         {
             if (bannerId == null)
                 return null;
-            string extension = FormatToExtension(format, bannerId);
+            var extension = FormatToExtension(format, bannerId);
             return $"{DiscordConfig.CDNUrl}banners/{userId}/{bannerId}.{extension}?size={size}";
         }
         /// <summary>
@@ -148,7 +148,7 @@ namespace Discord
         {
 	        if (string.IsNullOrEmpty(bannerId))
 		        return null;
-	        string extension = FormatToExtension(format, bannerId);
+	        var extension = FormatToExtension(format, bannerId);
 	        return $"{DiscordConfig.CDNUrl}banners/{guildId}/{bannerId}.{extension}" + (size.HasValue ? $"?size={size}" : string.Empty);
         }
         /// <summary>
@@ -174,7 +174,7 @@ namespace Discord
         /// </returns>
         public static string GetRichAssetUrl(ulong appId, string assetId, ushort size, ImageFormat format)
         {
-            string extension = FormatToExtension(format, "");
+            var extension = FormatToExtension(format, "");
             return $"{DiscordConfig.CDNUrl}app-assets/{appId}/{assetId}.{extension}?size={size}";
         }
 

--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -145,11 +145,11 @@ namespace Discord
         {
             get
             {
-                int titleLength = Title?.Length ?? 0;
-                int authorLength = Author?.Name?.Length ?? 0;
-                int descriptionLength = Description?.Length ?? 0;
-                int footerLength = Footer?.Text?.Length ?? 0;
-                int fieldSum = Fields.Sum(f => f.Name.Length + f.Value.ToString().Length);
+                var titleLength = Title?.Length ?? 0;
+                var authorLength = Author?.Name?.Length ?? 0;
+                var descriptionLength = Description?.Length ?? 0;
+                var footerLength = Footer?.Text?.Length ?? 0;
+                var fieldSum = Fields.Sum(f => f.Name.Length + f.Value.ToString().Length);
 
                 return titleLength + authorLength + descriptionLength + footerLength + fieldSum;
             }

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -141,7 +141,7 @@ namespace Discord
             bool? sendMessagesInThreads = null,
             bool? startEmbeddedActivities = null)
         {
-            ulong value = initialValue;
+            var value = initialValue;
 
             Permissions.SetValue(ref value, createInstantInvite, ChannelPermission.CreateInstantInvite);
             Permissions.SetValue(ref value, manageChannel, ChannelPermission.ManageChannels);
@@ -287,7 +287,7 @@ namespace Discord
             var perms = new List<ChannelPermission>();
             for (byte i = 0; i < Permissions.MaxBits; i++)
             {
-                ulong flag = ((ulong)1 << i);
+                var flag = ((ulong)1 << i);
                 if ((RawValue & flag) != 0)
                     perms.Add((ChannelPermission)flag);
             }

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -153,7 +153,7 @@ namespace Discord
             bool? startEmbeddedActivities = null,
             bool? moderateMembers = null)
         {
-            ulong value = initialValue;
+            var value = initialValue;
 
             Permissions.SetValue(ref value, createInstantInvite, GuildPermission.CreateInstantInvite);
             Permissions.SetValue(ref value, banMembers, GuildPermission.BanMembers);
@@ -358,7 +358,7 @@ namespace Discord
             // each of the GuildPermissions increments by 2^i from 0 to MaxBits
             for (byte i = 0; i < Permissions.MaxBits; i++)
             {
-                ulong flag = ((ulong)1 << i);
+                var flag = ((ulong)1 << i);
                 if ((RawValue & flag) != 0)
                     perms.Add((GuildPermission)flag);
             }

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -28,7 +28,7 @@ namespace Discord
         /// <summary> Returns a markdown-formatted string with codeblock formatting. </summary>
         public static string Code(string text, string language = null)
         {
-            if (language != null || text.Contains("\n"))
+            if (language != null || text.Contains('\n'))
                 return $"```{language ?? ""}\n{text}\n```";
             else
                 return $"`{text}`";
@@ -38,7 +38,7 @@ namespace Discord
         public static string Sanitize(string text)
         {
             if (text != null)
-                foreach (string unsafeChar in SensitiveCharacters)
+                foreach (var unsafeChar in SensitiveCharacters)
                     text = text.Replace(unsafeChar, $"\\{unsafeChar}");
             return text;
         }
@@ -55,9 +55,9 @@ namespace Discord
             if (string.IsNullOrWhiteSpace(text))
                 return text;
 
-            StringBuilder result = new StringBuilder();
+            StringBuilder result = new();
 
-            int startIndex = 0;
+            var startIndex = 0;
             int newLineIndex;
             do
             {
@@ -65,13 +65,13 @@ namespace Discord
                 if (newLineIndex == -1)
                 {
                     // read the rest of the string
-                    var str = text.Substring(startIndex);
+                    var str = text[startIndex..];
                     result.Append($"> {str}");
                 }
                 else
                 {
                     // read until the next newline
-                    var str = text.Substring(startIndex, newLineIndex - startIndex);
+                    var str = text[startIndex..newLineIndex];
                     result.Append($"> {str}\n");
                 }
                 startIndex = newLineIndex + 1;

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -144,9 +144,7 @@ namespace Discord.Rest
         {
             if (!_isDisposed)
             {
-#pragma warning disable IDISP007
                 ApiClient.Dispose();
-#pragma warning restore IDISP007
                 _stateLock?.Dispose();
                 _isDisposed = true;
             }
@@ -156,9 +154,7 @@ namespace Discord.Rest
         {
             if (!_isDisposed)
             {
-#pragma warning disable IDISP007
                 await ApiClient.DisposeAsync().ConfigureAwait(false);
-#pragma warning restore IDISP007
                 _stateLock?.Dispose();
                 _isDisposed = true;
             }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -9,7 +9,7 @@ namespace Discord.Rest
     internal static class AuditLogHelper
     {
         private static readonly Dictionary<ActionType, Func<BaseDiscordClient, Model, EntryModel, IAuditLogData>> CreateMapping
-            = new Dictionary<ActionType, Func<BaseDiscordClient, Model, EntryModel, IAuditLogData>>()
+            = new()
         {
             [ActionType.GuildUpdated] = GuildUpdateAuditLogData.Create,
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
@@ -15,7 +15,7 @@ namespace Discord.Rest
             Thread = thread;
             ThreadType = type;
             Before = before;
-            After = After;
+            After = after;
         }
 
         internal static ThreadUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -17,11 +17,11 @@ namespace Discord.Rest
     public class RestGroupChannel : RestChannel, IGroupChannel, IRestPrivateChannel, IRestMessageChannel, IRestAudioChannel
     {
         #region RestGroupChannel
-        private string _iconId;
         private ImmutableDictionary<ulong, RestGroupUser> _users;
 
         /// <inheritdoc />
         public string Name { get; private set; }
+
         /// <inheritdoc/>
         public string RTCRegion { get; private set; }
 
@@ -43,8 +43,6 @@ namespace Discord.Rest
         {
             if (model.Name.IsSpecified)
                 Name = model.Name.Value;
-            if (model.Icon.IsSpecified)
-                _iconId = model.Icon.Value;
 
             if (model.Recipients.IsSpecified)
                 UpdateUsers(model.Recipients.Value);

--- a/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
@@ -142,9 +142,8 @@ namespace Discord.Rest
         ///     Updates the message which this component resides in with the type <see cref="InteractionResponseType.UpdateMessage"/>
         /// </summary>
         /// <param name="func">A delegate containing the properties to modify the message with.</param>
-        /// <param name="options">The request options for this <see langword="async"/> request.</param>
         /// <returns>A string that contains json to write back to the incoming http request.</returns>
-        public string Update(Action<MessageProperties> func, RequestOptions options = null)
+        public string Update(Action<MessageProperties> func)
         {
             var args = new MessageProperties();
             func(args);
@@ -384,11 +383,10 @@ namespace Discord.Rest
         ///     Defers an interaction and responds with type 5 (<see cref="InteractionResponseType.DeferredChannelMessageWithSource"/>)
         /// </summary>
         /// <param name="ephemeral"><see langword="true"/> to send this message ephemerally, otherwise <see langword="false"/>.</param>
-        /// <param name="options">The request options for this <see langword="async"/> request.</param>
         /// <returns>
         ///     A string that contains json to write back to the incoming http request.
         /// </returns>
-        public string DeferLoading(bool ephemeral = false, RequestOptions options = null)
+        public string DeferLoading(bool ephemeral = false)
         {
             if (!InteractionHelper.CanSendResponse(this))
                 throw new TimeoutException($"Cannot defer an interaction after {InteractionHelper.ResponseTimeLimit} seconds of no response/acknowledgement");

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
@@ -49,11 +49,10 @@ namespace Discord.Rest
         ///         there is no choices for their autocompleted input.
         ///     </remarks>
         /// </param>
-        /// <param name="options">The request options for this response.</param>
         /// <returns>
         ///     A string that contains json to write back to the incoming http request.
         /// </returns>
-        public string Respond(IEnumerable<AutocompleteResult> result, RequestOptions options = null)
+        public string Respond(IEnumerable<AutocompleteResult> result)
         {
             if (!InteractionHelper.CanSendResponse(this))
                 throw new TimeoutException($"Cannot respond to an interaction after {InteractionHelper.ResponseTimeLimit} seconds!");

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueue.cs
@@ -24,7 +24,7 @@ namespace Discord.Net.Queue
         private CancellationToken _requestCancelToken; //Parent token + Clear token
         private DateTimeOffset _waitUntil;
 
-        private Task _cleanupTask;
+        private readonly Task _cleanupTask;
 
         public RequestQueue()
         {
@@ -42,7 +42,7 @@ namespace Discord.Net.Queue
 
         public async Task SetCancelTokenAsync(CancellationToken cancelToken)
         {
-            await _tokenLock.WaitAsync().ConfigureAwait(false);
+            await _tokenLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
             try
             {
                 _parentToken = cancelToken;

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2242,7 +2242,7 @@ namespace Discord.WebSocket
                                         //Only strip out the port if the endpoint contains it
                                         var portBegin = endpoint.LastIndexOf(':');
                                         if (portBegin > 0)
-                                            endpoint = endpoint.Substring(0, portBegin);
+                                            endpoint = endpoint[..portBegin];
 
                                         var _ = guild.FinishConnectAudio(endpoint, data.Token).ConfigureAwait(false);
                                     }
@@ -2978,7 +2978,7 @@ namespace Discord.WebSocket
         {
             return SocketDMChannel.Create(this, state, channelId, model);
         }
-        internal SocketDMChannel CreateDMChannel(ulong channelId, SocketUser user, ClientState state)
+        internal SocketDMChannel CreateDMChannel(ulong channelId, SocketUser user, ClientState _)
         {
             return new SocketDMChannel(this, channelId, user);
         }

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -33,7 +33,6 @@ namespace Discord.WebSocket
     public class SocketGuild : SocketEntity<ulong>, IGuild, IDisposable
     {
         #region SocketGuild
-#pragma warning disable IDISP002, IDISP006
         private readonly SemaphoreSlim _audioLock;
         private TaskCompletionSource<bool> _syncPromise, _downloaderPromise;
         private TaskCompletionSource<AudioClient> _audioConnectPromise;
@@ -47,7 +46,6 @@ namespace Discord.WebSocket
 
         private AudioClient _audioClient;
         private VoiceStateUpdateParams _voiceStateUpdateParams;
-#pragma warning restore IDISP002, IDISP006
 
         /// <inheritdoc />
         public string Name { get; private set; }
@@ -585,7 +583,7 @@ namespace Discord.WebSocket
             //    _ = _downloaderPromise.TrySetResultAsync(true);
         }*/
 
-        internal void Update(ClientState state, EmojiUpdateModel model)
+        internal void Update(ClientState _, EmojiUpdateModel model)
         {
             var emotes = ImmutableArray.CreateBuilder<GuildEmote>(model.Emojis.Length);
             for (int i = 0; i < model.Emojis.Length; i++)
@@ -1607,11 +1605,9 @@ namespace Discord.WebSocket
 
                 if (external)
                 {
-#pragma warning disable IDISP001
                     var _ = promise.TrySetResultAsync(null);
                     await Discord.ApiClient.SendVoiceStateUpdateAsync(_voiceStateUpdateParams).ConfigureAwait(false);
                     return null;
-#pragma warning restore IDISP001
                 }
 
                 if (_audioClient == null)
@@ -1634,14 +1630,10 @@ namespace Discord.WebSocket
                     };
                     audioClient.Connected += () =>
                     {
-#pragma warning disable IDISP001
                         var _ = promise.TrySetResultAsync(_audioClient);
-#pragma warning restore IDISP001
                         return Task.Delay(0);
                     };
-#pragma warning disable IDISP003
                     _audioClient = audioClient;
-#pragma warning restore IDISP003
                 }
 
                 await Discord.ApiClient.SendVoiceStateUpdateAsync(_voiceStateUpdateParams).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -143,7 +143,7 @@ namespace Discord.WebSocket
         {
             var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model));
             entity.Update(state, model);
-            entity.UpdateRoles(new ulong[0]);
+            entity.UpdateRoles(Array.Empty<ulong>());
             return entity;
         }
         internal static SocketGuildUser Create(SocketGuild guild, ClientState state, MemberModel model)
@@ -151,7 +151,7 @@ namespace Discord.WebSocket
             var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model.User));
             entity.Update(state, model);
             if (!model.Roles.IsSpecified)
-                entity.UpdateRoles(new ulong[0]);
+                entity.UpdateRoles(Array.Empty<ulong>());
             return entity;
         }
         internal static SocketGuildUser Create(SocketGuild guild, ClientState state, PresenceModel model)
@@ -159,7 +159,7 @@ namespace Discord.WebSocket
             var entity = new SocketGuildUser(guild, guild.Discord.GetOrCreateUser(state, model.User));
             entity.Update(state, model, false);
             if (!model.Roles.IsSpecified)
-                entity.UpdateRoles(new ulong[0]);
+                entity.UpdateRoles(Array.Empty<ulong>());
             return entity;
         }
         internal void Update(ClientState state, MemberModel model)
@@ -180,7 +180,7 @@ namespace Discord.WebSocket
             if (model.Pending.IsSpecified)
                 IsPending = model.Pending.Value;
         }
-        internal void Update(ClientState state, PresenceModel model, bool updatePresence)
+        internal void Update(ClientState _, PresenceModel model, bool updatePresence)
         {
             if (updatePresence)
             {

--- a/test/Discord.Net.Tests.Integration/ChannelsTests.cs
+++ b/test/Discord.Net.Tests.Integration/ChannelsTests.cs
@@ -13,20 +13,20 @@ namespace Discord
     [CollectionDefinition("ChannelsTests", DisableParallelization = true)]
     public class ChannelsTests : IClassFixture<RestGuildFixture>
     {
-        private IGuild guild;
-        private readonly ITestOutputHelper output;
+        private readonly IGuild guild;
+        private readonly ITestOutputHelper _output;
 
         public ChannelsTests(RestGuildFixture guildFixture, ITestOutputHelper output)
         {
             guild = guildFixture.Guild;
-            output = output;
-            output.WriteLine($"RestGuildFixture using guild: {guild.Id}");
+            _output = output;
+            _output.WriteLine($"RestGuildFixture using guild: {guild.Id}");
             // capture all console output
             guildFixture.Client.Log += LogAsync;
         }
         private Task LogAsync(LogMessage message)
         {
-            output.WriteLine(message.ToString());
+            _output.WriteLine(message.ToString());
             return Task.CompletedTask;
         }
 
@@ -100,7 +100,7 @@ namespace Discord
         public async Task ModifyChannelCategories()
         {
             // util method for checking if a category is set
-            async Task CheckAsync(INestedChannel channel, ICategoryChannel cat)
+            static async Task CheckAsync(INestedChannel channel, ICategoryChannel cat)
             {
                 // check that the category is not set
                 if (cat == null)

--- a/test/Discord.Net.Tests.Integration/GuildTests.cs
+++ b/test/Discord.Net.Tests.Integration/GuildTests.cs
@@ -10,21 +10,21 @@ namespace Discord
     [CollectionDefinition("GuildTests", DisableParallelization = true)]
     public class GuildTests : IClassFixture<RestGuildFixture>
     {
-        private IDiscordClient client;
-        private IGuild guild;
-        private readonly ITestOutputHelper output;
+        private readonly IDiscordClient client;
+        private readonly IGuild guild;
+        private readonly ITestOutputHelper _output;
 
         public GuildTests(RestGuildFixture guildFixture, ITestOutputHelper output)
         {
             client = guildFixture.Client;
             guild = guildFixture.Guild;
-            output = output;
-            output.WriteLine($"RestGuildFixture using guild: {guild.Id}");
+            _output = output;
+            _output.WriteLine($"RestGuildFixture using guild: {guild.Id}");
             guildFixture.Client.Log += LogAsync;
         }
         private Task LogAsync(LogMessage message)
         {
-            output.WriteLine(message.ToString());
+            _output.WriteLine(message.ToString());
             return Task.CompletedTask;
         }
         /// <summary>

--- a/test/Discord.Net.Tests.Unit/ColorTests.cs
+++ b/test/Discord.Net.Tests.Unit/ColorTests.cs
@@ -10,6 +10,7 @@ namespace Discord
     /// </summary>
     public class ColorTests
     {
+        [Fact]
         public void Color_New()
         {
             Assert.Equal(0u, new Color().RawValue);


### PR DESCRIPTION
This PR removes, modifies & introduces a huge amount of code refactoring to the DNet code base. This PR does not go paired with our current targets for out-of-support frameworks. 

## Fixes

Removes all warnings and a large amount of messages in the codebase in respect to code conventions. Also resolves some very minor errors in the codebase with assignment in some locations.

## Breaking

`RequestOptions` has been removed from `LoginAsync` as it doesn't use the parameter at all.
`RequestOptions` have been removed from `RestInteraction` serializing methods as they don't use it at all.

## Internal

There is no reference to `ClientBucketType` anywhere, it has been removed from the `RestApiClient`.
Changes explicit variables to implicit where it is clear what the type the variable presents.
Swaps `SubString` for range operator & `AsSpan`. 
