### PR TITLE
Add support for attachments on interaction response type 7

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
@@ -226,8 +226,12 @@ namespace Discord.WebSocket
 
             bool hasText = args.Content.IsSpecified ? !string.IsNullOrEmpty(args.Content.Value) : !string.IsNullOrEmpty(Message.Content);
             bool hasEmbeds = embed.IsSpecified && embed.Value != null || embeds.IsSpecified && embeds.Value?.Length > 0 || Message.Embeds.Any();
+            bool hasComponents = args.Components.IsSpecified && args.Components.Value != null;
+            bool hasAttachments = args.Attachments.IsSpecified;
+            bool hasFlags = args.Flags.IsSpecified;
 
-            if (!hasText && !hasEmbeds)
+            // No content needed if modifying flags
+            if ((!hasComponents && !hasText && !hasEmbeds && !hasAttachments) && !hasFlags)
                 Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
 
             var apiEmbeds = embed.IsSpecified || embeds.IsSpecified ? new List<API.Embed>() : null;


### PR DESCRIPTION
This PR adds support for modifying attachments on interaction response type 7 (`SocketMessageComponent.UpdateAsync`).