### PR TITLE
Using RespondWithModalAsync<IModal>() without prior IModal declaration

### DIFF
--- a/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
+++ b/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
@@ -22,7 +22,20 @@ namespace Discord.Interactions
             await SendModalResponseAsync(interaction, customId, modalInfo, options, modifyModal);
         }
 
-        public static async Task RespondWithModalSafelyAsync<T>(this IDiscordInteraction interaction, string customId, InteractionService interactionService,
+        /// <summary>
+        ///     Respond to an interaction with a <see cref="IModal"/>.
+        /// </summary>
+        /// <remarks>
+        ///     This method overload uses the <paramref name="interactionService"/> parameter to create a new <see cref="ModalInfo"/>
+        ///     if there isn't a built one already in cache.
+        /// </remarks>
+        /// <typeparam name="T">Type of the <see cref="IModal"/> implementation.</typeparam>
+        /// <param name="interaction">The interaction to respond to.</param>
+        /// <param name="interactionService">Interaction service instance that should be used to build <see cref="ModalInfo"/>s.</param>
+        /// <param name="options">The request options for this <see langword="async"/> request.</param>
+        /// <param name="modifyModal">Delegate that can be used to modify the modal.</param>
+        /// <returns></returns>
+        public static async Task RespondWithModalAsync<T>(this IDiscordInteraction interaction, string customId, InteractionService interactionService,
             RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
             where T : class, IModal
         {

--- a/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
+++ b/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
@@ -19,9 +19,23 @@ namespace Discord.Interactions
             if (!ModalUtils.TryGet<T>(out var modalInfo))
                 throw new ArgumentException($"{typeof(T).FullName} isn't referenced by any registered Modal Interaction Command and doesn't have a cached {typeof(ModalInfo)}");
 
+            await SendModalResponseAsync(interaction, customId, modalInfo, options, modifyModal);
+        }
+
+        public static async Task RespondWithModalSafelyAsync<T>(this IDiscordInteraction interaction, string customId, InteractionService interactionService,
+            RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
+            where T : class, IModal
+        {
+            var modalInfo = ModalUtils.GetOrAdd<T>(interactionService);
+
+            await SendModalResponseAsync(interaction, customId, modalInfo, options, modifyModal);
+        }
+
+        private static async Task SendModalResponseAsync(IDiscordInteraction interaction, string customId, ModalInfo modalInfo, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
+        {
             var builder = new ModalBuilder(modalInfo.Title, customId);
 
-            foreach(var input in modalInfo.Components)
+            foreach (var input in modalInfo.Components)
                 switch (input)
                 {
                     case TextInputComponentInfo textComponent:


### PR DESCRIPTION
This PR adds a `RespondWithModalAsync` overload to the interaction service that is capable of creating ModalInfo instances on the runtime.