### PR TITLE
Fix IGuild.DisconnectAsync(IUser) not disconnecting users

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -1404,7 +1404,7 @@ namespace Discord.Rest
         /// </summary>
         /// <param name="user">The user to disconnect.</param>
         /// <returns>A task that represents the asynchronous operation for disconnecting a user.</returns>
-        async Task IGuild.DisconnectAsync(IGuildUser user) => await user.ModifyAsync(x => x.Channel = new Optional<IVoiceChannel>());
+        async Task IGuild.DisconnectAsync(IGuildUser user) => await user.ModifyAsync(x => x.Channel = null);
 
         /// <inheritdoc />
         async Task<IGuildUser> IGuild.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1410,7 +1410,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="user">The user to disconnect.</param>
         /// <returns>A task that represents the asynchronous operation for disconnecting a user.</returns>
-        async Task IGuild.DisconnectAsync(IGuildUser user) => await user.ModifyAsync(x => x.Channel = new Optional<IVoiceChannel>());
+        async Task IGuild.DisconnectAsync(IGuildUser user) => await user.ModifyAsync(x => x.Channel = null);
         #endregion
 
         #region Stickers


### PR DESCRIPTION
This PR fixes an issue where calling `IGuild.DisconnectAsync(IUser)` doesn't work, This is due to the `Channel` property being set with `new Optional<IVoiceChannel>()` which creates an unspecified optional when a specified optional containing a null value is expected in the `UserHelper`.

https://github.com/discord-net/Discord.Net/blob/20f0932612c15d9f0f22d6cb40ffff11b42426dc/src/Discord.Net.Rest/Entities/Users/UserHelper.cs#L46-L47