### PR TITLE
[DOCS] Add a note about `IgnoreGroupNames` to IF docs

### DIFF
--- a/docs/guides/int_framework/intro.md
+++ b/docs/guides/int_framework/intro.md
@@ -291,6 +291,9 @@ By nesting commands inside a module that is tagged with [GroupAttribute] you can
 > Although creating nested module stuctures are allowed,
 > you are not permitted to use more than 2 [GroupAttribute]'s in module hierarchy.
 
+> [!NOTE]
+> [ComponentInteraction] and [ModalInteraction] handlers require `ignoreGroupNames` parameter set to `true` to work in classes with [GroupAttribute]
+
 [!code-csharp[Command Group Example](samples/intro/groupmodule.cs)]
 
 ## Executing Commands
@@ -383,6 +386,8 @@ delegate can be used to create HTTP responses from a deserialized json object st
 [ChannelTypesAttribute]: xref:Discord.Interactions.ChannelTypesAttribute
 [MaxValueAttribute]: xref:Discord.Interactions.MaxValueAttribute
 [MinValueAttribute]: xref:Discord.Interactions.MinValueAttribute
+[ComponentInteraction]: xref:Discord.Interactions.ComponentInteractionAttribute
+[ModalInteraction]: xref:Discord.Interactions.ModalInteractionAttribute
 
 [IChannel]: xref:Discord.IChannel
 [IRole]: xref:Discord.IRole

--- a/docs/guides/int_framework/intro.md
+++ b/docs/guides/int_framework/intro.md
@@ -294,7 +294,7 @@ By nesting commands inside a module that is tagged with [GroupAttribute] you can
 > [!NOTE]
 > To not use the command group's name as a prefix for component or modal interaction's custom id set `ignoreGroupNames` parameter to `true` in classes with [GroupAttribute]
 >
-> However you have to be careful to prevent overlapping ids of buttons and modals
+> However, you have to be careful to prevent overlapping ids of buttons and modals
 
 [!code-csharp[Command Group Example](samples/intro/groupmodule.cs)]
 

--- a/docs/guides/int_framework/intro.md
+++ b/docs/guides/int_framework/intro.md
@@ -292,7 +292,9 @@ By nesting commands inside a module that is tagged with [GroupAttribute] you can
 > you are not permitted to use more than 2 [GroupAttribute]'s in module hierarchy.
 
 > [!NOTE]
-> [ComponentInteraction] and [ModalInteraction] handlers require `ignoreGroupNames` parameter set to `true` to work in classes with [GroupAttribute]
+> To not use the command group's name as a prefix for component or modal interaction's custom id set `ignoreGroupNames` parameter to `true` in classes with [GroupAttribute]
+>
+> However you have to be careful to prevent overlapping ids of buttons and modals
 
 [!code-csharp[Command Group Example](samples/intro/groupmodule.cs)]
 
@@ -386,8 +388,6 @@ delegate can be used to create HTTP responses from a deserialized json object st
 [ChannelTypesAttribute]: xref:Discord.Interactions.ChannelTypesAttribute
 [MaxValueAttribute]: xref:Discord.Interactions.MaxValueAttribute
 [MinValueAttribute]: xref:Discord.Interactions.MinValueAttribute
-[ComponentInteraction]: xref:Discord.Interactions.ComponentInteractionAttribute
-[ModalInteraction]: xref:Discord.Interactions.ModalInteractionAttribute
 
 [IChannel]: xref:Discord.IChannel
 [IRole]: xref:Discord.IRole

--- a/docs/guides/int_framework/samples/intro/groupmodule.cs
+++ b/docs/guides/int_framework/samples/intro/groupmodule.cs
@@ -16,6 +16,11 @@ public class CommandGroupModule : InteractionModuleBase<SocketInteractionContext
         // group-name subcommand-group-name echo
         [SlashCommand("echo", "Echo an input")]
         public async Task EchoSubcommand(string input)
-            => await RespondAsync(input);
+            => await RespondAsync(input, components: new ComponentBuilder().WithButton("Echo", $"echoButton_{input}").Build());
+
+        // Component interaction with ignoreGroupNames set to true
+        [ComponentInteraction("echoButton_*", true)]
+        public async Task EchoButton(string input)
+            => await RespondAsync(input);  
     }
 }


### PR DESCRIPTION
This PR adds a note about `IgnoreGroupNames` parameter in `ModalInteraction` & `ComponentInteraction` attributes to Interaction Framework intro and adds an example of its usage