### PR TITLE
ForumChannel GetActiveThreads issue and more changes

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -163,54 +163,5 @@ namespace Discord
         public Task<IThreadChannel> CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
             MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None);
-
-        /// <summary>
-        ///     Gets a collection of active threads within this forum channel.
-        /// </summary>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
-        ///     a collection of active threads.
-        /// </returns>
-        Task<IReadOnlyCollection<IThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null);
-
-        /// <summary>
-        ///     Gets a collection of publicly archived threads within this forum channel.
-        /// </summary>
-        /// <param name="limit">The optional limit of how many to get.</param>
-        /// <param name="before">The optional date to return threads created before this timestamp.</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
-        ///     a collection of publicly archived threads.
-        /// </returns>
-        Task<IReadOnlyCollection<IThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null);
-
-        /// <summary>
-        ///     Gets a collection of privately archived threads within this forum channel.
-        /// </summary>
-        /// <remarks>
-        ///     The bot requires the <see cref="GuildPermission.ManageThreads"/> permission in order to execute this request.
-        /// </remarks>
-        /// <param name="limit">The optional limit of how many to get.</param>
-        /// <param name="before">The optional date to return threads created before this timestamp.</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
-        ///     a collection of privately archived threads.
-        /// </returns>
-        Task<IReadOnlyCollection<IThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null);
-
-        /// <summary>
-        ///     Gets a collection of privately archived threads that the current bot has joined within this forum channel.
-        /// </summary>
-        /// <param name="limit">The optional limit of how many to get.</param>
-        /// <param name="before">The optional date to return threads created before this timestamp.</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
-        ///     a collection of privately archived threads.
-        /// </returns>
-        Task<IReadOnlyCollection<IThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
@@ -155,5 +155,54 @@ namespace Discord
         ///     represents the user; <c>null</c> if none is found.
         /// </returns>
         new Task<IGuildUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a collection of active threads within this guild channel.
+        /// </summary>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
+        ///     a collection of active threads.
+        /// </returns>
+        Task<IReadOnlyCollection<IThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a collection of publicly archived threads within this guild channel.
+        /// </summary>
+        /// <param name="limit">The optional limit of how many to get.</param>
+        /// <param name="before">The optional date to return threads created before this timestamp.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
+        ///     a collection of publicly archived threads.
+        /// </returns>
+        Task<IReadOnlyCollection<IThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a collection of privately archived threads within this guild channel.
+        /// </summary>
+        /// <remarks>
+        ///     The bot requires the <see cref="GuildPermission.ManageThreads"/> permission in order to execute this request.
+        /// </remarks>
+        /// <param name="limit">The optional limit of how many to get.</param>
+        /// <param name="before">The optional date to return threads created before this timestamp.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
+        ///     a collection of privately archived threads.
+        /// </returns>
+        Task<IReadOnlyCollection<IThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a collection of privately archived threads that the current bot has joined within this guild channel.
+        /// </summary>
+        /// <param name="limit">The optional limit of how many to get.</param>
+        /// <param name="before">The optional date to return threads created before this timestamp.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
+        ///     a collection of privately archived threads.
+        /// </returns>
+        Task<IReadOnlyCollection<IThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -595,31 +595,15 @@ namespace Discord.API
             return await SendAsync<ChannelThreads>("GET", () => $"guilds/{guildId}/threads/active", bucket, options: options);
         }
 
-        public async Task<ChannelThreads> GetActiveThreadsInChannelAsync(ulong guildId, ulong parentChannel, RequestOptions options = null)
+        public async Task<ChannelThreads> GetActiveThreadsInChannelAsync(ulong channelId, RequestOptions options = null)
         {
-            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            Preconditions.NotEqual(channelId, 0, nameof(channelId));
 
             options = RequestOptions.CreateOrClone(options);
 
-            var bucket = new BucketIds(guildId: guildId);
+            var bucket = new BucketIds(channelId: channelId);
 
-            ChannelThreads allChannelThreads = await SendAsync<ChannelThreads>("GET", () => $"guilds/{guildId}/threads/active", bucket, options: options);
-            ChannelThreads filteredThreads = new ChannelThreads();
-
-            filteredThreads.Threads = allChannelThreads.Threads.Where(x => x.CategoryId == parentChannel).ToArray();
-
-            List<ThreadMember> members = new List<ThreadMember>();
-
-            foreach (ThreadMember m in allChannelThreads.Members)
-            {
-                if (filteredThreads.Threads.Where(x => x.Id == (ulong)m.Id).Count() == 0)
-                    continue;
-                members.Add(m);
-            }
-
-            filteredThreads.Members = members.ToArray();
-
-            return filteredThreads;
+            return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/active", bucket, options: options);
         }
 
         public async Task<ChannelThreads> GetPublicArchivedThreadsAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -584,7 +584,7 @@ namespace Discord.API
             return await SendAsync<ThreadMember>("GET", () => $"channels/{channelId}/thread-members/{userId}", bucket, options: options).ConfigureAwait(false);
         }
 
