### PR TITLE
Upload file size limit fix

### DIFF
--- a/src/Discord.Net.Rest/AssemblyInfo.cs
+++ b/src/Discord.Net.Rest/AssemblyInfo.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Discord.Net.Commands")]
 [assembly: InternalsVisibleTo("Discord.Net.Tests")]
 [assembly: InternalsVisibleTo("Discord.Net.Tests.Unit")]
+[assembly: InternalsVisibleTo("Discord.Net.Tests.Integration")]
 [assembly: InternalsVisibleTo("Discord.Net.Interactions")]
 
 [assembly: TypeForwardedTo(typeof(Discord.Embed))]

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -132,12 +132,15 @@ namespace Discord.Rest
         }
         public static ulong GetUploadLimit(IGuild guild)
         {
-            return guild.PremiumTier switch
+            var tierFactor = guild.PremiumTier switch
             {
-                PremiumTier.Tier2 => 50ul * 1000000,
-                PremiumTier.Tier3 => 100ul * 1000000,
-                _ => 8ul * 1000000
+                PremiumTier.Tier2 => 50,
+                PremiumTier.Tier3 => 100,
+                _ => 8
             };
+
+            var mebibyte = Math.Pow(2, 20);
+            return (ulong) (tierFactor * mebibyte);
         }
         #endregion
 
@@ -151,7 +154,7 @@ namespace Discord.Rest
                 if (fromUserId.HasValue)
                     return GetBansAsync(guild, client, fromUserId.Value + 1, Direction.Before, around + 1, options)
                         .Concat(GetBansAsync(guild, client, fromUserId.Value, Direction.After, around, options));
-                else 
+                else
                     return GetBansAsync(guild, client, null, Direction.Before, around + 1, options);
             }
 
@@ -908,7 +911,7 @@ namespace Discord.Rest
             if (endTime != null && endTime <= startTime)
                 throw new ArgumentOutOfRangeException(nameof(endTime), $"{nameof(endTime)} cannot be before the start time");
 
-            
+
             var apiArgs = new CreateGuildScheduledEventParams()
             {
                 ChannelId = channelId ?? Optional<ulong>.Unspecified,

--- a/test/Discord.Net.Tests.Integration/Discord.Net.Tests.Integration.csproj
+++ b/test/Discord.Net.Tests.Integration/Discord.Net.Tests.Integration.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Discord.Net.Tests.Unit/Discord.Net.Tests.Unit.csproj
+++ b/test/Discord.Net.Tests.Unit/Discord.Net.Tests.Unit.csproj
@@ -12,7 +12,9 @@
     <ProjectReference Include="../../src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Upload file. File size limit fix
Guild helper used `megabyte`(1000^2) instead of `mebibyte`(1024^2).
Issue #2311 

## Tests
- `DiscordRestApiClient.UploadFileAsync()`
- `GuildHelper.GetUploadLimit()`
## Changes
- Fix `GuildHelper.GetUploadLimit()`
## Packages
Added packages [FluentAssertions](https://fluentassertions.com/) and [Moq](https://github.com/moq/moq4) for easier test writing.
