### PR TITLE
[Feature] Add missing properties in forum & thread channels

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/ChannelFlags.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ChannelFlags.cs
@@ -1,0 +1,22 @@
+namespace Discord;
+
+/// <summary>
+///     Represents public flags for a channel.
+/// </summary>
+public enum ChannelFlags
+{
+    /// <summary> 
+    ///     Default value for flags, when none are given to a channel.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///      Flag given to a thread channel pinned on top of parent forum channel.
+    /// </summary>
+    Pinned = 1 << 1,
+
+    /// <summary>
+    ///     Flag given to a forum channel that requires people to select tags when posting.
+    /// </summary>
+    RequireTag = 1 << 4
+}

--- a/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
@@ -47,4 +47,9 @@ public class ForumChannelProperties : TextChannelProperties
     /// Gets or sets a collection of tags inside of this forum channel.
     /// </summary>
     public Optional<IEnumerable<ForumTagProperties>> Tags { get; set; }
+
+    /// <summary>
+    /// Gets or sets a new default reaction emoji in this forum channel.
+    /// </summary>
+    public Optional<IEmote> DefaultReactionEmoji { get; set; }
 }

--- a/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+
+namespace Discord;
+
+public class ForumChannelProperties : TextChannelProperties
+{
+
+    /// <summary>
+    ///     Gets or sets the topic of the channel.
+    /// </summary>
+    /// <remarks>
+    ///     Not available in forum channels.
+    /// </remarks>
+    public new Optional<int> SlowModeInterval { get; }
+
+    /// <summary>
+    /// Gets or sets rate limit on creating posts in this forum channel.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this value to anything above zero will require each user to wait X seconds before
+    ///     creating another thread; setting this value to <c>0</c> will disable rate limits for this channel.
+    ///     <note>
+    ///         Users with <see cref="Discord.ChannelPermission.ManageMessages"/> or 
+    ///         <see cref="ChannelPermission.ManageChannels"/> will be exempt from rate limits.
+    ///     </note>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value does not fall within [0, 21600].</exception>
+    public Optional<int> ThreadCreationInterval { get; set; }
+
+
+    /// <summary>
+    /// Gets or sets the default slow-mode for threads in this channel.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this value to anything above zero will require each user to wait X seconds before
+    ///     sending another message; setting this value to <c>0</c> will disable slow-mode for child threads.
+    ///     <note>
+    ///         Users with <see cref="Discord.ChannelPermission.ManageMessages"/> or 
+    ///         <see cref="ChannelPermission.ManageChannels"/> will be exempt from slow-mode.
+    ///     </note>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value does not fall within [0, 21600].</exception>
+    public Optional<int> DefaultSlowModeInterval { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of tags inside of this forum channel.
+    /// </summary>
+    public Optional<IEnumerable<ForumTagProperties>> Tags { get; set; }
+}

--- a/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
@@ -52,4 +52,9 @@ public class ForumChannelProperties : TextChannelProperties
     /// Gets or sets a new default reaction emoji in this forum channel.
     /// </summary>
     public Optional<IEmote> DefaultReactionEmoji { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rule used to order posts in forum channels.
+    /// </summary>
+    public Optional<ForumSortOrder> DefaultSortOrder { get; set; }
 }

--- a/src/Discord.Net.Core/Entities/Channels/ForumSortOrder.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ForumSortOrder.cs
@@ -1,0 +1,17 @@
+namespace Discord;
+
+/// <summary>
+/// Defines the rule used to order posts in forum channels.
+/// </summary>
+public enum ForumSortOrder
+{
+    /// <summary>
+    ///     Sort forum posts by activity.
+    /// </summary>
+    LatestActivity = 0,
+
+    /// <summary>
+    ///     Sort forum posts by creation time (from most recent to oldest).
+    /// </summary>
+    CreationDate = 1
+}

--- a/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/GuildChannelProperties.cs
@@ -36,5 +36,10 @@ namespace Discord
         ///     Gets or sets the permission overwrites for this channel.
         /// </summary>
         public Optional<IEnumerable<Overwrite>> PermissionOverwrites { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the flags of the channel.
+        /// </summary>
+        public Optional<ChannelFlags> Flags { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -63,6 +63,14 @@ namespace Discord
         IEmote DefaultReactionEmoji { get; }
 
         /// <summary>
+        /// Gets or sets the rule used to order posts in forum channels.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to null, which indicates a preferred sort order hasn't been set
+        /// </remarks>
+        ForumSortOrder? DefaultSortOrder { get; }
+
+        /// <summary>
         ///     Modifies this forum channel.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -54,6 +54,20 @@ namespace Discord
         int DefaultSlowModeInterval { get; }
 
         /// <summary>
+        ///     Modifies this forum channel.
+        /// </summary>
+        /// <remarks>
+        ///     This method modifies the current forum channel with the specified properties. To see an example of this
+        ///     method and what properties are available, please refer to <see cref="ForumChannelProperties"/>.
+        /// </remarks>
+        /// <param name="func">The delegate containing the properties to modify the channel with.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        Task ModifyAsync(Action<ForumChannelProperties> func, RequestOptions options = null);
+
+        /// <summary>
         ///     Creates a new post (thread) within the forum.
         /// </summary>
         /// <param name="title">The title of the post.</param>

--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface IForumChannel : IGuildChannel, IMentionable
+    public interface IForumChannel : IGuildChannel, IMentionable, INestedChannel
     {
         /// <summary>
         ///     Gets a value that indicates whether the channel is NSFW.

--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -36,6 +36,24 @@ namespace Discord
         IReadOnlyCollection<ForumTag> Tags { get; }
 
         /// <summary>
+        /// Gets the current rate limit on creating posts in this forum channel.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="int"/> representing the time in seconds required before the user can send another
+        ///     message; <c>0</c> if disabled.
+        /// </returns>
+        int ThreadCreationInterval { get; }
+
+        /// <summary>
+        /// Gets the current default slow-mode delay for threads in this forum channel.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="int"/> representing the time in seconds required before the user can send another
+        ///     message; <c>0</c> if disabled.
+        /// </returns>
+        int DefaultSlowModeInterval { get; }
+
+        /// <summary>
         ///     Creates a new post (thread) within the forum.
         /// </summary>
         /// <param name="title">The title of the post.</param>

--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -54,6 +54,15 @@ namespace Discord
         int DefaultSlowModeInterval { get; }
 
         /// <summary>
+        /// 	Gets the emoji to show in the add reaction button on a thread in a forum channel
+        /// </summary>
+        /// <remarks>
+        ///     If the emoji is <see cref="Emote"/> only the <see cref="Emote.Id"/> will be populated.
+        ///     Use <see cref="IGuild.GetEmoteAsync"/> to get the emoji.
+        /// </remarks>
+        IEmote DefaultReactionEmoji { get; }
+
+        /// <summary>
         ///     Modifies this forum channel.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -101,12 +101,13 @@ namespace Discord
         /// <param name="stickers">A collection of stickers to send with the message.</param>
         /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
         /// <param name="flags">A message flag to be applied to the sent message, only <see cref="MessageFlags.SuppressEmbeds"/> is permitted.</param>
+        /// <param name="tags">An array of <see cref="ForumTag"/> to be applied to the post.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation.
         /// </returns>
         Task<IThreadChannel> CreatePostAsync(string title, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay, int? slowmode = null,
             string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None);
+            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null);
 
         /// <summary>
         ///     Creates a new post (thread) within the forum.
@@ -127,13 +128,14 @@ namespace Discord
         /// <param name="stickers">A collection of stickers to send with the file.</param>
         /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
         /// <param name="flags">A message flag to be applied to the sent message, only <see cref="MessageFlags.SuppressEmbeds"/> is permitted.</param>
+        /// <param name="tags">An array of <see cref="ForumTag"/> to be applied to the post.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation.
         /// </returns>
         Task<IThreadChannel> CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
-            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None);
+            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null);
 
         /// <summary>
         ///     Creates a new post (thread) within the forum.
@@ -155,13 +157,14 @@ namespace Discord
         /// <param name="stickers">A collection of stickers to send with the file.</param>
         /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
         /// <param name="flags">A message flag to be applied to the sent message, only <see cref="MessageFlags.SuppressEmbeds"/> is permitted.</param>
+        /// <param name="tags">An array of <see cref="ForumTag"/> to be applied to the post.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation.
         /// </returns>
         public Task<IThreadChannel> CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
-            ISticker[] stickers = null, Embed[] embeds = null,MessageFlags flags = MessageFlags.None);
+            ISticker[] stickers = null, Embed[] embeds = null,MessageFlags flags = MessageFlags.None, ForumTag[] tags = null);
 
         /// <summary>
         ///     Creates a new post (thread) within the forum.
@@ -181,12 +184,13 @@ namespace Discord
         /// <param name="stickers">A collection of stickers to send with the file.</param>
         /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
         /// <param name="flags">A message flag to be applied to the sent message, only <see cref="MessageFlags.SuppressEmbeds"/> is permitted.</param>
+        /// <param name="tags">An array of <see cref="ForumTag"/> to be applied to the post.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation.
         /// </returns>
         public Task<IThreadChannel> CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None);
+            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null);
 
         /// <summary>
         ///     Creates a new post (thread) within the forum.
@@ -204,14 +208,15 @@ namespace Discord
         /// </param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
         /// <param name="stickers">A collection of stickers to send with the file.</param>
-        /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
+        /// <param name="embeds">An array of <see cref="Embed"/>s to send with this response. Max 10.</param>
         /// <param name="flags">A message flag to be applied to the sent message, only <see cref="MessageFlags.SuppressEmbeds"/> is permitted.</param>
+        /// <param name="tags">An array of <see cref="ForumTag"/> to be applied to the post.</param>
         /// <returns>
         ///     A task that represents the asynchronous creation operation.
         /// </returns>
         public Task<IThreadChannel> CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None);
+            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null);
 
         /// <summary>
         ///     Gets a collection of active threads within this forum channel.

--- a/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
@@ -22,6 +22,17 @@ namespace Discord
         int Position { get; }
 
         /// <summary>
+        ///     Gets the flags related to this channel.
+        /// </summary>
+        /// <remarks>
+        ///     This value is determined by bitwise OR-ing <see cref="ChannelFlags"/> values together.
+        /// </remarks>
+        /// <returns>
+        ///     A channel's flags, if any is associated.
+        /// </returns>
+        ChannelFlags Flags { get; }
+
+        /// <summary>
         ///     Gets the guild associated with this channel.
         /// </summary>
         /// <returns>

--- a/src/Discord.Net.Core/Entities/Channels/IThreadChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IThreadChannel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -55,6 +56,14 @@ namespace Discord
         ///     This property is only available on private threads.
         /// </remarks>
         bool? IsInvitable { get; }
+
+        /// <summary>
+        ///     Gets ids of tags applied to a forum thread
+        /// </summary>
+        /// <remarks>
+        ///     This property is only available on forum threads.
+        /// </remarks>
+        IReadOnlyCollection<ulong> AppliedTags { get; }
 
         /// <summary>
         ///     Gets when the thread was created.

