### PR TITLE
Add async callbacks for IModuleBase

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -206,6 +206,7 @@ namespace Discord.Commands
 
                 try
                 {
+                    await instance.BeforeExecuteAsync(cmd).ConfigureAwait(false);
                     instance.BeforeExecute(cmd);
 
                     var task = method.Invoke(instance, args) as Task ?? Task.Delay(0);
@@ -221,6 +222,7 @@ namespace Discord.Commands
                 }
                 finally
                 {
+                    await instance.AfterExecuteAsync(cmd).ConfigureAwait(false);
                     instance.AfterExecute(cmd);
                     (instance as IDisposable)?.Dispose();
                 }

--- a/src/Discord.Net.Commands/IModuleBase.cs
+++ b/src/Discord.Net.Commands/IModuleBase.cs
@@ -1,4 +1,5 @@
 using Discord.Commands.Builders;
+using System.Threading.Tasks;
 
 namespace Discord.Commands
 {
@@ -14,10 +15,22 @@ namespace Discord.Commands
         void SetContext(ICommandContext context);
 
         /// <summary>
+        ///     Executed asynchronously before a command is run in this module base.
+        /// </summary>
+        /// <param name="command">The command thats about to run.</param>
+        Task BeforeExecuteAsync(CommandInfo command);
+
+        /// <summary>
         ///     Executed before a command is run in this module base.
         /// </summary>
         /// <param name="command">The command thats about to run.</param>
         void BeforeExecute(CommandInfo command);
+
+        /// <summary>
+        ///     Executed asynchronously after a command is run in this module base.
+        /// </summary>
+        /// <param name="command">The command thats about to run.</param>
+        Task AfterExecuteAsync(CommandInfo command);
 
         /// <summary>
         ///     Executed after a command is ran in this module base.

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -46,12 +46,22 @@ namespace Discord.Commands
             return await Context.Channel.SendMessageAsync(message, isTTS, embed, options, allowedMentions, messageReference, components, stickers, embeds).ConfigureAwait(false);
         }
         /// <summary>
+        ///     The method to execute asynchronously before executing the command.
+        /// </summary>
+        /// <param name="command">The <see cref="CommandInfo"/> of the command to be executed.</param>
+        protected virtual Task BeforeExecuteAsync(CommandInfo command) => Task.CompletedTask;
+        /// <summary>
         ///     The method to execute before executing the command.
         /// </summary>
         /// <param name="command">The <see cref="CommandInfo"/> of the command to be executed.</param>
         protected virtual void BeforeExecute(CommandInfo command)
         {
         }
+        /// <summary>
+        ///     The method to execute asynchronously after executing the command.
+        /// </summary>
+        /// <param name="command">The <see cref="CommandInfo"/> of the command to be executed.</param>
+        protected virtual Task AfterExecuteAsync(CommandInfo command) => Task.CompletedTask;
         /// <summary>
         ///     The method to execute after executing the command.
         /// </summary>
@@ -76,7 +86,9 @@ namespace Discord.Commands
             var newValue = context as T;
             Context = newValue ?? throw new InvalidOperationException($"Invalid context type. Expected {typeof(T).Name}, got {context.GetType().Name}.");
         }
+        Task IModuleBase.BeforeExecuteAsync(CommandInfo command) => BeforeExecuteAsync(command);
         void IModuleBase.BeforeExecute(CommandInfo command) => BeforeExecute(command);
+        Task IModuleBase.AfterExecuteAsync(CommandInfo command) => AfterExecuteAsync(command);
         void IModuleBase.AfterExecute(CommandInfo command) => AfterExecute(command);
         void IModuleBase.OnModuleBuilding(CommandService commandService, ModuleBuilder builder) => OnModuleBuilding(commandService, builder);
         #endregion


### PR DESCRIPTION
# Summary 
This small change allows text-based commands to have asynchronous versions of the BeforeExecute and AfterExecute methods, similar to what is implemented for IInteractionModuleBase.
## Changes
Add `BeforeExecuteAsync` and `AfterExecuteAsync` to `IModuleBase` and default implementations to `ModuleBase`.