### PR TITLE
fix: Upload file size limit

### DIFF
--- a/src/Discord.Net.Rest/AssemblyInfo.cs
+++ b/src/Discord.Net.Rest/AssemblyInfo.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Discord.Net.Commands")]
 [assembly: InternalsVisibleTo("Discord.Net.Tests")]
 [assembly: InternalsVisibleTo("Discord.Net.Tests.Unit")]
+[assembly: InternalsVisibleTo("Discord.Net.Tests.Integration")]
 [assembly: InternalsVisibleTo("Discord.Net.Interactions")]
 
 [assembly: TypeForwardedTo(typeof(Discord.Embed))]

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -132,12 +132,15 @@ namespace Discord.Rest
         }
         public static ulong GetUploadLimit(IGuild guild)
         {
-            return guild.PremiumTier switch
+            var tierFactor = guild.PremiumTier switch
             {
-                PremiumTier.Tier2 => 50ul * 1000000,
-                PremiumTier.Tier3 => 100ul * 1000000,
-                _ => 8ul * 1000000
+                PremiumTier.Tier2 => 50,
+                PremiumTier.Tier3 => 100,
+                _ => 8
             };
+
+            var mebibyte = Math.Pow(2, 20);
+            return (ulong) (tierFactor * mebibyte);
         }
         #endregion
 
@@ -151,7 +154,7 @@ namespace Discord.Rest
                 if (fromUserId.HasValue)
                     return GetBansAsync(guild, client, fromUserId.Value + 1, Direction.Before, around + 1, options)
                         .Concat(GetBansAsync(guild, client, fromUserId.Value, Direction.After, around, options));
-                else 
+                else
                     return GetBansAsync(guild, client, null, Direction.Before, around + 1, options);
             }
 
@@ -908,7 +911,7 @@ namespace Discord.Rest
             if (endTime != null && endTime <= startTime)
                 throw new ArgumentOutOfRangeException(nameof(endTime), $"{nameof(endTime)} cannot be before the start time");
 
-            
+
             var apiArgs = new CreateGuildScheduledEventParams()
             {
                 ChannelId = channelId ?? Optional<ulong>.Unspecified,

--- a/test/Discord.Net.Tests.Integration/Discord.Net.Tests.Integration.csproj
+++ b/test/Discord.Net.Tests.Integration/Discord.Net.Tests.Integration.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Discord.Net.Tests.Integration/DiscordRestApiClientTests.cs
+++ b/test/Discord.Net.Tests.Integration/DiscordRestApiClientTests.cs
@@ -1,0 +1,53 @@
+﻿using Discord.API;
+using Discord.API.Rest;
+using Discord.Net;
+using Discord.Rest;
+using FluentAssertions;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Discord;
+
+[CollectionDefinition(nameof(DiscordRestApiClientTests), DisableParallelization = true)]
+public class DiscordRestApiClientTests : IClassFixture<RestGuildFixture>, IAsyncDisposable
+{
+    private readonly DiscordRestApiClient _apiClient;
+    private readonly IGuild _guild;
+    private readonly ITextChannel _channel;
+
+    public DiscordRestApiClientTests(RestGuildFixture guildFixture)
+    {
+        _guild = guildFixture.Guild;
+        _apiClient = guildFixture.Client.ApiClient;
+        _channel = _guild.CreateTextChannelAsync("testChannel").Result;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _channel.DeleteAsync();
+    }
+
+    [Fact]
+    public async Task UploadFile_WithMaximumSize_DontThrowsException()
+    {
+        var fileSize = GuildHelper.GetUploadLimit(_guild);
+        using var stream = new MemoryStream(new byte[fileSize]);
+
+        await _apiClient.UploadFileAsync(_channel.Id, new UploadFileParams(new FileAttachment(stream, "filename")));
+    }
+
+    [Fact]
+    public async Task UploadFile_WithOverSize_ThrowsException()
+    {
+        var fileSize = GuildHelper.GetUploadLimit(_guild) + 1;
+        using var stream = new MemoryStream(new byte[fileSize]);
+
+        Func<Task> upload = async () =>
+            await _apiClient.UploadFileAsync(_channel.Id, new UploadFileParams(new FileAttachment(stream, "filename")));
+
+        await upload.Should().ThrowExactlyAsync<HttpException>()
+                 .Where(e => e.DiscordCode == DiscordErrorCode.RequestEntityTooLarge);
+    }
+}

--- a/test/Discord.Net.Tests.Unit/Discord.Net.Tests.Unit.csproj
+++ b/test/Discord.Net.Tests.Unit/Discord.Net.Tests.Unit.csproj
@@ -12,7 +12,9 @@
     <ProjectReference Include="../../src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Discord.Net.Tests.Unit/GuildHelperTests.cs
+++ b/test/Discord.Net.Tests.Unit/GuildHelperTests.cs
@@ -1,0 +1,25 @@
+﻿using Discord.Rest;
+using FluentAssertions;
+using Moq;
+using System;
+using Xunit;
+
+namespace Discord;
+
+public class GuildHelperTests
+{
+    [Theory]
+    [InlineData(PremiumTier.None, 8)]
+    [InlineData(PremiumTier.Tier1, 8)]
+    [InlineData(PremiumTier.Tier2, 50)]
+    [InlineData(PremiumTier.Tier3, 100)]
+    public void GetUploadLimit(PremiumTier tier, ulong factor)
+    {
+        var guild = Mock.Of<IGuild>(g => g.PremiumTier == tier);
+        var expected = factor * (ulong)Math.Pow(2, 20);
+
+        var actual = GuildHelper.GetUploadLimit(guild);
+
+        actual.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
# Upload file size limit fix
Guild helper used `megabyte`(1000^2) instead of `mebibyte`(1024^2).
Issue #2311 

## Tests
- `DiscordRestApiClient.UploadFileAsync()`
- `GuildHelper.GetUploadLimit()`
## Changes
- Fix `GuildHelper.GetUploadLimit()`
## Packages
Added packages [FluentAssertions](https://fluentassertions.com/) and [Moq](https://github.com/moq/moq4) for easier test writing.
