### PR TITLE
Add missing interaction properties

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
@@ -52,6 +52,9 @@ namespace Discord
         /// <summary>
         ///     Gets the preferred locale of the invoking User.
         /// </summary>
+        /// <remarks>
+        ///     This property returns <see langword="null"/> if the interaction is a REST ping interaction.
+        /// </remarks>
         string UserLocale { get; }
 
         /// <summary>
@@ -66,6 +69,27 @@ namespace Discord
         ///     Gets whether or not this interaction was executed in a dm channel.
         /// </summary>
         bool IsDMInteraction { get; }
+
+        /// <summary>
+        ///     Gets the ID of the channel this interaction was executed in.
+        /// </summary>
+        /// <remarks>
+        ///     This property returns <see langword="null"/> if the interaction is a REST ping interaction.
+        /// </remarks>
+        ulong? ChannelId { get; }
+
+        /// <summary>
+        ///     Gets the ID of the guild this interaction was executed in.
+        /// </summary>
+        /// <remarks>
+        ///     This property returns <see langword="null"/> if the interaction was not executed in a guild.
+        /// </remarks>
+        ulong? GuildId { get; }
+
+        /// <summary>
+        ///     Gets the ID of the application this interaction is for.
+        /// </summary>
+        ulong ApplicationId { get; }
 
         /// <summary>
         ///     Responds to an Interaction with type <see cref="InteractionResponseType.ChannelMessageWithSource"/>.


### PR DESCRIPTION
This PR adds some properties that were missing in the `IDiscordInteraction` interface and makes some changes in the comments.

Changes:
- Added `IDiscordInteraction.ChannelId`
- Added `IDiscordInteraction.GuildId`
- Added `IDiscordInteraction.Application`
- Removed incorrect information about `ChannelId` and bot scopes
- Adapted `RestInteraction` and `SocketInteraction` to use the new properties