-        public async Task<ChannelThreads> GetActiveThreadsAsync(ulong guildId, RequestOptions options = null)
+        public async Task<ChannelThreads> GetActiveThreadsInGuildAsync(ulong guildId, RequestOptions options = null)
         {
             Preconditions.NotEqual(guildId, 0, nameof(guildId));
 
@@ -595,34 +595,18 @@ namespace Discord.API
             return await SendAsync<ChannelThreads>("GET", () => $"guilds/{guildId}/threads/active", bucket, options: options);
         }
 
-        public async Task<ChannelThreads> GetActiveThreadsInChannelAsync(ulong guildId, ulong parentChannel, RequestOptions options = null)
+        public async Task<ChannelThreads> GetActiveThreadsInChannelAsync(ulong channelId, RequestOptions options = null)
         {
-            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+            Preconditions.NotEqual(channelId, 0, nameof(channelId));
 
             options = RequestOptions.CreateOrClone(options);
 
-            var bucket = new BucketIds(guildId: guildId);
+            var bucket = new BucketIds(channelId: channelId);
 
-            ChannelThreads allChannelThreads = await SendAsync<ChannelThreads>("GET", () => $"guilds/{guildId}/threads/active", bucket, options: options);
-            ChannelThreads filteredThreads = new ChannelThreads();
-
-            filteredThreads.Threads = allChannelThreads.Threads.Where(x => x.CategoryId == parentChannel).ToArray();
-
-            List<ThreadMember> members = new List<ThreadMember>();
-
-            foreach (ThreadMember m in allChannelThreads.Members)
-            {
-                if (filteredThreads.Threads.Where(x => x.Id == (ulong)m.Id).Count() == 0)
-                    continue;
-                members.Add(m);
-            }
-
-            filteredThreads.Members = members.ToArray();
-
-            return filteredThreads;
+            return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/active", bucket, options: options);
         }
 
-        public async Task<ChannelThreads> GetPublicArchivedThreadsAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null, RequestOptions options = null)
+        public async Task<ChannelThreads> GetPublicArchivedThreadsInChannelAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null, RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));
 
@@ -644,7 +628,7 @@ namespace Discord.API
             return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/archived/public{query}", bucket, options: options);
         }
 
-        public async Task<ChannelThreads> GetPrivateArchivedThreadsAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null,
+        public async Task<ChannelThreads> GetPrivateArchivedThreadsInChannelAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null,
             RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));
@@ -667,7 +651,7 @@ namespace Discord.API
             return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/archived/private{query}", bucket, options: options);
         }
 
-        public async Task<ChannelThreads> GetJoinedPrivateArchivedThreadsAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null,
+        public async Task<ChannelThreads> GetJoinedPrivateArchivedThreadsInChannelAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null,
             RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -595,6 +595,33 @@ namespace Discord.API
             return await SendAsync<ChannelThreads>("GET", () => $"guilds/{guildId}/threads/active", bucket, options: options);
         }
 
