### PR TITLE
Max/Min length fields for ApplicationCommandOption

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -81,12 +81,12 @@ namespace Discord
         /// </summary>
         public double? MaxValue { get; set; }
 
-        // <summary>
+        /// <summary>
         ///     Gets or sets the minimum allowed length for a string input.
         /// </summary>
         public int? MinLength { get; set; }
 
-        // <summary>
+        /// <summary>
         ///     Gets or sets the maximum allowed length for a string input.
         /// </summary>
         public int? MaxLength { get; set; }

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -81,6 +81,16 @@ namespace Discord
         /// </summary>
         public double? MaxValue { get; set; }
 
+        // <summary>
+        ///     Gets or sets the minimum allowed length for a string input.
+        /// </summary>
+        public int? MinLength { get; set; }
+
+        // <summary>
+        ///     Gets or sets the maximum allowed length for a string input.
+        /// </summary>
+        public int? MaxLength { get; set; }
+
         /// <summary>
         ///     Gets or sets the choices for string and int types for the user to pick from.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
@@ -48,6 +48,16 @@ namespace Discord
         double? MaxValue { get; }
 
         /// <summary>
+        ///     Gets the minimum allowed length for a string input.
+        /// </summary>
+        int? MinLength { get; }
+
+        /// <summary>
+        ///     Gets the maximum allowed length for a string input.
+        /// </summary>
+        int? MaxLength { get; }
+
+        /// <summary>
         ///     Gets the choices for string and int types for the user to pick from.
         /// </summary>
         IReadOnlyCollection<IApplicationCommandOptionChoice> Choices { get; }

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -196,7 +196,7 @@ namespace Discord
         /// <returns>The current builder.</returns>
         public SlashCommandBuilder AddOption(string name, ApplicationCommandOptionType type,
            string description, bool? isRequired = null, bool? isDefault = null, bool isAutocomplete = false, double? minValue = null, double? maxValue = null,
-           List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
+           int? minLength = null, int? maxLength = null, List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             Preconditions.Options(name, description);
 
@@ -222,6 +222,8 @@ namespace Discord
                 ChannelTypes = channelTypes,
                 MinValue = minValue,
                 MaxValue = maxValue,
+                MinLength = minLength,
+                MaxLength = maxLength,
             };
 
             return AddOption(option);
@@ -358,6 +360,16 @@ namespace Discord
         public double? MaxValue { get; set; }
 
         /// <summary>
