### PR TITLE
adding scheduled events to audit log

### DIFF
--- a/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
@@ -182,15 +182,15 @@ namespace Discord
         StickerDeleted = 92,
 
         /// <summary>
-        ///     A thread was created.
+        ///     A scheduled event was created.
         /// </summary>
         EventCreate = 100,
         /// <summary>
-        ///     A thread was created.
+        ///     A scheduled event was created.
         /// </summary>
         EventUpdate = 101,
         /// <summary>
-        ///     A thread was created.
+        ///     A scheduled event was created.
         /// </summary>
         EventDelete = 102,
 

--- a/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
@@ -180,6 +180,20 @@ namespace Discord
         ///     A sticker was deleted.
         /// </summary>
         StickerDeleted = 92,
+
+        /// <summary>
+        ///     A thread was created.
+        /// </summary>
+        EventCreate = 100,
+        /// <summary>
+        ///     A thread was created.
+        /// </summary>
+        EventUpdate = 101,
+        /// <summary>
+        ///     A thread was created.
+        /// </summary>
+        EventDelete = 102,
+
         /// <summary>
         ///     A thread was created.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -52,6 +52,10 @@ namespace Discord.Rest
             [ActionType.MessagePinned] = MessagePinAuditLogData.Create,
             [ActionType.MessageUnpinned] = MessageUnpinAuditLogData.Create,
 
