### PR TITLE
[Docs] Update samples to use `MessageContent` intent & update `v2 => v3 guide`

### DIFF
--- a/docs/guides/v2_v3_guide/v2_to_v3_guide.md
+++ b/docs/guides/v2_v3_guide/v2_to_v3_guide.md
@@ -37,6 +37,7 @@ _client = new DiscordSocketClient(config);
 - AllUnprivileged: This is a group of most common intents, that do NOT require any [developer portal] intents to be enabled.
   This includes intents that receive messages such as: `GatewayIntents.GuildMessages, GatewayIntents.DirectMessages`
 - GuildMembers: An intent disabled by default, as you need to enable it in the [developer portal].
+- MessageContent: An intent also disabled by default as you also need to enable it in the [developer portal].
 - GuildPresences: Also disabled by default, this intent together with `GuildMembers` are the only intents not included in `AllUnprivileged`.
 - All: All intents, it is ill advised to use this without care, as it _can_ cause a memory leak from presence.
   The library will give responsive warnings if you specify unnecessary intents.

--- a/samples/BasicBot/Program.cs
+++ b/samples/BasicBot/Program.cs
@@ -34,9 +34,16 @@ namespace BasicBot
 
         public Program()
         {
+            // Config used by DiscordSocketClient
+            // Define intents for the client
+            var config = new DiscordSocketConfig
+            {
+                GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
+            };
+
             // It is recommended to Dispose of a client when you are finished
             // using it, at the end of your app's lifetime.
-            _client = new DiscordSocketClient();
+            _client = new DiscordSocketClient(config);
 
             // Subscribing to client events, so that we may receive them whenever they're invoked.
             _client.Log += LogAsync;

--- a/samples/BasicBot/_BasicBot.csproj
+++ b/samples/BasicBot/_BasicBot.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.WebSocket" Version="3.6.1"/>
+    <PackageReference Include="Discord.Net.WebSocket" Version="3.8.1"/>
   </ItemGroup>
 
 </Project>

--- a/samples/InteractionFramework/_InteractionFramework.csproj
+++ b/samples/InteractionFramework/_InteractionFramework.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Discord.Net.Interactions" Version="3.6.1" />
+    <PackageReference Include="Discord.Net.Interactions" Version="3.8.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/ShardedClient/Program.cs
+++ b/samples/ShardedClient/Program.cs
@@ -28,7 +28,8 @@ namespace ShardedClient
             // have 1 shard per 1500-2000 guilds your bot is in.
             var config = new DiscordSocketConfig
             {
-                TotalShards = 2
+                TotalShards = 2,
+                GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
             };
 
             // You should dispose a service provider created using ASP.NET

--- a/samples/ShardedClient/_ShardedClient.csproj
+++ b/samples/ShardedClient/_ShardedClient.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Discord.Net" Version="3.6.1" />
+    <PackageReference Include="Discord.Net" Version="3.8.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/TextCommandFramework/Program.cs
+++ b/samples/TextCommandFramework/Program.cs
@@ -60,6 +60,10 @@ namespace TextCommandFramework
         private ServiceProvider ConfigureServices()
         {
             return new ServiceCollection()
+                .AddSingleton(new DiscordSocketConfig
+                {
+                    GatewayIntents = GatewayIntents.AllUnprivileged | GatewayIntents.MessageContent
+                })
                 .AddSingleton<DiscordSocketClient>()
                 .AddSingleton<CommandService>()
                 .AddSingleton<CommandHandlingService>()

--- a/samples/TextCommandFramework/_TextCommandFramework.csproj
+++ b/samples/TextCommandFramework/_TextCommandFramework.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Discord.Net.Commands" Version="3.6.1" />
-    <PackageReference Include="Discord.Net.Websocket" Version="3.6.1" />
+    <PackageReference Include="Discord.Net.Commands" Version="3.8.1" />
+    <PackageReference Include="Discord.Net.Websocket" Version="3.8.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/WebhookClient/_WebhookClient.csproj
+++ b/samples/WebhookClient/_WebhookClient.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Webhook" Version="3.6.1" />
+    <PackageReference Include="Discord.Net.Webhook" Version="3.8.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Changes:
- bump D.Net version in samples to `3.8.1`
- add `MessageContent` intent to samples
- add a note about `MessageContent` to `v2 => v3 guide`