### PR TITLE
fix: Missing Fact attribute in ColorTests

### DIFF
--- a/test/Discord.Net.Tests.Unit/ColorTests.cs
+++ b/test/Discord.Net.Tests.Unit/ColorTests.cs
@@ -10,6 +10,7 @@ namespace Discord
     /// </summary>
     public class ColorTests
     {
+        [Fact]
         public void Color_New()
         {
             Assert.Equal(0u, new Color().RawValue);


### PR DESCRIPTION
The Fact attribute on `Color_New()` in `ColorTests` was removed unexpectedly by this merge:
https://github.com/discord-net/Discord.Net/commit/933ea42eaac47094ef77608aa2aa3f6d602ac30d