### PR TITLE
Fix: remove Module from _typedModuleDefs

### DIFF
--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -270,6 +270,11 @@ namespace Discord.Commands
             await _moduleLock.WaitAsync().ConfigureAwait(false);
             try
             {
+                var typeModulePair = _typedModuleDefs.FirstOrDefault(x => x.Value.Equals(module));
+
+                if (!typeModulePair.Equals(default(KeyValuePair<Type, ModuleInfo>)))
+                    _typedModuleDefs.TryRemove(typeModulePair.Key, out var _);
+
                 return RemoveModuleInternal(module);
             }
             finally


### PR DESCRIPTION
---
# Abstract

This PR fixes the `RemoveModuleAsync` method from the `CommandService` class which doesn't remove the values from `_typedModuleDefs`. This change is required in particular if you want to unload individual assemblies using `AssemblyLoadContext.Unload()`

## Changes

Now the values in `_typedModuleDefs` are removed when you are calling the `RemoveModuleAsync` method from `CommandService`

## Tests

With this PR you are able to completley remove the `CommandService` from assemblies. I tested to load the `CommandService`  in external libraries and remove it with the `RemoveModuleAsync`, with this PR you are able to unload it.