--- a/src/Discord.Net.Core/Entities/Channels/IThreadChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IThreadChannel.cs
@@ -111,5 +111,16 @@ namespace Discord
         ///     A task that represents the asynchronous operation of removing a user from this thread.
         /// </returns>
         Task RemoveUserAsync(IGuildUser user, RequestOptions options = null);
+
+        /// <summary>
+        ///     Modifies this thread channel.
+        /// </summary>
+        /// <param name="func">The delegate containing the properties to modify the channel with.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        /// <seealso cref="ThreadChannelProperties"/>
+        Task ModifyAsync(Action<ThreadChannelProperties> func, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
@@ -41,24 +41,9 @@ namespace Discord
         public Optional<int> SlowModeInterval { get; set; }
 
         /// <summary>
-        ///     Gets or sets whether or not the thread is archived.
-        /// </summary>
-        public Optional<bool> Archived { get; set; }
-
-        /// <summary>
-        ///     Gets or sets whether or not the thread is locked.
-        /// </summary>
-        public Optional<bool> Locked { get; set; }
-
-        /// <summary>
         ///     Gets or sets the auto archive duration.
         /// </summary>
         public Optional<ThreadArchiveDuration> AutoArchiveDuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the tags applied to a forum thread
-        /// </summary>
-        public Optional<IEnumerable<ulong>> AppliedTags { get; set; }
 
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Discord
 {
@@ -53,6 +54,11 @@ namespace Discord
         ///     Gets or sets the auto archive duration.
         /// </summary>
         public Optional<ThreadArchiveDuration> AutoArchiveDuration { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the tags applied to a forum thread
+        /// </summary>
+        public Optional<IEnumerable<ulong>> AppliedTags { get; set; }
+
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/ThreadChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ThreadChannelProperties.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Discord;
+
+
+/// <summary>
+///     Provides properties that are used to modify an <see cref="IThreadChannel"/> with the specified changes.
+/// </summary>
+/// <seealso cref="IThreadChannel.ModifyAsync(System.Action{ThreadChannelProperties}, RequestOptions)"/>
+public class ThreadChannelProperties : TextChannelProperties
+{
+    /// <summary>
+    /// Gets or sets the tags applied to a forum thread
+    /// </summary>
+    public Optional<IEnumerable<ulong>> AppliedTags { get; set; }
+
+    /// <summary>
+    ///     Gets or sets whether or not the thread is locked.
+    /// </summary>
+    public Optional<bool> Locked { get; set; }
+
+    /// <summary>
+    ///     Gets or sets whether or not the thread is archived.
+    /// </summary>
+    public Optional<bool> Archived { get; set; }
+}

--- a/src/Discord.Net.Core/Entities/ForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTag.cs
@@ -26,7 +26,13 @@ namespace Discord
         /// </summary>
         public IEmote Emoji { get; }
 
-        internal ForumTag(ulong id, string name, ulong? emojiId, string emojiName)
+        /// <summary>
+        /// Gets whether this tag can only be added to or removed from threads by a member
+        /// with the <see cref="GuildPermissions.ManageThreads"/> permission
+        /// </summary>
+        public bool Moderated { get; }
+
+        internal ForumTag(ulong id, string name, ulong? emojiId, string emojiName, bool moderated)
         {
             if (emojiId.HasValue && emojiId.Value != 0)
                 Emoji = new Emote(emojiId.Value, emojiName, false);
@@ -37,6 +43,7 @@ namespace Discord
 
             Id = id;
             Name = name;
+            Moderated = moderated;
         }
     }
 }

--- a/src/Discord.Net.Core/Entities/ForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTag.cs
@@ -9,7 +9,7 @@ namespace Discord
     /// <summary>
     ///     A struct representing a forum channel tag.
     /// </summary>
-    public struct ForumTag
+    public struct ForumTag : ISnowflakeEntity
     {
         /// <summary>
         ///     Gets the Id of the tag.
@@ -31,6 +31,11 @@ namespace Discord
         /// with the <see cref="GuildPermissions.ManageThreads"/> permission
         /// </summary>
         public bool Moderated { get; }
+
+        /// <summary>
+        /// Gets when the tag was created.
+        /// </summary>
+        public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
 
         internal ForumTag(ulong id, string name, ulong? emojiId, string emojiName, bool moderated)
         {

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Discord
 {
     /// <summary>
@@ -24,23 +26,27 @@ namespace Discord
         /// <summary>
         ///     Gets the emoji of the tag or <see langword="null"/> if none is set.
         /// </summary>
-        public IEmote Emoji { get; }
+        /// <remarks>
+        ///     If the emoji is <see cref="Emote"/> only the <see cref="Emote.Id"/> will be populated.
+        ///     Use <see cref="IGuild.GetEmoteAsync"/> to get the emoji.
+        /// </remarks>
+        public IEmote? Emoji { get; }
 
         /// <summary>
         /// Gets whether this tag can only be added to or removed from threads by a member
         /// with the <see cref="GuildPermissions.ManageThreads"/> permission
         /// </summary>
-        public bool Moderated { get; }
+        public bool IsModerated { get; }
 
         /// <summary>
         /// Gets when the tag was created.
         /// </summary>
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
 
-        internal ForumTag(ulong id, string name, ulong? emojiId, string emojiName, bool moderated)
+        internal ForumTag(ulong id, string name, ulong? emojiId, string? emojiName, bool moderated)
         {
             if (emojiId.HasValue && emojiId.Value != 0)
-                Emoji = new Emote(emojiId.Value, emojiName, false);
+                Emoji = new Emote(emojiId.Value, null, false);
             else if (emojiName != null)
                 Emoji = new Emoji(name);
             else
@@ -48,7 +54,7 @@ namespace Discord
 
             Id = id;
             Name = name;
-            Moderated = moderated;
+            IsModerated = moderated;
         }
     }
 }

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
@@ -43,12 +43,12 @@ namespace Discord
         /// </summary>
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
 
-        internal ForumTag(ulong id, string name, ulong? emojiId, string? emojiName, bool moderated)
+        internal ForumTag(ulong id, string name, ulong? emojiId = null, string? emojiName = null, bool moderated = false)
         {
             if (emojiId.HasValue && emojiId.Value != 0)
                 Emoji = new Emote(emojiId.Value, null, false);
             else if (emojiName != null)
-                Emoji = new Emoji(name);
+                Emoji = new Emoji(emojiName);
             else
                 Emoji = null;
 

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
@@ -11,36 +11,23 @@ namespace Discord
     /// <summary>
     ///     A struct representing a forum channel tag.
     /// </summary>
-    public struct ForumTag : ISnowflakeEntity
+    public struct ForumTag : ISnowflakeEntity, IForumTag
     {
         /// <summary>
         ///     Gets the Id of the tag.
         /// </summary>
         public ulong Id { get; }
 
-        /// <summary>
-        ///     Gets the name of the tag.
-        /// </summary>
+        /// <inheritdoc/>
         public string Name { get; }
 
-        /// <summary>
-        ///     Gets the emoji of the tag or <see langword="null"/> if none is set.
-        /// </summary>
-        /// <remarks>
-        ///     If the emoji is <see cref="Emote"/> only the <see cref="Emote.Id"/> will be populated.
-        ///     Use <see cref="IGuild.GetEmoteAsync"/> to get the emoji.
-        /// </remarks>
+        /// <inheritdoc/>
         public IEmote? Emoji { get; }
 
-        /// <summary>
-        /// Gets whether this tag can only be added to or removed from threads by a member
-        /// with the <see cref="GuildPermissions.ManageThreads"/> permission
-        /// </summary>
+        /// <inheritdoc/>
         public bool IsModerated { get; }
 
-        /// <summary>
-        /// Gets when the tag was created.
-        /// </summary>
+        /// <inheritdoc/>
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
 
         internal ForumTag(ulong id, string name, ulong? emojiId = null, string? emojiName = null, bool moderated = false)
@@ -56,5 +43,25 @@ namespace Discord
             Name = name;
             IsModerated = moderated;
         }
+
+        public override int GetHashCode() => (Id, Name, Emoji, IsModerated).GetHashCode();
+        
+        public override bool Equals(object? obj)
+            => obj is ForumTag tag && Equals(tag);
+
+        /// <summary>
+        /// Gets whether supplied tag is equals to the current one.
+        /// </summary>
+        public bool Equals(ForumTag tag)
+            => Id == tag.Id &&
+               Name == tag.Name &&
+               (Emoji is Emoji emoji && tag.Emoji is Emoji otherEmoji && emoji.Equals(otherEmoji) ||
+                Emoji is Emote emote && tag.Emoji is Emote otherEmote && emote.Equals(otherEmote)) &&
+               IsModerated == tag.IsModerated;
+
+        public static bool operator ==(ForumTag? left, ForumTag? right)
+            => left?.Equals(right) ?? right is null;
+
+        public static bool operator !=(ForumTag? left, ForumTag? right) => !(left == right);
     }
 }

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
@@ -82,7 +82,7 @@ public class ForumTagBuilder
     {
         Name = name;
         if(emoteId is not null)
-            Emoji = new Emote(emoteId.Value, string.Empty,  false);
+            Emoji = new Emote(emoteId.Value, null,  false);
         IsModerated = moderated;
     }
 

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
@@ -1,0 +1,128 @@
+#nullable enable
+using System;
+
+namespace Discord;
+
+public class ForumTagBuilder
+{
+    private string? _name;
+    private IEmote? _emoji;
+    private bool _moderated;
+
+    /// <summary>
+    ///     Returns the maximum length of name allowed by Discord.
+    /// </summary>
+    public const int MaxNameLength = 20;
+
+    /// <summary>
+    ///     Gets or sets the name of the tag.
+    /// </summary>
+    /// <exception cref="ArgumentException">Name length must be less than or equal to <see cref="MaxNameLength"/>.</exception>
+    public string? Name
+    {
+        get { return _name; }
+        set
+        {
+            if (value?.Length > MaxNameLength)
+                throw new ArgumentException(message: $"Name length must be less than or equal to {MaxNameLength}.", paramName: nameof(Name));
+            _name = value;
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets the emoji of the tag.
+    /// </summary>
+    public IEmote? Emoji
+    {
+        get { return _emoji; }
+        set { _emoji = value; }
+    }
+
+    /// <summary>
+    /// Gets or sets whether this tag can only be added to or removed from threads by a member
+    /// with the <see cref="GuildPermissions.ManageThreads"/> permission
+    /// </summary>
+    public bool IsModerated
+    {
+        get { return _moderated; }
+        set { _moderated = value; }
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="ForumTagBuilder"/> class.
+    /// </summary>
+    public ForumTagBuilder()
+    {
+
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="ForumTagBuilder"/> class with values
+    /// </summary>
+    public ForumTagBuilder(string name)
+    {
+        Name = name;
+        IsModerated = false;
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="ForumTagBuilder"/> class with values
+    /// </summary>
+    public ForumTagBuilder(string name, IEmote? emoji = null, bool moderated = false)
+    {
+        Name = name;
+        Emoji = emoji;
+        IsModerated = moderated;
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="ForumTagBuilder"/> class with values
+    /// </summary>
+    public ForumTagBuilder(string name, ulong? emoteId = null, bool moderated = false)
+    {
+        Name = name;
+        if(emoteId is not null)
+            Emoji = new Emote(emoteId.Value, string.Empty,  false);
+        IsModerated = moderated;
+    }
+
+    /// <summary>
+    /// Builds the Tag.
+    /// </summary>
+    /// <returns>An instance of <see cref="ForumTagProperties"/></returns>
+    /// <exception cref="ArgumentNullException">"Name must be set to build the tag"</exception>
+    public ForumTagProperties Build()
+    {
+        if (_name is null)
+            throw new ArgumentNullException(nameof(Name), "Name must be set to build the tag");
+        return new ForumTagProperties(_name!, _emoji, _moderated);
+    }
+
+    /// <summary>
+    /// Sets the name of the tag.
+    /// </summary>
+    /// <exception cref="ArgumentException">Name length must be less than or equal to <see cref="MaxNameLength"/>.</exception>
+    public ForumTagBuilder WithName(string name)
+    {
+        Name = name;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the emoji of the tag.
+    /// </summary>
+    public ForumTagBuilder WithEmoji(IEmote? emoji)
+    {
+        Emoji = emoji;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the IsModerated of the tag.
+    /// </summary>
+    public ForumTagBuilder WithModerated(bool moderated)
+    {
+        IsModerated = moderated;
+        return this;
+    }
+}

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
@@ -8,11 +8,24 @@ public class ForumTagBuilder
     private string? _name;
     private IEmote? _emoji;
     private bool _moderated;
+    private ulong? _id;
 
     /// <summary>
     ///     Returns the maximum length of name allowed by Discord.
     /// </summary>
     public const int MaxNameLength = 20;
+
+    /// <summary>
+    ///     Gets or sets the snowflake Id of the tag.
+    /// </summary>
+    /// <remarks>
+    ///     If set this will update existing tag or will create a new one otherwise.
+    /// </remarks>
+    public ulong? Id
+    {
+        get { return _id; }
+        set { _id = value; }
+    }
 
     /// <summary>
     ///     Gets or sets the name of the tag.
@@ -50,7 +63,7 @@ public class ForumTagBuilder
 
     /// <summary>
     /// Initializes a new <see cref="ForumTagBuilder"/> class.
-    /// </summary>
+    /// </summary> 
     public ForumTagBuilder()
     {
 
@@ -59,31 +72,48 @@ public class ForumTagBuilder
     /// <summary>
     /// Initializes a new <see cref="ForumTagBuilder"/> class with values
     /// </summary>
-    public ForumTagBuilder(string name)
+    /// <param name="id"> If set existing tag will be updated or a new one will be created otherwise.</param>
+    /// <param name="name"> Name of the tag.</param>
+    /// <param name="isModerated"> Sets whether this tag can only be added to or removed from threads by a member
+    /// with the <see cref="GuildPermissions.ManageThreads"/> permission. </param>
+    public ForumTagBuilder(string name, ulong? id = null, bool isModerated = false)
     {
         Name = name;
-        IsModerated = false;
+        IsModerated = isModerated;
+        Id = id;
     }
 
     /// <summary>
     /// Initializes a new <see cref="ForumTagBuilder"/> class with values
     /// </summary>
-    public ForumTagBuilder(string name, IEmote? emoji = null, bool moderated = false)
+    /// <param name="name"> Name of the tag.</param>
+    /// <param name="id"> If set existing tag will be updated or a new one will be created otherwise.</param>
+    /// <param name="emoji"> Display emoji of the tag.</param>
+    /// <param name="isModerated"> Sets whether this tag can only be added to or removed from threads by a member
+    /// with the <see cref="GuildPermissions.ManageThreads"/> permission. </param>
+    public ForumTagBuilder(string name, ulong? id = null, bool isModerated = false, IEmote? emoji = null)
     {
         Name = name;
         Emoji = emoji;
-        IsModerated = moderated;
+        IsModerated = isModerated;
+        Id = id;
     }
 
     /// <summary>
     /// Initializes a new <see cref="ForumTagBuilder"/> class with values
     /// </summary>
-    public ForumTagBuilder(string name, ulong? emoteId = null, bool moderated = false)
+    /// /// <param name="name"> Name of the tag.</param>
+    /// <param name="id"> If set existing tag will be updated or a new one will be created otherwise.</param>
+    /// <param name="emoteId"> The id of custom Display emoji of the tag.</param>
+    /// <param name="isModerated"> Sets whether this tag can only be added to or removed from threads by a member
+    /// with the <see cref="GuildPermissions.ManageThreads"/> permission </param>
+    public ForumTagBuilder(string name, ulong? id = null, bool isModerated = false, ulong? emoteId = null)
     {
         Name = name;
         if(emoteId is not null)
             Emoji = new Emote(emoteId.Value, null,  false);
-        IsModerated = moderated;
+        IsModerated = isModerated;
+        Id = id;
     }
 
     /// <summary>
@@ -109,6 +139,17 @@ public class ForumTagBuilder
     }
 
     /// <summary>
+    /// Sets the id of the tag.
+    /// </summary>
+    /// <param name="id"> If set existing tag will be updated or a new one will be created otherwise.</param>
+    /// <exception cref="ArgumentException">Name length must be less than or equal to <see cref="MaxNameLength"/>.</exception>
+    public ForumTagBuilder WithId(ulong? id)
+    {
+        Id = id;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the emoji of the tag.
     /// </summary>
     public ForumTagBuilder WithEmoji(IEmote? emoji)
@@ -118,11 +159,33 @@ public class ForumTagBuilder
     }
 
     /// <summary>
-    /// Sets the IsModerated of the tag.
+    /// Sets whether this tag can only be added to or removed from threads by a member
+    /// with the <see cref="GuildPermissions.ManageThreads"/> permission
     /// </summary>
     public ForumTagBuilder WithModerated(bool moderated)
     {
         IsModerated = moderated;
         return this;
     }
+
+    public override int GetHashCode() => base.GetHashCode();
+
+    public override bool Equals(object? obj)
+        => obj is ForumTagBuilder builder && Equals(builder);
+
+    /// <summary>
+    /// Gets whether supplied tag builder is equals to the current one.
+    /// </summary>
+    public bool Equals(ForumTagBuilder? builder)
+        => builder is not null &&
+           Id == builder.Id &&
+           Name == builder.Name &&
+           (Emoji is Emoji emoji &&  builder.Emoji is Emoji otherEmoji && emoji.Equals(otherEmoji) ||
+            Emoji is Emote emote && builder.Emoji is Emote otherEmote && emote.Equals(otherEmote)) &&
+           IsModerated == builder.IsModerated;
+
+    public static bool operator ==(ForumTagBuilder? left, ForumTagBuilder? right)
+    => left?.Equals(right) ?? right is null ;
+
+    public static bool operator !=(ForumTagBuilder? left, ForumTagBuilder? right) => !(left == right);
 }

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilderExtensions.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilderExtensions.cs
@@ -1,0 +1,11 @@
+namespace Discord;
+
+public static class ForumTagBuilderExtensions
+{
+    public static ForumTagBuilder ToForumTagBuilder(this ForumTag tag)
+        => new ForumTagBuilder(tag.Name, tag.Emoji, tag.IsModerated);
+
+    public static ForumTagBuilder ToForumTagBuilder(this ForumTagProperties tag)
+        => new ForumTagBuilder(tag.Name, tag.Emoji, tag.IsModerated);
+
+}

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilderExtensions.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilderExtensions.cs
@@ -3,9 +3,9 @@ namespace Discord;
 public static class ForumTagBuilderExtensions
 {
     public static ForumTagBuilder ToForumTagBuilder(this ForumTag tag)
-        => new ForumTagBuilder(tag.Name, tag.Emoji, tag.IsModerated);
+        => new ForumTagBuilder(tag.Name, tag.Id, tag.IsModerated, tag.Emoji);
 
     public static ForumTagBuilder ToForumTagBuilder(this ForumTagProperties tag)
-        => new ForumTagBuilder(tag.Name, tag.Emoji, tag.IsModerated);
+        => new ForumTagBuilder(tag.Name, tag.Id, tag.IsModerated, tag.Emoji);
 
 }

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagProperties.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagProperties.cs
@@ -2,22 +2,20 @@ namespace Discord;
 
 #nullable enable
 
-public class ForumTagProperties
+public class ForumTagProperties : IForumTag
 {
     /// <summary>
-    ///     Gets the name of the tag.
+    ///     Gets the Id of the tag.
     /// </summary>
+    public ulong Id { get; }
+
+    /// <inheritdoc/>
     public string Name { get; }
 
-    /// <summary>
-    ///     Gets the emoji of the tag or <see langword="null"/> if none is set.
-    /// </summary>
+    /// <inheritdoc/>
     public IEmote? Emoji { get; }
 
-    /// <summary>
-    /// Gets whether this tag can only be added to or removed from threads by a member
-    /// with the <see cref="GuildPermissions.ManageThreads"/> permission
-    /// </summary>
+    /// <inheritdoc/>
     public bool IsModerated { get; }
 
     internal ForumTagProperties(string name, IEmote? emoji = null, bool isMmoderated = false)
@@ -26,4 +24,25 @@ public class ForumTagProperties
         Emoji = emoji;
         IsModerated = isMmoderated;
     }
+
+    public override int GetHashCode() => (Id, Name, Emoji, IsModerated).GetHashCode();
+
+    public override bool Equals(object? obj)
+        => obj is ForumTagProperties tag && Equals(tag);
+
+    /// <summary>
+    /// Gets whether supplied tag is equals to the current one.
+    /// </summary>
+    public bool Equals(ForumTagProperties? tag)
+        => tag is not null &&
+           Id == tag.Id &&
+           Name == tag.Name &&
+           (Emoji is Emoji emoji && tag.Emoji is Emoji otherEmoji && emoji.Equals(otherEmoji) ||
+            Emoji is Emote emote && tag.Emoji is Emote otherEmote && emote.Equals(otherEmote)) &&
+           IsModerated == tag.IsModerated;
+
+    public static bool operator ==(ForumTagProperties? left, ForumTagProperties? right)
+        => left?.Equals(right) ?? right is null;
+
+    public static bool operator !=(ForumTagProperties? left, ForumTagProperties? right) => !(left == right);
 }

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagProperties.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagProperties.cs
@@ -1,0 +1,29 @@
+namespace Discord;
+
+#nullable enable
+
+public class ForumTagProperties
+{
+    /// <summary>
+    ///     Gets the name of the tag.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    ///     Gets the emoji of the tag or <see langword="null"/> if none is set.
+    /// </summary>
+    public IEmote? Emoji { get; }
+
+    /// <summary>
+    /// Gets whether this tag can only be added to or removed from threads by a member
+    /// with the <see cref="GuildPermissions.ManageThreads"/> permission
+    /// </summary>
+    public bool IsModerated { get; }
+
+    internal ForumTagProperties(string name, IEmote? emoji = null, bool isMmoderated = false)
+    {
+        Name = name;
+        Emoji = emoji;
+        IsModerated = isMmoderated;
+    }
+}

--- a/src/Discord.Net.Core/Entities/ForumTags/IForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/IForumTag.cs
@@ -1,0 +1,29 @@
+namespace Discord;
+
+#nullable enable
+
+/// <summary>
+/// Represents a Discord forum tag
+/// </summary>
+public interface IForumTag
+{
+    /// <summary>
+    ///     Gets the name of the tag.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    ///     Gets the emoji of the tag or <see langword="null"/> if none is set.
+    /// </summary>
+    /// <remarks>
+    ///     If the emoji is <see cref="Emote"/> only the <see cref="Emote.Id"/> will be populated.
+    ///     Use <see cref="IGuild.GetEmoteAsync"/> to get the emoji.
+    /// </remarks>
+    IEmote? Emoji { get; }
+
+    /// <summary>
+    /// Gets whether this tag can only be added to or removed from threads by a member
+    /// with the <see cref="GuildPermissions.ManageThreads"/> permission
+    /// </summary>
+    bool IsModerated { get; }
+}

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -762,6 +762,18 @@ namespace Discord
         Task<ICategoryChannel> CreateCategoryAsync(string name, Action<GuildChannelProperties> func = null, RequestOptions options = null);
 
         /// <summary>
+        ///     Creates a new channel forum in this guild.
+        /// </summary>
+        /// <param name="name">The new name for the forum.</param>
+        /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous creation operation. The task result contains the newly created
+        ///     forum channel.
+        /// </returns>
+        Task<IForumChannel> CreateForumChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null);
+
+        /// <summary>
         ///     Gets a collection of all the voice regions this guild can access.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionType.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionType.cs
@@ -21,7 +21,7 @@ namespace Discord
         String = 3,
 
         /// <summary>
-        ///     An <see langword="int"/>.
+        ///     An <see langword="long"/>.
         /// </summary>
         Integer = 4,
 

--- a/src/Discord.Net.Core/Extensions/ChannelExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/ChannelExtensions.cs
@@ -46,6 +46,9 @@ namespace Discord
 
                 case ITextChannel:
                     return ChannelType.Text;
+
+                case IForumChannel:
+                    return ChannelType.Forum;
             }
 
             return null;

--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -76,5 +76,8 @@ namespace Discord.API
 
         [JsonProperty("default_auto_archive_duration")]
         public Optional<ThreadArchiveDuration> AutoArchiveDuration { get; set; }
+
+        [JsonProperty("default_thread_rate_limit_per_user")]
+        public Optional<int> ThreadRateLimitPerUser { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -70,7 +70,10 @@ namespace Discord.API
         //ForumChannel
         [JsonProperty("available_tags")]
         public Optional<ForumTags[]> ForumTags { get; set; }
-        
+
+        [JsonProperty("applied_tags")]
+        public Optional<ulong[]> AppliedTags { get; set; }
+
         [JsonProperty("default_auto_archive_duration")]
         public Optional<ThreadArchiveDuration> AutoArchiveDuration { get; set; }
     }

--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -82,5 +82,8 @@ namespace Discord.API
 
         [JsonProperty("flags")]
         public Optional<ChannelFlags> Flags { get; set; }
+
+        [JsonProperty("default_reaction_emoji")]
+        public Optional<ForumReactionEmoji> DefaultReactionEmoji { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -79,5 +79,8 @@ namespace Discord.API
 
         [JsonProperty("default_thread_rate_limit_per_user")]
         public Optional<int> ThreadRateLimitPerUser { get; set; }
+
+        [JsonProperty("flags")]
+        public Optional<ChannelFlags> Flags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -83,7 +83,11 @@ namespace Discord.API
         [JsonProperty("flags")]
         public Optional<ChannelFlags> Flags { get; set; }
 
+        [JsonProperty("default_sort_order")]
+        public Optional<ForumSortOrder?> DefaultSortOrder { get; set; }
+
         [JsonProperty("default_reaction_emoji")]
         public Optional<ForumReactionEmoji> DefaultReactionEmoji { get; set; }
+
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ForumReactionEmoji.cs
+++ b/src/Discord.Net.Rest/API/Common/ForumReactionEmoji.cs
@@ -5,7 +5,7 @@ namespace Discord.API;
 public class ForumReactionEmoji
 {
     [JsonProperty("emoji_id")]
-    public Optional<ulong?> EmojiId { get; set; }
+    public ulong? EmojiId { get; set; }
 
     [JsonProperty("emoji_name")]
     public Optional<string> EmojiName { get; set; }

--- a/src/Discord.Net.Rest/API/Common/ForumReactionEmoji.cs
+++ b/src/Discord.Net.Rest/API/Common/ForumReactionEmoji.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Discord.API;
+
+public class ForumReactionEmoji
+{
+    [JsonProperty("emoji_id")]
+    public Optional<ulong> EmojiId { get; set; }
+
+    [JsonProperty("emoji_name")]
+    public Optional<string> EmojiName { get; set; }
+}

--- a/src/Discord.Net.Rest/API/Common/ForumTags.cs
+++ b/src/Discord.Net.Rest/API/Common/ForumTags.cs
@@ -17,5 +17,8 @@ namespace Discord.API
         public Optional<ulong?> EmojiId { get; set; }
         [JsonProperty("emoji_name")]
         public Optional<string> EmojiName { get; set; }
+
+        [JsonProperty("moderated")]
+        public bool Moderated { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
@@ -23,12 +23,22 @@ namespace Discord.API.Rest
         public Optional<bool> IsNsfw { get; set; }
         [JsonProperty("rate_limit_per_user")]
         public Optional<int> SlowModeInterval { get; set; }
+        [JsonProperty("default_auto_archive_duration")]
+        public Optional<ThreadArchiveDuration> DefaultAutoArchiveDuration { get; set; }
 
         //Voice channels
         [JsonProperty("bitrate")]
         public Optional<int> Bitrate { get; set; }
         [JsonProperty("user_limit")]
         public Optional<int?> UserLimit { get; set; }
+
+        //Forum channels
+        [JsonProperty("default_reaction_emoji")]
+        public Optional<ModifyForumReactionEmojiParams> DefaultReactionEmoji { get; set; }
+        [JsonProperty("default_thread_rate_limit_per_user")]
+        public Optional<int> ThreadRateLimitPerUser { get; set; }
+        [JsonProperty("available_tags")]
+        public Optional<ModifyForumTagParams[]> AvailableTags { get; set; }
 
         public CreateGuildChannelParams(string name, ChannelType type)
         {

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
@@ -39,6 +39,8 @@ namespace Discord.API.Rest
         public Optional<int> ThreadRateLimitPerUser { get; set; }
         [JsonProperty("available_tags")]
         public Optional<ModifyForumTagParams[]> AvailableTags { get; set; }
+        [JsonProperty("default_sort_order")]
+        public Optional<ForumSortOrder?> DefaultSortOrder { get; set; }
 
         public CreateGuildChannelParams(string name, ChannelType type)
         {

--- a/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
@@ -27,6 +27,7 @@ namespace Discord.API.Rest
         public Optional<ActionRowComponent[]> MessageComponent { get; set; }
         public Optional<MessageFlags?> Flags { get; set; }
         public Optional<ulong[]> Stickers { get; set; }
+        public Optional<ulong[]> TagIds { get; set; }
 
         public CreateMultipartPostAsync(params FileAttachment[] attachments)
         {
@@ -59,6 +60,8 @@ namespace Discord.API.Rest
                 message["sticker_ids"] = Stickers.Value;
             if (Flags.IsSpecified)
                 message["flags"] = Flags.Value;
+            if (TagIds.IsSpecified)
+                message["applied_tags"] = TagIds.Value;
 
             List<object> attachments = new();
 

--- a/src/Discord.Net.Rest/API/Rest/CreatePostParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreatePostParams.cs
@@ -21,5 +21,8 @@ namespace Discord.API.Rest
 
         [JsonProperty("message")]
         public ForumThreadMessage Message { get; set; }
+
+        [JsonProperty("applied_tags")]
+        public Optional<ulong[]> Tags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ForumTagParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ForumTagParams.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+    internal class ForumTagParams
+    {
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("emoji_id")]
+        public Optional<ulong?> EmojiId { get; set; }
+
+        [JsonProperty("emoji_name")]
+        public Optional<string> EmojiName { get; set; }
+
+        [JsonProperty("moderated")]
+        public bool Moderated { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Rest/ForumTagParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ForumTagParams.cs
@@ -5,6 +5,8 @@ namespace Discord.API
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ForumTagParams
     {
+        [JsonProperty("id")]
+        public Optional<ulong> Id { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
@@ -17,4 +17,7 @@ internal class ModifyForumChannelParams : ModifyTextChannelParams
 
     [JsonProperty("default_reaction_emoji")]
     public Optional<ModifyForumReactionEmojiParams> DefaultReactionEmoji { get; set; }
+
+    [JsonProperty("default_sort_order")]
+    public Optional<ForumSortOrder> DefaultSortOrder { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
@@ -7,11 +7,14 @@ namespace Discord.API.Rest;
 internal class ModifyForumChannelParams : ModifyTextChannelParams
 {
     [JsonProperty("available_tags")]
-    public Optional<ForumTagParams[]> Tags { get; set; }
+    public Optional<ModifyForumTagParams[]> Tags { get; set; }
 
     [JsonProperty("default_thread_rate_limit_per_user")]
     public Optional<int> DefaultSlowModeInterval { get; set; }
 
     [JsonProperty("rate_limit_per_user")]
     public Optional<int> ThreadCreationInterval { get; set; }
+
+    [JsonProperty("default_reaction_emoji")]
+    public Optional<ModifyForumReactionEmojiParams> DefaultReactionEmoji { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+
+namespace Discord.API.Rest;
+
+
+[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+internal class ModifyForumChannelParams : ModifyTextChannelParams
+{
+    [JsonProperty("available_tags")]
+    public Optional<ForumTagParams[]> Tags { get; set; }
+
+    [JsonProperty("default_thread_rate_limit_per_user")]
+    public Optional<int> DefaultSlowModeInterval { get; set; }
+
+    [JsonProperty("rate_limit_per_user")]
+    public Optional<int> ThreadCreationInterval { get; set; }
+}

--- a/src/Discord.Net.Rest/API/Rest/ModifyForumReactionEmojiParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyForumReactionEmojiParams.cs
@@ -2,7 +2,8 @@ using Newtonsoft.Json;
 
 namespace Discord.API;
 
-public class ForumReactionEmoji
+[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+public class ModifyForumReactionEmojiParams
 {
     [JsonProperty("emoji_id")]
     public Optional<ulong?> EmojiId { get; set; }
@@ -10,3 +11,5 @@ public class ForumReactionEmoji
     [JsonProperty("emoji_name")]
     public Optional<string> EmojiName { get; set; }
 }
+
+

--- a/src/Discord.Net.Rest/API/Rest/ModifyForumTagParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyForumTagParams.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 namespace Discord.API
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-    internal class ForumTagParams
+    internal class ModifyForumTagParams
     {
         [JsonProperty("id")]
         public Optional<ulong> Id { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
@@ -13,5 +13,7 @@ namespace Discord.API.Rest
         public Optional<ulong?> CategoryId { get; set; }
         [JsonProperty("permission_overwrites")]
         public Optional<Overwrite[]> Overwrites { get; set; }
+        [JsonProperty("flags")]
+        public Optional<ChannelFlags?> Flags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Discord.API.Rest
 {
@@ -18,5 +19,8 @@ namespace Discord.API.Rest
 
         [JsonProperty("rate_limit_per_user")]
         public Optional<int> Slowmode { get; set; }
+
+        [JsonProperty("applied_tags")]
+        public Optional<IEnumerable<ulong>> AppliedTags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
@@ -22,5 +22,8 @@ namespace Discord.API.Rest
 
         [JsonProperty("applied_tags")]
         public Optional<IEnumerable<ulong>> AppliedTags { get; set; }
+
+        [JsonProperty("flags")]
+        public Optional<ChannelFlags> Flags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -38,6 +38,7 @@ namespace Discord.Rest
                         Deny = overwrite.Permissions.DenyValue.ToString()
                     }).ToArray()
                     : Optional.Create<API.Overwrite[]>(),
+                Flags = args.Flags.GetValueOrDefault(),
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
@@ -14,6 +14,9 @@ internal static class ForumHelper
     {
         var args = new ForumChannelProperties();
         func(args);
+
+        Preconditions.AtMost(args.Tags.IsSpecified ? args.Tags.Value.Count() : 0, 5, nameof(args.Tags), "Forum channel can have max 20 tags.");
+        
         var apiArgs = new API.Rest.ModifyForumChannelParams()
         {
             Name = args.Name,

--- a/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
@@ -52,7 +52,8 @@ internal static class ForumHelper
                     EmojiName = args.DefaultReactionEmoji.Value is Emoji emoji ?
                         emoji.Name : Optional<string>.Unspecified
                 }
-                : Optional<ModifyForumReactionEmojiParams>.Unspecified
+                : Optional<ModifyForumReactionEmojiParams>.Unspecified,
+            DefaultSortOrder = args.DefaultSortOrder
         };
         return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
     }

--- a/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Model = Discord.API.Channel;
+
+namespace Discord.Rest;
+
+internal static class ForumHelper
+{
+    public static async Task<Model> ModifyAsync(IForumChannel channel, BaseDiscordClient client,
+        Action<ForumChannelProperties> func,
+        RequestOptions options)
+    {
+        var args = new ForumChannelProperties();
+        func(args);
+        var apiArgs = new API.Rest.ModifyForumChannelParams()
+        {
+            Name = args.Name,
+            Position = args.Position,
+            CategoryId = args.CategoryId,
+            Overwrites = args.PermissionOverwrites.IsSpecified
+                ? args.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                {
+                    TargetId = overwrite.TargetId,
+                    TargetType = overwrite.TargetType,
+                    Allow = overwrite.Permissions.AllowValue.ToString(),
+                    Deny = overwrite.Permissions.DenyValue.ToString()
+                }).ToArray()
+                : Optional.Create<API.Overwrite[]>(),
+            DefaultSlowModeInterval = args.DefaultSlowModeInterval,
+            ThreadCreationInterval = args.ThreadCreationInterval,
+            Tags = args.Tags.IsSpecified
+                ? args.Tags.Value.Select(tag => new API.ForumTagParams
+                {
+                    Name = tag.Name,
+                    EmojiId = tag.Emoji is Emote emote
+                        ? emote.Id
+                        : Optional<ulong?>.Unspecified,
+                    EmojiName = tag.Emoji is Emoji emoji
+                        ? emoji.Name
+                        : Optional<string>.Unspecified
+                }).ToArray()
+                : Optional.Create<API.ForumTagParams[]>(),
+            Flags = args.Flags.GetValueOrDefault(),
+            Topic = args.Topic,
+        };
+        return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
@@ -1,3 +1,4 @@
+using Discord.API;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -30,7 +31,7 @@ internal static class ForumHelper
             DefaultSlowModeInterval = args.DefaultSlowModeInterval,
             ThreadCreationInterval = args.ThreadCreationInterval,
             Tags = args.Tags.IsSpecified
-                ? args.Tags.Value.Select(tag => new API.ForumTagParams
+                ? args.Tags.Value.Select(tag => new API.ModifyForumTagParams
                 {
                     Name = tag.Name,
                     EmojiId = tag.Emoji is Emote emote
@@ -40,9 +41,18 @@ internal static class ForumHelper
                         ? emoji.Name
                         : Optional<string>.Unspecified
                 }).ToArray()
-                : Optional.Create<API.ForumTagParams[]>(),
+                : Optional.Create<API.ModifyForumTagParams[]>(),
             Flags = args.Flags.GetValueOrDefault(),
             Topic = args.Topic,
+            DefaultReactionEmoji = args.DefaultReactionEmoji.IsSpecified
+                ? new API.ModifyForumReactionEmojiParams
+                {
+                    EmojiId = args.DefaultReactionEmoji.Value is Emote emote ?
+                        emote.Id : Optional<ulong?>.Unspecified,
+                    EmojiName = args.DefaultReactionEmoji.Value is Emoji emoji ?
+                        emoji.Name : Optional<string>.Unspecified
+                }
+                : Optional<ModifyForumReactionEmojiParams>.Unspecified
         };
         return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
     }

--- a/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
@@ -30,13 +30,15 @@ namespace Discord.Rest
                 ChannelType.Stage or
                 ChannelType.NewsThread or
                 ChannelType.PrivateThread or
-                ChannelType.PublicThread
+                ChannelType.PublicThread or
+                ChannelType.Forum
                     => RestGuildChannel.Create(discord, new RestGuild(discord, model.GuildId.Value), model),
                 ChannelType.DM or ChannelType.Group => CreatePrivate(discord, model) as RestChannel,
                 ChannelType.Category => RestCategoryChannel.Create(discord, new RestGuild(discord, model.GuildId.Value), model),
                 _ => new RestChannel(discord, model.Id),
             };
         }
+
         internal static RestChannel Create(BaseDiscordClient discord, Model model, IGuild guild)
         {
             return model.Type switch
@@ -47,7 +49,8 @@ namespace Discord.Rest
                 ChannelType.Stage or
                 ChannelType.NewsThread or
                 ChannelType.PrivateThread or
-                ChannelType.PublicThread
+                ChannelType.PublicThread or
+                ChannelType.Forum
                     => RestGuildChannel.Create(discord, guild, model),
                 ChannelType.DM or ChannelType.Group => CreatePrivate(discord, model) as RestChannel,
                 ChannelType.Category => RestCategoryChannel.Create(discord, guild, model),

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -41,9 +41,9 @@ namespace Discord.Rest
 
         }
 
-        internal new static RestStageChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
+        internal new static RestForumChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestStageChannel(discord, guild, model.Id);
+            var entity = new RestForumChannel(discord, guild, model.Id);
             entity.Update(model);
             return entity;
         }
@@ -64,6 +64,13 @@ namespace Discord.Rest
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
                 x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault(), x.Moderated)
             ).ToImmutableArray();
+        }
+
+        /// <inheritdoc/>
+        public async Task ModifyAsync(Action<ForumChannelProperties> func, RequestOptions options = null)
+        {
+            var model = await ForumHelper.ModifyAsync(this, Discord, func, options);
+            Update(model);
         }
 
         /// <inheritdoc cref="IForumChannel.CreatePostAsync(string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -39,6 +39,9 @@ namespace Discord.Rest
         public IEmote DefaultReactionEmoji { get; private set; }
 
         /// <inheritdoc/>
+        public ForumSortOrder? DefaultSortOrder { get; private set; }
+
+        /// <inheritdoc/>
         public string Mention => MentionUtils.MentionChannel(Id);
 
         internal RestForumChannel(BaseDiscordClient client, IGuild guild, ulong id)
@@ -67,14 +70,16 @@ namespace Discord.Rest
             if(model.SlowMode.IsSpecified)
                 ThreadCreationInterval = model.SlowMode.Value;
 
+            DefaultSortOrder = model.DefaultSortOrder.GetValueOrDefault();
+
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
                 x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault(), x.Moderated)
             ).ToImmutableArray();
 
-            if (model.DefaultReactionEmoji.IsSpecified)
+            if (model.DefaultReactionEmoji.IsSpecified && model.DefaultReactionEmoji.Value is not null)
             {
-                if (model.DefaultReactionEmoji.Value.EmojiId.IsSpecified && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
-                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value.GetValueOrDefault(), null, false);
+                if (model.DefaultReactionEmoji.Value.EmojiId.HasValue && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
+                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.GetValueOrDefault(), null, false);
                 else if (model.DefaultReactionEmoji.Value.EmojiName.IsSpecified)
                     DefaultReactionEmoji = new Emoji(model.DefaultReactionEmoji.Value.EmojiName.Value);
                 else

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -36,6 +36,9 @@ namespace Discord.Rest
         public ulong? CategoryId { get; private set; }
 
         /// <inheritdoc/>
+        public IEmote DefaultReactionEmoji { get; private set; }
+
+        /// <inheritdoc/>
         public string Mention => MentionUtils.MentionChannel(Id);
 
         internal RestForumChannel(BaseDiscordClient client, IGuild guild, ulong id)
@@ -67,6 +70,16 @@ namespace Discord.Rest
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
                 x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault(), x.Moderated)
             ).ToImmutableArray();
+
+            if (model.DefaultReactionEmoji.IsSpecified)
+            {
+                if (model.DefaultReactionEmoji.Value.EmojiId.IsSpecified && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
+                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value, null, false);
+                else if (model.DefaultReactionEmoji.Value.EmojiName.IsSpecified)
+                    DefaultReactionEmoji = new Emoji(model.DefaultReactionEmoji.Value.EmojiName.Value);
+                else
+                    DefaultReactionEmoji = null;
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -100,7 +100,7 @@ namespace Discord.Rest
             Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
             => ThreadHelper.CreatePostAsync(this, Discord, title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public async Task<RestThreadChannel> CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
@@ -110,7 +110,7 @@ namespace Discord.Rest
             return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray()).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, Stream, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, Stream, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public async Task<RestThreadChannel> CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
@@ -120,13 +120,13 @@ namespace Discord.Rest
             return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray()).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, FileAttachment, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, FileAttachment, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public Task<RestThreadChannel> CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
             MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
             => ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { attachment }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFilesAsync(string, IEnumerable{FileAttachment}, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFilesAsync(string, IEnumerable{FileAttachment}, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public Task<RestThreadChannel> CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
             MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -33,6 +33,9 @@ namespace Discord.Rest
         public int DefaultSlowModeInterval { get; private set; }
 
         /// <inheritdoc/>
+        public ulong? CategoryId { get; private set; }
+
+        /// <inheritdoc/>
         public string Mention => MentionUtils.MentionChannel(Id);
 
         internal RestForumChannel(BaseDiscordClient client, IGuild guild, ulong id)
@@ -145,6 +148,34 @@ namespace Discord.Rest
         async Task<IThreadChannel> IForumChannel.CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
             => await CreatePostWithFilesAsync(title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
 
+        #endregion
+
+        #region INestedChannel
+        /// <inheritdoc />
+        public virtual async Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
+        public virtual async Task<IInviteMetadata> CreateInviteToApplicationAsync(ulong applicationId, int? maxAge = 86400, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteToApplicationAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, applicationId, options);
+        /// <inheritdoc />
+        public virtual async Task<IInviteMetadata> CreateInviteToApplicationAsync(DefaultApplications application, int? maxAge = 86400, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteToApplicationAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, (ulong)application, options);
+        public virtual Task<IInviteMetadata> CreateInviteToStreamAsync(IUser user, int? maxAge, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => throw new NotImplementedException();
+        /// <inheritdoc />
+        public virtual async Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
+            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        async Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
+        {
+            if (CategoryId.HasValue && mode == CacheMode.AllowDownload)
+                return (await Guild.GetChannelAsync(CategoryId.Value, mode, options).ConfigureAwait(false)) as ICategoryChannel;
+            return null;
+        }
+
+        /// <inheritdoc />
+        public Task SyncPermissionsAsync(RequestOptions options = null)
+            => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
         #endregion
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -85,6 +85,8 @@ namespace Discord.Rest
                 else
                     DefaultReactionEmoji = null;
             }
+
+            CategoryId = model.CategoryId.GetValueOrDefault();
         }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -94,41 +94,43 @@ namespace Discord.Rest
             Update(model);
         }
 
-        /// <inheritdoc cref="IForumChannel.CreatePostAsync(string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
-        public Task<RestThreadChannel> CreatePostAsync(string title, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay, int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
-            => ThreadHelper.CreatePostAsync(this, Discord, title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
+        /// <inheritdoc cref="IForumChannel.CreatePostAsync(string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
+        public Task<RestThreadChannel> CreatePostAsync(string title, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay, int? slowmode = null, 
+            string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null,
+            Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
+            => ThreadHelper.CreatePostAsync(this, Discord, title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
         /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
         public async Task<RestThreadChannel> CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
-            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
+            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
         {
             using var file = new FileAttachment(filePath, isSpoiler: isSpoiler);
-            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
+            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray()).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, Stream, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
         public async Task<RestThreadChannel> CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
-            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
+            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
         {
             using var file = new FileAttachment(stream, filename, isSpoiler: isSpoiler);
-            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
+            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray()).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, FileAttachment, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
         public Task<RestThreadChannel> CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
-            => ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { attachment }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
+            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
+            => ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { attachment }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
         /// <inheritdoc cref="IForumChannel.CreatePostWithFilesAsync(string, IEnumerable{FileAttachment}, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
         public Task<RestThreadChannel> CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
-            => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
+            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
+            => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
         /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
@@ -155,15 +157,15 @@ namespace Discord.Rest
             => await GetPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
             => await GetJoinedPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostAsync(string title, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostAsync(string title, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostAsync(title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFileAsync(title, filePath, archiveDuration, slowmode, text, embed, options, isSpoiler, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFileAsync(title, stream, filename, archiveDuration, slowmode, text, embed, options, isSpoiler, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFileAsync(title, attachment, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFilesAsync(title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
 
         #endregion

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -62,7 +62,7 @@ namespace Discord.Rest
                 ThreadCreationInterval = model.SlowMode.Value;
 
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
-                x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault())
+                x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault(), x.Moderated)
             ).ToImmutableArray();
         }
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -74,7 +74,7 @@ namespace Discord.Rest
             if (model.DefaultReactionEmoji.IsSpecified)
             {
                 if (model.DefaultReactionEmoji.Value.EmojiId.IsSpecified && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
-                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value, null, false);
+                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value.GetValueOrDefault(), null, false);
                 else if (model.DefaultReactionEmoji.Value.EmojiName.IsSpecified)
                     DefaultReactionEmoji = new Emoji(model.DefaultReactionEmoji.Value.EmojiName.Value);
                 else

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -27,6 +27,12 @@ namespace Discord.Rest
         public IReadOnlyCollection<ForumTag> Tags { get; private set; }
 
         /// <inheritdoc/>
+        public int ThreadCreationInterval { get; private set; }
+
+        /// <inheritdoc/>
+        public int DefaultSlowModeInterval { get; private set; }
+
+        /// <inheritdoc/>
         public string Mention => MentionUtils.MentionChannel(Id);
 
         internal RestForumChannel(BaseDiscordClient client, IGuild guild, ulong id)
@@ -48,6 +54,12 @@ namespace Discord.Rest
             IsNsfw = model.Nsfw.GetValueOrDefault(false);
             Topic = model.Topic.GetValueOrDefault();
             DefaultAutoArchiveDuration = model.AutoArchiveDuration.GetValueOrDefault(ThreadArchiveDuration.OneDay);
+
+            if (model.ThreadRateLimitPerUser.IsSpecified)
+                DefaultSlowModeInterval = model.ThreadRateLimitPerUser.Value;
+
+            if(model.SlowMode.IsSpecified)
+                ThreadCreationInterval = model.SlowMode.Value;
 
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
                 x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault())

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -26,6 +26,9 @@ namespace Discord.Rest
         /// <inheritdoc />
         public ulong GuildId => Guild.Id;
 
+        /// <inheritdoc />
+        public ChannelFlags Flags { get; private set; }
+
         internal RestGuildChannel(BaseDiscordClient discord, IGuild guild, ulong id)
             : base(discord, id)
         {
@@ -62,6 +65,8 @@ namespace Discord.Rest
                     newOverwrites.Add(overwrites[i].ToEntity());
                 _overwrites = newOverwrites.ToImmutable();
             }
+
+            Flags = model.Flags.GetValueOrDefault(ChannelFlags.None);
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
@@ -37,6 +37,9 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public bool? IsInvitable { get; private set; }
 
+        /// <inheritdoc/>
+        public IReadOnlyCollection<ulong> AppliedTags { get; private set; }
+
         /// <inheritdoc cref="IThreadChannel.CreatedAt"/>
         public override DateTimeOffset CreatedAt { get; }
 
@@ -77,6 +80,8 @@ namespace Discord.Rest
             MessageCount = model.MessageCount.GetValueOrDefault(0);
             Type = (ThreadType)model.Type;
             ParentChannelId = model.CategoryId.Value;
+
+            AppliedTags = model.AppliedTags.GetValueOrDefault(Array.Empty<ulong>());
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
@@ -115,6 +115,13 @@ namespace Discord.Rest
         }
 
         /// <inheritdoc/>
+        public async Task ModifyAsync(Action<ThreadChannelProperties> func, RequestOptions options = null)
+        {
+            var model = await ThreadHelper.ModifyAsync(this, Discord, func, options);
+            Update(model);
+        }
+
+        /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>

--- a/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
@@ -81,7 +81,7 @@ namespace Discord.Rest
             Type = (ThreadType)model.Type;
             ParentChannelId = model.CategoryId.Value;
 
-            AppliedTags = model.AppliedTags.GetValueOrDefault(Array.Empty<ulong>());
+            AppliedTags = model.AppliedTags.GetValueOrDefault(Array.Empty<ulong>()).ToImmutableArray();
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -57,7 +57,8 @@ namespace Discord.Rest
                 Archived = args.Archived,
                 AutoArchiveDuration = args.AutoArchiveDuration,
                 Locked = args.Locked,
-                Slowmode = args.SlowModeInterval
+                Slowmode = args.SlowModeInterval,
+                AppliedTags = args.AppliedTags
             };
             return await client.ApiClient.ModifyThreadAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -46,10 +46,10 @@ namespace Discord.Rest
         }
 
         public static async Task<Model> ModifyAsync(IThreadChannel channel, BaseDiscordClient client,
-            Action<TextChannelProperties> func,
+            Action<ThreadChannelProperties> func,
             RequestOptions options)
         {
-            var args = new TextChannelProperties();
+            var args = new ThreadChannelProperties();
             func(args);
             var apiArgs = new ModifyThreadParams
             {

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -1,3 +1,4 @@
+using Discord.API;
 using Discord.API.Rest;
 using System;
 using System.Collections.Generic;
@@ -51,6 +52,9 @@ namespace Discord.Rest
         {
             var args = new ThreadChannelProperties();
             func(args);
+
+            Preconditions.AtMost(args.AppliedTags.IsSpecified ? args.AppliedTags.Value.Count() : 0, 5, nameof(args.AppliedTags), "Forum post can have max 5 applied tags.");
+
             var apiArgs = new ModifyThreadParams
             {
                 Name = args.Name,
@@ -117,6 +121,7 @@ namespace Discord.Rest
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
             Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(tagIds?.Length ?? 0, 5, nameof(tagIds), "Forum post can have max 5 applied tags.");
 
             // check that user flag and user Id list are exclusive, same with role flag and role Id list
             if (allowedMentions != null && allowedMentions.AllowedTypes.HasValue)
@@ -178,6 +183,8 @@ namespace Discord.Rest
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
             Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(tagIds?.Length ?? 0, 5, nameof(tagIds), "Forum post can have max 5 applied tags.");
+
 
             // check that user flag and user Id list are exclusive, same with role flag and role Id list
             if (allowedMentions != null && allowedMentions.AllowedTypes.HasValue)

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -58,7 +58,8 @@ namespace Discord.Rest
                 AutoArchiveDuration = args.AutoArchiveDuration,
                 Locked = args.Locked,
                 Slowmode = args.SlowModeInterval,
-                AppliedTags = args.AppliedTags
+                AppliedTags = args.AppliedTags,
+                Flags = args.Flags,
             };
             return await client.ApiClient.ModifyThreadAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -351,6 +351,8 @@ namespace Discord.Rest
             var props = new ForumChannelProperties();
             func?.Invoke(props);
 
+            Preconditions.AtMost(props.Tags.IsSpecified ? props.Tags.Value.Count() : 0, 5, nameof(props.Tags), "Forum channel can have max 20 tags.");
+
             var args = new CreateGuildChannelParams(name, ChannelType.Forum)
             {
                 Position = props.Position,

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -1,3 +1,4 @@
+using Discord.API;
 using Discord.API.Rest;
 using System;
 using System.Collections.Generic;
@@ -252,6 +253,7 @@ namespace Discord.Rest
                         Deny = overwrite.Permissions.DenyValue.ToString()
                     }).ToArray()
                     : Optional.Create<API.Overwrite[]>(),
+                DefaultAutoArchiveDuration = props.AutoArchiveDuration
             };
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
             return RestTextChannel.Create(client, guild, model);
@@ -337,6 +339,62 @@ namespace Discord.Rest
 
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
             return RestCategoryChannel.Create(client, guild, model);
+        }
+
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        public static async Task<RestForumChannel> CreateForumChannelAsync(IGuild guild, BaseDiscordClient client,
+            string name, RequestOptions options, Action<ForumChannelProperties> func = null)
+        {
+            if (name == null)
+                throw new ArgumentNullException(paramName: nameof(name));
+
+            var props = new ForumChannelProperties();
+            func?.Invoke(props);
+
+            var args = new CreateGuildChannelParams(name, ChannelType.Forum)
+            {
+                Position = props.Position,
+                Overwrites = props.PermissionOverwrites.IsSpecified
+                    ? props.PermissionOverwrites.Value.Select(overwrite => new API.Overwrite
+                    {
+                        TargetId = overwrite.TargetId,
+                        TargetType = overwrite.TargetType,
+                        Allow = overwrite.Permissions.AllowValue.ToString(),
+                        Deny = overwrite.Permissions.DenyValue.ToString()
+                    }).ToArray()
+                    : Optional.Create<API.Overwrite[]>(),
+                SlowModeInterval = props.ThreadCreationInterval,
+                AvailableTags = props.Tags.GetValueOrDefault().Select(
+                    x => new ModifyForumTagParams
+                    {
+                        Id = x.Id,
+                        Name = x.Name,
+                        EmojiId = x.Emoji is Emote emote
+                            ? emote.Id
+                            : Optional<ulong?>.Unspecified,
+                        EmojiName = x.Emoji is Emoji emoji
+                            ? emoji.Name
+                            : Optional<string>.Unspecified,
+                        Moderated = x.IsModerated
+                    }).ToArray(),
+                DefaultReactionEmoji = props.DefaultReactionEmoji.IsSpecified
+                    ? new API.ModifyForumReactionEmojiParams
+                    {
+                        EmojiId = props.DefaultReactionEmoji.Value is Emote emote ?
+                            emote.Id : Optional<ulong?>.Unspecified,
+                        EmojiName = props.DefaultReactionEmoji.Value is Emoji emoji ?
+                            emoji.Name : Optional<string>.Unspecified
+                    }
+                    : Optional<ModifyForumReactionEmojiParams>.Unspecified,
+                ThreadRateLimitPerUser = props.DefaultSlowModeInterval,
+                CategoryId = props.CategoryId,
+                IsNsfw = props.IsNsfw,
+                Topic = props.Topic,
+                DefaultAutoArchiveDuration = props.AutoArchiveDuration
+            };
+
+            var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
+            return RestForumChannel.Create(client, guild, model);
         }
         #endregion
 

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -364,7 +364,7 @@ namespace Discord.Rest
                     }).ToArray()
                     : Optional.Create<API.Overwrite[]>(),
                 SlowModeInterval = props.ThreadCreationInterval,
-                AvailableTags = props.Tags.GetValueOrDefault().Select(
+                AvailableTags = props.Tags.GetValueOrDefault(Array.Empty<ForumTagProperties>()).Select(
                     x => new ModifyForumTagParams
                     {
                         Id = x.Id,
@@ -390,7 +390,8 @@ namespace Discord.Rest
                 CategoryId = props.CategoryId,
                 IsNsfw = props.IsNsfw,
                 Topic = props.Topic,
-                DefaultAutoArchiveDuration = props.AutoArchiveDuration
+                DefaultAutoArchiveDuration = props.AutoArchiveDuration,
+                DefaultSortOrder = props.DefaultSortOrder.GetValueOrDefault(ForumSortOrder.LatestActivity)
             };
 
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -711,6 +711,19 @@ namespace Discord.Rest
             => GuildHelper.CreateCategoryChannelAsync(this, Discord, name, options, func);
 
         /// <summary>
+        ///     Creates a category channel with the provided name.
+        /// </summary>
+        /// <param name="name">The name of the new channel.</param>
+        /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="name" /> is <see langword="null"/>.</exception>
+        /// <returns>
+        ///     The created category channel.
+        /// </returns>
+        public Task<RestForumChannel> CreateForumChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null)
+            => GuildHelper.CreateForumChannelAsync(this, Discord, name, options, func);
+
+        /// <summary>
         ///     Gets a collection of all the voice regions this guild can access.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
@@ -1370,6 +1383,9 @@ namespace Discord.Rest
         /// <inheritdoc />
         async Task<ICategoryChannel> IGuild.CreateCategoryAsync(string name, Action<GuildChannelProperties> func, RequestOptions options)
             => await CreateCategoryChannelAsync(name, func, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IForumChannel> IGuild.CreateForumChannelAsync(string name, Action<ForumChannelProperties> func, RequestOptions options)
+            => await CreateForumChannelAsync(name, func, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IVoiceRegion>> IGuild.GetVoiceRegionsAsync(RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -63,6 +63,10 @@ namespace Discord.WebSocket
             ).ToImmutableArray();
         }
 
+        /// <inheritdoc />
+        public virtual Task ModifyAsync(Action<ForumChannelProperties> func, RequestOptions options = null)
+            => ForumHelper.ModifyAsync(this, Discord, func, options);
+
         /// <inheritdoc cref="IForumChannel.CreatePostAsync(string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
         public Task<RestThreadChannel> CreatePostAsync(string title, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay, int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
             => ThreadHelper.CreatePostAsync(this, Discord, title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -39,6 +39,9 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public ulong? CategoryId { get; private set; }
 
+        /// <inheritdoc/>
+        public IEmote DefaultReactionEmoji { get; private set; }
+
         /// <summary>
         ///     Gets the parent (category) of this channel in the guild's channel list.
         /// </summary>
@@ -73,6 +76,16 @@ namespace Discord.WebSocket
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
                 x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault(), x.Moderated)
             ).ToImmutableArray();
+
+            if (model.DefaultReactionEmoji.IsSpecified)
+            {
+                if (model.DefaultReactionEmoji.Value.EmojiId.IsSpecified && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
+                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value, null, false);
+                else if (model.DefaultReactionEmoji.Value.EmojiName.IsSpecified)
+                    DefaultReactionEmoji = new Emoji(model.DefaultReactionEmoji.Value.EmojiName.Value);
+                else
+                    DefaultReactionEmoji = null;
+            }
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -42,6 +42,9 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public IEmote DefaultReactionEmoji { get; private set; }
 
+        /// <inheritdoc/>
+        public ForumSortOrder? DefaultSortOrder { get; private set; }
+
         /// <summary>
         ///     Gets the parent (category) of this channel in the guild's channel list.
         /// </summary>
@@ -73,14 +76,16 @@ namespace Discord.WebSocket
             if (model.SlowMode.IsSpecified)
                 ThreadCreationInterval = model.SlowMode.Value;
 
+            DefaultSortOrder = model.DefaultSortOrder.GetValueOrDefault();
+
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
                 x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault(), x.Moderated)
             ).ToImmutableArray();
 
-            if (model.DefaultReactionEmoji.IsSpecified)
+            if (model.DefaultReactionEmoji.IsSpecified && model.DefaultReactionEmoji.Value is not null)
             {
-                if (model.DefaultReactionEmoji.Value.EmojiId.IsSpecified && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
-                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value.GetValueOrDefault(), null, false);
+                if (model.DefaultReactionEmoji.Value.EmojiId.HasValue && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
+                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.GetValueOrDefault(), null, false);
                 else if (model.DefaultReactionEmoji.Value.EmojiName.IsSpecified)
                     DefaultReactionEmoji = new Emoji(model.DefaultReactionEmoji.Value.EmojiName.Value);
                 else

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -91,6 +91,8 @@ namespace Discord.WebSocket
                 else
                     DefaultReactionEmoji = null;
             }
+
+            CategoryId = model.CategoryId.GetValueOrDefault();
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -28,6 +28,12 @@ namespace Discord.WebSocket
         public IReadOnlyCollection<ForumTag> Tags { get; private set; }
 
         /// <inheritdoc/>
+        public int ThreadCreationInterval { get; private set; }
+
+        /// <inheritdoc/>
+        public int DefaultSlowModeInterval { get; private set; }
+
+        /// <inheritdoc/>
         public string Mention => MentionUtils.MentionChannel(Id);
 
         internal SocketForumChannel(DiscordSocketClient discord, ulong id, SocketGuild guild) : base(discord, id, guild) { }
@@ -45,6 +51,12 @@ namespace Discord.WebSocket
             IsNsfw = model.Nsfw.GetValueOrDefault(false);
             Topic = model.Topic.GetValueOrDefault();
             DefaultAutoArchiveDuration = model.AutoArchiveDuration.GetValueOrDefault(ThreadArchiveDuration.OneDay);
+
+            if (model.ThreadRateLimitPerUser.IsSpecified)
+                DefaultSlowModeInterval = model.ThreadRateLimitPerUser.Value;
+
+            if (model.SlowMode.IsSpecified)
+                ThreadCreationInterval = model.SlowMode.Value;
 
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
                 x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault())

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -97,41 +97,41 @@ namespace Discord.WebSocket
         public virtual Task ModifyAsync(Action<ForumChannelProperties> func, RequestOptions options = null)
             => ForumHelper.ModifyAsync(this, Discord, func, options);
 
-        /// <inheritdoc cref="IForumChannel.CreatePostAsync(string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
-        public Task<RestThreadChannel> CreatePostAsync(string title, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay, int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
-            => ThreadHelper.CreatePostAsync(this, Discord, title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
+        /// <inheritdoc cref="IForumChannel.CreatePostAsync(string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
+        public Task<RestThreadChannel> CreatePostAsync(string title, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay, int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
+            => ThreadHelper.CreatePostAsync(this, Discord, title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public async Task<RestThreadChannel> CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
-            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
+            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
         {
             using var file = new FileAttachment(filePath, isSpoiler: isSpoiler);
-            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
+            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray()).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, Stream, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, Stream, string, ThreadArchiveDuration, int?, string, Embed, RequestOptions, bool, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public async Task<RestThreadChannel> CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, bool isSpoiler = false,
             AllowedMentions allowedMentions = null, MessageComponent components = null,
-            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
+            ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
         {
             using var file = new FileAttachment(stream, filename, isSpoiler: isSpoiler);
-            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
+            return await ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { file }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray()).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, FileAttachment, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFileAsync(string, FileAttachment, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public Task<RestThreadChannel> CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
-            => ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { attachment }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
+            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
+            => ThreadHelper.CreatePostAsync(this, Discord, title, new FileAttachment[] { attachment }, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
-        /// <inheritdoc cref="IForumChannel.CreatePostWithFilesAsync(string, IEnumerable{FileAttachment}, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags)"/>
+        /// <inheritdoc cref="IForumChannel.CreatePostWithFilesAsync(string, IEnumerable{FileAttachment}, ThreadArchiveDuration, int?, string, Embed, RequestOptions, AllowedMentions, MessageComponent, ISticker[], Embed[], MessageFlags, ForumTag[])"/>
         public Task<RestThreadChannel> CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration = ThreadArchiveDuration.OneDay,
             int? slowmode = null, string text = null, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None)
-            => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
+            MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
+            => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
         /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
@@ -158,15 +158,15 @@ namespace Discord.WebSocket
             => await GetPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int? limit, DateTimeOffset? before, RequestOptions options)
             => await GetJoinedPrivateArchivedThreadsAsync(limit, before, options).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostAsync(string title, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostAsync(string title, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostAsync(title, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, string filePath, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFileAsync(title, filePath, archiveDuration, slowmode, text, embed, options, isSpoiler, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, Stream stream, string filename, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFileAsync(title, stream, filename, archiveDuration, slowmode, text, embed, options, isSpoiler, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFileAsync(string title, FileAttachment attachment, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFileAsync(title, attachment, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags).ConfigureAwait(false);
-        async Task<IThreadChannel> IForumChannel.CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
+        async Task<IThreadChannel> IForumChannel.CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags, ForumTag[] tags)
             => await CreatePostWithFilesAsync(title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
 
         #endregion

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -80,7 +80,7 @@ namespace Discord.WebSocket
             if (model.DefaultReactionEmoji.IsSpecified)
             {
                 if (model.DefaultReactionEmoji.Value.EmojiId.IsSpecified && model.DefaultReactionEmoji.Value.EmojiId.Value != 0)
-                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value, null, false);
+                    DefaultReactionEmoji = new Emote(model.DefaultReactionEmoji.Value.EmojiId.Value.GetValueOrDefault(), null, false);
                 else if (model.DefaultReactionEmoji.Value.EmojiName.IsSpecified)
                     DefaultReactionEmoji = new Emoji(model.DefaultReactionEmoji.Value.EmojiName.Value);
                 else

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -59,7 +59,7 @@ namespace Discord.WebSocket
                 ThreadCreationInterval = model.SlowMode.Value;
 
             Tags = model.ForumTags.GetValueOrDefault(Array.Empty<API.ForumTags>()).Select(
-                x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault())
+                x => new ForumTag(x.Id, x.Name, x.EmojiId.GetValueOrDefault(null), x.EmojiName.GetValueOrDefault(), x.Moderated)
             ).ToImmutableArray();
         }
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -36,6 +36,18 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public string Mention => MentionUtils.MentionChannel(Id);
 
+        /// <inheritdoc/>
+        public ulong? CategoryId { get; private set; }
+
+        /// <summary>
+        ///     Gets the parent (category) of this channel in the guild's channel list.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="ICategoryChannel"/> representing the parent of this channel; <c>null</c> if none is set.
+        /// </returns>
+        public ICategoryChannel Category
+            => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
+
         internal SocketForumChannel(DiscordSocketClient discord, ulong id, SocketGuild guild) : base(discord, id, guild) { }
 
         internal new static SocketForumChannel Create(SocketGuild guild, ClientState state, Model model)
@@ -139,6 +151,30 @@ namespace Discord.WebSocket
         async Task<IThreadChannel> IForumChannel.CreatePostWithFilesAsync(string title, IEnumerable<FileAttachment> attachments, ThreadArchiveDuration archiveDuration, int? slowmode, string text, Embed embed, RequestOptions options, AllowedMentions allowedMentions, MessageComponent components, ISticker[] stickers, Embed[] embeds, MessageFlags flags)
             => await CreatePostWithFilesAsync(title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags);
 
+        #endregion
+
+        #region INestedChannel
+        /// <inheritdoc />
+        public virtual async Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, options).ConfigureAwait(false);
+        public virtual async Task<IInviteMetadata> CreateInviteToApplicationAsync(ulong applicationId, int? maxAge = 86400, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteToApplicationAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, applicationId, options);
+        /// <inheritdoc />
+        public virtual async Task<IInviteMetadata> CreateInviteToApplicationAsync(DefaultApplications application, int? maxAge = 86400, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => await ChannelHelper.CreateInviteToApplicationAsync(this, Discord, maxAge, maxUses, isTemporary, isUnique, (ulong)application, options);
+        public virtual Task<IInviteMetadata> CreateInviteToStreamAsync(IUser user, int? maxAge, int? maxUses = default(int?), bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
+            => throw new NotImplementedException();
+        /// <inheritdoc />
+        public virtual async Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
+            => await ChannelHelper.GetInvitesAsync(this, Discord, options).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        Task<ICategoryChannel> INestedChannel.GetCategoryAsync(CacheMode mode, RequestOptions options)
+            => Task.FromResult(Category);
+
+        /// <inheritdoc />
+        public virtual Task SyncPermissionsAsync(RequestOptions options = null)
+            => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
         #endregion
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -31,6 +31,9 @@ namespace Discord.WebSocket
         public int Position { get; private set; }
 
         /// <inheritdoc />
+        public ChannelFlags Flags { get; private set; }
+
+        /// <inheritdoc />
         public virtual IReadOnlyCollection<Overwrite> PermissionOverwrites => _overwrites;
         /// <summary>
         ///     Gets a collection of users that are able to view the channel.
@@ -74,6 +77,8 @@ namespace Discord.WebSocket
             for (int i = 0; i < overwrites.Length; i++)
                 newOverwrites.Add(overwrites[i].ToEntity());
             _overwrites = newOverwrites.ToImmutable();
+
+            Flags = model.Flags.GetValueOrDefault(ChannelFlags.None);
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -343,6 +343,10 @@ namespace Discord.WebSocket
             => ThreadHelper.ModifyAsync(this, Discord, func, options);
 
         /// <inheritdoc/>
+        public Task ModifyAsync(Action<ThreadChannelProperties> func, RequestOptions options = null)
+            => ThreadHelper.ModifyAsync(this, Discord, func, options);
+
+        /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -89,6 +89,9 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public bool? IsInvitable { get; private set; }
 
+        /// <inheritdoc/>
+        public IReadOnlyCollection<ulong> AppliedTags { get; private set; }
+
         /// <inheritdoc cref="IThreadChannel.CreatedAt"/>
         public override DateTimeOffset CreatedAt { get; }
 
@@ -149,6 +152,8 @@ namespace Discord.WebSocket
             }
 
             HasJoined = model.ThreadMember.IsSpecified;
+
+            AppliedTags = model.AppliedTags.GetValueOrDefault(Array.Empty<ulong>());
         }
 
         internal IReadOnlyCollection<SocketThreadUser> RemoveUsers(ulong[] users)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -153,7 +153,7 @@ namespace Discord.WebSocket
 
             HasJoined = model.ThreadMember.IsSpecified;
 
-            AppliedTags = model.AppliedTags.GetValueOrDefault(Array.Empty<ulong>());
+            AppliedTags = model.AppliedTags.GetValueOrDefault(Array.Empty<ulong>()).ToImmutableArray();
         }
 
         internal IReadOnlyCollection<SocketThreadUser> RemoveUsers(ulong[] users)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -339,9 +339,6 @@ namespace Discord.WebSocket
             => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
-        /// <remarks>
-        ///     <b>This method is not supported in threads.</b>
-        /// </remarks>
         public override Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null)
             => ThreadHelper.ModifyAsync(this, Discord, func, options);
 

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -302,6 +302,16 @@ namespace Discord.WebSocket
         /// </returns>
         public IReadOnlyCollection<SocketThreadChannel> ThreadChannels
             => Channels.OfType<SocketThreadChannel>().ToImmutableArray();
+
+        /// <summary>
+        ///     Gets a collection of all forum channels in this guild.
+        /// </summary>
+        /// <returns>
+        ///     A read-only collection of forum channels found within this guild.
+        /// </returns>
+        public IReadOnlyCollection<SocketForumChannel> ForumChannels
+            => Channels.OfType<SocketForumChannel>().ToImmutableArray();
+
         /// <summary>
         ///     Gets the current logged-in user.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -790,6 +790,7 @@ namespace Discord.WebSocket
         /// </returns>
         public Task<RestStageChannel> CreateStageChannelAsync(string name, Action<VoiceChannelProperties> func = null, RequestOptions options = null)
             => GuildHelper.CreateStageChannelAsync(this, Discord, name, options, func);
+
         /// <summary>
         ///     Creates a new channel category in this guild.
         /// </summary>
@@ -801,8 +802,23 @@ namespace Discord.WebSocket
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     category channel.
         /// </returns>
-        public Task<RestCategoryChannel> CreateCategoryChannelAsync(string name, Action<GuildChannelProperties> func = null, RequestOptions options = null)
+        public Task<RestCategoryChannel> CreateCategoryChannelAsync(string name,
+            Action<GuildChannelProperties> func = null, RequestOptions options = null)
             => GuildHelper.CreateCategoryChannelAsync(this, Discord, name, options, func);
+
+        /// <summary>
+        ///     Creates a new channel forum in this guild.
+        /// </summary>
+        /// <param name="name">The new name for the forum.</param>
+        /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+        /// <returns>
+        ///     A task that represents the asynchronous creation operation. The task result contains the newly created
+        ///     forum channel.
+        /// </returns>
+        public Task<RestForumChannel> CreateForumChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null)
+            => GuildHelper.CreateForumChannelAsync(this, Discord, name, options, func);
 
         internal SocketGuildChannel AddChannel(ClientState state, ChannelModel model)
         {
@@ -1897,6 +1913,9 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         async Task<ICategoryChannel> IGuild.CreateCategoryAsync(string name, Action<GuildChannelProperties> func, RequestOptions options)
             => await CreateCategoryChannelAsync(name, func, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IForumChannel> IGuild.CreateForumChannelAsync(string name, Action<ForumChannelProperties> func, RequestOptions options)
+            => await CreateForumChannelAsync(name, func, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IVoiceRegion>> IGuild.GetVoiceRegionsAsync(RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -802,8 +802,7 @@ namespace Discord.WebSocket
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     category channel.
         /// </returns>
-        public Task<RestCategoryChannel> CreateCategoryChannelAsync(string name,
-            Action<GuildChannelProperties> func = null, RequestOptions options = null)
+        public Task<RestCategoryChannel> CreateCategoryChannelAsync(string name, Action<GuildChannelProperties> func = null, RequestOptions options = null)
             => GuildHelper.CreateCategoryChannelAsync(this, Discord, name, options, func);
 
         /// <summary>

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedCategoryChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedCategoryChannel.cs
@@ -20,6 +20,8 @@ namespace Discord
         public DateTimeOffset CreatedAt => throw new NotImplementedException();
 
         public ulong Id => throw new NotImplementedException();
+        
+        public ChannelFlags Flags => throw new NotImplementedException();
 
         public Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
         {

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
@@ -34,6 +34,8 @@ namespace Discord
 
         public ulong Id => throw new NotImplementedException();
 
+        public ChannelFlags Flags => throw new NotImplementedException();
+
         public Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
         {
             throw new NotImplementedException();

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
@@ -36,6 +36,8 @@ namespace Discord
 
         public string Mention => throw new NotImplementedException();
 
+        public ChannelFlags Flags => throw new NotImplementedException();
+
         public Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null) => throw new NotImplementedException();
         public Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null) => throw new NotImplementedException();
         public Task<IAudioClient> ConnectAsync(bool selfDeaf = false, bool selfMute = false, bool external = false) => throw new NotImplementedException();


### PR DESCRIPTION
This PR adds support for missing channel properties and improves channel modification

Also it fixes a bug in `DiscordRestClient`

### Changes
- [x] new properties for editing channels:
  - `ThreadChannelProperties`
  - `ForumChannelProperties`
- [x] move `Locked` and `Archived` props from `TextChannelProperties` into `ThreadChannelProperties` **Might be breaking**
- [x] add `AppliedTags` property to:
  -  `IThreadChannel`
  - `RestThreadChannel`
  - `SocketThreadChannel`
  - `ThreadChannelProperties`
- [x] add `DefaultSlowModeInterval` and `ThreadCreationInterval` properties
  - to forum channels
  - to `ForumChannelProperties`
- [x] add support for `default_reaction_emoji`
- [x] add `ChannelFlags`
- [x] add `ForumTagBuilder`
- [x] add comparison operators on forum tags
- [x] add `CreateForumChannelAsync` methods to guilds
- [x] add `ForumChannels` property to `SocketGuild`
- [x] add support for `default_sort_order`\
- [x] support creating post with applied tags (also fixes #2503) **Might be breaking**

### Fixes
- [x] Fix `DiscordRestClient.GetChannelAsync` returning `null` if getting forum channel
- [x] Fix #2475
- [x] Fix misleading comment on `ApplicationCommandOptionType.Integer` 
- [x] Fix #2502 