+            [ActionType.EventCreate] = ScheduledEventCreateAuditLogData.Create,
+            [ActionType.EventUpdate] = ScheduledEventUpdateAuditLogData.Create,
+            [ActionType.EventDelete] = ScheduledEventDeleteAuditLogData.Create,
+
             [ActionType.ThreadCreate] = ThreadCreateAuditLogData.Create,
             [ActionType.ThreadUpdate] = ThreadUpdateAuditLogData.Create,
             [ActionType.ThreadDelete] = ThreadDeleteAuditLogData.Create,

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventCreateAuditLogData.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Linq;
+using Discord.API;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to a scheduled event creation.
+    /// </summary>
+    public class ScheduledEventCreateAuditLogData : IAuditLogData
+    {
+        private ScheduledEventCreateAuditLogData(ulong id, ulong guildId, ulong? channelId, ulong? creatorId, string name, string description, DateTimeOffset scheduledStartTime, DateTimeOffset? scheduledEndTime, GuildScheduledEventPrivacyLevel privacyLevel, GuildScheduledEventStatus status, GuildScheduledEventType entityType, ulong? entityId, string location, RestUser creator, int userCount, string image)
+        {
+            Id                 = id                ;
+            GuildId            = guildId           ;
+            ChannelId          = channelId         ;
+            CreatorId          = creatorId         ;
+            Name               = name              ;
+            Description        = description       ;
+            ScheduledStartTime = scheduledStartTime;
+            ScheduledEndTime   = scheduledEndTime  ;
+            PrivacyLevel       = privacyLevel      ;
+            Status             = status            ;
+            EntityType         = entityType        ;
+            EntityId           = entityId          ;
+            Location           = location          ;
+            Creator            = creator           ;
+            UserCount          = userCount         ;
+            Image              = image             ;
+        }
+
+        internal static ScheduledEventCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var id = entry.TargetId.Value;
+
+            var guildId = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "guild_id")
+                    .NewValue.ToObject<ulong>(discord.ApiClient.Serializer);
+            var channelId = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "channel_id")
+                    .NewValue.ToObject<ulong?>(discord.ApiClient.Serializer);
+            var creatorId = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "channel_id")
+                    .NewValue.ToObject<Optional<ulong?>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault();
+            var name = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name")
+                    .NewValue.ToObject<string>(discord.ApiClient.Serializer);
+            var description = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "description")
+                    .NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault();
+            var scheduledStartTime = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "scheduled_start_time")
+                    .NewValue.ToObject<DateTimeOffset>(discord.ApiClient.Serializer);
+            var scheduledEndTime = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "scheduled_end_time")
+                    .NewValue.ToObject<DateTimeOffset?>(discord.ApiClient.Serializer);
+            var privacyLevel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "privacy_level")
+                    .NewValue.ToObject<GuildScheduledEventPrivacyLevel>(discord.ApiClient.Serializer);
+            var status = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "status")
+                    .NewValue.ToObject<GuildScheduledEventStatus>(discord.ApiClient.Serializer);
+            var entityType = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "entity_type")
+                    .NewValue.ToObject<GuildScheduledEventType>(discord.ApiClient.Serializer);
+            var entityId = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "entity_id")
+                    .NewValue.ToObject<ulong?>(discord.ApiClient.Serializer);
+            var entityMetadata = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "entity_metadata")
+                    .NewValue.ToObject<GuildScheduledEventEntityMetadata>(discord.ApiClient.Serializer);
+            var creator = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "creator")
+                    .NewValue.ToObject<Optional<User>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault();
+            var userCount = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "user_count")
+                    .NewValue.ToObject<Optional<int>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault();
+            var image = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "image")
+                    .NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault();
+
+            var creatorUser = creator == null ? null : RestUser.Create(discord, creator);
+
+            return new ScheduledEventCreateAuditLogData(id, guildId, channelId, creatorId, name, description, scheduledStartTime, scheduledEndTime, privacyLevel, status, entityType, entityId, entityMetadata.Location.GetValueOrDefault(), creatorUser, userCount, image);
+        }
+
+        // Doc Note: Corresponds to the *current* data
+
+        /// <summary>
+        ///     Gets the snowflake id of the event.
+        /// </summary>
+        public ulong Id { get; }
+        /// <summary>
+        ///     Gets the snowflake id of the guild the event is associated with.
+        /// </summary>
+        public ulong GuildId { get; }
+        /// <summary>
+        ///     Gets the snowflake id of the channel the event is associated with.
+        /// </summary>
+        public ulong? ChannelId { get; }
+        /// <summary>
+        ///     Gets the snowflake id of the original creator of the event.
+        /// </summary>
+        public ulong? CreatorId { get; }
+        /// <summary>
+        ///     Gets name of the event.
+        /// </summary>
+        public string Name { get; }
+        /// <summary>
+        ///     Gets the description of the event. null if none is set.
+        /// </summary>
+        public string Description { get; }
+        /// <summary>
+        ///     Gets the time the event was scheduled for.
+        /// </summary>
+        public DateTimeOffset ScheduledStartTime { get; }
+        /// <summary>
+        ///     Gets the time the event was scheduled to end.
+        /// </summary>
+        public DateTimeOffset? ScheduledEndTime { get; }
+        /// <summary>
+        ///     Gets the privacy level of the event.
+        /// </summary>
+        public GuildScheduledEventPrivacyLevel PrivacyLevel { get; }
+        /// <summary>
+        ///     Gets the status of the event.
+        /// </summary>
+        public GuildScheduledEventStatus Status { get; }
+        /// <summary>
+        ///     Gets the type of the entity associated with the event (stage / void / external).
+        /// </summary>
+        public GuildScheduledEventType EntityType { get; }
+        /// <summary>
+        ///     Gets the snowflake id of the entity associated with the event (stage / void / external).
+        /// </summary>
+        public ulong? EntityId { get; }
+        /// <summary>
+        ///     Gets the metadata for the entity associated with the event.
+        /// </summary>
+        public string Location { get; }
+        /// <summary>
+        ///     Gets the user that originally created the event.
+        /// </summary>
+        public RestUser Creator { get; }
+        /// <summary>
+        ///     Gets the count of users interested in this event. 
+        /// </summary>
+        public int UserCount { get; }
+        /// <summary>
+        ///     Gets the image hash of the image that was attached to the event. Null if not set.
+        /// </summary>
+        public string Image { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventDeleteAuditLogData.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using Discord.API;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to a scheduled event creation.
+    /// </summary>
+    public class ScheduledEventDeleteAuditLogData : IAuditLogData
+    {
+        private ScheduledEventDeleteAuditLogData(ulong id)
+        {
+            Id = id;
+        }
+
+        internal static ScheduledEventDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var id = entry.TargetId.Value;
+
+            return new ScheduledEventDeleteAuditLogData(id);
+        }
+
+        // Doc Note: Corresponds to the *current* data
+
+        /// <summary>
+        ///     Gets the snowflake id of the event.
+        /// </summary>
+        public ulong Id { get; }
+        /// <summary>
+        ///     Gets the snowflake id of the guild the event is associated with.
+        /// </summary>
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventDeleteAuditLogData.cs
@@ -8,7 +8,7 @@ using EntryModel = Discord.API.AuditLogEntry;
 namespace Discord.Rest
 {
     /// <summary>
-    ///     Contains a piece of audit log data related to a scheduled event creation.
+    ///     Contains a piece of audit log data related to a scheduled event deleteion.
     /// </summary>
     public class ScheduledEventDeleteAuditLogData : IAuditLogData
     {
@@ -30,8 +30,5 @@ namespace Discord.Rest
         ///     Gets the snowflake id of the event.
         /// </summary>
         public ulong Id { get; }
-        /// <summary>
-        ///     Gets the snowflake id of the guild the event is associated with.
-        /// </summary>
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventInfo.cs
@@ -10,7 +10,7 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the snowflake id of the guild the event is associated with.
         /// </summary>
-        public ulong GuildId { get; }
+        public ulong? GuildId { get; }
         /// <summary>
         ///     Gets the snowflake id of the channel the event is associated with.
         /// </summary>
@@ -26,7 +26,7 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the time the event was scheduled for.
         /// </summary>
-        public DateTimeOffset ScheduledStartTime { get; }
+        public DateTimeOffset? ScheduledStartTime { get; }
         /// <summary>
         ///     Gets the time the event was scheduled to end.
         /// </summary>
@@ -34,15 +34,15 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the privacy level of the event.
         /// </summary>
-        public GuildScheduledEventPrivacyLevel PrivacyLevel { get; }
+        public GuildScheduledEventPrivacyLevel? PrivacyLevel { get; }
         /// <summary>
         ///     Gets the status of the event.
         /// </summary>
-        public GuildScheduledEventStatus Status { get; }
+        public GuildScheduledEventStatus? Status { get; }
         /// <summary>
         ///     Gets the type of the entity associated with the event (stage / void / external).
         /// </summary>
-        public GuildScheduledEventType EntityType { get; }
+        public GuildScheduledEventType? EntityType { get; }
         /// <summary>
         ///     Gets the snowflake id of the entity associated with the event (stage / void / external).
         /// </summary>
@@ -54,13 +54,13 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets the count of users interested in this event. 
         /// </summary>
-        public int UserCount { get; }
+        public int? UserCount { get; }
         /// <summary>
         ///     Gets the image hash of the image that was attached to the event. Null if not set.
         /// </summary>
         public string Image { get; }
 
-        internal ScheduledEventInfo(ulong guildId, ulong? channelId, string name, string description, DateTimeOffset scheduledStartTime, DateTimeOffset? scheduledEndTime, GuildScheduledEventPrivacyLevel privacyLevel, GuildScheduledEventStatus status, GuildScheduledEventType entityType, ulong? entityId, string location, int userCount, string image)
+        internal ScheduledEventInfo(ulong? guildId, ulong? channelId, string name, string description, DateTimeOffset? scheduledStartTime, DateTimeOffset? scheduledEndTime, GuildScheduledEventPrivacyLevel? privacyLevel, GuildScheduledEventStatus? status, GuildScheduledEventType? entityType, ulong? entityId, string location, int? userCount, string image)
         {
             GuildId            = guildId           ;
             ChannelId          = channelId         ;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventInfo.cs
@@ -1,0 +1,80 @@
+using System;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Represents information for a scheduled event.
+    /// </summary>
+    public class ScheduledEventInfo
+    {
+        /// <summary>
+        ///     Gets the snowflake id of the guild the event is associated with.
+        /// </summary>
+        public ulong GuildId { get; }
+        /// <summary>
+        ///     Gets the snowflake id of the channel the event is associated with.
+        /// </summary>
+        public ulong? ChannelId { get; }
+        /// <summary>
+        ///     Gets name of the event.
+        /// </summary>
+        public string Name { get; }
+        /// <summary>
+        ///     Gets the description of the event. null if none is set.
+        /// </summary>
+        public string Description { get; }
+        /// <summary>
+        ///     Gets the time the event was scheduled for.
+        /// </summary>
+        public DateTimeOffset ScheduledStartTime { get; }
+        /// <summary>
+        ///     Gets the time the event was scheduled to end.
+        /// </summary>
+        public DateTimeOffset? ScheduledEndTime { get; }
+        /// <summary>
+        ///     Gets the privacy level of the event.
+        /// </summary>
+        public GuildScheduledEventPrivacyLevel PrivacyLevel { get; }
+        /// <summary>
+        ///     Gets the status of the event.
+        /// </summary>
+        public GuildScheduledEventStatus Status { get; }
+        /// <summary>
+        ///     Gets the type of the entity associated with the event (stage / void / external).
+        /// </summary>
+        public GuildScheduledEventType EntityType { get; }
+        /// <summary>
+        ///     Gets the snowflake id of the entity associated with the event (stage / void / external).
+        /// </summary>
+        public ulong? EntityId { get; }
+        /// <summary>
+        ///     Gets the metadata for the entity associated with the event.
+        /// </summary>
+        public string Location { get; }
+        /// <summary>
+        ///     Gets the count of users interested in this event. 
+        /// </summary>
+        public int UserCount { get; }
+        /// <summary>
+        ///     Gets the image hash of the image that was attached to the event. Null if not set.
+        /// </summary>
+        public string Image { get; }
+
+        internal ScheduledEventInfo(ulong guildId, ulong? channelId, string name, string description, DateTimeOffset scheduledStartTime, DateTimeOffset? scheduledEndTime, GuildScheduledEventPrivacyLevel privacyLevel, GuildScheduledEventStatus status, GuildScheduledEventType entityType, ulong? entityId, string location, int userCount, string image)
+        {
+            GuildId            = guildId           ;
+            ChannelId          = channelId         ;
+            Name               = name              ;
+            Description        = description       ;
+            ScheduledStartTime = scheduledStartTime;
+            ScheduledEndTime   = scheduledEndTime  ;
+            PrivacyLevel       = privacyLevel      ;
+            Status             = status            ;
+            EntityType         = entityType        ;
+            EntityId           = entityId          ;
+            Location           = location          ;
+            UserCount          = userCount         ;
+            Image              = image             ;
+        }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
@@ -87,7 +87,13 @@ namespace Discord.Rest
         ///     Gets the snowflake id of the event.
         /// </summary>
         public ulong Id { get; }
+        /// <summary>
+        ///     Gets the state before the change.
+        /// </summary>
         public ScheduledEventInfo Before { get; }
+        /// <summary>
+        ///     Gets the state after the change.
+        /// </summary>
         public ScheduledEventInfo After { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using Discord.API;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to a scheduled event creation.
+    /// </summary>
+    public class ScheduledEventUpdateAuditLogData : IAuditLogData
+    {
+        private ScheduledEventUpdateAuditLogData(ulong id, ScheduledEventInfo before, ScheduledEventInfo after)
+        {
+            Id     = id;
+            Before = before;
+            After  = after;
+        }
+
+        internal static ScheduledEventUpdateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var id = entry.TargetId.Value;
+
+            var guildId = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "guild_id");
+            var channelId = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "channel_id");
+            var name = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var description = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "description");
+            var scheduledStartTime = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "scheduled_start_time");
+            var scheduledEndTime = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "scheduled_end_time");
+            var privacyLevel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "privacy_level");
+            var status = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "status");
+            var entityType = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "entity_type");
+            var entityId = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "entity_id");
+            var entityMetadata = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "entity_metadata");
+            var userCount = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "user_count");
+            var image = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "image");
+
+            var before = new ScheduledEventInfo(
+                guildId.OldValue.ToObject<ulong>(discord.ApiClient.Serializer),
+                channelId.OldValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                name.OldValue.ToObject<string>(discord.ApiClient.Serializer),
+                description.OldValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault(),
+                scheduledStartTime.OldValue.ToObject<DateTimeOffset>(discord.ApiClient.Serializer),
+                scheduledEndTime.OldValue.ToObject<DateTimeOffset?>(discord.ApiClient.Serializer),
+                privacyLevel.OldValue.ToObject<GuildScheduledEventPrivacyLevel>(discord.ApiClient.Serializer),
+                status.OldValue.ToObject<GuildScheduledEventStatus>(discord.ApiClient.Serializer),
+                entityType.OldValue.ToObject<GuildScheduledEventType>(discord.ApiClient.Serializer),
+                entityId.OldValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                entityMetadata.OldValue.ToObject<GuildScheduledEventEntityMetadata>(discord.ApiClient.Serializer)
+                    ?.Location.GetValueOrDefault(),
+                userCount.OldValue.ToObject<Optional<int>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault(),
+                image.OldValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault()
+            );
+            var after = new ScheduledEventInfo(
+                guildId.NewValue.ToObject<ulong>(discord.ApiClient.Serializer),
+                channelId.NewValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                name.NewValue.ToObject<string>(discord.ApiClient.Serializer),
+                description.NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault(),
+                scheduledStartTime.NewValue.ToObject<DateTimeOffset>(discord.ApiClient.Serializer),
+                scheduledEndTime.NewValue.ToObject<DateTimeOffset?>(discord.ApiClient.Serializer),
+                privacyLevel.NewValue.ToObject<GuildScheduledEventPrivacyLevel>(discord.ApiClient.Serializer),
+                status.NewValue.ToObject<GuildScheduledEventStatus>(discord.ApiClient.Serializer),
+                entityType.NewValue.ToObject<GuildScheduledEventType>(discord.ApiClient.Serializer),
+                entityId.NewValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                entityMetadata.NewValue.ToObject<GuildScheduledEventEntityMetadata>(discord.ApiClient.Serializer)
+                    ?.Location.GetValueOrDefault(),
+                userCount.NewValue.ToObject<Optional<int>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault(),
+                image.NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                    .GetValueOrDefault()
+            );
+
+            return new ScheduledEventUpdateAuditLogData(id, before, after);
+        }
+
+        // Doc Note: Corresponds to the *current* data
+
+        /// <summary>
+        ///     Gets the snowflake id of the event.
+        /// </summary>
+        public ulong Id { get; }
+        public ScheduledEventInfo Before { get; }
+        public ScheduledEventInfo After { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
@@ -40,41 +40,41 @@ namespace Discord.Rest
             var image = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "image");
 
             var before = new ScheduledEventInfo(
-                guildId.OldValue.ToObject<ulong>(discord.ApiClient.Serializer),
-                channelId.OldValue.ToObject<ulong?>(discord.ApiClient.Serializer),
-                name.OldValue.ToObject<string>(discord.ApiClient.Serializer),
-                description.OldValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                guildId?.OldValue.ToObject<ulong>(discord.ApiClient.Serializer),
+                channelId?.OldValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                name?.OldValue.ToObject<string>(discord.ApiClient.Serializer),
+                description?.OldValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
                     .GetValueOrDefault(),
-                scheduledStartTime.OldValue.ToObject<DateTimeOffset>(discord.ApiClient.Serializer),
-                scheduledEndTime.OldValue.ToObject<DateTimeOffset?>(discord.ApiClient.Serializer),
-                privacyLevel.OldValue.ToObject<GuildScheduledEventPrivacyLevel>(discord.ApiClient.Serializer),
-                status.OldValue.ToObject<GuildScheduledEventStatus>(discord.ApiClient.Serializer),
-                entityType.OldValue.ToObject<GuildScheduledEventType>(discord.ApiClient.Serializer),
-                entityId.OldValue.ToObject<ulong?>(discord.ApiClient.Serializer),
-                entityMetadata.OldValue.ToObject<GuildScheduledEventEntityMetadata>(discord.ApiClient.Serializer)
+                scheduledStartTime?.OldValue.ToObject<DateTimeOffset>(discord.ApiClient.Serializer),
+                scheduledEndTime?.OldValue.ToObject<DateTimeOffset?>(discord.ApiClient.Serializer),
+                privacyLevel?.OldValue.ToObject<GuildScheduledEventPrivacyLevel>(discord.ApiClient.Serializer),
+                status?.OldValue.ToObject<GuildScheduledEventStatus>(discord.ApiClient.Serializer),
+                entityType?.OldValue.ToObject<GuildScheduledEventType>(discord.ApiClient.Serializer),
+                entityId?.OldValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                entityMetadata?.OldValue.ToObject<GuildScheduledEventEntityMetadata>(discord.ApiClient.Serializer)
                     ?.Location.GetValueOrDefault(),
-                userCount.OldValue.ToObject<Optional<int>>(discord.ApiClient.Serializer)
+                userCount?.OldValue.ToObject<Optional<int>>(discord.ApiClient.Serializer)
                     .GetValueOrDefault(),
-                image.OldValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                image?.OldValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
                     .GetValueOrDefault()
             );
             var after = new ScheduledEventInfo(
-                guildId.NewValue.ToObject<ulong>(discord.ApiClient.Serializer),
-                channelId.NewValue.ToObject<ulong?>(discord.ApiClient.Serializer),
-                name.NewValue.ToObject<string>(discord.ApiClient.Serializer),
-                description.NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                guildId?.NewValue.ToObject<ulong>(discord.ApiClient.Serializer),
+                channelId?.NewValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                name?.NewValue.ToObject<string>(discord.ApiClient.Serializer),
+                description?.NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
                     .GetValueOrDefault(),
-                scheduledStartTime.NewValue.ToObject<DateTimeOffset>(discord.ApiClient.Serializer),
-                scheduledEndTime.NewValue.ToObject<DateTimeOffset?>(discord.ApiClient.Serializer),
-                privacyLevel.NewValue.ToObject<GuildScheduledEventPrivacyLevel>(discord.ApiClient.Serializer),
-                status.NewValue.ToObject<GuildScheduledEventStatus>(discord.ApiClient.Serializer),
-                entityType.NewValue.ToObject<GuildScheduledEventType>(discord.ApiClient.Serializer),
-                entityId.NewValue.ToObject<ulong?>(discord.ApiClient.Serializer),
-                entityMetadata.NewValue.ToObject<GuildScheduledEventEntityMetadata>(discord.ApiClient.Serializer)
+                scheduledStartTime?.NewValue.ToObject<DateTimeOffset>(discord.ApiClient.Serializer),
+                scheduledEndTime?.NewValue.ToObject<DateTimeOffset?>(discord.ApiClient.Serializer),
+                privacyLevel?.NewValue.ToObject<GuildScheduledEventPrivacyLevel>(discord.ApiClient.Serializer),
+                status?.NewValue.ToObject<GuildScheduledEventStatus>(discord.ApiClient.Serializer),
+                entityType?.NewValue.ToObject<GuildScheduledEventType>(discord.ApiClient.Serializer),
+                entityId?.NewValue.ToObject<ulong?>(discord.ApiClient.Serializer),
+                entityMetadata?.NewValue.ToObject<GuildScheduledEventEntityMetadata>(discord.ApiClient.Serializer)
                     ?.Location.GetValueOrDefault(),
-                userCount.NewValue.ToObject<Optional<int>>(discord.ApiClient.Serializer)
+                userCount?.NewValue.ToObject<Optional<int>>(discord.ApiClient.Serializer)
                     .GetValueOrDefault(),
-                image.NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
+                image?.NewValue.ToObject<Optional<string>>(discord.ApiClient.Serializer)
                     .GetValueOrDefault()
             );
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ScheduledEventUpdateAuditLogData.cs
@@ -8,7 +8,7 @@ using EntryModel = Discord.API.AuditLogEntry;
 namespace Discord.Rest
 {
     /// <summary>
-    ///     Contains a piece of audit log data related to a scheduled event creation.
+    ///     Contains a piece of audit log data related to a scheduled event updates.
     /// </summary>
     public class ScheduledEventUpdateAuditLogData : IAuditLogData
     {


### PR DESCRIPTION
I'll be frank, I just made this because i needed the `user` and `affected_id` for ScheduledEvent updates, as the corresponding event does not provide a field of who updated the ScheduledEvent. 

Was sad to see that apparently noone added auditLog ids 100-102 (the ones related to ScheduledEvents) and there does not seen to be a generic way of just getting an arbitrary field from those log entries (can't even really do reflection magic because of how the data is set up).

This isn't tested very well and might also still contain some copy paste problems, as well as problems related to me not knowing the inner workings of discord.net, also I didn't bother too much with getting used to style / structures of discord.net. Feel free to reject this if you don't want to put in work, as neither do I. It seems to work, but also I just wanted to have the ids. 