+        public async Task<ChannelThreads> GetActiveThreadsInChannelAsync(ulong guildId, ulong parentChannel, RequestOptions options = null)
+        {
+            Preconditions.NotEqual(guildId, 0, nameof(guildId));
+
+            options = RequestOptions.CreateOrClone(options);
+
+            var bucket = new BucketIds(guildId: guildId);
+
+            ChannelThreads allChannelThreads = await SendAsync<ChannelThreads>("GET", () => $"guilds/{guildId}/threads/active", bucket, options: options);
+            ChannelThreads filteredThreads = new ChannelThreads();
+
+            filteredThreads.Threads = allChannelThreads.Threads.Where(x => x.CategoryId == parentChannel).ToArray();
+
+            List<ThreadMember> members = new List<ThreadMember>();
+
+            foreach (ThreadMember m in allChannelThreads.Members)
+            {
+                if (filteredThreads.Threads.Where(x => x.Id == (ulong)m.Id).Count() == 0)
+                    continue;
+                members.Add(m);
+            }
+
+            filteredThreads.Members = members.ToArray();
+
+            return filteredThreads;
+        }
+
         public async Task<ChannelThreads> GetPublicArchivedThreadsAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null, RequestOptions options = null)
         {
             Preconditions.NotEqual(channelId, 0, nameof(channelId));

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -92,7 +92,7 @@ namespace Discord.Rest
 
         /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsAsync(Guild, Discord, options);
+            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
 
         /// <inheritdoc cref="IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -90,31 +90,8 @@ namespace Discord.Rest
             MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
             => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
 
-        /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
-
-        /// <inheritdoc cref="IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
-            => ThreadHelper.GetJoinedPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
-
-        /// <inheritdoc cref="IForumChannel.GetPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
-            => ThreadHelper.GetPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
-
-        /// <inheritdoc cref="IForumChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
-            => ThreadHelper.GetPublicArchivedThreadsAsync(this, Discord, limit, before, options);
 
         #region IForumChannel
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetActiveThreadsAsync(RequestOptions options)
-            => await GetActiveThreadsAsync(options).ConfigureAwait(false);
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPublicArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
-            => await GetPublicArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
-            => await GetPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
-            => await GetJoinedPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         async Task<IThreadChannel> IForumChannel.CreatePostAsync(string title, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
             => await CreatePostAsync(title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
         async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -236,7 +236,7 @@ namespace Discord.Rest
 
         /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
+            => ThreadHelper.GetActiveThreadsInChannelAsync(this, Discord, options);
 
         /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -236,7 +236,7 @@ namespace Discord.Rest
 
         /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
+            => ThreadHelper.GetActiveThreadsAsync(this, Discord, options);
 
         /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -232,6 +232,33 @@ namespace Discord.Rest
         /// <inheritdoc />
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuildUser>(null); //Overridden in Text/Voice
+
+
+        /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
+
+        /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
+            => ThreadHelper.GetPublicArchivedThreadsAsync(this, Discord, limit, before, options);
+
+        /// <inheritdoc cref="IGuildChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
+            => ThreadHelper.GetJoinedPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
+
+        /// <inheritdoc cref="IGuildChannel.GetPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
+            => ThreadHelper.GetPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
+
+
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetActiveThreadsAsync(RequestOptions options)
+            => await GetActiveThreadsAsync(options).ConfigureAwait(false);
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetPublicArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
+            => await GetPublicArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
+            => await GetPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetJoinedPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
+            => await GetJoinedPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         #endregion
 
         #region IChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -236,7 +236,7 @@ namespace Discord.Rest
 
         /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsAsync(this, Discord, options);
+            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
 
         /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -67,6 +67,11 @@ namespace Discord.Rest
             var result = await client.ApiClient.GetActiveThreadsAsync(guild.Id, options).ConfigureAwait(false);
             return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
         }
+        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsInChannelAsync(IGuild guild, IGuildChannel parentChannel, BaseDiscordClient client, RequestOptions options)
+        {
+            var result = await client.ApiClient.GetActiveThreadsInChannelAsync(guild.Id, parentChannel.Id, options).ConfigureAwait(false);
+            return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
+        }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,
             DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -64,33 +64,33 @@ namespace Discord.Rest
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(IGuild guild, BaseDiscordClient client, RequestOptions options)
         {
-            var result = await client.ApiClient.GetActiveThreadsInGuildAsync(guild.Id, options).ConfigureAwait(false);
+            var result = await client.ApiClient.GetActiveThreadsAsync(guild.Id, options).ConfigureAwait(false);
             return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
         }
-        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(IGuildChannel channel, BaseDiscordClient client, RequestOptions options)
+        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsInChannelAsync(IGuild guild, IGuildChannel parentChannel, BaseDiscordClient client, RequestOptions options)
         {
-            var result = await client.ApiClient.GetActiveThreadsInChannelAsync(channel.Id, options).ConfigureAwait(false);
-            return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
+            var result = await client.ApiClient.GetActiveThreadsInChannelAsync(guild.Id, parentChannel.Id, options).ConfigureAwait(false);
+            return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,
             DateTimeOffset? before = null, RequestOptions options = null)
         {
-            var result = await client.ApiClient.GetPublicArchivedThreadsInChannelAsync(channel.Id, before, limit, options);
+            var result = await client.ApiClient.GetPublicArchivedThreadsAsync(channel.Id, before, limit, options);
             return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetPrivateArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,
             DateTimeOffset? before = null, RequestOptions options = null)
         {
-            var result = await client.ApiClient.GetPrivateArchivedThreadsInChannelAsync(channel.Id, before, limit, options);
+            var result = await client.ApiClient.GetPrivateArchivedThreadsAsync(channel.Id, before, limit, options);
             return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,
             DateTimeOffset? before = null, RequestOptions options = null)
         {
-            var result = await client.ApiClient.GetJoinedPrivateArchivedThreadsInChannelAsync(channel.Id, before, limit, options);
+            var result = await client.ApiClient.GetJoinedPrivateArchivedThreadsAsync(channel.Id, before, limit, options);
             return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -67,10 +67,10 @@ namespace Discord.Rest
             var result = await client.ApiClient.GetActiveThreadsAsync(guild.Id, options).ConfigureAwait(false);
             return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
         }
-        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsInChannelAsync(IGuild guild, IGuildChannel parentChannel, BaseDiscordClient client, RequestOptions options)
+        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsInChannelAsync(IGuildChannel channel, BaseDiscordClient client, RequestOptions options)
         {
-            var result = await client.ApiClient.GetActiveThreadsInChannelAsync(guild.Id, parentChannel.Id, options).ConfigureAwait(false);
-            return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
+            var result = await client.ApiClient.GetActiveThreadsInChannelAsync(channel.Id, options).ConfigureAwait(false);
+            return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -64,33 +64,33 @@ namespace Discord.Rest
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(IGuild guild, BaseDiscordClient client, RequestOptions options)
         {
-            var result = await client.ApiClient.GetActiveThreadsAsync(guild.Id, options).ConfigureAwait(false);
+            var result = await client.ApiClient.GetActiveThreadsInGuildAsync(guild.Id, options).ConfigureAwait(false);
             return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
         }
-        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsInChannelAsync(IGuild guild, IGuildChannel parentChannel, BaseDiscordClient client, RequestOptions options)
+        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(IGuildChannel channel, BaseDiscordClient client, RequestOptions options)
         {
-            var result = await client.ApiClient.GetActiveThreadsInChannelAsync(guild.Id, parentChannel.Id, options).ConfigureAwait(false);
-            return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
+            var result = await client.ApiClient.GetActiveThreadsInChannelAsync(channel.Id, options).ConfigureAwait(false);
+            return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,
             DateTimeOffset? before = null, RequestOptions options = null)
         {
-            var result = await client.ApiClient.GetPublicArchivedThreadsAsync(channel.Id, before, limit, options);
+            var result = await client.ApiClient.GetPublicArchivedThreadsInChannelAsync(channel.Id, before, limit, options);
             return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetPrivateArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,
             DateTimeOffset? before = null, RequestOptions options = null)
         {
-            var result = await client.ApiClient.GetPrivateArchivedThreadsAsync(channel.Id, before, limit, options);
+            var result = await client.ApiClient.GetPrivateArchivedThreadsInChannelAsync(channel.Id, before, limit, options);
             return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,
             DateTimeOffset? before = null, RequestOptions options = null)
         {
-            var result = await client.ApiClient.GetJoinedPrivateArchivedThreadsAsync(channel.Id, before, limit, options);
+            var result = await client.ApiClient.GetJoinedPrivateArchivedThreadsInChannelAsync(channel.Id, before, limit, options);
             return result.Threads.Select(x => RestThreadChannel.Create(client, channel.Guild, x)).ToImmutableArray();
         }
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -105,7 +105,7 @@ namespace Discord.WebSocket
 
         #region IForumChannel
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetActiveThreadsAsync(RequestOptions options)
-            => await GetActiveThreadsInChannelAsync(options).ConfigureAwait(false);
+            => await GetActiveThreadsAsync(options).ConfigureAwait(false);
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPublicArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
             => await GetPublicArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -87,31 +87,9 @@ namespace Discord.WebSocket
             MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
             => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
 
-        /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
 
-        /// <inheritdoc cref="IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
-            => ThreadHelper.GetJoinedPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
-
-        /// <inheritdoc cref="IForumChannel.GetPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
-            => ThreadHelper.GetPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
-
-        /// <inheritdoc cref="IForumChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
-        public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
-            => ThreadHelper.GetPublicArchivedThreadsAsync(this, Discord, limit, before, options);
 
         #region IForumChannel
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetActiveThreadsAsync(RequestOptions options)
-            => await GetActiveThreadsAsync(options).ConfigureAwait(false);
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPublicArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
-            => await GetPublicArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
-            => await GetPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
-        async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
-            => await GetJoinedPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         async Task<IThreadChannel> IForumChannel.CreatePostAsync(string title, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
             => await CreatePostAsync(title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
         async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -89,7 +89,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsAsync(Guild, Discord, options);
+            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
 
         /// <inheritdoc cref="IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
@@ -105,7 +105,7 @@ namespace Discord.WebSocket
 
         #region IForumChannel
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetActiveThreadsAsync(RequestOptions options)
-            => await GetActiveThreadsAsync(options).ConfigureAwait(false);
+            => await GetActiveThreadsInChannelAsync(options).ConfigureAwait(false);
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPublicArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
             => await GetPublicArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -179,7 +179,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
+            => ThreadHelper.GetActiveThreadsInChannelAsync(this, Discord, options);
 
         /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -179,7 +179,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
+            => ThreadHelper.GetActiveThreadsAsync(this, Discord, options);
 
         /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -179,7 +179,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsAsync(this, Discord, options);
+            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
 
         /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -176,6 +176,24 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A string that resolves to <see cref="SocketGuildChannel.Name"/>.
         /// </returns>
+
+        /// <inheritdoc cref="IGuildChannel.GetActiveThreadsAsync(RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => ThreadHelper.GetActiveThreadsInChannelAsync(Guild, this, Discord, options);
+
+        /// <inheritdoc cref="IGuildChannel.GetPublicArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
+            => ThreadHelper.GetPublicArchivedThreadsAsync(this, Discord, limit, before, options);
+
+        /// <inheritdoc cref="IGuildChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
+            => ThreadHelper.GetJoinedPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
+
+        /// <inheritdoc cref="IGuildChannel.GetPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
+        public Task<IReadOnlyCollection<RestThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
+            => ThreadHelper.GetPrivateArchivedThreadsAsync(this, Discord, limit, before, options);
+
+
         public override string ToString() => Name;
         private string DebuggerDisplay => $"{Name} ({Id}, Guild)";
         internal new SocketGuildChannel Clone() => MemberwiseClone() as SocketGuildChannel;
@@ -219,6 +237,14 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => Task.FromResult<IGuildUser>(GetUser(id)); //Overridden in Text/Voice
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetActiveThreadsAsync(RequestOptions options)
+            => await GetActiveThreadsAsync(options).ConfigureAwait(false);
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetPublicArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
+            => await GetPublicArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
+            => await GetPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
+        async Task<IReadOnlyCollection<IThreadChannel>> IGuildChannel.GetJoinedPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
+            => await GetJoinedPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         #endregion
 
         #region IChannel

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedCategoryChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedCategoryChannel.cs
@@ -36,6 +36,9 @@ namespace Discord
             throw new NotImplementedException();
         }
 
+        public Task<IReadOnlyCollection<IThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
+
         public OverwritePermissions? GetPermissionOverwrite(IRole role)
         {
             throw new NotImplementedException();
@@ -45,6 +48,9 @@ namespace Discord
         {
             throw new NotImplementedException();
         }
+
+        public Task<IReadOnlyCollection<IThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
 
         public Task<IGuildUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
         {

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
@@ -218,5 +218,9 @@ namespace Discord
         public Task<IThreadChannel> CreateThreadAsync(string name, ThreadType type = ThreadType.PublicThread, ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay, IMessage message = null, bool? invitable = null, int? slowmode = null, RequestOptions options = null, MessageFlags flags = MessageFlags.None) => throw new NotImplementedException();
         public Task<IInviteMetadata> CreateInviteToApplicationAsync(DefaultApplications application, int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null) => throw new NotImplementedException();
         public Task<IThreadChannel> CreateThreadAsync(string name, ThreadType type = ThreadType.PublicThread, ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay, IMessage message = null, bool? invitable = null, int? slowmode = null, RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
     }
 }

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
@@ -74,5 +74,9 @@ namespace Discord
         public Task TriggerTypingAsync(RequestOptions options = null) => throw new NotImplementedException();
         Task<IUser> IChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options) => throw new NotImplementedException();
         IAsyncEnumerable<IReadOnlyCollection<IUser>> IChannel.GetUsersAsync(CacheMode mode, RequestOptions options) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
@Ori#9999 from Discord.Net discord server figured out that when you try to get all active threads of forum channel, instead of returning only threads inside this channel, the method returns all guild's threads.

All methods responsible for getting thread channels were removed from Forum Channels and instead were moved to Guild Channel. These methods will return only threads of needed channel.

Original method that allows to get all threads in guild still exists.