### PR TITLE
Better call control in ParseHttpInteraction

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -121,7 +121,7 @@ namespace Discord.Rest
         ///     A <see cref="RestInteraction"/> that represents the incoming http interaction.
         /// </returns>
         /// <exception cref="BadSignatureException">Thrown when the signature doesn't match the public key.</exception>
-        public Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, string body, Func<InteractionType, bool> doApiCallOnCreation = null)
+        public Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, string body, Func<InteractionProperties, bool> doApiCallOnCreation = null)
             => ParseHttpInteractionAsync(publicKey, signature, timestamp, Encoding.UTF8.GetBytes(body), doApiCallOnCreation);
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Discord.Rest
         ///     A <see cref="RestInteraction"/> that represents the incoming http interaction.
         /// </returns>
         /// <exception cref="BadSignatureException">Thrown when the signature doesn't match the public key.</exception>
-        public async Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, byte[] body, Func<InteractionType, bool> doApiCallOnCreation = null)
+        public async Task<RestInteraction> ParseHttpInteractionAsync(string publicKey, string signature, string timestamp, byte[] body, Func<InteractionProperties, bool> doApiCallOnCreation = null)
         {
             if (!IsValidHttpInteraction(publicKey, signature, timestamp, body))
             {
@@ -146,7 +146,7 @@ namespace Discord.Rest
             using (var jsonReader = new JsonTextReader(textReader))
             {
                 var model = Serializer.Deserialize<API.Interaction>(jsonReader);
-                return await RestInteraction.CreateAsync(this, model, doApiCallOnCreation != null ? doApiCallOnCreation(model.Type) : _apiOnCreation);
+                return await RestInteraction.CreateAsync(this, model, doApiCallOnCreation is not null ? doApiCallOnCreation(new InteractionProperties(model)) : _apiOnCreation);
             }
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionProperties.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionProperties.cs
@@ -52,7 +52,7 @@ namespace Discord.Rest
         ///     Gets the channel ID of the interaction.
         /// </summary>
         /// <remarks>
-        ///     This will be <see langword="null"/> if this interaction was executed in DM.
+        ///     This will be <see langword="null"/> if this interaction is <see cref="InteractionType.Ping"/>.
         /// </remarks>
         public ulong? ChannelId { get; }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionProperties.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionProperties.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Represents a class that contains data present in all interactions to evaluate against at rest-interaction creation.
+    /// </summary>
+    public readonly struct InteractionProperties
+    {
+        /// <summary>
+        ///     The type of this interaction.
+        /// </summary>
+        public InteractionType Type { get; }
+
+        /// <summary>
+        ///     Gets the type of application command this interaction represents.
+        /// </summary>
+        /// <remarks>
+        ///     This will be <see langword="null"/> if the <see cref="Type"/> is not <see cref="InteractionType.ApplicationCommand"/>.
+        /// </remarks>
+        public ApplicationCommandType? CommandType { get; }
+
+        /// <summary>
+        ///     Gets the name of the interaction.
+        /// </summary>
+        /// <remarks>
+        ///     This will be <see cref="string.Empty"/> if the <see cref="Type"/> is not <see cref="InteractionType.ApplicationCommand"/>.
+        /// </remarks>
+        public string Name { get; } = string.Empty;
+
+        /// <summary>
+        ///     Gets the custom ID of the interaction.
+        /// </summary>
+        /// <remarks>
+        ///     This will be <see cref="string.Empty"/> if the <see cref="Type"/> is not <see cref="InteractionType.MessageComponent"/> or <see cref="InteractionType.ModalSubmit"/>.
+        /// </remarks>
+        public string CustomId { get; } = string.Empty;
+
+        /// <summary>
+        ///     Gets the guild ID of the interaction.
+        /// </summary>
+        /// <remarks>
+        ///     This will be <see langword="null"/> if this interaction was not executed in a guild.
+        /// </remarks>
+        public ulong? GuildId { get; }
+
+        /// <summary>
+        ///     Gets the channel ID of the interaction.
+        /// </summary>
+        /// <remarks>
+        ///     This will be <see langword="null"/> if this interaction was executed in DM.
+        /// </remarks>
+        public ulong? ChannelId { get; }
+
+        internal InteractionProperties(API.Interaction model)
+        {
+            Type = model.Type;
+            CommandType = null;
+
+            if (model.GuildId.IsSpecified)
+                GuildId = model.GuildId.Value;
+            else
+                GuildId = null;
+
+            if (model.ChannelId.IsSpecified)
+                ChannelId = model.ChannelId.Value;
+            else
+                ChannelId = null;
+
+            switch (Type)
+            {
+                case InteractionType.ApplicationCommand:
+                    {
+                        var data = (API.ApplicationCommandInteractionData)model.Data;
+
+                        CommandType = data.Type;
+                        Name = data.Name;
+                    }
+                    break;
+                case InteractionType.MessageComponent:
+                    {
+                        var data = (API.MessageComponentInteractionData)model.Data;
+
+                        CustomId = data.CustomId;
+                    }
+                    break;
+                case InteractionType.ModalSubmit:
+                    {
+                        var data = (API.ModalInteractionData)model.Data;
+
+                        CustomId = data.CustomId;
+                    }
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The function has been modified to take a much more advanced properties struct as check for optional API calls in Rest interactions.

```cs
// Code example:

RestInteraction interaction = await _client.ParseHttpInteractionAsync(_pbk, signature, timestamp, body, x =>
{
    if (!string.IsNullOrEmpty(x.Name)) // slashcommand / channel
        return x.Name switch
        {
            "channel" => true,
            _ => false
        };

// this property will always be set if you don't use autocomplete and Name is empty ^ as above. 
// If you do, you will want to add a check for this.
    var range = x.CustomId.Split('-'); // button / channel-prune
    if (range.Any())
        return range.First() switch
        {
            "sar" => true,
            "channel" => true,
            _ => false
        };
    return false;
});
```