### PR TITLE
Update license and icon .nuspec Properties

### DIFF
--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -9,9 +9,9 @@
     <description>An asynchronous API wrapper for Discord. This metapackage includes all of the optional Discord.Net components.</description>
     <tags>discord;discordapp</tags>
     <projectUrl>https://github.com/discord-net/Discord.Net</projectUrl>
-    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://github.com/discord-net/Discord.Net/raw/dev/docs/marketing/logo/PackageLogo.png</iconUrl>
+    <icon>PackageLogo.png</icon>
     <dependencies>
         <group targetFramework="net6.0">
             <dependency id="Discord.Net.Core" version="3.8.1$suffix$" />
@@ -55,4 +55,7 @@
         </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="../../docs/marketing/logo/PackageLogo.png" />
+  </files>
 </package>


### PR DESCRIPTION
Replaces deprecated licenseUrl and iconUrl properties with license and icon respectively.