### PR TITLE
fix: NRE with bot scope and user parameters

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketResolvableData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketResolvableData.cs
@@ -59,7 +59,7 @@ namespace Discord.WebSocket
                 }
             }
 
-            if (resolved.Members.IsSpecified)
+            if (resolved.Members.IsSpecified && guild != null)
             {
                 foreach (var member in resolved.Members.Value)
                 {


### PR DESCRIPTION
## Summary
This PR fixes #2259 by checking whether or not the guild is null before attempting to update the resolved guild members