### PR TITLE
fix: Use IDiscordClient.GetUserAsync in DiscordSocketClient to use Cached users

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -403,7 +403,7 @@ namespace Discord.WebSocket
         ///     the snowflake identifier; <c>null</c> if the user is not found.
         /// </returns>
         public async ValueTask<IUser> GetUserAsync(ulong id, RequestOptions options = null)
-            => await ClientHelper.GetUserAsync(this, id, options).ConfigureAwait(false);
+            => await ((IDiscordClient)this).GetUserAsync(id, CacheMode.AllowDownload, options).ConfigureAwait(false);
         /// <summary>
         ///     Clears all cached channels from the client.
         /// </summary>


### PR DESCRIPTION
The `GetUserAsync` method of `DiscordSocketClient` only uses API calls to get the user which is not what the documentation says. Changing it to use `IDiscordClient.GetUserAsync` with `CacheMode.AllowDownload` should make the implementation correct.