### PR TITLE
Fix IGuild.GetBansAsync()

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -180,7 +180,7 @@ namespace Discord.Rest
                 },
                 nextPage: (info, lastPage) =>
                 {
-                    if (lastPage.Count != DiscordConfig.MaxMessagesPerBatch)
+                    if (lastPage.Count != DiscordConfig.MaxBansPerBatch)
                         return false;
                     if (dir == Direction.Before)
                         info.Position = lastPage.Min(x => x.User.Id);


### PR DESCRIPTION
Fixed the problem of not being able to get more than 1000 bans.

fixed https://github.com/discord-net/Discord.Net/issues/2232#issue-1194218215