### PR TITLE
Support the WEBHOOKS_UPDATED event

### DIFF
--- a/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
@@ -8,6 +8,6 @@ namespace Discord.API.Gateway
         public ulong GuildId { get; set; }
 
         [JsonProperty("channel_id")]
-        public ulong ChanelId { get; set; }
+        public ulong ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
@@ -1,12 +1,11 @@
 using Newtonsoft.Json;
 
-namespace Discord.API.Gateway;
-
-internal class WebhooksUpdatedEvent
+namespace Discord.API.Gateway
 {
-    [JsonProperty("guild_id")]
-    public ulong GuildId { get; set; }
+    internal class WebhooksUpdatedEvent
+    {
+        [JsonProperty("guild_id")] public ulong GuildId { get; set; }
 
-    [JsonProperty("channel_id")]
-    public ulong ChanelId { get; set; }
+        [JsonProperty("channel_id")] public ulong ChanelId { get; set; }
+    }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Discord.API.Gateway;
+
+internal class WebhooksUpdatedEvent
+{
+    [JsonProperty("guild_id")]
+    public ulong GuildId { get; set; }
+
+    [JsonProperty("channel_id")]
+    public ulong ChanelId { get; set; }
+}

--- a/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
@@ -4,8 +4,10 @@ namespace Discord.API.Gateway
 {
     internal class WebhooksUpdatedEvent
     {
-        [JsonProperty("guild_id")] public ulong GuildId { get; set; }
+        [JsonProperty("guild_id")]
+        public ulong GuildId { get; set; }
 
-        [JsonProperty("channel_id")] public ulong ChanelId { get; set; }
+        [JsonProperty("channel_id")]
+        public ulong ChanelId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -106,7 +106,7 @@ namespace Discord.WebSocket
         /// <remarks>
         ///     <para>
         ///         This event is fired when a message is deleted. The event handler must return a
-        ///         <see cref="Task"/> and accept a <see cref="Cacheable{TEntity,TId}"/> and 
+        ///         <see cref="Task"/> and accept a <see cref="Cacheable{TEntity,TId}"/> and
         ///         <see cref="ISocketMessageChannel"/> as its parameters.
         ///     </para>
         ///     <para>
@@ -117,11 +117,11 @@ namespace Discord.WebSocket
         ///         </note>
         ///         If caching is enabled via <see cref="DiscordSocketConfig"/>, the
         ///         <see cref="Cacheable{TEntity,TId}"/> entity will contain the deleted message; otherwise, in event
-        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the 
+        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the
         ///         <see cref="ulong"/>.
         ///     </para>
         ///     <para>
-        ///         The source channel of the removed message will be passed into the 
+        ///         The source channel of the removed message will be passed into the
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         /// </remarks>
@@ -143,7 +143,7 @@ namespace Discord.WebSocket
         ///     </note>
         ///     <para>
         ///         This event is fired when multiple messages are bulk deleted. The event handler must return a
-        ///         <see cref="Task"/> and accept an <see cref="IReadOnlyCollection{Cacheable}"/> and 
+        ///         <see cref="Task"/> and accept an <see cref="IReadOnlyCollection{Cacheable}"/> and
         ///         <see cref="ISocketMessageChannel"/> as its parameters.
         ///     </para>
         ///     <para>
@@ -154,11 +154,11 @@ namespace Discord.WebSocket
         ///         </note>
         ///         If caching is enabled via <see cref="DiscordSocketConfig"/>, the
         ///         <see cref="Cacheable{TEntity,TId}"/> entity will contain the deleted message; otherwise, in event
-        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the 
+        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the
         ///         <see cref="ulong"/>.
         ///     </para>
         ///     <para>
-        ///         The source channel of the removed message will be passed into the 
+        ///         The source channel of the removed message will be passed into the
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         /// </remarks>
@@ -178,14 +178,14 @@ namespace Discord.WebSocket
         ///     <para>
         ///         If caching is enabled via <see cref="DiscordSocketConfig"/>, the
         ///         <see cref="Cacheable{TEntity,TId}"/> entity will contain the original message; otherwise, in event
-        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the 
+        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the
         ///         <see cref="ulong"/>.
         ///     </para>
         ///     <para>
         ///         The updated message will be passed into the <see cref="SocketMessage"/> parameter.
         ///     </para>
         ///     <para>
-        ///         The source channel of the updated message will be passed into the 
+        ///         The source channel of the updated message will be passed into the
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         /// </remarks>
@@ -199,24 +199,24 @@ namespace Discord.WebSocket
         /// <remarks>
         ///     <para>
         ///         This event is fired when a reaction is added to a user message. The event handler must return a
-        ///         <see cref="Task"/> and accept a <see cref="Cacheable{TEntity,TId}"/>, an 
+        ///         <see cref="Task"/> and accept a <see cref="Cacheable{TEntity,TId}"/>, an
         ///         <see cref="ISocketMessageChannel"/>, and a <see cref="SocketReaction"/> as its parameter.
         ///     </para>
         ///     <para>
         ///         If caching is enabled via <see cref="DiscordSocketConfig"/>, the
         ///         <see cref="Cacheable{TEntity,TId}"/> entity will contain the original message; otherwise, in event
-        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the 
+        ///         that the message cannot be retrieved, the snowflake ID of the message is preserved in the
         ///         <see cref="ulong"/>.
         ///     </para>
         ///     <para>
-        ///         The source channel of the reaction addition will be passed into the 
+        ///         The source channel of the reaction addition will be passed into the
         ///         <see cref="ISocketMessageChannel"/> parameter.
         ///     </para>
         ///     <para>
         ///         The reaction that was added will be passed into the <see cref="SocketReaction"/> parameter.
         ///     </para>
         ///     <note>
-        ///         When fetching the reaction from this event, a user may not be provided under 
+        ///         When fetching the reaction from this event, a user may not be provided under
         ///         <see cref="SocketReaction.User"/>. Please see the documentation of the property for more
         ///         information.
         ///     </note>
@@ -367,7 +367,7 @@ namespace Discord.WebSocket
         }
         internal readonly AsyncEvent<Func<Cacheable<SocketGuildEvent, ulong>, SocketGuildEvent, Task>> _guildScheduledEventUpdated = new AsyncEvent<Func<Cacheable<SocketGuildEvent, ulong>, SocketGuildEvent, Task>>();
 
-        
+
         /// <summary>
         ///     Fired when a guild event is cancelled.
         /// </summary>
@@ -876,6 +876,21 @@ namespace Discord.WebSocket
             remove { _guildStickerDeleted.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketCustomSticker, Task>> _guildStickerDeleted = new AsyncEvent<Func<SocketCustomSticker, Task>>();
+        #endregion
+
+        #region Webhooks
+
+        /// <summary>
+        ///     Fired when a webhook is modified, moved, or deleted. If the webhook was
+        ///     moved the channel represents the destination channel, not the source.
+        /// </summary>
+        public event Func<SocketGuild, SocketChannel, Task> WebhooksUpdated
+        {
+            add { _webhooksUpdated.Add(value); }
+            remove { _webhooksUpdated.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<SocketGuild, SocketChannel, Task>> _webhooksUpdated = new AsyncEvent<Func<SocketGuild, SocketChannel, Task>>();
+
         #endregion
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -496,6 +496,8 @@ namespace Discord.WebSocket
             client.GuildScheduledEventStarted += (arg) => _guildScheduledEventStarted.InvokeAsync(arg);
             client.GuildScheduledEventUserAdd += (arg1, arg2) => _guildScheduledEventUserAdd.InvokeAsync(arg1, arg2);
             client.GuildScheduledEventUserRemove += (arg1, arg2) => _guildScheduledEventUserRemove.InvokeAsync(arg1, arg2);
+
+            client.WebhooksUpdated += (arg1, arg2) => _webhooksUpdated.InvokeAsync(arg1, arg2);
         }
         #endregion
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2839,6 +2839,23 @@ namespace Discord.WebSocket
 
                             #endregion
 
+                            #region Webhooks
+
+                            case "WEBHOOKS_UPDATE":
+                                {
+                                    var data = (payload as JToken).ToObject<WebhooksUpdatedEvent>(_serializer);
+                                    type = "WEBHOOKS_UPDATE";
+                                    await _gatewayLogger.DebugAsync("Received Dispatch (WEBHOOKS_UPDATE)").ConfigureAwait(false);
+
+                                    var guild = State.GetGuild(data.GuildId);
+                                    var channel = State.GetChannel(data.ChanelId);
+
+                                    await TimedInvokeAsync(_webhooksUpdated, nameof(WebhooksUpdated), guild, channel);
+                                }
+                                break;
+
+                            #endregion
+
                             #region Ignored (User only)
                             case "CHANNEL_PINS_ACK":
                                 await _gatewayLogger.DebugAsync("Ignored Dispatch (CHANNEL_PINS_ACK)").ConfigureAwait(false);
@@ -2857,9 +2874,6 @@ namespace Discord.WebSocket
                                 break;
                             case "USER_SETTINGS_UPDATE":
                                 await _gatewayLogger.DebugAsync("Ignored Dispatch (USER_SETTINGS_UPDATE)").ConfigureAwait(false);
-                                break;
-                            case "WEBHOOKS_UPDATE":
-                                await _gatewayLogger.DebugAsync("Ignored Dispatch (WEBHOOKS_UPDATE)").ConfigureAwait(false);
                                 break;
                             #endregion
 


### PR DESCRIPTION
The `WEBHOOKS_UPDATE` event is ignored by socket clients, and a comment claims it is user only, however it is [documented](https://discord.com/developers/docs/topics/gateway#webhooks-update) and other libraries appear to [support it](https://github.com/discordjs/discord.js/blob/e78c9c9ee9626b5aad7cbbd551bcdef666c11828/packages/discord.js/src/client/actions/WebhooksUpdate.js#L6). The event is useful in webhook caching solutions that need to know if a webhook was moved.
The ignored event is found at: https://github.com/discord-net/Discord.Net/blob/a890de93044cb5db12e64fce203e718286d8dd83/src/Discord.Net.WebSocket/DiscordSocketClient.cs#L2861-L2864

Example using the event:
```cs
client.WebhooksUpdated += (guild, channel) =>
{
    Console.ForegroundColor = ConsoleColor.Magenta;
    Console.WriteLine($"A webhook was updated in or moved to {guild}#{channel}");
    Console.ResetColor();
    return Task.CompletedTask;
};
```