### PR TITLE
Fix broken code snippet in dependency injection docs

### DIFF
--- a/docs/guides/dependency_injection/injection.md
+++ b/docs/guides/dependency_injection/injection.md
@@ -16,7 +16,7 @@ This can be done through property or constructor.
 Services can be injected from the constructor of the class.
 This is the preferred approach, because it automatically locks the readonly field in place with the provided service and isn't accessible outside of the class.
 
-[!code-csharp[Property Injection](samples/property-injecting.cs)]
+[!code-csharp[Constructor Injection](samples/ctor-injecting.cs)]
 
 ## Injecting through properties
 

--- a/docs/guides/dependency_injection/injection.md
+++ b/docs/guides/dependency_injection/injection.md
@@ -16,7 +16,7 @@ This can be done through property or constructor.
 Services can be injected from the constructor of the class.
 This is the preferred approach, because it automatically locks the readonly field in place with the provided service and isn't accessible outside of the class.
 
-[!code-csharp[Property Injection(samples/property-injecting.cs)]]
+[!code-csharp[Property Injection](samples/property-injecting.cs)]
 
 ## Injecting through properties
 


### PR DESCRIPTION
See title.  Right now the Dependency Injection -> Injection page has malformed Markdown for the constructor injection code snippet, and would also be pointing incorrectly to the property injection snippet

![image](https://user-images.githubusercontent.com/52503242/183306069-8f0555d4-1a88-454e-8090-cd24fe0cb293.png)