### PR TITLE
Fix issues related to the absence of bot scope

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2318,7 +2318,7 @@ namespace Discord.WebSocket
                             case "INTERACTION_CREATE":
                                 {
                                     await _gatewayLogger.DebugAsync("Received Dispatch (INTERACTION_CREATE)").ConfigureAwait(false);
-
+                                    
                                     var data = (payload as JToken).ToObject<API.Interaction>(_serializer);
 
                                     var guild = data.GuildId.IsSpecified ? GetGuild(data.GuildId.Value) : null;
@@ -2326,7 +2326,6 @@ namespace Discord.WebSocket
                                     if (guild != null && !guild.IsSynced)
                                     {
                                         await UnsyncedGuildAsync(type, guild.Id).ConfigureAwait(false);
-                                        return;
                                     }
 
                                     SocketUser user = data.User.IsSpecified
@@ -2346,15 +2345,8 @@ namespace Discord.WebSocket
                                             {
                                                 channel = CreateDMChannel(data.ChannelId.Value, user, State);
                                             }
-                                            else
-                                            {
-                                                if (guild != null) // The guild id is set, but the guild cannot be found as the bot scope is not set.
-                                                {
-                                                    await UnknownChannelAsync(type, data.ChannelId.Value).ConfigureAwait(false);
-                                                    return;
-                                                }
-                                                // The channel isnt required when responding to an interaction, so we can leave the channel null.
-                                            }
+
+                                            // The channel isnt required when responding to an interaction, so we can leave the channel null.
                                         }
                                     }
                                     else if (data.User.IsSpecified)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketCategoryChannel.cs
