### PR TITLE
[FIX] Fix gateway events warnings when using `DiscordShardedClient`

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -743,31 +743,49 @@ namespace Discord.WebSocket
 
         private async Task LogGatewayIntentsWarning()
         {
-            if(_gatewayIntents.HasFlag(GatewayIntents.GuildPresences) && !_presenceUpdated.HasSubscribers)
+            if (_gatewayIntents.HasFlag(GatewayIntents.GuildPresences) &&
+                (_shardedClient is null && !_presenceUpdated.HasSubscribers ||
+               (_shardedClient is not null && !_shardedClient._presenceUpdated.HasSubscribers)))
             {
                 await _gatewayLogger.WarningAsync("You're using the GuildPresences intent without listening to the PresenceUpdate event, consider removing the intent from your config.").ConfigureAwait(false);
             }
 
-            if(!_gatewayIntents.HasFlag(GatewayIntents.GuildPresences) && _presenceUpdated.HasSubscribers)
+            if(!_gatewayIntents.HasFlag(GatewayIntents.GuildPresences) &&
+               ((_shardedClient is null && _presenceUpdated.HasSubscribers) ||
+                (_shardedClient is not null && _shardedClient._presenceUpdated.HasSubscribers)))
             {
                 await _gatewayLogger.WarningAsync("You're using the PresenceUpdate event without specifying the GuildPresences intent. Discord wont send this event to your client without the intent set in your config.").ConfigureAwait(false);
             }
 
             bool hasGuildScheduledEventsSubscribers =
                 _guildScheduledEventCancelled.HasSubscribers ||
-                _guildScheduledEventUserRemove.HasSubscribers ||
-                _guildScheduledEventCompleted.HasSubscribers ||
-                _guildScheduledEventCreated.HasSubscribers ||
-                _guildScheduledEventStarted.HasSubscribers ||
-                _guildScheduledEventUpdated.HasSubscribers ||
-                _guildScheduledEventUserAdd.HasSubscribers;
+                 _guildScheduledEventUserRemove.HasSubscribers ||
+                 _guildScheduledEventCompleted.HasSubscribers ||
+                 _guildScheduledEventCreated.HasSubscribers ||
+                 _guildScheduledEventStarted.HasSubscribers ||
+                 _guildScheduledEventUpdated.HasSubscribers ||
+                 _guildScheduledEventUserAdd.HasSubscribers;
 
-            if(_gatewayIntents.HasFlag(GatewayIntents.GuildScheduledEvents) && !hasGuildScheduledEventsSubscribers)
+            bool shardedClientHasGuildScheduledEventsSubscribers =
+                 _shardedClient is not null && 
+                 (_shardedClient._guildScheduledEventCancelled.HasSubscribers ||
+                 _shardedClient._guildScheduledEventUserRemove.HasSubscribers ||
+                 _shardedClient._guildScheduledEventCompleted.HasSubscribers ||
+                 _shardedClient._guildScheduledEventCreated.HasSubscribers ||
+                 _shardedClient._guildScheduledEventStarted.HasSubscribers ||
+                 _shardedClient._guildScheduledEventUpdated.HasSubscribers ||
+                 _shardedClient._guildScheduledEventUserAdd.HasSubscribers);
+
+            if (_gatewayIntents.HasFlag(GatewayIntents.GuildScheduledEvents) &&
+                ((_shardedClient is null && !hasGuildScheduledEventsSubscribers) ||
+                 (_shardedClient is not null && !shardedClientHasGuildScheduledEventsSubscribers)))
             {
                 await _gatewayLogger.WarningAsync("You're using the GuildScheduledEvents gateway intent without listening to any events related to that intent, consider removing the intent from your config.").ConfigureAwait(false);
             }
 
-            if(!_gatewayIntents.HasFlag(GatewayIntents.GuildScheduledEvents) && hasGuildScheduledEventsSubscribers)
+            if(!_gatewayIntents.HasFlag(GatewayIntents.GuildScheduledEvents) &&
+               ((_shardedClient is null && hasGuildScheduledEventsSubscribers) ||
+                (_shardedClient is not null && shardedClientHasGuildScheduledEventsSubscribers)))
             {
                 await _gatewayLogger.WarningAsync("You're using events related to the GuildScheduledEvents gateway intent without specifying the intent. Discord wont send this event to your client without the intent set in your config.").ConfigureAwait(false);
             }
@@ -776,12 +794,21 @@ namespace Discord.WebSocket
                 _inviteCreatedEvent.HasSubscribers ||
                 _inviteDeletedEvent.HasSubscribers;
 
-            if (_gatewayIntents.HasFlag(GatewayIntents.GuildInvites) && !hasInviteEventSubscribers)
+            bool shardedClientHasInviteEventSubscribers =
+                _shardedClient is not null &&
+                (_shardedClient._inviteCreatedEvent.HasSubscribers ||
+                 _shardedClient._inviteDeletedEvent.HasSubscribers);
+
+            if (_gatewayIntents.HasFlag(GatewayIntents.GuildInvites) &&
+                ((_shardedClient is null && !hasInviteEventSubscribers) ||
+                 (_shardedClient is not null && !shardedClientHasInviteEventSubscribers)))
             {
                 await _gatewayLogger.WarningAsync("You're using the GuildInvites gateway intent without listening to any events related to that intent, consider removing the intent from your config.").ConfigureAwait(false);
             }
 
-            if (!_gatewayIntents.HasFlag(GatewayIntents.GuildInvites) && hasInviteEventSubscribers)
+            if (!_gatewayIntents.HasFlag(GatewayIntents.GuildInvites) &&
+                ((_shardedClient is null && hasInviteEventSubscribers) ||
+                (_shardedClient is not null && shardedClientHasInviteEventSubscribers)))
             {
                 await _gatewayLogger.WarningAsync("You're using events related to the GuildInvites gateway intent without specifying the intent. Discord wont send this event to your client without the intent set in your config.").ConfigureAwait(false);
             }


### PR DESCRIPTION
This PR fixes issue mentioned in #2461 (gateway intent warnings being logged logged without subscribers)

### Changes
- Add  additional checks for sharded client to `DiscordSocketClient.LogGatewayIntentsWarning()` method
