### PR TITLE
Added DeleteMessagesAsync for TIV and added remaining rate limit in client log

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -24,6 +25,44 @@ namespace Discord
         ///     channel at once; <c>null</c> if a limit is not set.
         /// </returns>
         int? UserLimit { get; }
+
+        /// <summary>
+        ///     Bulk-deletes multiple messages.
+        /// </summary>
+        /// <example>
+        ///     <para>The following example gets 250 messages from the channel and deletes them.</para>
+        ///     <code language="cs">
+        ///     var messages = await voiceChannel.GetMessagesAsync(250).FlattenAsync();
+        ///     await voiceChannel.DeleteMessagesAsync(messages);
+        ///     </code>
+        /// </example>
+        /// <remarks>
+        ///     This method attempts to remove the messages specified in bulk.
+        ///     <note type="important">
+        ///         Due to the limitation set by Discord, this method can only remove messages that are posted within 14 days!
+        ///     </note>
+        /// </remarks>
+        /// <param name="messages">The messages to be bulk-deleted.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous bulk-removal operation.
+        /// </returns>
+        Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null);
+        /// <summary>
+        ///     Bulk-deletes multiple messages.
+        /// </summary>
+        /// <remarks>
+        ///     This method attempts to remove the messages specified in bulk.
+        ///     <note type="important">
+        ///         Due to the limitation set by Discord, this method can only remove messages that are posted within 14 days!
+        ///     </note>
+        /// </remarks>
+        /// <param name="messageIds">The snowflake identifier of the messages to be bulk-deleted.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous bulk-removal operation.
+        /// </returns>
+        Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null);
 
         /// <summary>
         ///     Modifies this voice channel.

--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -57,7 +57,7 @@ namespace Discord.Rest
                 if (info == null)
                     await _restLogger.VerboseAsync($"Preemptive Rate limit triggered: {endpoint} {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
                 else
-                    await _restLogger.WarningAsync($"Rate limit triggered: {endpoint} {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
+                    await _restLogger.WarningAsync($"Rate limit triggered: {endpoint} Remaining: {info.Value.RetryAfter}s {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
             };
             ApiClient.SentRequest += async (method, endpoint, millis) => await _restLogger.VerboseAsync($"{method} {endpoint}: {millis} ms").ConfigureAwait(false);
         }
@@ -257,6 +257,6 @@ namespace Discord.Rest
         /// <inheritdoc />
         Task IDiscordClient.StopAsync()
             => Task.Delay(0);
-        #endregion 
+        #endregion
     }
 }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
@@ -12,6 +12,9 @@ namespace Discord
         public int Bitrate => throw new NotImplementedException();
 
         public int? UserLimit => throw new NotImplementedException();
+        public Task DeleteMessagesAsync(IEnumerable<IMessage> messages, RequestOptions options = null) => throw new NotImplementedException();
+
+        public Task DeleteMessagesAsync(IEnumerable<ulong> messageIds, RequestOptions options = null) => throw new NotImplementedException();
 
         public ulong? CategoryId => throw new NotImplementedException();
 


### PR DESCRIPTION

This finishes the implementation of DeleteMessagesAsync for TIV channel. Apparently the implementation existed but the method didn't.