### PR TITLE
Removes GroupContext from requirecontext

### DIFF
--- a/src/Discord.Net.Interactions/Attributes/Preconditions/RequireContextAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/Preconditions/RequireContextAttribute.cs
@@ -58,7 +58,7 @@ namespace Discord.Interactions
 
             if ((Contexts & ContextType.Guild) != 0)
                 isValid = !context.Interaction.IsDMInteraction;
-            if ((Contexts & ContextType.DM) != 0 && (Contexts & ContextType.Group) != 0)
+            if ((Contexts & ContextType.DM) != 0)
                 isValid = context.Interaction.IsDMInteraction;
 
             if (isValid)


### PR DESCRIPTION
Because bots have no access to groups, this entire check is unnecessary.

Closes #2262 