### PR TITLE
Fixing localizations

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -748,7 +748,7 @@ namespace Discord
                 Value = value
             };
             if (nameLocalizations is not null)
-                props.NameLocalizations = nameLocalizations
+                props.NameLocalizations = nameLocalizations;
             
             Choices.Add(props);
 

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -561,7 +561,7 @@ namespace Discord
             if (_nameLocalizations is not null)
                 props.NameLocalizations = _nameLocalizations;
             if (_descriptionLocalizations is not null)
-                props.DescriptionLocalizations = _descriptionLocalizations,
+                props.DescriptionLocalizations = _descriptionLocalizations;
             
             return props
         }

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -741,13 +741,16 @@ namespace Discord
                 Preconditions.AtLeast(str.Length, 1, nameof(value));
                 Preconditions.AtMost(str.Length, 100, nameof(value));
             }
-
-            Choices.Add(new ApplicationCommandOptionChoiceProperties
+            
+            var props = new ApplicationCommandOptionChoiceProperties
             {
                 Name = name,
-                Value = value,
-                NameLocalizations = nameLocalizations
-            });
+                Value = value
+            };
+            if (nameLocalizations is not null)
+                props.NameLocalizations = nameLocalizations
+            
+            Choices.Add(props);
 
             return this;
         }

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -563,7 +563,7 @@ namespace Discord
             if (_descriptionLocalizations is not null)
                 props.DescriptionLocalizations = _descriptionLocalizations;
             
-            return props
+            return props;
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -107,11 +107,13 @@ namespace Discord
                 Name = Name,
                 Description = Description,
                 IsDefaultPermission = IsDefaultPermission,
-                NameLocalizations = _nameLocalizations,
-                DescriptionLocalizations = _descriptionLocalizations,
                 IsDMEnabled = IsDMEnabled,
                 DefaultMemberPermissions = DefaultMemberPermissions ?? Optional<GuildPermission>.Unspecified
             };
+            if (_nameLocalizations is not null)
+                props.NameLocalizations = _nameLocalizations;
+            if (_descriptionLocalizations is not null)
+                props.DescriptionLocalizations = _descriptionLocalizations;
 
             if (Options != null && Options.Any())
             {
@@ -538,7 +540,7 @@ namespace Discord
             if (isStrType && MaxLength is not null && MaxLength < 1)
                 throw new InvalidOperationException("MaxLength cannot be smaller than 1.");
 
-            return new ApplicationCommandOptionProperties
+            var props = new ApplicationCommandOptionProperties
             {
                 Name = Name,
                 Description = Description,
@@ -553,11 +555,15 @@ namespace Discord
                 ChannelTypes = ChannelTypes,
                 MinValue = MinValue,
                 MaxValue = MaxValue,
-                NameLocalizations = _nameLocalizations,
-                DescriptionLocalizations = _descriptionLocalizations,
                 MinLength = MinLength,
                 MaxLength = MaxLength,
             };
+            if (_nameLocalizations is not null)
+                props.NameLocalizations = _nameLocalizations;
+            if (_descriptionLocalizations is not null)
+                props.DescriptionLocalizations = _descriptionLocalizations,
+            
+            return props
         }
 
         /// <summary>
@@ -907,7 +913,7 @@ namespace Discord
             if (descriptionLocalizations is null)
                 throw new ArgumentNullException(nameof(descriptionLocalizations));
 
-            foreach (var (locale, description) in _descriptionLocalizations)
+            foreach (var (locale, description) in descriptionLocalizations)
             {
                 if(!Regex.IsMatch(locale, @"^\w{2}(?:-\w{2})?$"))
                     throw new ArgumentException($"Invalid locale: {locale}", nameof(locale));
@@ -933,7 +939,7 @@ namespace Discord
 
             EnsureValidCommandOptionName(name);
 
-            _descriptionLocalizations ??= new();
+            _nameLocalizations ??= new();
             _nameLocalizations.Add(locale, name);
 
             return this;

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -107,13 +107,11 @@ namespace Discord
                 Name = Name,
                 Description = Description,
                 IsDefaultPermission = IsDefaultPermission,
+                NameLocalizations = _nameLocalizations,
+                DescriptionLocalizations = _descriptionLocalizations,
                 IsDMEnabled = IsDMEnabled,
                 DefaultMemberPermissions = DefaultMemberPermissions ?? Optional<GuildPermission>.Unspecified
             };
-            if (_nameLocalizations is not null)
-                props.NameLocalizations = _nameLocalizations;
-            if (_descriptionLocalizations is not null)
-                props.DescriptionLocalizations = _descriptionLocalizations;
 
             if (Options != null && Options.Any())
             {
@@ -540,7 +538,7 @@ namespace Discord
             if (isStrType && MaxLength is not null && MaxLength < 1)
                 throw new InvalidOperationException("MaxLength cannot be smaller than 1.");
 
-            var props = new ApplicationCommandOptionProperties
+            return new ApplicationCommandOptionProperties
             {
                 Name = Name,
                 Description = Description,
@@ -555,15 +553,11 @@ namespace Discord
                 ChannelTypes = ChannelTypes,
                 MinValue = MinValue,
                 MaxValue = MaxValue,
+                NameLocalizations = _nameLocalizations,
+                DescriptionLocalizations = _descriptionLocalizations,
                 MinLength = MinLength,
                 MaxLength = MaxLength,
             };
-            if (_nameLocalizations is not null)
-                props.NameLocalizations = _nameLocalizations;
-            if (_descriptionLocalizations is not null)
-                props.DescriptionLocalizations = _descriptionLocalizations;
-            
-            return props;
         }
 
         /// <summary>
@@ -741,16 +735,13 @@ namespace Discord
                 Preconditions.AtLeast(str.Length, 1, nameof(value));
                 Preconditions.AtMost(str.Length, 100, nameof(value));
             }
-            
-            var props = new ApplicationCommandOptionChoiceProperties
+
+            Choices.Add(new ApplicationCommandOptionChoiceProperties
             {
                 Name = name,
-                Value = value
-            };
-            if (nameLocalizations is not null)
-                props.NameLocalizations = nameLocalizations;
-            
-            Choices.Add(props);
+                Value = value,
+                NameLocalizations = nameLocalizations
+            });
 
             return this;
         }


### PR DESCRIPTION
* Fixed typo in `SlashCommandOptionBuilder.WithDescriptionLocalizations`
* Fixed typo in `SlashCommandOptionBuilder.AddNameLocalization`
* Changed `Build` method of both `SlashCommandBuilder` and `SlashCommandOptionBuilder` to not set the `NameLocalizations` and `DescriptionLocalizations` if null in the builder. Was causing an error in the setter.
