### PR TITLE
Fix: Command path returns an array but is modified later

### DIFF
--- a/src/Discord.Net.Interactions/Utilities/CommandHierarchy.cs
+++ b/src/Discord.Net.Interactions/Utilities/CommandHierarchy.cs
@@ -26,7 +26,7 @@ namespace Discord.Interactions
         public static IList<string> GetCommandPath(this ICommandInfo commandInfo)
         {
             if (commandInfo.IgnoreGroupNames)
-                return new string[] { commandInfo.Name };
+                return new List<string> { commandInfo.Name };
 
             var path = commandInfo.Module.GetModulePath();
             path.Add(commandInfo.Name);
@@ -48,6 +48,6 @@ namespace Discord.Interactions
         }
 
         public static IList<string> GetTypePath(Type type) =>
-            new string[] { EscapeChar + type.FullName };
+            new List<string> { EscapeChar + type.FullName };
     }
 }


### PR DESCRIPTION
When using slash commands and the ignoreGroupName property of the attribute is set to true, the GetCommandPath returns an array with the command name.
However, this is hidden within an IList and, if you look at the GetParameterPath below, will get an attempt to add another item to it. This is not possible as arrays are a fixed size.
<details>
<summary>Exception</summary>
<p>

```
System.NotSupportedException: Collection was of a fixed size.
   at System.SZArrayHelper.Add[T](T value)
   at Discord.Interactions.CommandHierarchy.GetParameterPath(IParameterInfo parameterInfo)
   at Discord.Interactions.ApplicationCommandRestUtil.ToApplicationCommandOptionProps(SlashCommandParameterInfo parameterInfo)
   at Discord.Interactions.ApplicationCommandRestUtil.<>c.<ToApplicationCommandProps>b__1_0(SlashCommandParameterInfo x)
   at System.Linq.Enumerable.SelectIListIterator`2.ToList()
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Discord.Interactions.ApplicationCommandRestUtil.ToApplicationCommandProps(SlashCommandInfo commandInfo)
   at Discord.Interactions.ApplicationCommandRestUtil.<>c.<ParseModuleModel>b__5_1(SlashCommandInfo x)
   at System.Linq.Enumerable.SelectIListIterator`2.MoveNext()
   at System.Collections.Generic.List`1.InsertRange(Int32 index, IEnumerable`1 collection)
   at System.Collections.Generic.List`1.AddRange(IEnumerable`1 collection)
   at Discord.Interactions.ApplicationCommandRestUtil.ParseModuleModel(ModuleInfo moduleInfo, List`1 args, Boolean ignoreDontRegister)
   at Discord.Interactions.ApplicationCommandRestUtil.ToApplicationCommandProps(ModuleInfo moduleInfo, Boolean ignoreDontRegister)
   at Discord.Interactions.InteractionService.<>c.<AddModulesToGuildAsync>b__87_0(ModuleInfo x)
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToList()
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Discord.Interactions.InteractionService.AddModulesToGuildAsync(UInt64 guildId, Boolean deleteMissing, ModuleInfo[] modules)
   at Discord.Interactions.InteractionService.AddModulesToGuildAsync(IGuild guild, Boolean deleteMissing, ModuleInfo[] modules)
   at GasaiYuno.Discord.Listeners.SlashCommandListener.Start() in H:\Repositories\Visual Studio\GasaiYuno\Discord\GasaiYuno.Discord\Listeners\SlashCommandListener.cs:line 60
```

</p>
</details>