### PR TITLE
Update Slash commands regex and fix localization on app context commands

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -145,10 +145,10 @@ namespace Discord
             if (name.Length > 32)
                 throw new ArgumentOutOfRangeException(nameof(name), "Name length must be less than or equal to 32.");
 
-            if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                throw new FormatException($"{nameof(name)} must match the regex ^[\\w-]{{1,32}}$");
+            if (!Regex.IsMatch(name, @"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$"))
+                throw new ArgumentException(@"Name must match the regex ^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$", nameof(name));
 
-            if (name.Any(x => char.IsUpper(x)))
+            if (name.Any(char.IsUpper))
                 throw new FormatException("Name cannot contain any uppercase characters.");
         }
 

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandProperties.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandProperties.cs
@@ -42,8 +42,9 @@ namespace Discord
 
                     Preconditions.AtLeast(name.Length, 1, nameof(name));
                     Preconditions.AtMost(name.Length, SlashCommandBuilder.MaxNameLength, nameof(name));
-                    if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                        throw new ArgumentException("Option name cannot contain any special characters or whitespaces!", nameof(name));
+
+                    if (Type == ApplicationCommandType.Slash && !Regex.IsMatch(name, @"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$"))
+                        throw new ArgumentException(@"Name must match the regex ^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$", nameof(name));
                 }
                 _nameLocalizations = value;
             }

--- a/src/Discord.Net.Core/Entities/Interactions/ContextMenus/MessageCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ContextMenus/MessageCommandBuilder.cs
@@ -67,7 +67,8 @@ namespace Discord
                 Name = Name,
                 IsDefaultPermission = IsDefaultPermission,
                 IsDMEnabled = IsDMEnabled,
-                DefaultMemberPermissions = DefaultMemberPermissions ?? Optional<GuildPermission>.Unspecified
+                DefaultMemberPermissions = DefaultMemberPermissions ?? Optional<GuildPermission>.Unspecified,
+                NameLocalizations = NameLocalizations
             };
 
             return props;
@@ -157,14 +158,6 @@ namespace Discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, MaxNameLength, nameof(name));
-
-            // Discord updated the docs, this regex prevents special characters like @!$%(... etc,
-            // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
-            if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(name));
-
-            if (name.Any(x => char.IsUpper(x)))
-                throw new FormatException("Name cannot contain any uppercase characters.");
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/ContextMenus/UserCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ContextMenus/UserCommandBuilder.cs
@@ -65,7 +65,8 @@ namespace Discord
                 Name = Name,
                 IsDefaultPermission = IsDefaultPermission,
                 IsDMEnabled = IsDMEnabled,
-                DefaultMemberPermissions = DefaultMemberPermissions ?? Optional<GuildPermission>.Unspecified
+                DefaultMemberPermissions = DefaultMemberPermissions ?? Optional<GuildPermission>.Unspecified,
+                NameLocalizations = NameLocalizations
             };
 
             return props;
@@ -155,14 +156,6 @@ namespace Discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, MaxNameLength, nameof(name));
-
-            // Discord updated the docs, this regex prevents special characters like @!$%(... etc,
-            // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
-            if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(name));
-
-            if (name.Any(x => char.IsUpper(x)))
-                throw new FormatException("Name cannot contain any uppercase characters.");
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -207,10 +207,9 @@ namespace Discord
         {
             Preconditions.Options(name, description);
 
-            // Discord updated the docs, this regex prevents special characters like @!$%( and s p a c e s.. etc,
-            // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
-            if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(name));
+            // https://discord.com/developers/docs/interactions/application-commands
+            if (!Regex.IsMatch(name, @"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$"))
+                throw new ArgumentException(@"Name must match the regex ^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$", nameof(name));
 
             // make sure theres only one option with default set to true
             if (isDefault == true && Options?.Any(x => x.IsDefault == true) == true)
@@ -376,12 +375,11 @@ namespace Discord
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, MaxNameLength, nameof(name));
 
-            // Discord updated the docs, this regex prevents special characters like @!$%(... etc,
-            // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
-            if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(name));
+            // https://discord.com/developers/docs/interactions/application-commands
+            if (!Regex.IsMatch(name, @"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$"))
+                throw new ArgumentException(@"Name must match the regex ^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$", nameof(name));
 
-            if (name.Any(x => char.IsUpper(x)))
+            if (name.Any(char.IsUpper))
                 throw new FormatException("Name cannot contain any uppercase characters.");
         }
 
@@ -587,10 +585,9 @@ namespace Discord
         {
             Preconditions.Options(name, description);
 
-            // Discord updated the docs, this regex prevents special characters like @!$%( and s p a c e s.. etc,
-            // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
-            if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(name));
+            // https://discord.com/developers/docs/interactions/application-commands
+            if (!Regex.IsMatch(name, @"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$"))
+                throw new ArgumentException(@"Name must match the regex ^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$", nameof(name));
 
             // make sure theres only one option with default set to true
             if (isDefault && Options?.Any(x => x.IsDefault == true) == true)
@@ -966,8 +963,10 @@ namespace Discord
         {
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, SlashCommandBuilder.MaxNameLength, nameof(name));
-            if (!Regex.IsMatch(name, @"^[\w-]{1,32}$"))
-                throw new ArgumentException("Option name cannot contain any special characters or whitespaces!", nameof(name));
+
+            // https://discord.com/developers/docs/interactions/application-commands
+            if (!Regex.IsMatch(name, @"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$"))
+                throw new ArgumentException(@"Name must match the regex ^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$", nameof(name));
         }
 
         private static void EnsureValidCommandOptionDescription(string description)


### PR DESCRIPTION
This PR fixes the exceptions caused by the old regex and removes the regex check on context menu commands because only slash commands need it.