### PR TITLE
Fix BulkOverwriteCommands NRE

### DIFF
--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -150,8 +150,6 @@ namespace Discord.Rest
                     DmPermission = arg.IsDMEnabled.ToNullable()
                 };
 
-                Console.WriteLine("Locales:" + string.Join(",", arg.NameLocalizations.Keys));
-
                 if (arg is SlashCommandProperties slashProps)
                 {
                     Preconditions.NotNullOrEmpty(slashProps.Description, nameof(slashProps.Description));


### PR DESCRIPTION
This PR fixes the NRE thrown by the `BulkOverwriteGlobalCommandsAsync` method of `InteractionHelper`