+        ///     Gets or sets the minimum allowed length for a string input.
+        /// </summary>
+        public int? MinLength { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the maximum allowed length for a string input.
+        /// </summary>
+        public int? MaxLength { get; set; }
+
+        /// <summary>
         ///     Gets or sets the choices for string and int types for the user to pick from.
         /// </summary>
         public List<ApplicationCommandOptionChoiceProperties> Choices { get; set; }
@@ -380,6 +392,7 @@ namespace Discord
         {
             bool isSubType = Type == ApplicationCommandOptionType.SubCommandGroup;
             bool isIntType = Type == ApplicationCommandOptionType.Integer;
+            bool isStrType = Type == ApplicationCommandOptionType.String;
 
             if (isSubType && (Options == null || !Options.Any()))
                 throw new InvalidOperationException("SubCommands/SubCommandGroups must have at least one option");
@@ -392,6 +405,12 @@ namespace Discord
 
             if (isIntType && MaxValue != null && MaxValue % 1 != 0)
                 throw new InvalidOperationException("MaxValue cannot have decimals on Integer command options.");
+
+            if(isStrType && MinLength is not null && MinLength < 0)
+                throw new InvalidOperationException("MinLength cannot be smaller than 0.");
+
+            if (isStrType && MaxLength is not null && MaxLength < 1)
+                throw new InvalidOperationException("MaxLength cannot be smaller than 1.");
 
             return new ApplicationCommandOptionProperties
             {
@@ -407,7 +426,9 @@ namespace Discord
                 IsAutocomplete = IsAutocomplete,
                 ChannelTypes = ChannelTypes,
                 MinValue = MinValue,
-                MaxValue = MaxValue
+                MaxValue = MaxValue,
+                MinLength = MinLength,
+                MaxLength = MaxLength,
             };
         }        
 
@@ -428,7 +449,7 @@ namespace Discord
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddOption(string name, ApplicationCommandOptionType type,
            string description, bool? isRequired = null, bool isDefault = false, bool isAutocomplete = false, double? minValue = null, double? maxValue = null,
-           List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
+           int? minLength = null, int? maxLength = null, List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             Preconditions.Options(name, description);
 
@@ -450,6 +471,8 @@ namespace Discord
                 IsAutocomplete = isAutocomplete,
                 MinValue = minValue,
                 MaxValue = maxValue,
+                MinLength = minLength,
+                MaxLength = maxLength,
                 Options = options,
                 Type = type,
                 Choices = (choices ?? Array.Empty<ApplicationCommandOptionChoiceProperties>()).ToList(),
@@ -649,6 +672,28 @@ namespace Discord
         public SlashCommandOptionBuilder WithMaxValue(double value)
         {
             MaxValue = value;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the current builders min length field.
+        /// </summary>
+        /// <param name="length">The value to set.</param>
+        /// <returns>The current builder.</returns>
+        public SlashCommandOptionBuilder WithMinLength(int length)
+        {
+            MinLength = length;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the current builders max length field.
+        /// </summary>
+        /// <param name="lenght">The value to set.</param>
+        /// <returns>The current builder.</returns>
+        public SlashCommandOptionBuilder WithMaxLength(int lenght)
+        {
+            MaxLength = lenght;
             return this;
         }
 

--- a/src/Discord.Net.Interactions/Attributes/MaxLengthAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/MaxLengthAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Discord.Interactions
+{
+    /// <summary>
+    ///     Sets the maximum length allowed for a string type parameter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    public class MaxLengthAttribute : Attribute
+    {
+        /// <summary>
+        ///     Gets the maximum length allowed for a string type parameter.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        ///     Sets the maximum length allowed for a string type parameter.
+        /// </summary>
+        /// <param name="lenght">Maximum string length allowed.</param>
+        public MaxLengthAttribute(int lenght)
+        {
+            Length = lenght;
+        }
+    }
+}

--- a/src/Discord.Net.Interactions/Attributes/MinLengthAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/MinLengthAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Discord.Interactions
+{
+    /// <summary>
+    ///     Sets the minimum length allowed for a string type parameter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    public class MinLengthAttribute : Attribute
+    {
+        /// <summary>
+        ///     Gets the minimum length allowed for a string type parameter.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        ///     Sets the minimum length allowed for a string type parameter.
+        /// </summary>
+        /// <param name="lenght">Minimum string length allowed.</param>
+        public MinLengthAttribute(int lenght)
+        {
+            Length = lenght;
+        }
+    }
+}

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -463,6 +463,12 @@ namespace Discord.Interactions.Builders
                     case MinValueAttribute minValue:
                         builder.MinValue = minValue.Value;
                         break;
+                    case MinLengthAttribute minLength:
+                        builder.MinLength = minLength.Length;
+                        break;
+                    case MaxLengthAttribute maxLength:
+                        builder.MaxLength = maxLength.Length;
+                        break;
                     case ComplexParameterAttribute complexParameter:
                         {
                             builder.IsComplexParameter = true;

--- a/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
@@ -29,6 +29,16 @@ namespace Discord.Interactions.Builders
         public double? MinValue { get; set; }
 
         /// <summary>
+        ///     Gets or sets the minimum length allowed for a string type parameter.
+        /// </summary>
+        public int? MinLength { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the maximum length allowed for a string type parameter.
+        /// </summary>
+        public int? MaxLength { get; set; }
+
+        /// <summary>
         ///     Gets a collection of the choices of this command.
         /// </summary>
         public IReadOnlyCollection<ParameterChoice> Choices => _choices;
@@ -122,6 +132,32 @@ namespace Discord.Interactions.Builders
         public SlashCommandParameterBuilder WithMaxValue(double value)
         {
             MaxValue = value;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MinLength"/>.
+        /// </summary>
+        /// <param name="length">New value of the <see cref="MinLength"/>.</param>
+        /// <returns>
+        ///     The builder instance.
+        /// </returns>
+        public SlashCommandParameterBuilder WithMinLength(int length)
+        {
+            MinLength = length;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets <see cref="MaxLength"/>.
+        /// </summary>
+        /// <param name="length">New value of the <see cref="MaxLength"/>.</param>
+        /// <returns>
+        ///     The builder instance.
+        /// </returns>
+        public SlashCommandParameterBuilder WithMaxLength(int length)
+        {
+            MaxLength = length;
             return this;
         }
 

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -39,6 +39,16 @@ namespace Discord.Interactions
         public double? MaxValue { get; }
 
         /// <summary>
+        ///     Gets the minimum length allowed for a string type parameter.
+        /// </summary>
+        public int? MinLength { get; }
+
+        /// <summary>
+        ///     Gets the maximum length allowed for a string type parameter.
+        /// </summary>
+        public int? MaxLength { get; }
+
+        /// <summary>
         ///     Gets the <see cref="TypeConverter{T}"/> that will be used to convert the incoming <see cref="Discord.WebSocket.SocketSlashCommandDataOption"/> into
         ///     <see cref="CommandParameterInfo.ParameterType"/>.
         /// </summary>
@@ -86,6 +96,8 @@ namespace Discord.Interactions
             Description = builder.Description;
             MaxValue = builder.MaxValue;
             MinValue = builder.MinValue;
+            MinLength = builder.MinLength;
+            MaxLength = builder.MaxLength;
             IsComplexParameter = builder.IsComplexParameter;
             IsAutocomplete = builder.Autocomplete;
             Choices = builder.Choices.ToImmutableArray();

--- a/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
+++ b/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
@@ -23,7 +23,9 @@ namespace Discord.Interactions
                 ChannelTypes = parameterInfo.ChannelTypes?.ToList(),
                 IsAutocomplete = parameterInfo.IsAutocomplete,
                 MaxValue = parameterInfo.MaxValue,
-                MinValue = parameterInfo.MinValue
+                MinValue = parameterInfo.MinValue,
+                MinLength = parameterInfo.MinLength,
+                MaxLength = parameterInfo.MaxLength,
             };
 
             parameterInfo.TypeConverter.Write(props, parameterInfo);
@@ -209,7 +211,13 @@ namespace Discord.Interactions
                     Name = x.Name,
                     Value = x.Value
                 }).ToList(),
-                Options = commandOption.Options?.Select(x => x.ToApplicationCommandOptionProps()).ToList()
+                Options = commandOption.Options?.Select(x => x.ToApplicationCommandOptionProps()).ToList(),
+                MaxLength = commandOption.MaxLength,
+                MinLength = commandOption.MinLength,
+                MaxValue = commandOption.MaxValue,
+                MinValue = commandOption.MinValue,
+                IsAutocomplete = commandOption.IsAutocomplete.GetValueOrDefault(),
+                ChannelTypes = commandOption.ChannelTypes.ToList(),
             };
 
         public static Modal ToModal(this ModalInfo modalInfo, string customId, Action<ModalBuilder> modifyModal = null)

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
@@ -38,6 +38,12 @@ namespace Discord.API
         [JsonProperty("channel_types")]
         public Optional<ChannelType[]> ChannelTypes { get; set; }
 
+        [JsonProperty("min_length")]
+        public Optional<int> MinLength { get; set; }
+
+        [JsonProperty("max_length")]
+        public Optional<int> MaxLength { get; set; }
+
         public ApplicationCommandOption() { }
 
         public ApplicationCommandOption(IApplicationCommandOption cmd)
@@ -56,6 +62,8 @@ namespace Discord.API
             Default = cmd.IsDefault ?? Optional<bool>.Unspecified;
             MinValue = cmd.MinValue ?? Optional<double>.Unspecified;
             MaxValue = cmd.MaxValue ?? Optional<double>.Unspecified;
+            MinLength = cmd.MinLength ?? Optional<int>.Unspecified;
+            MaxLength = cmd.MaxLength ?? Optional<int>.Unspecified;
             Autocomplete = cmd.IsAutocomplete ?? Optional<bool>.Unspecified;
 
             Name = cmd.Name;
@@ -77,6 +85,8 @@ namespace Discord.API
             Default = option.IsDefault ?? Optional<bool>.Unspecified;
             MinValue = option.MinValue ?? Optional<double>.Unspecified;
             MaxValue = option.MaxValue ?? Optional<double>.Unspecified;
+            MinLength = option.MinLength ?? Optional<int>.Unspecified;
+            MaxLength = option.MaxLength ?? Optional<int>.Unspecified;
 
             ChannelTypes = option.ChannelTypes?.ToArray() ?? Optional<ChannelType[]>.Unspecified;
 

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
@@ -35,6 +35,12 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public double? MaxValue { get; private set; }
 
+        /// <inheritdoc/>
+        public int? MinLength { get; private set; }
+
+        /// <inheritdoc/>
+        public int? MaxLength { get; private set; }
+
         /// <summary>
         ///     Gets a collection of <see cref="RestApplicationCommandChoice"/>s for this command.
         /// </summary>
@@ -77,6 +83,9 @@ namespace Discord.Rest
 
             if (model.Autocomplete.IsSpecified)
                 IsAutocomplete = model.Autocomplete.Value;
+
+            MinLength = model.MinLength.ToNullable();
+            MaxLength = model.MaxLength.ToNullable();
 
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(Create).ToImmutableArray()

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
@@ -33,6 +33,12 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public double? MaxValue { get; private set; }
 
+        /// <inheritdoc/>
+        public int? MinLength { get; private set; }
+
+        /// <inheritdoc/>
+        public int? MaxLength { get; private set; }
+
         /// <summary>
         ///     Gets a collection of choices for the user to pick from.
         /// </summary>
@@ -71,6 +77,9 @@ namespace Discord.WebSocket
             MaxValue = model.MaxValue.ToNullable();
 
             IsAutocomplete = model.Autocomplete.ToNullable();
+
+            MinLength = model.MinLength.ToNullable();
+            MaxLength = model.MaxLength.ToNullable();
 
             Choices = model.Choices.IsSpecified
                 ? model.Choices.Value.Select(SocketApplicationCommandChoice.Create).ToImmutableArray()


### PR DESCRIPTION
Implements the newly added API fields `minLength` and `maxLength` of ApplicationCommandOption to the Core and Interactions packages.