### PR TITLE
Update xmldocs to reflect the ConnectedUsers split

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -36,8 +36,8 @@ namespace Discord.WebSocket
         ///     Gets a collection of users that are able to view the channel.
         /// </summary>
         /// <remarks>
-        ///     If this channel is a voice channel, a collection of users who are currently connected to this channel
-        ///     is returned.
+        ///     If this channel is a voice channel, use <see cref="SocketVoiceChannel.ConnectedUsers"/> to retrieve a
+        ///     collection of users who are currently connected to this channel.
         /// </remarks>
         /// <returns>
         ///     A read-only collection of users that can access the channel (i.e. the users seen in the user list).


### PR DESCRIPTION
Release v3.7.0 changed `SocketVoiceChannel.Users` to return all users and added `SocketVoiceChannel.ConnectedUsers` to return just the connected users. The xmldocs inherited from `SocketGuildChannel.Users` has an outdated remark. This PR updates that remark.