@@ -39,7 +39,7 @@ namespace Discord.WebSocket
         }
         internal new static SocketCategoryChannel Create(SocketGuild guild, ClientState state, Model model)
         {
-            var entity = new SocketCategoryChannel(guild.Discord, model.Id, guild);
+            var entity = new SocketCategoryChannel(guild?.Discord, model.Id, guild);
             entity.Update(state, model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -34,7 +34,7 @@ namespace Discord.WebSocket
 
         internal new static SocketForumChannel Create(SocketGuild guild, ClientState state, Model model)
         {
-            var entity = new SocketForumChannel(guild.Discord, model.Id, guild);
+            var entity = new SocketForumChannel(guild?.Discord, model.Id, guild);
             entity.Update(state, model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -23,7 +23,7 @@ namespace Discord.WebSocket
         }
         internal new static SocketNewsChannel Create(SocketGuild guild, ClientState state, Model model)
         {
-            var entity = new SocketNewsChannel(guild.Discord, model.Id, guild);
+            var entity = new SocketNewsChannel(guild?.Discord, model.Id, guild);
             entity.Update(state, model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
@@ -49,7 +49,7 @@ namespace Discord.WebSocket
 
         internal new static SocketStageChannel Create(SocketGuild guild, ClientState state, Model model)
         {
-            var entity = new SocketStageChannel(guild.Discord, model.Id, guild);
+            var entity = new SocketStageChannel(guild?.Discord, model.Id, guild);
             entity.Update(state, model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -61,12 +61,12 @@ namespace Discord.WebSocket
         internal SocketTextChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
             : base(discord, id, guild)
         {
-            if (Discord.MessageCacheSize > 0)
+            if (Discord?.MessageCacheSize > 0)
                 _messages = new MessageCache(Discord);
         }
         internal new static SocketTextChannel Create(SocketGuild guild, ClientState state, Model model)
         {
-            var entity = new SocketTextChannel(guild.Discord, model.Id, guild);
+            var entity = new SocketTextChannel(guild?.Discord, model.Id, guild);
             entity.Update(state, model);
             return entity;
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -50,7 +50,7 @@ namespace Discord.WebSocket
         }
         internal new static SocketVoiceChannel Create(SocketGuild guild, ClientState state, Model model)
         {
-            var entity = new SocketVoiceChannel(guild.Discord, model.Id, guild);
+            var entity = new SocketVoiceChannel(guild?.Discord, model.Id, guild);
             entity.Update(state, model);
             return entity;
         }
@@ -58,8 +58,8 @@ namespace Discord.WebSocket
         internal override void Update(ClientState state, Model model)
         {
             base.Update(state, model);
-            Bitrate = model.Bitrate.Value;
-            UserLimit = model.UserLimit.Value != 0 ? model.UserLimit.Value : (int?)null;
+            Bitrate = model.Bitrate.GetValueOrDefault(64000);
+            UserLimit = model.UserLimit.GetValueOrDefault() != 0 ? model.UserLimit.Value : (int?)null;
             RTCRegion = model.RTCRegion.GetValueOrDefault(null);
         }
 

--- a/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/MessageCommands/SocketMessageCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/MessageCommands/SocketMessageCommand.cs
@@ -20,9 +20,7 @@ namespace Discord.WebSocket
                 ? (DataModel)model.Data.Value
                 : null;
 
-            ulong? guildId = null;
-            if (Channel is SocketGuildChannel guildChannel)
-                guildId = guildChannel.Guild.Id;
+            ulong? guildId = model.GuildId.ToNullable();
 
             Data = SocketMessageCommandData.Create(client, dataModel, model.Id, guildId);
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/UserCommands/SocketUserCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/ContextMenuCommands/UserCommands/SocketUserCommand.cs
@@ -20,9 +20,7 @@ namespace Discord.WebSocket
                 ? (DataModel)model.Data.Value
                 : null;
 
-            ulong? guildId = null;
-            if (Channel is SocketGuildChannel guildChannel)
-                guildId = guildChannel.Guild.Id;
+            ulong? guildId = model.GuildId.ToNullable();
 
             Data = SocketUserCommandData.Create(client, dataModel, model.Id, guildId);
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
@@ -61,7 +61,9 @@ namespace Discord.WebSocket
                             author = channel.Guild.GetUser(model.Message.Value.Author.Value.Id);
                     }
                     else if (model.Message.Value.Author.IsSpecified)
-                        author = (Channel as SocketChannel).GetUser(model.Message.Value.Author.Value.Id);
+                        author = (Channel as SocketChannel)?.GetUser(model.Message.Value.Author.Value.Id);
+
+                    author ??= Discord.State.GetOrAddUser(model.Message.Value.Author.Value.Id, _ => SocketGlobalUser.Create(Discord, Discord.State, model.Message.Value.Author.Value));
 
                     Message = SocketUserMessage.Create(Discord, Discord.State, author, Channel, model.Message.Value);
                 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketSlashCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketSlashCommand.cs
@@ -20,9 +20,7 @@ namespace Discord.WebSocket
                 ? (DataModel)model.Data.Value
                 : null;
 
-            ulong? guildId = null;
-            if (Channel is SocketGuildChannel guildChannel)
-                guildId = guildChannel.Guild.Id;
+            ulong? guildId = model.GuildId.ToNullable();
 
             Data = SocketSlashCommandData.Create(client, dataModel, guildId);
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
@@ -19,7 +19,7 @@ namespace Discord.WebSocket
         ///    Gets whether or not this command is a global application command.
         /// </summary>
         public bool IsGlobalCommand
-            => Guild == null;
+            => GuildId is null;
 
         /// <inheritdoc/>
         public ulong ApplicationId { get; private set; }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
@@ -43,9 +43,7 @@ namespace Discord.WebSocket
                 ? (DataModel)model.Data.Value
                 : null;
 
-            ulong? guildId = null;
-            if (Channel is SocketGuildChannel guildChannel)
-                guildId = guildChannel.Guild.Id;
+            ulong? guildId = model.GuildId.ToNullable();
 
             Data = SocketCommandBaseData.Create(client, dataModel, model.Id, guildId);
         }

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketUserMessage.cs
@@ -127,7 +127,7 @@ namespace Discord.WebSocket
                             refMsgAuthor = guild.GetUser(refMsg.Author.Value.Id);
                     }
                     else
-                        refMsgAuthor = (Channel as SocketChannel).GetUser(refMsg.Author.Value.Id);
+                        refMsgAuthor = (Channel as SocketChannel)?.GetUser(refMsg.Author.Value.Id);
                     if (refMsgAuthor == null)
                         refMsgAuthor = SocketUnknownUser.Create(Discord, state, refMsg.Author.Value);
                 }

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -63,7 +63,7 @@ namespace Discord.WebSocket
             => Guild.Users.Where(x => x.Roles.Any(r => r.Id == Id));
 
         internal SocketRole(SocketGuild guild, ulong id)
-            : base(guild.Discord, id)
+            : base(guild?.Discord, id)
         {
             Guild = guild;
         }


### PR DESCRIPTION
This PR fixes the remaining issues related to the absence of the `bot` scope. Most of the changes are fixes to bugs caused by `null` guilds and channels. Like #2217, these changes will cause some properties to be `null` or methods that require a non-`null` guild to fail.

This PR also makes a small change in `DiscordSocketClient` so interactions can be used while having no intents (`GatewayIntents.None`). This change allows bots to be used without intents regardless of the bot scope. I haven't noticed any bug while testing this change. This fixes Discord-Net-Labs/Discord.Net-Labs#345.