### PR TITLE
[Docs] Text Commands: Added a warning about the `message content` intent

### DIFF
--- a/docs/guides/text_commands/intro.md
+++ b/docs/guides/text_commands/intro.md
@@ -8,7 +8,7 @@ title: Introduction to the Chat Command Service
 [Discord.Commands](xref:Discord.Commands) provides an attribute-based
 command parser.
 
-> [!WARNING]
+> [!IMPORTANT]
 > The 'Message Content' intent, required for text commands, is now a 
 > privilleged intent. Please use [Slash commands](xref:Guides.SlashCommands.Intro) 
 > instead for making commands. For more information about this change

--- a/docs/guides/text_commands/intro.md
+++ b/docs/guides/text_commands/intro.md
@@ -9,8 +9,10 @@ title: Introduction to the Chat Command Service
 command parser.
 
 > [!WARNING]
-> The 'Message Content' intent, required for text commands, is now a privilleged intent. Please use [Slash commands](xref:Guides.SlashCommands.Intro) instead for making commands.
-> For more information about this change please check [this announcement made by discord](https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ)
+> The 'Message Content' intent, required for text commands, is now a 
+> privilleged intent. Please use [Slash commands](xref:Guides.SlashCommands.Intro) 
+> instead for making commands. For more information about this change
+> please check [this announcement made by discord](https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ)
 
 
 ## Get Started

--- a/docs/guides/text_commands/intro.md
+++ b/docs/guides/text_commands/intro.md
@@ -8,6 +8,11 @@ title: Introduction to the Chat Command Service
 [Discord.Commands](xref:Discord.Commands) provides an attribute-based
 command parser.
 
+> [!WARNING]
+> The 'Message Content' intent, required for text commands, is now a privilleged intent. Please use [Slash commands](xref:Guides.SlashCommands.Intro) instead for making commands.
+> For more information about this change please check [this announcement made by discord](https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ)
+
+
 ## Get Started
 
 To use commands, you must create a [Command Service] and a command


### PR DESCRIPTION
Improved the Text-Command intro.md by adding a warning about the use of a privileged intent.
The warning includes a link to the Slash Command guide.

Relevant convo: https://discord.com/channels/848176216011046962/848177410306342942/1017356435291644065
