### PR TITLE
[Draft] Switch from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -11,7 +11,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- For .Net 3.0 and earlier the System.Text.Json package has to be installed -->
+    <PackageReference Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1' " Include="System.Text.Json" Version="7.0.0-rc.2.22472.3" />
     <PackageReference Include="System.Interactive.Async" Version="5.0.0" />
     <PackageReference Include="IDisposableAnalyzers" Version="3.4.15">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -19,7 +18,7 @@ namespace Discord
         ///     Gets a <see cref="OverwritePermissions" /> that grants all permissions for the given channel.
         /// </summary>
         /// <exception cref="ArgumentException">Unknown channel type.</exception>
-        public static OverwritePermissions AllowAll(IChannel channel) 
+        public static OverwritePermissions AllowAll(IChannel channel)
             => new OverwritePermissions(ChannelPermissions.All(channel).RawValue, 0);
         /// <summary>
         ///     Gets a <see cref="OverwritePermissions" /> that denies all permissions for the given channel.
@@ -116,24 +115,24 @@ namespace Discord
 
         private OverwritePermissions(ulong allowValue, ulong denyValue,
             PermValue? createInstantInvite = null,
-            PermValue? manageChannel = null, 
+            PermValue? manageChannel = null,
             PermValue? addReactions = null,
             PermValue? viewChannel = null,
             PermValue? sendMessages = null,
             PermValue? sendTTSMessages = null,
-            PermValue? manageMessages = null, 
+            PermValue? manageMessages = null,
             PermValue? embedLinks = null,
             PermValue? attachFiles = null,
             PermValue? readMessageHistory = null,
-            PermValue? mentionEveryone = null, 
+            PermValue? mentionEveryone = null,
             PermValue? useExternalEmojis = null,
             PermValue? connect = null,
             PermValue? speak = null,
-            PermValue? muteMembers = null, 
+            PermValue? muteMembers = null,
             PermValue? deafenMembers = null,
             PermValue? moveMembers = null,
             PermValue? useVoiceActivation = null,
-            PermValue? manageRoles = null, 
+            PermValue? manageRoles = null,
             PermValue? manageWebhooks = null,
             PermValue? prioritySpeaker = null,
             PermValue? stream = null,
@@ -194,7 +193,7 @@ namespace Discord
             PermValue viewChannel = PermValue.Inherit,
             PermValue sendMessages = PermValue.Inherit,
             PermValue sendTTSMessages = PermValue.Inherit,
-            PermValue manageMessages = PermValue.Inherit, 
+            PermValue manageMessages = PermValue.Inherit,
             PermValue embedLinks = PermValue.Inherit,
             PermValue attachFiles = PermValue.Inherit,
             PermValue readMessageHistory = PermValue.Inherit,
@@ -221,8 +220,8 @@ namespace Discord
             PermValue useExternalStickers = PermValue.Inherit,
             PermValue sendMessagesInThreads = PermValue.Inherit,
             PermValue startEmbeddedActivities = PermValue.Inherit)
-            : this(0, 0, createInstantInvite, manageChannel, addReactions, viewChannel, sendMessages, sendTTSMessages, manageMessages, 
-                  embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, 
+            : this(0, 0, createInstantInvite, manageChannel, addReactions, viewChannel, sendMessages, sendTTSMessages, manageMessages,
+                  embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers,
                   moveMembers, useVoiceActivation, manageRoles, manageWebhooks, prioritySpeaker, stream, useSlashCommands, useApplicationCommands,
                   requestToSpeak, manageThreads, createPublicThreads, createPrivateThreads, usePublicThreads, usePrivateThreads, useExternalStickers,
                   sendMessagesInThreads, startEmbeddedActivities) { }
@@ -238,11 +237,11 @@ namespace Discord
             PermValue? viewChannel = null,
             PermValue? sendMessages = null,
             PermValue? sendTTSMessages = null,
-            PermValue? manageMessages = null, 
+            PermValue? manageMessages = null,
             PermValue? embedLinks = null,
             PermValue? attachFiles = null,
             PermValue? readMessageHistory = null,
-            PermValue? mentionEveryone = null, 
+            PermValue? mentionEveryone = null,
             PermValue? useExternalEmojis = null,
             PermValue? connect = null,
             PermValue? speak = null,
@@ -265,8 +264,8 @@ namespace Discord
             PermValue? useExternalStickers = null,
             PermValue? sendMessagesInThreads = null,
             PermValue? startEmbeddedActivities = null)
-            => new OverwritePermissions(AllowValue, DenyValue, createInstantInvite, manageChannel, addReactions, viewChannel, sendMessages, sendTTSMessages, manageMessages, 
-                embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, 
+            => new OverwritePermissions(AllowValue, DenyValue, createInstantInvite, manageChannel, addReactions, viewChannel, sendMessages, sendTTSMessages, manageMessages,
+                embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers,
                 moveMembers, useVoiceActivation, manageRoles, manageWebhooks, prioritySpeaker, stream, useSlashCommands, useApplicationCommands,
                   requestToSpeak, manageThreads, createPublicThreads, createPrivateThreads, usePublicThreads, usePrivateThreads, useExternalStickers,
                   sendMessagesInThreads, startEmbeddedActivities);
@@ -305,7 +304,7 @@ namespace Discord
         }
 
         public override string ToString() => $"Allow {AllowValue}, Deny {DenyValue}";
-        private string DebuggerDisplay => 
+        private string DebuggerDisplay =>
             $"Allow {string.Join(", ", ToAllowList())}, " +
             $"Deny {string.Join(", ", ToDenyList())}";
     }

--- a/src/Discord.Net.Rest/API/Common/ActionRowComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/ActionRowComponent.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Linq;
 
 namespace Discord.API
 {
     internal class ActionRowComponent : IMessageComponent
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ComponentType Type { get; set; }
 
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public IMessageComponent[] Components { get; set; }
 
         internal ActionRowComponent() { }

--- a/src/Discord.Net.Rest/API/Common/AllowedMentions.cs
+++ b/src/Discord.Net.Rest/API/Common/AllowedMentions.cs
@@ -1,17 +1,17 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class AllowedMentions
     {
-        [JsonProperty("parse")]
+        [JsonPropertyName("parse")]
         public Optional<string[]> Parse { get; set; }
         // Roles and Users have a max size of 100
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<ulong[]> Roles { get; set; }
-        [JsonProperty("users")]
+        [JsonPropertyName("users")]
         public Optional<ulong[]> Users { get; set; }
-        [JsonProperty("replied_user")]
+        [JsonPropertyName("replied_user")]
         public Optional<bool> RepliedUser { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Application.cs
+++ b/src/Discord.Net.Rest/API/Common/Application.cs
@@ -1,36 +1,36 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Application
     {
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
-        [JsonProperty("rpc_origins")]
+        [JsonPropertyName("rpc_origins")]
         public Optional<string[]> RPCOrigins { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public string Icon { get; set; }
-        [JsonProperty("bot_public")]
+        [JsonPropertyName("bot_public")]
         public bool IsBotPublic { get; set; }
-        [JsonProperty("bot_require_code_grant")]
+        [JsonPropertyName("bot_require_code_grant")]
         public bool BotRequiresCodeGrant { get; set; }
-        [JsonProperty("install_params")]
+        [JsonPropertyName("install_params")]
         public Optional<InstallParams> InstallParams { get; set; }
-        [JsonProperty("team")]
+        [JsonPropertyName("team")]
         public Team Team { get; set; }
-        [JsonProperty("flags"), Int53]
+        [JsonPropertyName("flags"), Int53]
         public Optional<ApplicationFlags> Flags { get; set; }
-        [JsonProperty("owner")]
+        [JsonPropertyName("owner")]
         public Optional<User> Owner { get; set; }
-        [JsonProperty("tags")]
+        [JsonPropertyName("tags")]
         public Optional<string[]> Tags { get; set; }
-        [JsonProperty("terms_of_service_url")]
+        [JsonPropertyName("terms_of_service_url")]
         public string TermsOfService { get; set; }
-        [JsonProperty("privacy_policy_url")]
+        [JsonPropertyName("privacy_policy_url")]
         public string PrivacyPolicy { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommand.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommand.cs
@@ -1,48 +1,48 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API
 {
     internal class ApplicationCommand
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandType Type { get; set; } = ApplicationCommandType.Slash; // defaults to 1 which is slash.
 
-        [JsonProperty("application_id")]
+        [JsonPropertyName("application_id")]
         public ulong ApplicationId { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public Optional<ApplicationCommandOption[]> Options { get; set; }
 
-        [JsonProperty("default_permission")]
+        [JsonPropertyName("default_permission")]
         public Optional<bool> DefaultPermissions { get; set; }
 
-        [JsonProperty("name_localizations")]
+        [JsonPropertyName("name_localizations")]
         public Optional<Dictionary<string, string>> NameLocalizations { get; set; }
 
-        [JsonProperty("description_localizations")]
+        [JsonPropertyName("description_localizations")]
         public Optional<Dictionary<string, string>> DescriptionLocalizations { get; set; }
 
-        [JsonProperty("name_localized")]
+        [JsonPropertyName("name_localized")]
         public Optional<string> NameLocalized { get; set; }
 
-        [JsonProperty("description_localized")]
+        [JsonPropertyName("description_localized")]
         public Optional<string> DescriptionLocalized { get; set; }
-        
+
         // V2 Permissions
-        [JsonProperty("dm_permission")]
+        [JsonPropertyName("dm_permission")]
         public Optional<bool?> DmPermission { get; set; }
 
-        [JsonProperty("default_member_permissions")]
+        [JsonPropertyName("default_member_permissions")]
         public Optional<GuildPermission?> DefaultMemberPermission { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class ApplicationCommandInteractionData : IResolvable, IDiscordInteractionData
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public Optional<ApplicationCommandInteractionDataOption[]> Options { get; set; }
 
-        [JsonProperty("resolved")]
+        [JsonPropertyName("resolved")]
         public Optional<ApplicationCommandInteractionDataResolved> Resolved { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandType Type { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class ApplicationCommandInteractionDataOption
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandOptionType Type { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public Optional<object> Value { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public Optional<ApplicationCommandInteractionDataOption[]> Options { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataResolved.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataResolved.cs
@@ -1,24 +1,24 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API
 {
     internal class ApplicationCommandInteractionDataResolved
     {
-        [JsonProperty("users")]
+        [JsonPropertyName("users")]
         public Optional<Dictionary<string, User>> Users { get; set; }
 
-        [JsonProperty("members")]
+        [JsonPropertyName("members")]
         public Optional<Dictionary<string, GuildMember>> Members { get; set; }
 
-        [JsonProperty("channels")]
+        [JsonPropertyName("channels")]
         public Optional<Dictionary<string, Channel>> Channels { get; set; }
 
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<Dictionary<string, Role>> Roles { get; set; }
-        [JsonProperty("messages")]
+        [JsonPropertyName("messages")]
         public Optional<Dictionary<string, Message>> Messages { get; set; }
-        [JsonProperty("attachments")]
+        [JsonPropertyName("attachments")]
         public Optional<Dictionary<string, Attachment>> Attachments { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,55 +6,55 @@ namespace Discord.API
 {
     internal class ApplicationCommandOption
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandOptionType Type { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public Optional<bool> Default { get; set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public Optional<bool> Required { get; set; }
 
-        [JsonProperty("choices")]
+        [JsonPropertyName("choices")]
         public Optional<ApplicationCommandOptionChoice[]> Choices { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public Optional<ApplicationCommandOption[]> Options { get; set; }
 
-        [JsonProperty("autocomplete")]
+        [JsonPropertyName("autocomplete")]
         public Optional<bool> Autocomplete { get; set; }
 
-        [JsonProperty("min_value")]
+        [JsonPropertyName("min_value")]
         public Optional<double> MinValue { get; set; }
 
-        [JsonProperty("max_value")]
+        [JsonPropertyName("max_value")]
         public Optional<double> MaxValue { get; set; }
 
-        [JsonProperty("channel_types")]
+        [JsonPropertyName("channel_types")]
         public Optional<ChannelType[]> ChannelTypes { get; set; }
 
-        [JsonProperty("name_localizations")]
+        [JsonPropertyName("name_localizations")]
         public Optional<Dictionary<string, string>> NameLocalizations { get; set; }
 
-        [JsonProperty("description_localizations")]
+        [JsonPropertyName("description_localizations")]
         public Optional<Dictionary<string, string>> DescriptionLocalizations { get; set; }
 
-        [JsonProperty("name_localized")]
+        [JsonPropertyName("name_localized")]
         public Optional<string> NameLocalized { get; set; }
 
-        [JsonProperty("description_localized")]
+        [JsonPropertyName("description_localized")]
         public Optional<string> DescriptionLocalized { get; set; }
 
-        [JsonProperty("min_length")]
+        [JsonPropertyName("min_length")]
         public Optional<int> MinLength { get; set; }
 
-        [JsonProperty("max_length")]
+        [JsonPropertyName("max_length")]
         public Optional<int> MaxLength { get; set; }
 
         public ApplicationCommandOption() { }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOptionChoice.cs
@@ -1,20 +1,20 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API
 {
     internal class ApplicationCommandOptionChoice
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public object Value { get; set; }
 
-        [JsonProperty("name_localizations")]
+        [JsonPropertyName("name_localizations")]
         public Optional<Dictionary<string, string>> NameLocalizations { get; set; }
 
-        [JsonProperty("name_localized")]
+        [JsonPropertyName("name_localized")]
         public Optional<string> NameLocalized { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandPermissions.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandPermissions.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class ApplicationCommandPermissions
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandPermissionTarget Type { get; set; }
 
-        [JsonProperty("permission")]
+        [JsonPropertyName("permission")]
         public bool Permission { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Attachment.cs
+++ b/src/Discord.Net.Rest/API/Common/Attachment.cs
@@ -1,28 +1,28 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Attachment
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("filename")]
+        [JsonPropertyName("filename")]
         public string Filename { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public Optional<string> Description { get; set; }
-        [JsonProperty("content_type")]
+        [JsonPropertyName("content_type")]
         public Optional<string> ContentType { get; set; }
-        [JsonProperty("size")]
+        [JsonPropertyName("size")]
         public int Size { get; set; }
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
-        [JsonProperty("proxy_url")]
+        [JsonPropertyName("proxy_url")]
         public string ProxyUrl { get; set; }
-        [JsonProperty("height")]
+        [JsonPropertyName("height")]
         public Optional<int> Height { get; set; }
-        [JsonProperty("width")]
+        [JsonPropertyName("width")]
         public Optional<int> Width { get; set; }
-        [JsonProperty("ephemeral")]
+        [JsonPropertyName("ephemeral")]
         public Optional<bool> Ephemeral { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/AuditLog.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLog.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class AuditLog
     {
-        [JsonProperty("webhooks")]
+        [JsonPropertyName("webhooks")]
         public Webhook[] Webhooks { get; set; }
 
-        [JsonProperty("threads")]
+        [JsonPropertyName("threads")]
         public Channel[] Threads { get; set; }
 
-        [JsonProperty("integrations")]
+        [JsonPropertyName("integrations")]
         public Integration[] Integrations { get; set; }
 
-        [JsonProperty("users")]
+        [JsonPropertyName("users")]
         public User[] Users { get; set; }
 
-        [JsonProperty("audit_log_entries")]
+        [JsonPropertyName("audit_log_entries")]
         public AuditLogEntry[] Entries { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/AuditLogChange.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogChange.cs
@@ -1,17 +1,17 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 using Newtonsoft.Json.Linq;
 
 namespace Discord.API
 {
     internal class AuditLogChange
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string ChangedProperty { get; set; }
 
-        [JsonProperty("new_value")]
+        [JsonPropertyName("new_value")]
         public JToken NewValue { get; set; }
 
-        [JsonProperty("old_value")]
+        [JsonPropertyName("old_value")]
         public JToken OldValue { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/AuditLogEntry.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogEntry.cs
@@ -1,26 +1,26 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class AuditLogEntry
     {
-        [JsonProperty("target_id")]
+        [JsonPropertyName("target_id")]
         public ulong? TargetId { get; set; }
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong? UserId { get; set; }
 
-        [JsonProperty("changes")]
+        [JsonPropertyName("changes")]
         public AuditLogChange[] Changes { get; set; }
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public AuditLogOptions Options { get; set; }
 
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("action_type")]
+        [JsonPropertyName("action_type")]
         public ActionType Action { get; set; }
 
-        [JsonProperty("reason")]
+        [JsonPropertyName("reason")]
         public string Reason { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
+++ b/src/Discord.Net.Rest/API/Common/AuditLogOptions.cs
@@ -1,28 +1,28 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class AuditLogOptions
     {
-        [JsonProperty("count")]
+        [JsonPropertyName("count")]
         public int? Count { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong? ChannelId { get; set; }
-        [JsonProperty("message_id")]
+        [JsonPropertyName("message_id")]
         public ulong? MessageId { get; set; }
 
         //Prune
-        [JsonProperty("delete_member_days")]
+        [JsonPropertyName("delete_member_days")]
         public int? PruneDeleteMemberDays { get; set; }
-        [JsonProperty("members_removed")]
+        [JsonPropertyName("members_removed")]
         public int? PruneMembersRemoved { get; set; }
 
         //Overwrite Update
-        [JsonProperty("role_name")]
+        [JsonPropertyName("role_name")]
         public string OverwriteRoleName { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public PermissionTarget OverwriteType { get; set; }
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong? OverwriteTargetId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/AutocompleteInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/AutocompleteInteractionData.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class AutocompleteInteractionData : IDiscordInteractionData
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandType Type { get; set; }
 
-        [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public ulong Version { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public AutocompleteInteractionDataOption[] Options { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/AutocompleteInteractionDataOption.cs
+++ b/src/Discord.Net.Rest/API/Common/AutocompleteInteractionDataOption.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class AutocompleteInteractionDataOption
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandOptionType Type { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public Optional<AutocompleteInteractionDataOption[]> Options { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public Optional<object> Value { get; set; }
 
-        [JsonProperty("focused")]
+        [JsonPropertyName("focused")]
         public Optional<bool> Focused { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Ban.cs
+++ b/src/Discord.Net.Rest/API/Common/Ban.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Ban
     {
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
-        [JsonProperty("reason")]
+        [JsonPropertyName("reason")]
         public string Reason { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ButtonComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/ButtonComponent.cs
@@ -1,28 +1,28 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class ButtonComponent : IMessageComponent
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ComponentType Type { get; set; }
 
-        [JsonProperty("style")]
+        [JsonPropertyName("style")]
         public ButtonStyle Style { get; set; }
 
-        [JsonProperty("label")]
+        [JsonPropertyName("label")]
         public Optional<string> Label { get; set; }
 
-        [JsonProperty("emoji")]
+        [JsonPropertyName("emoji")]
         public Optional<Emoji> Emote { get; set; }
 
-        [JsonProperty("custom_id")]
+        [JsonPropertyName("custom_id")]
         public Optional<string> CustomId { get; set; }
 
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public Optional<string> Url { get; set; }
 
-        [JsonProperty("disabled")]
+        [JsonPropertyName("disabled")]
         public Optional<bool> Disabled { get; set; }
 
         public ButtonComponent() { }

--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
@@ -6,72 +6,72 @@ namespace Discord.API
     internal class Channel
     {
         //Shared
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ChannelType Type { get; set; }
-        [JsonProperty("last_message_id")]
+        [JsonPropertyName("last_message_id")]
         public ulong? LastMessageId { get; set; }
 
         //GuildChannel
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("position")]
+        [JsonPropertyName("position")]
         public Optional<int> Position { get; set; }
-        [JsonProperty("permission_overwrites")]
+        [JsonPropertyName("permission_overwrites")]
         public Optional<Overwrite[]> PermissionOverwrites { get; set; }
-        [JsonProperty("parent_id")]
+        [JsonPropertyName("parent_id")]
         public ulong? CategoryId { get; set; }
 
         //TextChannel
-        [JsonProperty("topic")]
+        [JsonPropertyName("topic")]
         public Optional<string> Topic { get; set; }
-        [JsonProperty("last_pin_timestamp")]
+        [JsonPropertyName("last_pin_timestamp")]
         public Optional<DateTimeOffset?> LastPinTimestamp { get; set; }
-        [JsonProperty("nsfw")]
+        [JsonPropertyName("nsfw")]
         public Optional<bool> Nsfw { get; set; }
-        [JsonProperty("rate_limit_per_user")]
+        [JsonPropertyName("rate_limit_per_user")]
         public Optional<int> SlowMode { get; set; }
 
         //VoiceChannel
-        [JsonProperty("bitrate")]
+        [JsonPropertyName("bitrate")]
         public Optional<int> Bitrate { get; set; }
-        [JsonProperty("user_limit")]
+        [JsonPropertyName("user_limit")]
         public Optional<int> UserLimit { get; set; }
-        [JsonProperty("rtc_region")]
+        [JsonPropertyName("rtc_region")]
         public Optional<string> RTCRegion { get; set; }
 
         //PrivateChannel
-        [JsonProperty("recipients")]
+        [JsonPropertyName("recipients")]
         public Optional<User[]> Recipients { get; set; }
 
         //GroupChannel
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public Optional<string> Icon { get; set; }
 
         //ThreadChannel
-        [JsonProperty("member")]
+        [JsonPropertyName("member")]
         public Optional<ThreadMember> ThreadMember { get; set; }
 
-        [JsonProperty("thread_metadata")]
+        [JsonPropertyName("thread_metadata")]
         public Optional<ThreadMetadata> ThreadMetadata { get; set; }
 
-        [JsonProperty("owner_id")]
+        [JsonPropertyName("owner_id")]
         public Optional<ulong> OwnerId { get; set; }
 
-        [JsonProperty("message_count")]
+        [JsonPropertyName("message_count")]
         public Optional<int> MessageCount { get; set; }
 
-        [JsonProperty("member_count")]
+        [JsonPropertyName("member_count")]
         public Optional<int> MemberCount { get; set; }
 
         //ForumChannel
-        [JsonProperty("available_tags")]
+        [JsonPropertyName("available_tags")]
         public Optional<ForumTags[]> ForumTags { get; set; }
-        
-        [JsonProperty("default_auto_archive_duration")]
+
+        [JsonPropertyName("default_auto_archive_duration")]
         public Optional<ThreadArchiveDuration> AutoArchiveDuration { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ChannelThreads.cs
+++ b/src/Discord.Net.Rest/API/Common/ChannelThreads.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class ChannelThreads
     {
-        [JsonProperty("threads")]
+        [JsonPropertyName("threads")]
         public Channel[] Threads { get; set; }
 
-        [JsonProperty("members")]
+        [JsonPropertyName("members")]
         public ThreadMember[] Members { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Connection.cs
+++ b/src/Discord.Net.Rest/API/Common/Connection.cs
@@ -1,27 +1,27 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API
 {
     internal class Connection
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; set; }
-        [JsonProperty("revoked")]
+        [JsonPropertyName("revoked")]
         public Optional<bool> Revoked { get; set; }
-        [JsonProperty("integrations")]
+        [JsonPropertyName("integrations")]
         public Optional<IReadOnlyCollection<Integration>> Integrations { get; set; }
-        [JsonProperty("verified")]
+        [JsonPropertyName("verified")]
         public bool Verified { get; set; }
-        [JsonProperty("friend_sync")]
+        [JsonPropertyName("friend_sync")]
         public bool FriendSync { get; set; }
-        [JsonProperty("show_activity")]
+        [JsonPropertyName("show_activity")]
         public bool ShowActivity { get; set; }
-        [JsonProperty("visibility")]
+        [JsonPropertyName("visibility")]
         public ConnectionVisibility Visibility { get; set; }
 
     }

--- a/src/Discord.Net.Rest/API/Common/DiscordError.cs
+++ b/src/Discord.Net.Rest/API/Common/DiscordError.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,11 +10,11 @@ namespace Discord.API
     [JsonConverter(typeof(Discord.Net.Converters.DiscordErrorConverter))]
     internal class DiscordError
     {
-        [JsonProperty("message")]
+        [JsonPropertyName("message")]
         public string Message { get; set; }
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public DiscordErrorCode Code { get; set; }
-        [JsonProperty("errors")]
+        [JsonPropertyName("errors")]
         public Optional<ErrorDetails[]> Errors { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Embed.cs
+++ b/src/Discord.Net.Rest/API/Common/Embed.cs
@@ -1,36 +1,36 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Discord.Net.Converters;
 
 namespace Discord.API
 {
     internal class Embed
     {
-        [JsonProperty("title")]
+        [JsonPropertyName("title")]
         public string Title { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
-        [JsonProperty("color")]
+        [JsonPropertyName("color")]
         public uint? Color { get; set; }
-        [JsonProperty("type"), JsonConverter(typeof(EmbedTypeConverter))]
+        [JsonPropertyName("type"), JsonConverter(typeof(EmbedTypeConverter))]
         public EmbedType Type { get; set; }
-        [JsonProperty("timestamp")]
+        [JsonPropertyName("timestamp")]
         public DateTimeOffset? Timestamp { get; set; }
-        [JsonProperty("author")]
+        [JsonPropertyName("author")]
         public Optional<EmbedAuthor> Author { get; set; }
-        [JsonProperty("footer")]
+        [JsonPropertyName("footer")]
         public Optional<EmbedFooter> Footer { get; set; }
-        [JsonProperty("video")]
+        [JsonPropertyName("video")]
         public Optional<EmbedVideo> Video { get; set; }
-        [JsonProperty("thumbnail")]
+        [JsonPropertyName("thumbnail")]
         public Optional<EmbedThumbnail> Thumbnail { get; set; }
-        [JsonProperty("image")]
+        [JsonPropertyName("image")]
         public Optional<EmbedImage> Image { get; set; }
-        [JsonProperty("provider")]
+        [JsonPropertyName("provider")]
         public Optional<EmbedProvider> Provider { get; set; }
-        [JsonProperty("fields")]
+        [JsonPropertyName("fields")]
         public Optional<EmbedField[]> Fields { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedAuthor.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedAuthor.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class EmbedAuthor
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
-        [JsonProperty("icon_url")]
+        [JsonPropertyName("icon_url")]
         public string IconUrl { get; set; }
-        [JsonProperty("proxy_icon_url")]
+        [JsonPropertyName("proxy_icon_url")]
         public string ProxyIconUrl { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedField.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedField.cs
@@ -1,14 +1,14 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class EmbedField
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public string Value { get; set; }
-        [JsonProperty("inline")]
+        [JsonPropertyName("inline")]
         public bool Inline { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedFooter.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedFooter.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class EmbedFooter
     {
-        [JsonProperty("text")]
+        [JsonPropertyName("text")]
         public string Text { get; set; }
-        [JsonProperty("icon_url")]
+        [JsonPropertyName("icon_url")]
         public string IconUrl { get; set; }
-        [JsonProperty("proxy_icon_url")]
+        [JsonPropertyName("proxy_icon_url")]
         public string ProxyIconUrl { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedImage.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedImage.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class EmbedImage
     {
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
-        [JsonProperty("proxy_url")]
+        [JsonPropertyName("proxy_url")]
         public string ProxyUrl { get; set; }
-        [JsonProperty("height")]
+        [JsonPropertyName("height")]
         public Optional<int> Height { get; set; }
-        [JsonProperty("width")]
+        [JsonPropertyName("width")]
         public Optional<int> Width { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedProvider.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedProvider.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class EmbedProvider
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedThumbnail.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedThumbnail.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class EmbedThumbnail
     {
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
-        [JsonProperty("proxy_url")]
+        [JsonPropertyName("proxy_url")]
         public string ProxyUrl { get; set; }
-        [JsonProperty("height")]
+        [JsonPropertyName("height")]
         public Optional<int> Height { get; set; }
-        [JsonProperty("width")]
+        [JsonPropertyName("width")]
         public Optional<int> Width { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/EmbedVideo.cs
+++ b/src/Discord.Net.Rest/API/Common/EmbedVideo.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class EmbedVideo
     {
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
-        [JsonProperty("height")]
+        [JsonPropertyName("height")]
         public Optional<int> Height { get; set; }
-        [JsonProperty("width")]
+        [JsonPropertyName("width")]
         public Optional<int> Width { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Emoji.cs
+++ b/src/Discord.Net.Rest/API/Common/Emoji.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Emoji
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong? Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("animated")]
+        [JsonPropertyName("animated")]
         public bool? Animated { get; set; }
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public ulong[] Roles { get; set; }
-        [JsonProperty("require_colons")]
+        [JsonPropertyName("require_colons")]
         public bool RequireColons { get; set; }
-        [JsonProperty("managed")]
+        [JsonPropertyName("managed")]
         public bool Managed { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public Optional<User> User { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Error.cs
+++ b/src/Discord.Net.Rest/API/Common/Error.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Error
     {
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; set; }
-        [JsonProperty("message")]
+        [JsonPropertyName("message")]
         public string Message { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ForumTags.cs
+++ b/src/Discord.Net.Rest/API/Common/ForumTags.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,13 +9,13 @@ namespace Discord.API
 {
     internal class ForumTags
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("emoji_id")]
+        [JsonPropertyName("emoji_id")]
         public Optional<ulong?> EmojiId { get; set; }
-        [JsonProperty("emoji_name")]
+        [JsonPropertyName("emoji_name")]
         public Optional<string> EmojiName { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ForumThreadMessage.cs
+++ b/src/Discord.Net.Rest/API/Common/ForumThreadMessage.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,25 +9,25 @@ namespace Discord.API
 {
     internal class ForumThreadMessage
     {
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public Optional<string> Content { get; set; }
 
-        [JsonProperty("nonce")]
+        [JsonPropertyName("nonce")]
         public Optional<string> Nonce { get; set; }
 
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<Embed[]> Embeds { get; set; }
 
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
 
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<API.ActionRowComponent[]> Components { get; set; }
 
-        [JsonProperty("sticker_ids")]
+        [JsonPropertyName("sticker_ids")]
         public Optional<ulong[]> Stickers { get; set; }
 
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public Optional<MessageFlags> Flags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Game.cs
+++ b/src/Discord.Net.Rest/API/Common/Game.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json.Serialization;
 using System.Runtime.Serialization;
 
@@ -6,41 +6,41 @@ namespace Discord.API
 {
     internal class Game
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public Optional<string> StreamUrl { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public Optional<ActivityType?> Type { get; set; }
-        [JsonProperty("details")]
+        [JsonPropertyName("details")]
         public Optional<string> Details { get; set; }
-        [JsonProperty("state")]
+        [JsonPropertyName("state")]
         public Optional<string> State { get; set; }
-        [JsonProperty("application_id")]
+        [JsonPropertyName("application_id")]
         public Optional<ulong> ApplicationId { get; set; }
-        [JsonProperty("assets")]
+        [JsonPropertyName("assets")]
         public Optional<API.GameAssets> Assets { get; set; }
-        [JsonProperty("party")]
+        [JsonPropertyName("party")]
         public Optional<API.GameParty> Party { get; set; }
-        [JsonProperty("secrets")]
+        [JsonPropertyName("secrets")]
         public Optional<API.GameSecrets> Secrets { get; set; }
-        [JsonProperty("timestamps")]
+        [JsonPropertyName("timestamps")]
         public Optional<API.GameTimestamps> Timestamps { get; set; }
-        [JsonProperty("instance")]
+        [JsonPropertyName("instance")]
         public Optional<bool> Instance { get; set; }
-        [JsonProperty("sync_id")]
+        [JsonPropertyName("sync_id")]
         public Optional<string> SyncId { get; set; }
-        [JsonProperty("session_id")]
+        [JsonPropertyName("session_id")]
         public Optional<string> SessionId { get; set; }
-        [JsonProperty("Flags")]
+        [JsonPropertyName("Flags")]
         public Optional<ActivityProperties> Flags { get; set; }
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public Optional<string> Id { get; set; }
-        [JsonProperty("emoji")]
+        [JsonPropertyName("emoji")]
         public Optional<Emoji> Emoji { get; set; }
-        [JsonProperty("created_at")]
+        [JsonPropertyName("created_at")]
         public Optional<long> CreatedAt { get; set; }
-        //[JsonProperty("buttons")]
+        //[JsonPropertyName("buttons")]
         //public Optional<RichPresenceButton[]> Buttons { get; set; }
 
         [OnError]

--- a/src/Discord.Net.Rest/API/Common/GameAssets.cs
+++ b/src/Discord.Net.Rest/API/Common/GameAssets.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class GameAssets
     {
-        [JsonProperty("small_text")]
+        [JsonPropertyName("small_text")]
         public Optional<string> SmallText { get; set; }
-        [JsonProperty("small_image")]
+        [JsonPropertyName("small_image")]
         public Optional<string> SmallImage { get; set; }
-        [JsonProperty("large_text")]
+        [JsonPropertyName("large_text")]
         public Optional<string> LargeText { get; set; }
-        [JsonProperty("large_image")]
+        [JsonPropertyName("large_image")]
         public Optional<string> LargeImage { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GameParty.cs
+++ b/src/Discord.Net.Rest/API/Common/GameParty.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class GameParty
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
-        [JsonProperty("size")]
+        [JsonPropertyName("size")]
         public long[] Size { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GameSecrets.cs
+++ b/src/Discord.Net.Rest/API/Common/GameSecrets.cs
@@ -1,14 +1,14 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class GameSecrets
     {
-        [JsonProperty("match")]
+        [JsonPropertyName("match")]
         public string Match { get; set; }
-        [JsonProperty("join")]
+        [JsonPropertyName("join")]
         public string Join { get; set; }
-        [JsonProperty("spectate")]
+        [JsonPropertyName("spectate")]
         public string Spectate { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GameTimestamps.cs
+++ b/src/Discord.Net.Rest/API/Common/GameTimestamps.cs
@@ -1,14 +1,14 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class GameTimestamps
     {
-        [JsonProperty("start")]
+        [JsonPropertyName("start")]
         [UnixTimestamp]
         public Optional<DateTimeOffset> Start { get; set; }
-        [JsonProperty("end")]
+        [JsonPropertyName("end")]
         [UnixTimestamp]
         public Optional<DateTimeOffset> End { get; set; }
     }

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -1,87 +1,87 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Guild
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public string Icon { get; set; }
-        [JsonProperty("splash")]
+        [JsonPropertyName("splash")]
         public string Splash { get; set; }
-        [JsonProperty("discovery_splash")]
+        [JsonPropertyName("discovery_splash")]
         public string DiscoverySplash { get; set; }
-        [JsonProperty("owner_id")]
+        [JsonPropertyName("owner_id")]
         public ulong OwnerId { get; set; }
-        [JsonProperty("region")]
+        [JsonPropertyName("region")]
         public string Region { get; set; }
-        [JsonProperty("afk_channel_id")]
+        [JsonPropertyName("afk_channel_id")]
         public ulong? AFKChannelId { get; set; }
-        [JsonProperty("afk_timeout")]
+        [JsonPropertyName("afk_timeout")]
         public int AFKTimeout { get; set; }
-        [JsonProperty("verification_level")]
+        [JsonPropertyName("verification_level")]
         public VerificationLevel VerificationLevel { get; set; }
-        [JsonProperty("default_message_notifications")]
+        [JsonPropertyName("default_message_notifications")]
         public DefaultMessageNotifications DefaultMessageNotifications { get; set; }
-        [JsonProperty("explicit_content_filter")]
+        [JsonPropertyName("explicit_content_filter")]
         public ExplicitContentFilterLevel ExplicitContentFilter { get; set; }
-        [JsonProperty("voice_states")]
+        [JsonPropertyName("voice_states")]
         public VoiceState[] VoiceStates { get; set; }
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Role[] Roles { get; set; }
-        [JsonProperty("emojis")]
+        [JsonPropertyName("emojis")]
         public Emoji[] Emojis { get; set; }
-        [JsonProperty("features")]
+        [JsonPropertyName("features")]
         public GuildFeatures Features { get; set; }
-        [JsonProperty("mfa_level")]
+        [JsonPropertyName("mfa_level")]
         public MfaLevel MfaLevel { get; set; }
-        [JsonProperty("application_id")]
+        [JsonPropertyName("application_id")]
         public ulong? ApplicationId { get; set; }
-        [JsonProperty("widget_enabled")]
+        [JsonPropertyName("widget_enabled")]
         public Optional<bool> WidgetEnabled { get; set; }
-        [JsonProperty("widget_channel_id")]
+        [JsonPropertyName("widget_channel_id")]
         public Optional<ulong?> WidgetChannelId { get; set; }
-        [JsonProperty("system_channel_id")]
+        [JsonPropertyName("system_channel_id")]
         public ulong? SystemChannelId { get; set; }
-        [JsonProperty("premium_tier")]
+        [JsonPropertyName("premium_tier")]
         public PremiumTier PremiumTier { get; set; }
-        [JsonProperty("vanity_url_code")]
+        [JsonPropertyName("vanity_url_code")]
         public string VanityURLCode { get; set; }
-        [JsonProperty("banner")]
+        [JsonPropertyName("banner")]
         public string Banner { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
         // this value is inverted, flags set will turn OFF features
-        [JsonProperty("system_channel_flags")]
+        [JsonPropertyName("system_channel_flags")]
         public SystemChannelMessageDeny SystemChannelFlags { get; set; }
-        [JsonProperty("rules_channel_id")]
+        [JsonPropertyName("rules_channel_id")]
         public ulong? RulesChannelId { get; set; }
-        [JsonProperty("max_presences")]
+        [JsonPropertyName("max_presences")]
         public Optional<int?> MaxPresences { get; set; }
-        [JsonProperty("max_members")]
+        [JsonPropertyName("max_members")]
         public Optional<int> MaxMembers { get; set; }
-        [JsonProperty("premium_subscription_count")]
+        [JsonPropertyName("premium_subscription_count")]
         public int? PremiumSubscriptionCount { get; set; }
-        [JsonProperty("preferred_locale")]
+        [JsonPropertyName("preferred_locale")]
         public string PreferredLocale { get; set; }
-        [JsonProperty("public_updates_channel_id")]
+        [JsonPropertyName("public_updates_channel_id")]
         public ulong? PublicUpdatesChannelId { get; set; }
-        [JsonProperty("max_video_channel_users")]
+        [JsonPropertyName("max_video_channel_users")]
         public Optional<int> MaxVideoChannelUsers { get; set; }
-        [JsonProperty("approximate_member_count")]
+        [JsonPropertyName("approximate_member_count")]
         public Optional<int> ApproximateMemberCount { get; set; }
-        [JsonProperty("approximate_presence_count")]
+        [JsonPropertyName("approximate_presence_count")]
         public Optional<int> ApproximatePresenceCount { get; set; }
-        [JsonProperty("threads")]
+        [JsonPropertyName("threads")]
         public Optional<Channel[]> Threads { get; set; }
-        [JsonProperty("nsfw_level")]
+        [JsonPropertyName("nsfw_level")]
         public NsfwLevel NsfwLevel { get; set; }
-        [JsonProperty("stickers")]
+        [JsonPropertyName("stickers")]
         public Sticker[] Stickers { get; set; }
-        [JsonProperty("premium_progress_bar_enabled")]
+        [JsonPropertyName("premium_progress_bar_enabled")]
         public Optional<bool> IsBoostProgressBarEnabled { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildApplicationCommandPermissions.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildApplicationCommandPermissions.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class GuildApplicationCommandPermission
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("application_id")]
+        [JsonPropertyName("application_id")]
         public ulong ApplicationId { get; set; }
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
 
-        [JsonProperty("permissions")]
+        [JsonPropertyName("permissions")]
         public ApplicationCommandPermissions[] Permissions { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildMember.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildMember.cs
@@ -1,29 +1,29 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
 {
     internal class GuildMember
     {
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
-        [JsonProperty("nick")]
+        [JsonPropertyName("nick")]
         public Optional<string> Nick { get; set; }
-        [JsonProperty("avatar")]
+        [JsonPropertyName("avatar")]
         public Optional<string> Avatar { get; set; }
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<ulong[]> Roles { get; set; }
-        [JsonProperty("joined_at")]
+        [JsonPropertyName("joined_at")]
         public Optional<DateTimeOffset> JoinedAt { get; set; }
-        [JsonProperty("deaf")]
+        [JsonPropertyName("deaf")]
         public Optional<bool> Deaf { get; set; }
-        [JsonProperty("mute")]
+        [JsonPropertyName("mute")]
         public Optional<bool> Mute { get; set; }
-        [JsonProperty("pending")]
+        [JsonPropertyName("pending")]
         public Optional<bool> Pending { get; set; }
-        [JsonProperty("premium_since")]
+        [JsonPropertyName("premium_since")]
         public Optional<DateTimeOffset?> PremiumSince { get; set; }
-        [JsonProperty("communication_disabled_until")]
+        [JsonPropertyName("communication_disabled_until")]
         public Optional<DateTimeOffset?> TimedOutUntil { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildScheduledEvent.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildScheduledEvent.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,37 +9,37 @@ namespace Discord.API
 {
     internal class GuildScheduledEvent
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public Optional<ulong?> ChannelId { get; set; }
-        [JsonProperty("creator_id")]
+        [JsonPropertyName("creator_id")]
         public Optional<ulong> CreatorId { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public Optional<string> Description { get; set; }
-        [JsonProperty("scheduled_start_time")]
+        [JsonPropertyName("scheduled_start_time")]
         public DateTimeOffset ScheduledStartTime { get; set; }
-        [JsonProperty("scheduled_end_time")]
+        [JsonPropertyName("scheduled_end_time")]
         public DateTimeOffset? ScheduledEndTime { get; set; }
-        [JsonProperty("privacy_level")]
+        [JsonPropertyName("privacy_level")]
         public GuildScheduledEventPrivacyLevel PrivacyLevel { get; set; }
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public GuildScheduledEventStatus Status { get; set; }
-        [JsonProperty("entity_type")]
+        [JsonPropertyName("entity_type")]
         public GuildScheduledEventType EntityType { get; set; }
-        [JsonProperty("entity_id")]
+        [JsonPropertyName("entity_id")]
         public ulong? EntityId { get; set; }
-        [JsonProperty("entity_metadata")]
+        [JsonPropertyName("entity_metadata")]
         public GuildScheduledEventEntityMetadata EntityMetadata { get; set; }
-        [JsonProperty("creator")]
+        [JsonPropertyName("creator")]
         public Optional<User> Creator { get; set; }
-        [JsonProperty("user_count")]
+        [JsonPropertyName("user_count")]
         public Optional<int> UserCount { get; set; }
-        [JsonProperty("image")]
+        [JsonPropertyName("image")]
         public string Image { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildScheduledEventEntityMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildScheduledEventEntityMetadata.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +9,7 @@ namespace Discord.API
 {
     internal class GuildScheduledEventEntityMetadata
     {
-        [JsonProperty("location")]
+        [JsonPropertyName("location")]
         public Optional<string> Location { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildScheduledEventUser.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildScheduledEventUser.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,11 +9,11 @@ namespace Discord.API
 {
     internal class GuildScheduledEventUser
     {
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
-        [JsonProperty("member")]
+        [JsonPropertyName("member")]
         public Optional<GuildMember> Member { get; set; }
-        [JsonProperty("guild_scheduled_event_id")]
+        [JsonPropertyName("guild_scheduled_event_id")]
         public ulong GuildScheduledEventId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/GuildWidget.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildWidget.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class GuildWidget
     {
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong? ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InstallParams.cs
+++ b/src/Discord.Net.Rest/API/Common/InstallParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +9,9 @@ namespace Discord.API
 {
     internal class InstallParams
     {
-        [JsonProperty("scopes")]
+        [JsonPropertyName("scopes")]
         public string[] Scopes { get; set; }
-        [JsonProperty("permissions")]
+        [JsonPropertyName("permissions")]
         public ulong Permission { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Integration.cs
+++ b/src/Discord.Net.Rest/API/Common/Integration.cs
@@ -1,42 +1,42 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
 {
     internal class Integration
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
 
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; set; }
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; set; }
-        [JsonProperty("syncing")]
+        [JsonPropertyName("syncing")]
         public Optional<bool?> Syncing { get; set; }
-        [JsonProperty("role_id")]
+        [JsonPropertyName("role_id")]
         public Optional<ulong?> RoleId { get; set; }
-        [JsonProperty("enable_emoticons")]
+        [JsonPropertyName("enable_emoticons")]
         public Optional<bool?> EnableEmoticons { get; set; }
-        [JsonProperty("expire_behavior")]
+        [JsonPropertyName("expire_behavior")]
         public Optional<IntegrationExpireBehavior> ExpireBehavior { get; set; }
-        [JsonProperty("expire_grace_period")]
+        [JsonPropertyName("expire_grace_period")]
         public Optional<int?> ExpireGracePeriod { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public Optional<User> User { get; set; }
-        [JsonProperty("account")]
+        [JsonPropertyName("account")]
         public Optional<IntegrationAccount> Account { get; set; }
-        [JsonProperty("synced_at")]
+        [JsonPropertyName("synced_at")]
         public Optional<DateTimeOffset> SyncedAt { get; set; }
-        [JsonProperty("subscriber_count")]
+        [JsonPropertyName("subscriber_count")]
         public Optional<int?> SubscriberAccount { get; set; }
-        [JsonProperty("revoked")]
+        [JsonPropertyName("revoked")]
         public Optional<bool?> Revoked { get; set; }
-        [JsonProperty("application")]
+        [JsonPropertyName("application")]
         public Optional<IntegrationApplication> Application { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/IntegrationAccount.cs
+++ b/src/Discord.Net.Rest/API/Common/IntegrationAccount.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class IntegrationAccount
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/IntegrationApplication.cs
+++ b/src/Discord.Net.Rest/API/Common/IntegrationApplication.cs
@@ -1,20 +1,20 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class IntegrationApplication
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public Optional<string> Icon { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
-        [JsonProperty("summary")]
+        [JsonPropertyName("summary")]
         public string Summary { get; set; }
-        [JsonProperty("bot")]
+        [JsonPropertyName("bot")]
         public Optional<User> Bot { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Interaction.cs
+++ b/src/Discord.Net.Rest/API/Common/Interaction.cs
@@ -1,47 +1,47 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     [JsonConverter(typeof(Net.Converters.InteractionConverter))]
     internal class Interaction
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("application_id")]
+        [JsonPropertyName("application_id")]
         public ulong ApplicationId { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public InteractionType Type { get; set; }
 
-        [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public Optional<IDiscordInteractionData> Data { get; set; }
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
 
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public Optional<ulong> ChannelId { get; set; }
 
-        [JsonProperty("member")]
+        [JsonPropertyName("member")]
         public Optional<GuildMember> Member { get; set; }
 
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public Optional<User> User { get; set; }
 
-        [JsonProperty("token")]
+        [JsonPropertyName("token")]
         public string Token { get; set; }
 
-        [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public int Version { get; set; }
 
-        [JsonProperty("message")]
+        [JsonPropertyName("message")]
         public Optional<Message> Message { get; set; }
 
-        [JsonProperty("locale")]
+        [JsonPropertyName("locale")]
         public Optional<string> UserLocale { get; set; }
 
-        [JsonProperty("guild_locale")]
+        [JsonPropertyName("guild_locale")]
         public Optional<string> GuildLocale { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InteractionCallbackData.cs
+++ b/src/Discord.Net.Rest/API/Common/InteractionCallbackData.cs
@@ -1,34 +1,34 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class InteractionCallbackData
     {
-        [JsonProperty("tts")]
+        [JsonPropertyName("tts")]
         public Optional<bool> TTS { get; set; }
 
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public Optional<string> Content { get; set; }
 
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<Embed[]> Embeds { get; set; }
 
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
 
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public Optional<MessageFlags> Flags { get; set; }
 
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<ActionRowComponent[]> Components { get; set; }
 
-        [JsonProperty("choices")]
+        [JsonPropertyName("choices")]
         public Optional<ApplicationCommandOptionChoice[]> Choices { get; set; }
 
-        [JsonProperty("title")]
+        [JsonPropertyName("title")]
         public Optional<string> Title { get; set; }
 
-        [JsonProperty("custom_id")]
+        [JsonPropertyName("custom_id")]
         public Optional<string> CustomId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InteractionResponse.cs
+++ b/src/Discord.Net.Rest/API/Common/InteractionResponse.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class InteractionResponse
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public InteractionResponseType Type { get; set; }
 
-        [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public Optional<InteractionCallbackData> Data { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Invite.cs
+++ b/src/Discord.Net.Rest/API/Common/Invite.cs
@@ -1,24 +1,24 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Invite
     {
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; set; }
-        [JsonProperty("guild")]
+        [JsonPropertyName("guild")]
         public Optional<InviteGuild> Guild { get; set; }
-        [JsonProperty("channel")]
+        [JsonPropertyName("channel")]
         public InviteChannel Channel { get; set; }
-        [JsonProperty("inviter")]
+        [JsonPropertyName("inviter")]
         public Optional<User> Inviter { get; set; }
-        [JsonProperty("approximate_presence_count")]
+        [JsonPropertyName("approximate_presence_count")]
         public Optional<int?> PresenceCount { get; set; }
-        [JsonProperty("approximate_member_count")]
+        [JsonPropertyName("approximate_member_count")]
         public Optional<int?> MemberCount { get; set; }
-        [JsonProperty("target_user")]
+        [JsonPropertyName("target_user")]
         public Optional<User> TargetUser { get; set; }
-        [JsonProperty("target_user_type")]
+        [JsonPropertyName("target_user_type")]
         public Optional<TargetUserType> TargetUserType { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InviteChannel.cs
+++ b/src/Discord.Net.Rest/API/Common/InviteChannel.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class InviteChannel
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public int Type { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InviteGuild.cs
+++ b/src/Discord.Net.Rest/API/Common/InviteGuild.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class InviteGuild
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("splash_hash")]
+        [JsonPropertyName("splash_hash")]
         public string SplashHash { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InviteMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/InviteMetadata.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
 {
     internal class InviteMetadata : Invite
     {
-        [JsonProperty("uses")]
+        [JsonPropertyName("uses")]
         public int Uses { get; set; }
-        [JsonProperty("max_uses")]
+        [JsonPropertyName("max_uses")]
         public int MaxUses { get; set; }
-        [JsonProperty("max_age")]
+        [JsonPropertyName("max_age")]
         public int MaxAge { get; set; }
-        [JsonProperty("temporary")]
+        [JsonPropertyName("temporary")]
         public bool Temporary { get; set; }
-        [JsonProperty("created_at")]
+        [JsonPropertyName("created_at")]
         public DateTimeOffset CreatedAt { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InviteVanity.cs
+++ b/src/Discord.Net.Rest/API/Common/InviteVanity.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
@@ -10,13 +10,13 @@ namespace Discord.API
         /// <summary>
         /// The unique code for the invite link.
         /// </summary>
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; set; }
 
         /// <summary>
         /// The total amount of vanity invite uses.
         /// </summary>
-        [JsonProperty("uses")]
+        [JsonPropertyName("uses")]
         public int Uses { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Message.cs
+++ b/src/Discord.Net.Rest/API/Common/Message.cs
@@ -1,66 +1,66 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
 {
     internal class Message
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public MessageType Type { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
         // ALWAYS sent on WebSocket messages
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
-        [JsonProperty("webhook_id")]
+        [JsonPropertyName("webhook_id")]
         public Optional<ulong> WebhookId { get; set; }
-        [JsonProperty("author")]
+        [JsonPropertyName("author")]
         public Optional<User> Author { get; set; }
         // ALWAYS sent on WebSocket messages
-        [JsonProperty("member")]
+        [JsonPropertyName("member")]
         public Optional<GuildMember> Member { get; set; }
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public Optional<string> Content { get; set; }
-        [JsonProperty("timestamp")]
+        [JsonPropertyName("timestamp")]
         public Optional<DateTimeOffset> Timestamp { get; set; }
-        [JsonProperty("edited_timestamp")]
+        [JsonPropertyName("edited_timestamp")]
         public Optional<DateTimeOffset?> EditedTimestamp { get; set; }
-        [JsonProperty("tts")]
+        [JsonPropertyName("tts")]
         public Optional<bool> IsTextToSpeech { get; set; }
-        [JsonProperty("mention_everyone")]
+        [JsonPropertyName("mention_everyone")]
         public Optional<bool> MentionEveryone { get; set; }
-        [JsonProperty("mentions")]
+        [JsonPropertyName("mentions")]
         public Optional<User[]> UserMentions { get; set; }
-        [JsonProperty("mention_roles")]
+        [JsonPropertyName("mention_roles")]
         public Optional<ulong[]> RoleMentions { get; set; }
-        [JsonProperty("attachments")]
+        [JsonPropertyName("attachments")]
         public Optional<Attachment[]> Attachments { get; set; }
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<Embed[]> Embeds { get; set; }
-        [JsonProperty("pinned")]
+        [JsonPropertyName("pinned")]
         public Optional<bool> Pinned { get; set; }
-        [JsonProperty("reactions")]
+        [JsonPropertyName("reactions")]
         public Optional<Reaction[]> Reactions { get; set; }
         // sent with Rich Presence-related chat embeds
-        [JsonProperty("activity")]
+        [JsonPropertyName("activity")]
         public Optional<MessageActivity> Activity { get; set; }
         // sent with Rich Presence-related chat embeds
-        [JsonProperty("application")]
+        [JsonPropertyName("application")]
         public Optional<MessageApplication> Application { get; set; }
-        [JsonProperty("message_reference")]
+        [JsonPropertyName("message_reference")]
         public Optional<MessageReference> Reference { get; set; }
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public Optional<MessageFlags> Flags { get; set; }
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
-        [JsonProperty("referenced_message")]
+        [JsonPropertyName("referenced_message")]
         public Optional<Message> ReferencedMessage { get; set; }
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<API.ActionRowComponent[]> Components { get; set; }
         public Optional<MessageInteraction> Interaction { get; set; }
-        [JsonProperty("sticker_items")]
+        [JsonPropertyName("sticker_items")]
         public Optional<StickerItem[]> StickerItems { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/MessageActivity.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageActivity.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +9,9 @@ namespace Discord.API
 {
     public class MessageActivity
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public Optional<MessageActivityType> Type { get; set; }
-        [JsonProperty("party_id")]
+        [JsonPropertyName("party_id")]
         public Optional<string> PartyId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/MessageApplication.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageApplication.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,27 +12,27 @@ namespace Discord.API
         /// <summary>
         ///     Gets the snowflake ID of the application.
         /// </summary>
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
         /// <summary>
         ///     Gets the ID of the embed's image asset.
         /// </summary>
-        [JsonProperty("cover_image")]
+        [JsonPropertyName("cover_image")]
         public string CoverImage { get; set; }
         /// <summary>
         ///     Gets the application's description.
         /// </summary>
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
         /// <summary>
         ///     Gets the ID of the application's icon.
         /// </summary>
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public string Icon { get; set; }
         /// <summary>
         ///     Gets the name of the application.
         /// </summary>
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/MessageComponentInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageComponentInteractionData.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class MessageComponentInteractionData : IDiscordInteractionData
     {
-        [JsonProperty("custom_id")]
+        [JsonPropertyName("custom_id")]
         public string CustomId { get; set; }
 
-        [JsonProperty("component_type")]
+        [JsonPropertyName("component_type")]
         public ComponentType ComponentType { get; set; }
 
-        [JsonProperty("values")]
+        [JsonPropertyName("values")]
         public Optional<string[]> Values { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public Optional<string> Value { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/MessageInteraction.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageInteraction.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,13 +9,13 @@ namespace Discord.API
 {
     internal class MessageInteraction
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public InteractionType Type { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/MessageReference.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageReference.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class MessageReference
     {
-        [JsonProperty("message_id")]
+        [JsonPropertyName("message_id")]
         public Optional<ulong> MessageId { get; set; }
 
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public Optional<ulong> ChannelId { get; set; } // Optional when sending, always present when receiving
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
 
-        [JsonProperty("fail_if_not_exists")]
+        [JsonPropertyName("fail_if_not_exists")]
         public Optional<bool> FailIfNotExists { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ModalInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/ModalInteractionData.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class ModalInteractionData : IDiscordInteractionData
     {
-        [JsonProperty("custom_id")]
+        [JsonPropertyName("custom_id")]
         public string CustomId { get; set; }
 
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public API.ActionRowComponent[] Components { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/NitroStickerPacks.cs
+++ b/src/Discord.Net.Rest/API/Common/NitroStickerPacks.cs
@@ -1,11 +1,11 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API
 {
     internal class NitroStickerPacks
     {
-        [JsonProperty("sticker_packs")]
+        [JsonPropertyName("sticker_packs")]
         public List<StickerPack> StickerPacks { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Overwrite.cs
+++ b/src/Discord.Net.Rest/API/Common/Overwrite.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Overwrite
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong TargetId { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public PermissionTarget TargetType { get; set; }
-        [JsonProperty("deny"), Int53]
+        [JsonPropertyName("deny"), Int53]
         public string Deny { get; set; }
-        [JsonProperty("allow"), Int53]
+        [JsonPropertyName("allow"), Int53]
         public string Allow { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Presence.cs
+++ b/src/Discord.Net.Rest/API/Common/Presence.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 
@@ -6,27 +6,27 @@ namespace Discord.API
 {
     internal class Presence
     {
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public UserStatus Status { get; set; }
 
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<ulong[]> Roles { get; set; }
-        [JsonProperty("nick")]
+        [JsonPropertyName("nick")]
         public Optional<string> Nick { get; set; }
         // This property is a Dictionary where each key is the ClientType
         // and the values are the current client status.
         // The client status values are all the same.
         // Example:
         //   "client_status": { "desktop": "dnd", "mobile": "dnd" }
-        [JsonProperty("client_status")]
+        [JsonPropertyName("client_status")]
         public Optional<Dictionary<string, string>> ClientStatus { get; set; }
-        [JsonProperty("activities")]
+        [JsonPropertyName("activities")]
         public List<Game> Activities { get; set; }
-        [JsonProperty("premium_since")]
+        [JsonPropertyName("premium_since")]
         public Optional<DateTimeOffset?> PremiumSince { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/PropertyErrorDescription.cs
+++ b/src/Discord.Net.Rest/API/Common/PropertyErrorDescription.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +9,9 @@ namespace Discord.API
 {
     internal class ErrorDetails
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("errors")]
+        [JsonPropertyName("errors")]
         public Error[] Errors { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Ratelimit.cs
+++ b/src/Discord.Net.Rest/API/Common/Ratelimit.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,13 +9,13 @@ namespace Discord.API
 {
     internal class Ratelimit
     {
-        [JsonProperty("global")]
+        [JsonPropertyName("global")]
         public bool Global { get; set; }
 
-        [JsonProperty("message")]
+        [JsonPropertyName("message")]
         public string Message { get; set; }
 
-        [JsonProperty("retry_after")]
+        [JsonPropertyName("retry_after")]
         public double RetryAfter { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Reaction.cs
+++ b/src/Discord.Net.Rest/API/Common/Reaction.cs
@@ -1,14 +1,14 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Reaction
     {
-        [JsonProperty("count")]
+        [JsonPropertyName("count")]
         public int Count { get; set; }
-        [JsonProperty("me")]
+        [JsonPropertyName("me")]
         public bool Me { get; set; }
-        [JsonProperty("emoji")]
+        [JsonPropertyName("emoji")]
         public Emoji Emoji { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ReadState.cs
+++ b/src/Discord.Net.Rest/API/Common/ReadState.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class ReadState
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("mention_count")]
+        [JsonPropertyName("mention_count")]
         public int MentionCount { get; set; }
-        [JsonProperty("last_message_id")]
+        [JsonPropertyName("last_message_id")]
         public Optional<ulong> LastMessageId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Relationship.cs
+++ b/src/Discord.Net.Rest/API/Common/Relationship.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Relationship
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public RelationshipType Type { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Role.cs
+++ b/src/Discord.Net.Rest/API/Common/Role.cs
@@ -1,30 +1,30 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Role
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public Optional<string> Icon { get; set; }
-        [JsonProperty("unicode_emoji")]
+        [JsonPropertyName("unicode_emoji")]
         public Optional<string> Emoji { get; set; }
-        [JsonProperty("color")]
+        [JsonPropertyName("color")]
         public uint Color { get; set; }
-        [JsonProperty("hoist")]
+        [JsonPropertyName("hoist")]
         public bool Hoist { get; set; }
-        [JsonProperty("mentionable")]
+        [JsonPropertyName("mentionable")]
         public bool Mentionable { get; set; }
-        [JsonProperty("position")]
+        [JsonPropertyName("position")]
         public int Position { get; set; }
-        [JsonProperty("permissions"), Int53]
+        [JsonPropertyName("permissions"), Int53]
         public string Permissions { get; set; }
-        [JsonProperty("managed")]
+        [JsonPropertyName("managed")]
         public bool Managed { get; set; }
-        [JsonProperty("tags")]
+        [JsonPropertyName("tags")]
         public Optional<RoleTags> Tags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/RoleTags.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleTags.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class RoleTags
     {
-        [JsonProperty("bot_id")]
+        [JsonPropertyName("bot_id")]
         public Optional<ulong> BotId { get; set; }
-        [JsonProperty("integration_id")]
+        [JsonPropertyName("integration_id")]
         public Optional<ulong> IntegrationId { get; set; }
-        [JsonProperty("premium_subscriber")]
+        [JsonPropertyName("premium_subscriber")]
         public Optional<bool?> IsPremiumSubscriber { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/SelectMenuComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/SelectMenuComponent.cs
@@ -1,32 +1,32 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Linq;
 
 namespace Discord.API
 {
     internal class SelectMenuComponent : IMessageComponent
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ComponentType Type { get; set; }
 
-        [JsonProperty("custom_id")]
+        [JsonPropertyName("custom_id")]
         public string CustomId { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public SelectMenuOption[] Options { get; set; }
 
-        [JsonProperty("placeholder")]
+        [JsonPropertyName("placeholder")]
         public Optional<string> Placeholder { get; set; }
 
-        [JsonProperty("min_values")]
+        [JsonPropertyName("min_values")]
         public int MinValues { get; set; }
 
-        [JsonProperty("max_values")]
+        [JsonPropertyName("max_values")]
         public int MaxValues { get; set; }
 
-        [JsonProperty("disabled")]
+        [JsonPropertyName("disabled")]
         public bool Disabled { get; set; }
 
-        [JsonProperty("values")]
+        [JsonPropertyName("values")]
         public Optional<string[]> Values { get; set; }
         public SelectMenuComponent() { }
 

--- a/src/Discord.Net.Rest/API/Common/SelectMenuOption.cs
+++ b/src/Discord.Net.Rest/API/Common/SelectMenuOption.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class SelectMenuOption
     {
-        [JsonProperty("label")]
+        [JsonPropertyName("label")]
         public string Label { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public string Value { get; set; }
 
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public Optional<string> Description { get; set; }
 
-        [JsonProperty("emoji")]
+        [JsonPropertyName("emoji")]
         public Optional<Emoji> Emoji { get; set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public Optional<bool> Default { get; set; }
 
         public SelectMenuOption() { }

--- a/src/Discord.Net.Rest/API/Common/SessionStartLimit.cs
+++ b/src/Discord.Net.Rest/API/Common/SessionStartLimit.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class SessionStartLimit
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public int Total { get; set; }
-        [JsonProperty("remaining")]
+        [JsonPropertyName("remaining")]
         public int Remaining { get; set; }
-        [JsonProperty("reset_after")]
+        [JsonPropertyName("reset_after")]
         public int ResetAfter { get; set; }
-        [JsonProperty("max_concurrency")]
+        [JsonPropertyName("max_concurrency")]
         public int MaxConcurrency { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/StageInstance.cs
+++ b/src/Discord.Net.Rest/API/Common/StageInstance.cs
@@ -1,25 +1,25 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class StageInstance
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
 
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
 
-        [JsonProperty("topic")]
+        [JsonPropertyName("topic")]
         public string Topic { get; set; }
 
-        [JsonProperty("privacy_level")]
+        [JsonPropertyName("privacy_level")]
         public StagePrivacyLevel PrivacyLevel { get; set; }
 
-        [JsonProperty("discoverable_disabled")]
+        [JsonPropertyName("discoverable_disabled")]
         public bool DiscoverableDisabled { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Sticker.cs
+++ b/src/Discord.Net.Rest/API/Common/Sticker.cs
@@ -1,30 +1,30 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Sticker
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("pack_id")]
+        [JsonPropertyName("pack_id")]
         public ulong PackId { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
-        [JsonProperty("tags")]
+        [JsonPropertyName("tags")]
         public Optional<string> Tags { get; set; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public StickerType Type { get; set; }
-        [JsonProperty("format_type")]
+        [JsonPropertyName("format_type")]
         public StickerFormatType FormatType { get; set; }
-        [JsonProperty("available")]
+        [JsonPropertyName("available")]
         public bool? Available { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public Optional<User> User { get; set; }
-        [JsonProperty("sort_value")]
+        [JsonPropertyName("sort_value")]
         public int? SortValue { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/StickerItem.cs
+++ b/src/Discord.Net.Rest/API/Common/StickerItem.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class StickerItem
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("format_type")]
+        [JsonPropertyName("format_type")]
         public StickerFormatType FormatType { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/StickerPack.cs
+++ b/src/Discord.Net.Rest/API/Common/StickerPack.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class StickerPack
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("stickers")]
+        [JsonPropertyName("stickers")]
         public Sticker[] Stickers { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("sku_id")]
+        [JsonPropertyName("sku_id")]
         public ulong SkuId { get; set; }
-        [JsonProperty("cover_sticker_id")]
+        [JsonPropertyName("cover_sticker_id")]
         public Optional<ulong> CoverStickerId { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
-        [JsonProperty("banner_asset_id")]
+        [JsonPropertyName("banner_asset_id")]
         public ulong BannerAssetId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Team.cs
+++ b/src/Discord.Net.Rest/API/Common/Team.cs
@@ -1,18 +1,18 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Team
     {
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public Optional<string> Icon { get; set; }
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("members")]
+        [JsonPropertyName("members")]
         public TeamMember[] TeamMembers { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("owner_user_id")]
+        [JsonPropertyName("owner_user_id")]
         public ulong OwnerUserId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/TeamMember.cs
+++ b/src/Discord.Net.Rest/API/Common/TeamMember.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class TeamMember
     {
-        [JsonProperty("membership_state")]
+        [JsonPropertyName("membership_state")]
         public MembershipState MembershipState { get; set; }
-        [JsonProperty("permissions")]
+        [JsonPropertyName("permissions")]
         public string[] Permissions { get; set; }
-        [JsonProperty("team_id")]
+        [JsonPropertyName("team_id")]
         public ulong TeamId { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/TextInputComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/TextInputComponent.cs
@@ -1,34 +1,34 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class TextInputComponent : IMessageComponent
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ComponentType Type { get; set; }
 
-        [JsonProperty("style")]
+        [JsonPropertyName("style")]
         public TextInputStyle Style { get; set; }
 
-        [JsonProperty("custom_id")]
+        [JsonPropertyName("custom_id")]
         public string CustomId { get; set; }
 
-        [JsonProperty("label")]
+        [JsonPropertyName("label")]
         public string Label { get; set; }
 
-        [JsonProperty("placeholder")]
+        [JsonPropertyName("placeholder")]
         public Optional<string> Placeholder { get; set; }
 
-        [JsonProperty("min_length")]
+        [JsonPropertyName("min_length")]
         public Optional<int> MinLength { get; set; }
 
-        [JsonProperty("max_length")]
+        [JsonPropertyName("max_length")]
         public Optional<int> MaxLength { get; set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public Optional<string> Value { get; set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public Optional<bool> Required { get; set; }
 
         public TextInputComponent() { }

--- a/src/Discord.Net.Rest/API/Common/ThreadMember.cs
+++ b/src/Discord.Net.Rest/API/Common/ThreadMember.cs
@@ -1,20 +1,20 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
 {
     internal class ThreadMember
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public Optional<ulong> Id { get; set; }
 
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public Optional<ulong> UserId { get; set; }
 
-        [JsonProperty("join_timestamp")]
+        [JsonPropertyName("join_timestamp")]
         public DateTimeOffset JoinTimestamp { get; set; }
 
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public int Flags { get; set; } // No enum type (yet?)
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ThreadMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/ThreadMetadata.cs
@@ -1,26 +1,26 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
 {
     internal class ThreadMetadata
     {
-        [JsonProperty("archived")]
+        [JsonPropertyName("archived")]
         public bool Archived { get; set; }
 
-        [JsonProperty("auto_archive_duration")]
+        [JsonPropertyName("auto_archive_duration")]
         public ThreadArchiveDuration AutoArchiveDuration { get; set; }
 
-        [JsonProperty("archive_timestamp")]
+        [JsonPropertyName("archive_timestamp")]
         public DateTimeOffset ArchiveTimestamp { get; set; }
 
-        [JsonProperty("locked")]
+        [JsonPropertyName("locked")]
         public Optional<bool> Locked { get; set; }
 
-        [JsonProperty("invitable")]
+        [JsonPropertyName("invitable")]
         public Optional<bool> Invitable { get; set; }
 
-        [JsonProperty("create_timestamp")]
+        [JsonPropertyName("create_timestamp")]
         public Optional<DateTimeOffset?> CreatedAt { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/User.cs
+++ b/src/Discord.Net.Rest/API/Common/User.cs
@@ -1,38 +1,38 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class User
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("username")]
+        [JsonPropertyName("username")]
         public Optional<string> Username { get; set; }
-        [JsonProperty("discriminator")]
+        [JsonPropertyName("discriminator")]
         public Optional<string> Discriminator { get; set; }
-        [JsonProperty("bot")]
+        [JsonPropertyName("bot")]
         public Optional<bool> Bot { get; set; }
-        [JsonProperty("avatar")]
+        [JsonPropertyName("avatar")]
         public Optional<string> Avatar { get; set; }
-        [JsonProperty("banner")]
+        [JsonPropertyName("banner")]
         public Optional<string> Banner { get; set; }
-        [JsonProperty("accent_color")]
+        [JsonPropertyName("accent_color")]
         public Optional<uint?> AccentColor { get; set; }
 
         //CurrentUser
-        [JsonProperty("verified")]
+        [JsonPropertyName("verified")]
         public Optional<bool> Verified { get; set; }
-        [JsonProperty("email")]
+        [JsonPropertyName("email")]
         public Optional<string> Email { get; set; }
-        [JsonProperty("mfa_enabled")]
+        [JsonPropertyName("mfa_enabled")]
         public Optional<bool> MfaEnabled { get; set; }
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public Optional<UserProperties> Flags { get; set; }
-        [JsonProperty("premium_type")]
+        [JsonPropertyName("premium_type")]
         public Optional<PremiumType> PremiumType { get; set; }
-        [JsonProperty("locale")]
+        [JsonPropertyName("locale")]
         public Optional<string> Locale { get; set; }
-        [JsonProperty("public_flags")]
+        [JsonPropertyName("public_flags")]
         public Optional<UserProperties> PublicFlags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/UserGuild.cs
+++ b/src/Discord.Net.Rest/API/Common/UserGuild.cs
@@ -1,18 +1,18 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class UserGuild
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public string Icon { get; set; }
-        [JsonProperty("owner")]
+        [JsonPropertyName("owner")]
         public bool Owner { get; set; }
-        [JsonProperty("permissions"), Int53]
+        [JsonPropertyName("permissions"), Int53]
         public string Permissions { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/VoiceRegion.cs
+++ b/src/Discord.Net.Rest/API/Common/VoiceRegion.cs
@@ -1,20 +1,20 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class VoiceRegion
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("vip")]
+        [JsonPropertyName("vip")]
         public bool IsVip { get; set; }
-        [JsonProperty("optimal")]
+        [JsonPropertyName("optimal")]
         public bool IsOptimal { get; set; }
-        [JsonProperty("deprecated")]
+        [JsonPropertyName("deprecated")]
         public bool IsDeprecated { get; set; }
-        [JsonProperty("custom")]
+        [JsonPropertyName("custom")]
         public bool IsCustom { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/VoiceState.cs
+++ b/src/Discord.Net.Rest/API/Common/VoiceState.cs
@@ -1,36 +1,36 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API
 {
     internal class VoiceState
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong? GuildId { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong? ChannelId { get; set; }
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong UserId { get; set; }
         // ALWAYS sent over WebSocket, never on REST
-        [JsonProperty("member")]
+        [JsonPropertyName("member")]
         public Optional<GuildMember> Member { get; set; }
-        [JsonProperty("session_id")]
+        [JsonPropertyName("session_id")]
         public string SessionId { get; set; }
-        [JsonProperty("deaf")]
+        [JsonPropertyName("deaf")]
         public bool Deaf { get; set; }
-        [JsonProperty("mute")]
+        [JsonPropertyName("mute")]
         public bool Mute { get; set; }
-        [JsonProperty("self_deaf")]
+        [JsonPropertyName("self_deaf")]
         public bool SelfDeaf { get; set; }
-        [JsonProperty("self_mute")]
+        [JsonPropertyName("self_mute")]
         public bool SelfMute { get; set; }
-        [JsonProperty("suppress")]
+        [JsonPropertyName("suppress")]
         public bool Suppress { get; set; }
-        [JsonProperty("self_stream")]
+        [JsonPropertyName("self_stream")]
         public bool SelfStream { get; set; }
-        [JsonProperty("self_video")]
+        [JsonPropertyName("self_video")]
         public bool SelfVideo { get; set; }
-        [JsonProperty("request_to_speak_timestamp")]
+        [JsonPropertyName("request_to_speak_timestamp")]
         public Optional<DateTimeOffset?> RequestToSpeakTimestamp { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Webhook.cs
+++ b/src/Discord.Net.Rest/API/Common/Webhook.cs
@@ -1,26 +1,26 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class Webhook
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("token")]
+        [JsonPropertyName("token")]
         public string Token { get; set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("avatar")]
+        [JsonPropertyName("avatar")]
         public Optional<string> Avatar { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
 
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public Optional<User> Creator { get; set; }
-        [JsonProperty("application_id")]
+        [JsonPropertyName("application_id")]
         public ulong? ApplicationId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/AddGuildMemberParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/AddGuildMemberParams.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class AddGuildMemberParams
     {
-        [JsonProperty("access_token")]
+        [JsonPropertyName("access_token")]
         public string AccessToken { get; set; }
-        [JsonProperty("nick")]
+        [JsonPropertyName("nick")]
         public Optional<string> Nickname { get; set; }
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<ulong[]> RoleIds { get; set; }
-        [JsonProperty("mute")]
+        [JsonPropertyName("mute")]
         public Optional<bool> IsMuted { get; set; }
-        [JsonProperty("deaf")]
+        [JsonPropertyName("deaf")]
         public Optional<bool> IsDeafened { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateApplicationCommandParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateApplicationCommandParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -8,31 +8,31 @@ namespace Discord.API.Rest
 {
     internal class CreateApplicationCommandParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ApplicationCommandType Type { get; set; }
 
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public Optional<ApplicationCommandOption[]> Options { get; set; }
 
-        [JsonProperty("default_permission")]
+        [JsonPropertyName("default_permission")]
         public Optional<bool> DefaultPermission { get; set; }
 
-        [JsonProperty("name_localizations")]
+        [JsonPropertyName("name_localizations")]
         public Optional<Dictionary<string, string>> NameLocalizations { get; set; }
 
-        [JsonProperty("description_localizations")]
+        [JsonPropertyName("description_localizations")]
         public Optional<Dictionary<string, string>> DescriptionLocalizations { get; set; }
 
-        [JsonProperty("dm_permission")]
+        [JsonPropertyName("dm_permission")]
         public Optional<bool?> DmPermission { get; set; }
 
-        [JsonProperty("default_member_permissions")]
+        [JsonPropertyName("default_member_permissions")]
         public Optional<GuildPermission?> DefaultMemberPermission { get; set; }
 
         public CreateApplicationCommandParams() { }

--- a/src/Discord.Net.Rest/API/Rest/CreateChannelInviteParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateChannelInviteParams.cs
@@ -1,23 +1,23 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateChannelInviteParams
     {
-        [JsonProperty("max_age")]
+        [JsonPropertyName("max_age")]
         public Optional<int> MaxAge { get; set; }
-        [JsonProperty("max_uses")]
+        [JsonPropertyName("max_uses")]
         public Optional<int> MaxUses { get; set; }
-        [JsonProperty("temporary")]
+        [JsonPropertyName("temporary")]
         public Optional<bool> IsTemporary { get; set; }
-        [JsonProperty("unique")]
+        [JsonPropertyName("unique")]
         public Optional<bool> IsUnique { get; set; }
-        [JsonProperty("target_type")]
+        [JsonPropertyName("target_type")]
         public Optional<TargetUserType> TargetType { get; set; }
-        [JsonProperty("target_user_id")]
+        [JsonPropertyName("target_user_id")]
         public Optional<ulong> TargetUserId { get; set; }
-        [JsonProperty("target_application_id")]
+        [JsonPropertyName("target_application_id")]
         public Optional<ulong> TargetApplicationId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateDMChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateDMChannelParams.cs
@@ -1,11 +1,11 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateDMChannelParams
     {
-        [JsonProperty("recipient_id")]
+        [JsonPropertyName("recipient_id")]
         public ulong RecipientId { get; }
 
         public CreateDMChannelParams(ulong recipientId)

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
@@ -1,33 +1,33 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateGuildChannelParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ChannelType Type { get; }
-        [JsonProperty("parent_id")]
+        [JsonPropertyName("parent_id")]
         public Optional<ulong?> CategoryId { get; set; }
-        [JsonProperty("position")]
+        [JsonPropertyName("position")]
         public Optional<int> Position { get; set; }
-        [JsonProperty("permission_overwrites")]
+        [JsonPropertyName("permission_overwrites")]
         public Optional<Overwrite[]> Overwrites { get; set; }
 
         //Text channels
-        [JsonProperty("topic")]
+        [JsonPropertyName("topic")]
         public Optional<string> Topic { get; set; }
-        [JsonProperty("nsfw")]
+        [JsonPropertyName("nsfw")]
         public Optional<bool> IsNsfw { get; set; }
-        [JsonProperty("rate_limit_per_user")]
+        [JsonPropertyName("rate_limit_per_user")]
         public Optional<int> SlowModeInterval { get; set; }
 
         //Voice channels
-        [JsonProperty("bitrate")]
+        [JsonPropertyName("bitrate")]
         public Optional<int> Bitrate { get; set; }
-        [JsonProperty("user_limit")]
+        [JsonPropertyName("user_limit")]
         public Optional<int?> UserLimit { get; set; }
 
         public CreateGuildChannelParams(string name, ChannelType type)

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildEmoteParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildEmoteParams.cs
@@ -1,15 +1,15 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateGuildEmoteParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("image")]
+        [JsonPropertyName("image")]
         public Image Image { get; set; }
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<ulong[]> RoleIds { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildIntegrationParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildIntegrationParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateGuildIntegrationParams
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; }
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; }
 
         public CreateGuildIntegrationParams(ulong id, string type)

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildParams.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateGuildParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; }
-        [JsonProperty("region")]
+        [JsonPropertyName("region")]
         public string RegionId { get; }
 
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public Optional<Image?> Icon { get; set; }
 
         public CreateGuildParams(string name, string regionId)

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildScheduledEventParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildScheduledEventParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,23 +9,23 @@ namespace Discord.API.Rest
 {
     internal class CreateGuildScheduledEventParams
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public Optional<ulong> ChannelId { get; set; }
-        [JsonProperty("entity_metadata")]
+        [JsonPropertyName("entity_metadata")]
         public Optional<GuildScheduledEventEntityMetadata> EntityMetadata { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("privacy_level")]
+        [JsonPropertyName("privacy_level")]
         public GuildScheduledEventPrivacyLevel PrivacyLevel { get; set; }
-        [JsonProperty("scheduled_start_time")]
+        [JsonPropertyName("scheduled_start_time")]
         public DateTimeOffset StartTime { get; set; }
-        [JsonProperty("scheduled_end_time")]
+        [JsonPropertyName("scheduled_end_time")]
         public Optional<DateTimeOffset> EndTime { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public Optional<string> Description { get; set; }
-        [JsonProperty("entity_type")]
+        [JsonPropertyName("entity_type")]
         public GuildScheduledEventType Type { get; set; }
-        [JsonProperty("image")]
+        [JsonPropertyName("image")]
         public Optional<Image> Image { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateMessageParams.cs
@@ -1,35 +1,35 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateMessageParams
     {
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public string Content { get; }
 
-        [JsonProperty("nonce")]
+        [JsonPropertyName("nonce")]
         public Optional<string> Nonce { get; set; }
 
-        [JsonProperty("tts")]
+        [JsonPropertyName("tts")]
         public Optional<bool> IsTTS { get; set; }
 
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<Embed[]> Embeds { get; set; }
 
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
 
-        [JsonProperty("message_reference")]
+        [JsonPropertyName("message_reference")]
         public Optional<MessageReference> MessageReference { get; set; }
 
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<API.ActionRowComponent[]> Components { get; set; }
 
-        [JsonProperty("sticker_ids")]
+        [JsonPropertyName("sticker_ids")]
         public Optional<ulong[]> Stickers { get; set; }
-        
-        [JsonProperty("flags")]
+
+        [JsonPropertyName("flags")]
         public Optional<MessageFlags> Flags { get; set; }
 
         public CreateMessageParams(string content)

--- a/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
@@ -1,6 +1,6 @@
 using Discord.Net.Converters;
 using Discord.Net.Rest;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Discord.Net.Rest/API/Rest/CreatePostParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreatePostParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,16 +10,16 @@ namespace Discord.API.Rest
     internal class CreatePostParams
     {
         // thread
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Title { get; set; }
 
-        [JsonProperty("auto_archive_duration")]
+        [JsonPropertyName("auto_archive_duration")]
         public ThreadArchiveDuration ArchiveDuration { get; set; }
 
-        [JsonProperty("rate_limit_per_user")]
+        [JsonPropertyName("rate_limit_per_user")]
         public Optional<int?> Slowmode { get; set; }
 
-        [JsonProperty("message")]
+        [JsonPropertyName("message")]
         public ForumThreadMessage Message { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateStageInstanceParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateStageInstanceParams.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class CreateStageInstanceParams
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
 
-        [JsonProperty("topic")]
+        [JsonPropertyName("topic")]
         public string Topic { get; set; }
 
-        [JsonProperty("privacy_level")]
+        [JsonPropertyName("privacy_level")]
         public Optional<StagePrivacyLevel> PrivacyLevel { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
@@ -1,6 +1,6 @@
 using Discord.Net.Converters;
 using Discord.Net.Rest;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -12,34 +12,34 @@ namespace Discord.API.Rest
     {
         private static JsonSerializer _serializer = new JsonSerializer { ContractResolver = new DiscordContractResolver() };
 
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public Optional<string> Content { get; set;  }
 
-        [JsonProperty("nonce")]
+        [JsonPropertyName("nonce")]
         public Optional<string> Nonce { get; set; }
 
-        [JsonProperty("tts")]
+        [JsonPropertyName("tts")]
         public Optional<bool> IsTTS { get; set; }
 
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<Embed[]> Embeds { get; set; }
 
-        [JsonProperty("username")]
+        [JsonPropertyName("username")]
         public Optional<string> Username { get; set; }
 
-        [JsonProperty("avatar_url")]
+        [JsonPropertyName("avatar_url")]
         public Optional<string> AvatarUrl { get; set; }
 
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
 
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public Optional<MessageFlags> Flags { get; set; }
 
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<API.ActionRowComponent[]> Components { get; set; }
 
-        [JsonProperty("file")]
+        [JsonPropertyName("file")]
         public Optional<MultipartFile> File { get; set; }
 
         public IReadOnlyDictionary<string, object> ToDictionary()

--- a/src/Discord.Net.Rest/API/Rest/CreateWebhookParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateWebhookParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class CreateWebhookParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty("avatar")]
+        [JsonPropertyName("avatar")]
         public Optional<Image?> Avatar { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/DeleteMessagesParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/DeleteMessagesParams.cs
@@ -1,11 +1,11 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class DeleteMessagesParams
     {
-        [JsonProperty("messages")]
+        [JsonPropertyName("messages")]
         public ulong[] MessageIds { get; }
 
         public DeleteMessagesParams(ulong[] messageIds)

--- a/src/Discord.Net.Rest/API/Rest/GetBotGatewayResponse.cs
+++ b/src/Discord.Net.Rest/API/Rest/GetBotGatewayResponse.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class GetBotGatewayResponse
     {
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
-        [JsonProperty("shards")]
+        [JsonPropertyName("shards")]
         public int Shards { get; set; }
-        [JsonProperty("session_start_limit")]
+        [JsonPropertyName("session_start_limit")]
         public SessionStartLimit SessionStartLimit { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/GetGatewayResponse.cs
+++ b/src/Discord.Net.Rest/API/Rest/GetGatewayResponse.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class GetGatewayResponse
     {
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/GetGuildPruneCountResponse.cs
+++ b/src/Discord.Net.Rest/API/Rest/GetGuildPruneCountResponse.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class GetGuildPruneCountResponse
     {
-        [JsonProperty("pruned")]
+        [JsonPropertyName("pruned")]
         public int Pruned { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/GuildPruneParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/GuildPruneParams.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class GuildPruneParams
     {
-        [JsonProperty("days")]
+        [JsonPropertyName("days")]
         public int Days { get; }
 
-        [JsonProperty("include_roles")]
+        [JsonPropertyName("include_roles")]
         public ulong[] IncludeRoleIds { get; }
 
         public GuildPruneParams(int days, ulong[] includeRoleIds)

--- a/src/Discord.Net.Rest/API/Rest/ModifyApplicationCommandParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyApplicationCommandParams.cs
@@ -1,26 +1,26 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API.Rest
 {
     internal class ModifyApplicationCommandParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
 
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public Optional<string> Description { get; set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public Optional<ApplicationCommandOption[]> Options { get; set; }
 
-        [JsonProperty("default_permission")]
+        [JsonPropertyName("default_permission")]
         public Optional<bool> DefaultPermission { get; set; }
 
-        [JsonProperty("name_localizations")]
+        [JsonPropertyName("name_localizations")]
         public Optional<Dictionary<string, string>> NameLocalizations { get; set; }
 
-        [JsonProperty("description_localizations")]
+        [JsonPropertyName("description_localizations")]
         public Optional<Dictionary<string, string>> DescriptionLocalizations { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyChannelPermissionsParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyChannelPermissionsParams.cs
@@ -1,15 +1,15 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyChannelPermissionsParams
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public int Type { get; }
-        [JsonProperty("allow")]
+        [JsonPropertyName("allow")]
         public string Allow { get; }
-        [JsonProperty("deny")]
+        [JsonPropertyName("deny")]
         public string Deny { get; }
 
         public ModifyChannelPermissionsParams(int type, string allow, string deny)

--- a/src/Discord.Net.Rest/API/Rest/ModifyCurrentUserNickParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyCurrentUserNickParams.cs
@@ -1,11 +1,11 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyCurrentUserNickParams
     {
-        [JsonProperty("nick")]
+        [JsonPropertyName("nick")]
         public string Nickname { get; }
 
         public ModifyCurrentUserNickParams(string nickname)

--- a/src/Discord.Net.Rest/API/Rest/ModifyCurrentUserParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyCurrentUserParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyCurrentUserParams
     {
-        [JsonProperty("username")]
+        [JsonPropertyName("username")]
         public Optional<string> Username { get; set; }
-        [JsonProperty("avatar")]
+        [JsonPropertyName("avatar")]
         public Optional<Image?> Avatar { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissions.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissions.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class ModifyGuildApplicationCommandPermissions
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("permissions")]
+        [JsonPropertyName("permissions")]
         public ApplicationCommandPermissions[] Permissions { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissionsParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissionsParams.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class ModifyGuildApplicationCommandPermissionsParams
     {
-        [JsonProperty("permissions")]
+        [JsonPropertyName("permissions")]
         public ApplicationCommandPermissions[] Permissions { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelParams.cs
@@ -1,17 +1,17 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildChannelParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("position")]
+        [JsonPropertyName("position")]
         public Optional<int> Position { get; set; }
-        [JsonProperty("parent_id")]
+        [JsonPropertyName("parent_id")]
         public Optional<ulong?> CategoryId { get; set; }
-        [JsonProperty("permission_overwrites")]
+        [JsonPropertyName("permission_overwrites")]
         public Optional<Overwrite[]> Overwrites { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelsParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildChannelsParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildChannelsParams
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; }
-        [JsonProperty("position")]
+        [JsonPropertyName("position")]
         public int Position { get; }
 
         public ModifyGuildChannelsParams(ulong id, int position)

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildEmbedParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildEmbedParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildEmbedParams
-    {        
-        [JsonProperty("enabled")]
+    {
+        [JsonPropertyName("enabled")]
         public Optional<bool> Enabled { get; set; }
-        [JsonProperty("channel")]
+        [JsonPropertyName("channel")]
         public Optional<ulong?> ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildEmoteParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildEmoteParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildEmoteParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<ulong[]> RoleIds { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildIntegrationParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildIntegrationParams.cs
@@ -1,15 +1,15 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildIntegrationParams
     {
-        [JsonProperty("expire_behavior")]
+        [JsonPropertyName("expire_behavior")]
         public Optional<int> ExpireBehavior { get; set; }
-        [JsonProperty("expire_grace_period")]
+        [JsonPropertyName("expire_grace_period")]
         public Optional<int> ExpireGracePeriod { get; set; }
-        [JsonProperty("enable_emoticons")]
+        [JsonPropertyName("enable_emoticons")]
         public Optional<bool> EnableEmoticons { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildMemberParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildMemberParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API.Rest
@@ -6,17 +6,17 @@ namespace Discord.API.Rest
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildMemberParams
     {
-        [JsonProperty("mute")]
+        [JsonPropertyName("mute")]
         public Optional<bool> Mute { get; set; }
-        [JsonProperty("deaf")]
+        [JsonPropertyName("deaf")]
         public Optional<bool> Deaf { get; set; }
-        [JsonProperty("nick")]
+        [JsonPropertyName("nick")]
         public Optional<string> Nickname { get; set; }
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public Optional<ulong[]> RoleIds { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public Optional<ulong?> ChannelId { get; set; }
-        [JsonProperty("communication_disabled_until")]
+        [JsonPropertyName("communication_disabled_until")]
         public Optional<DateTimeOffset?> TimedOutUntil { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
@@ -1,41 +1,41 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildParams
     {
-        [JsonProperty("username")]
+        [JsonPropertyName("username")]
         public Optional<string> Username { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("region")]
+        [JsonPropertyName("region")]
         public Optional<string> RegionId { get; set; }
-        [JsonProperty("verification_level")]
+        [JsonPropertyName("verification_level")]
         public Optional<VerificationLevel> VerificationLevel { get; set; }
-        [JsonProperty("default_message_notifications")]
+        [JsonPropertyName("default_message_notifications")]
         public Optional<DefaultMessageNotifications> DefaultMessageNotifications { get; set; }
-        [JsonProperty("afk_timeout")]
+        [JsonPropertyName("afk_timeout")]
         public Optional<int> AfkTimeout { get; set; }
-        [JsonProperty("system_channel_id")]
+        [JsonPropertyName("system_channel_id")]
         public Optional<ulong?> SystemChannelId { get; set; }
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public Optional<Image?> Icon { get; set; }
-        [JsonProperty("banner")]
+        [JsonPropertyName("banner")]
         public Optional<Image?> Banner { get; set; }
-        [JsonProperty("splash")]
+        [JsonPropertyName("splash")]
         public Optional<Image?> Splash { get; set; }
-        [JsonProperty("afk_channel_id")]
+        [JsonPropertyName("afk_channel_id")]
         public Optional<ulong?> AfkChannelId { get; set; }
-        [JsonProperty("owner_id")]
+        [JsonPropertyName("owner_id")]
         public Optional<ulong> OwnerId { get; set; }
-        [JsonProperty("explicit_content_filter")]
+        [JsonPropertyName("explicit_content_filter")]
         public Optional<ExplicitContentFilterLevel> ExplicitContentFilter { get; set; }
-        [JsonProperty("system_channel_flags")]
+        [JsonPropertyName("system_channel_flags")]
         public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
-        [JsonProperty("preferred_locale")]
+        [JsonPropertyName("preferred_locale")]
         public string PreferredLocale { get; set; }
-        [JsonProperty("premium_progress_bar_enabled")]
+        [JsonPropertyName("premium_progress_bar_enabled")]
         public Optional<bool> IsBoostProgressBarEnabled { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildRoleParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildRoleParams.cs
@@ -1,23 +1,23 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildRoleParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("permissions")]
+        [JsonPropertyName("permissions")]
         public Optional<string> Permissions { get; set; }
-        [JsonProperty("color")]
+        [JsonPropertyName("color")]
         public Optional<uint> Color { get; set; }
-        [JsonProperty("hoist")]
+        [JsonPropertyName("hoist")]
         public Optional<bool> Hoist { get; set; }
-        [JsonProperty("icon")]
+        [JsonPropertyName("icon")]
         public Optional<Image?> Icon { get; set; }
-        [JsonProperty("unicode_emoji")]
+        [JsonPropertyName("unicode_emoji")]
         public Optional<string> Emoji { get; set; }
-        [JsonProperty("mentionable")]
+        [JsonPropertyName("mentionable")]
         public Optional<bool> Mentionable { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildRolesParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildRolesParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildRolesParams : ModifyGuildRoleParams
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; }
-        [JsonProperty("position")]
+        [JsonPropertyName("position")]
         public int Position { get; }
 
         public ModifyGuildRolesParams(ulong id, int position)

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildScheduledEventParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildScheduledEventParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,25 +9,25 @@ namespace Discord.API.Rest
 {
     internal class ModifyGuildScheduledEventParams
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public Optional<ulong?> ChannelId { get; set; }
-        [JsonProperty("entity_metadata")]
+        [JsonPropertyName("entity_metadata")]
         public Optional<GuildScheduledEventEntityMetadata> EntityMetadata { get; set; }
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("privacy_level")]
+        [JsonPropertyName("privacy_level")]
         public Optional<GuildScheduledEventPrivacyLevel> PrivacyLevel { get; set; }
-        [JsonProperty("scheduled_start_time")]
+        [JsonPropertyName("scheduled_start_time")]
         public Optional<DateTimeOffset> StartTime { get; set; }
-        [JsonProperty("scheduled_end_time")]
+        [JsonPropertyName("scheduled_end_time")]
         public Optional<DateTimeOffset> EndTime { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public Optional<string> Description { get; set; }
-        [JsonProperty("entity_type")]
+        [JsonPropertyName("entity_type")]
         public Optional<GuildScheduledEventType> Type { get; set; }
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public Optional<GuildScheduledEventStatus> Status { get; set; }
-        [JsonProperty("image")]
+        [JsonPropertyName("image")]
         public Optional<Image?> Image { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildWidgetParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildWidgetParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyGuildWidgetParams
-    {        
-        [JsonProperty("enabled")]
+    {
+        [JsonPropertyName("enabled")]
         public Optional<bool> Enabled { get; set; }
-        [JsonProperty("channel")]
+        [JsonPropertyName("channel")]
         public Optional<ulong?> ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class ModifyInteractionResponseParams
     {
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public Optional<string> Content { get; set; }
 
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<Embed[]> Embeds { get; set; }
 
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
 
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<ActionRowComponent[]> Components { get; set; }
 
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public Optional<MessageFlags?> Flags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyMessageParams.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyMessageParams
     {
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public Optional<string> Content { get; set; }
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<API.Embed[]> Embeds { get; set; }
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<API.ActionRowComponent[]> Components { get; set; }
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public Optional<MessageFlags?> Flags { get; set; }
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyStageInstanceParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyStageInstanceParams.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class ModifyStageInstanceParams
     {
-        [JsonProperty("topic")]
+        [JsonPropertyName("topic")]
         public Optional<string> Topic { get; set; }
 
-        [JsonProperty("privacy_level")]
+        [JsonPropertyName("privacy_level")]
         public Optional<StagePrivacyLevel> PrivacyLevel { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyStickerParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyStickerParams.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class ModifyStickerParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public Optional<string> Description { get; set; }
-        [JsonProperty("tags")]
+        [JsonPropertyName("tags")]
         public Optional<string> Tags { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
@@ -1,15 +1,15 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyTextChannelParams : ModifyGuildChannelParams
     {
-        [JsonProperty("topic")]
+        [JsonPropertyName("topic")]
         public Optional<string> Topic { get; set; }
-        [JsonProperty("nsfw")]
+        [JsonPropertyName("nsfw")]
         public Optional<bool> IsNsfw { get; set; }
-        [JsonProperty("rate_limit_per_user")]
+        [JsonPropertyName("rate_limit_per_user")]
         public Optional<int> SlowModeInterval { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class ModifyThreadParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
 
-        [JsonProperty("archived")]
+        [JsonPropertyName("archived")]
         public Optional<bool> Archived { get; set; }
 
-        [JsonProperty("auto_archive_duration")]
+        [JsonPropertyName("auto_archive_duration")]
         public Optional<ThreadArchiveDuration> AutoArchiveDuration { get; set; }
 
-        [JsonProperty("locked")]
+        [JsonPropertyName("locked")]
         public Optional<bool> Locked { get; set; }
 
-        [JsonProperty("rate_limit_per_user")]
+        [JsonPropertyName("rate_limit_per_user")]
         public Optional<int> Slowmode { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyVoiceChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyVoiceChannelParams.cs
@@ -1,15 +1,15 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyVoiceChannelParams : ModifyGuildChannelParams
     {
-        [JsonProperty("bitrate")]
+        [JsonPropertyName("bitrate")]
         public Optional<int> Bitrate { get; set; }
-        [JsonProperty("user_limit")]
+        [JsonPropertyName("user_limit")]
         public Optional<int> UserLimit { get; set; }
-        [JsonProperty("rtc_region")]
+        [JsonPropertyName("rtc_region")]
         public Optional<string> RTCRegion { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyVoiceStateParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyVoiceStateParams.cs
@@ -1,17 +1,17 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API.Rest
 {
     internal class ModifyVoiceStateParams
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
 
-        [JsonProperty("suppress")]
+        [JsonPropertyName("suppress")]
         public Optional<bool> Suppressed { get; set; }
 
-        [JsonProperty("request_to_speak_timestamp")]
+        [JsonPropertyName("request_to_speak_timestamp")]
         public Optional<DateTimeOffset> RequestToSpeakTimestamp { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyWebhookMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyWebhookMessageParams.cs
@@ -1,17 +1,17 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyWebhookMessageParams
     {
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public Optional<string> Content { get; set; }
-        [JsonProperty("embeds")]
+        [JsonPropertyName("embeds")]
         public Optional<Embed[]> Embeds { get; set; }
-        [JsonProperty("allowed_mentions")]
+        [JsonPropertyName("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
-        [JsonProperty("components")]
+        [JsonPropertyName("components")]
         public Optional<API.ActionRowComponent[]> Components { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyWebhookParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyWebhookParams.cs
@@ -1,15 +1,15 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ModifyWebhookParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public Optional<string> Name { get; set; }
-        [JsonProperty("avatar")]
+        [JsonPropertyName("avatar")]
         public Optional<Image?> Avatar { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public Optional<ulong> ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/StartThreadParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/StartThreadParams.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {
     internal class StartThreadParams
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
-        [JsonProperty("auto_archive_duration")]
+        [JsonPropertyName("auto_archive_duration")]
         public ThreadArchiveDuration Duration { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public ThreadType Type { get; set; }
 
-        [JsonProperty("invitable")]
+        [JsonPropertyName("invitable")]
         public Optional<bool> Invitable { get; set; }
 
-        [JsonProperty("rate_limit_per_user")]
+        [JsonPropertyName("rate_limit_per_user")]
         public Optional<int?> Ratelimit { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/UploadFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadFileParams.cs
@@ -1,6 +1,6 @@
 using Discord.Net.Converters;
 using Discord.Net.Rest;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -32,7 +32,7 @@ namespace Discord.API.Rest
         public IReadOnlyDictionary<string, object> ToDictionary()
         {
             var d = new Dictionary<string, object>();
-            
+
             var payload = new Dictionary<string, object>();
             if (Content.IsSpecified)
                 payload["content"] = Content.Value;

--- a/src/Discord.Net.Rest/API/Rest/UploadInteractionFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadInteractionFileParams.cs
@@ -1,6 +1,6 @@
 using Discord.Net.Converters;
 using Discord.Net.Rest;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -41,7 +41,7 @@ namespace Discord.API.Rest
         public IReadOnlyDictionary<string, object> ToDictionary()
         {
             var d = new Dictionary<string, object>();
-           
+
 
             var payload = new Dictionary<string, object>();
             payload["type"] = Type;

--- a/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Text;
 using Discord.Net.Converters;
 using Discord.Net.Rest;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
@@ -142,13 +142,13 @@ namespace Discord.Rest
             GuildId = model.GuildId.IsSpecified
                 ? model.GuildId.Value
                 : null;
-            
+
             IsDMInteraction = GuildId is null;
 
             Data = model.Data.IsSpecified
                 ? model.Data.Value
                 : null;
-            
+
             Token = model.Token;
             Version = model.Version;
             Type = model.Type;
@@ -176,7 +176,7 @@ namespace Discord.Rest
                     User = RestUser.Create(Discord, model.User.Value);
                 }
             }
-            
+
 
             if (Channel is null && ChannelId is not null)
             {
@@ -294,7 +294,7 @@ namespace Discord.Rest
         }
         /// <inheritdoc/>
         public abstract string RespondWithModal(Modal modal, RequestOptions options = null);
-        
+
         /// <inheritdoc/>
         public abstract string Respond(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null);
 

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Discord.Net.Rest/Net/Converters/DiscordContractResolver.cs
+++ b/src/Discord.Net.Rest/Net/Converters/DiscordContractResolver.cs
@@ -14,7 +14,7 @@ namespace Discord.Net.Converters
         private static readonly TypeInfo _ienumerable = typeof(IEnumerable<ulong[]>).GetTypeInfo();
         private static readonly MethodInfo _shouldSerialize = typeof(DiscordContractResolver).GetTypeInfo().GetDeclaredMethod("ShouldSerialize");
 
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        protected override JsonPropertyName CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
             if (property.Ignored)
@@ -33,7 +33,7 @@ namespace Discord.Net.Converters
             return property;
         }
 
-        private static JsonConverter GetConverter(JsonProperty property, PropertyInfo propInfo, Type type, int depth)
+        private static JsonConverter GetConverter(JsonPropertyName property, PropertyInfo propInfo, Type type, int depth)
         {
             if (type.IsArray)
                 return MakeGenericConverter(property, propInfo, typeof(ArrayConverter<>), type.GetElementType(), depth);
@@ -107,7 +107,7 @@ namespace Discord.Net.Converters
             return (getter as Func<TOwner, Optional<TValue>>)((TOwner)owner).IsSpecified;
         }
 
-        private static JsonConverter MakeGenericConverter(JsonProperty property, PropertyInfo propInfo, Type converterType, Type innerType, int depth)
+        private static JsonConverter MakeGenericConverter(JsonPropertyName property, PropertyInfo propInfo, Type converterType, Type innerType, int depth)
         {
             var genericType = converterType.MakeGenericType(innerType).GetTypeInfo();
             var innerConverter = GetConverter(property, propInfo, innerType, depth + 1);

--- a/src/Discord.Net.WebSocket/API/Gateway/ApplicationCommandCreatedUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ApplicationCommandCreatedUpdatedEvent.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class ApplicationCommandCreatedUpdatedEvent : ApplicationCommand
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/ExtendedGuild.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ExtendedGuild.cs
@@ -1,35 +1,35 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API.Gateway
 {
     internal class ExtendedGuild : Guild
     {
-        [JsonProperty("unavailable")]
+        [JsonPropertyName("unavailable")]
         public bool? Unavailable { get; set; }
 
-        [JsonProperty("member_count")]
+        [JsonPropertyName("member_count")]
         public int MemberCount { get; set; }
 
-        [JsonProperty("large")]
+        [JsonPropertyName("large")]
         public bool Large { get; set; }
 
-        [JsonProperty("presences")]
+        [JsonPropertyName("presences")]
         public Presence[] Presences { get; set; }
 
-        [JsonProperty("members")]
+        [JsonPropertyName("members")]
         public GuildMember[] Members { get; set; }
 
-        [JsonProperty("channels")]
+        [JsonPropertyName("channels")]
         public Channel[] Channels { get; set; }
 
-        [JsonProperty("joined_at")]
+        [JsonPropertyName("joined_at")]
         public DateTimeOffset JoinedAt { get; set; }
 
-        [JsonProperty("threads")]
+        [JsonPropertyName("threads")]
         public new Channel[] Threads { get; set; }
 
-        [JsonProperty("guild_scheduled_events")]
+        [JsonPropertyName("guild_scheduled_events")]
         public GuildScheduledEvent[] GuildScheduledEvents { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildBanEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildBanEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildBanEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildEmojiUpdateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildEmojiUpdateEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildEmojiUpdateEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("emojis")]
+        [JsonPropertyName("emojis")]
         public Emoji[] Emojis { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildJoinRequestDeleteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildJoinRequestDeleteEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildJoinRequestDeleteEvent
     {
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong UserId { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildMemberAddEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildMemberAddEvent.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildMemberAddEvent : GuildMember
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildMemberRemoveEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildMemberRemoveEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildMemberRemoveEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildMemberUpdateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildMemberUpdateEvent.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API.Gateway
 {
     internal class GuildMemberUpdateEvent : GuildMember
     {
-        [JsonProperty("joined_at")]
+        [JsonPropertyName("joined_at")]
         public new DateTimeOffset? JoinedAt { get; set; }
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildMembersChunkEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildMembersChunkEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildMembersChunkEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("members")]
+        [JsonPropertyName("members")]
         public GuildMember[] Members { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildRoleCreateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildRoleCreateEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildRoleCreateEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("role")]
+        [JsonPropertyName("role")]
         public Role Role { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildRoleDeleteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildRoleDeleteEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildRoleDeleteEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("role_id")]
+        [JsonPropertyName("role_id")]
         public ulong RoleId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildRoleUpdateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildRoleUpdateEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildRoleUpdateEvent
     {
-		[JsonProperty("guild_id")]
+		[JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("role")]
+        [JsonPropertyName("role")]
         public Role Role { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildScheduledEventUserAddRemoveEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildScheduledEventUserAddRemoveEvent.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,11 +9,11 @@ namespace Discord.API.Gateway
 {
     internal class GuildScheduledEventUserAddRemoveEvent
     {
-        [JsonProperty("guild_scheduled_event_id")]
+        [JsonPropertyName("guild_scheduled_event_id")]
         public ulong EventId { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong UserId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildStickerUpdateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildStickerUpdateEvent.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildStickerUpdateEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
 
-        [JsonProperty("stickers")]
+        [JsonPropertyName("stickers")]
         public Sticker[] Stickers { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildSyncEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildSyncEvent.cs
@@ -1,17 +1,17 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class GuildSyncEvent
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("large")]
+        [JsonPropertyName("large")]
         public bool Large { get; set; }
 
-        [JsonProperty("presences")]
+        [JsonPropertyName("presences")]
         public Presence[] Presences { get; set; }
-        [JsonProperty("members")]
+        [JsonPropertyName("members")]
         public GuildMember[] Members { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/HelloEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/HelloEvent.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class HelloEvent
     {
-        [JsonProperty("heartbeat_interval")]
+        [JsonPropertyName("heartbeat_interval")]
         public int HeartbeatInterval { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/IdentifyParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/IdentifyParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API.Gateway
@@ -6,17 +6,17 @@ namespace Discord.API.Gateway
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class IdentifyParams
     {
-        [JsonProperty("token")]
+        [JsonPropertyName("token")]
         public string Token { get; set; }
-        [JsonProperty("properties")]
+        [JsonPropertyName("properties")]
         public IDictionary<string, string> Properties { get; set; }
-        [JsonProperty("large_threshold")]
+        [JsonPropertyName("large_threshold")]
         public int LargeThreshold { get; set; }
-        [JsonProperty("shard")]
+        [JsonPropertyName("shard")]
         public Optional<int[]> ShardingParams { get; set; }
-        [JsonProperty("presence")]
+        [JsonPropertyName("presence")]
         public Optional<PresenceUpdateParams> Presence { get; set; }
-        [JsonProperty("intents")]
+        [JsonPropertyName("intents")]
         public Optional<int> Intents { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/IntegrationDeletedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/IntegrationDeletedEvent.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class IntegrationDeletedEvent
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("application_id")]
+        [JsonPropertyName("application_id")]
         public Optional<ulong> ApplicationID { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
@@ -1,31 +1,31 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API.Gateway
 {
     internal class InviteCreateEvent
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; set; }
-        [JsonProperty("created_at")]
+        [JsonPropertyName("created_at")]
         public DateTimeOffset CreatedAt { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
-        [JsonProperty("inviter")]
+        [JsonPropertyName("inviter")]
         public Optional<User> Inviter { get; set; }
-        [JsonProperty("max_age")]
+        [JsonPropertyName("max_age")]
         public int MaxAge { get; set; }
-        [JsonProperty("max_uses")]
+        [JsonPropertyName("max_uses")]
         public int MaxUses { get; set; }
-        [JsonProperty("target_user")]
+        [JsonPropertyName("target_user")]
         public Optional<User> TargetUser { get; set; }
-        [JsonProperty("target_user_type")]
+        [JsonPropertyName("target_user_type")]
         public Optional<TargetUserType> TargetUserType { get; set; }
-        [JsonProperty("temporary")]
+        [JsonPropertyName("temporary")]
         public bool Temporary { get; set; }
-        [JsonProperty("uses")]
+        [JsonPropertyName("uses")]
         public int Uses { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteCreatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteCreatedEvent.cs
@@ -1,5 +1,5 @@
 using Discord.API;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,23 +10,23 @@ namespace Discord.API.Gateway
 {
     internal class InviteCreatedEvent
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelID { get; set; }
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string InviteCode { get; set; }
-        [JsonProperty("timestamp")]
+        [JsonPropertyName("timestamp")]
         public Optional<DateTimeOffset> RawTimestamp { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong? GuildID { get; set; }
-        [JsonProperty("inviter")]
+        [JsonPropertyName("inviter")]
         public Optional<User> Inviter { get; set; }
-        [JsonProperty("max_age")]
+        [JsonPropertyName("max_age")]
         public int RawAge { get; set; }
-        [JsonProperty("max_uses")]
+        [JsonPropertyName("max_uses")]
         public int MaxUsers { get; set; }
-        [JsonProperty("temporary")]
+        [JsonPropertyName("temporary")]
         public bool TempInvite { get; set; }
-        [JsonProperty("uses")]
+        [JsonPropertyName("uses")]
         public int Uses { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteDeleteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteDeleteEvent.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class InviteDeleteEvent
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteDeletedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteDeletedEvent.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,11 +9,11 @@ namespace Discord.WebSocket
 {
     internal class InviteDeletedEvent
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelID { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildID { get; set; }
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/MessageDeleteBulkEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/MessageDeleteBulkEvent.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API.Gateway
 {
     internal class MessageDeleteBulkEvent
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("ids")]
+        [JsonPropertyName("ids")]
         public ulong[] Ids { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/PartialApplication.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/PartialApplication.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,10 +9,10 @@ namespace Discord.API.Gateway
 {
     internal class PartialApplication
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("flags")]
+        [JsonPropertyName("flags")]
         public ApplicationFlags Flags { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/Reaction.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/Reaction.cs
@@ -1,20 +1,20 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class Reaction
     {
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong UserId { get; set; }
-        [JsonProperty("message_id")]
+        [JsonPropertyName("message_id")]
         public ulong MessageId { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
-        [JsonProperty("emoji")]
+        [JsonPropertyName("emoji")]
         public Emoji Emoji { get; set; }
-        [JsonProperty("member")]
+        [JsonPropertyName("member")]
         public Optional<GuildMember> Member { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/ReadyEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ReadyEvent.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
@@ -6,36 +6,36 @@ namespace Discord.API.Gateway
     {
         public class ReadState
         {
-            [JsonProperty("id")]
+            [JsonPropertyName("id")]
             public string ChannelId { get; set; }
-            [JsonProperty("mention_count")]
+            [JsonPropertyName("mention_count")]
             public int MentionCount { get; set; }
-            [JsonProperty("last_message_id")]
+            [JsonPropertyName("last_message_id")]
             public string LastMessageId { get; set; }
         }
 
-        [JsonProperty("v")]
+        [JsonPropertyName("v")]
         public int Version { get; set; }
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
-        [JsonProperty("session_id")]
+        [JsonPropertyName("session_id")]
         public string SessionId { get; set; }
-        [JsonProperty("resume_gateway_url")]
+        [JsonPropertyName("resume_gateway_url")]
         public string ResumeGatewayUrl { get; set; }
-        [JsonProperty("read_state")]
+        [JsonPropertyName("read_state")]
         public ReadState[] ReadStates { get; set; }
-        [JsonProperty("guilds")]
+        [JsonPropertyName("guilds")]
         public ExtendedGuild[] Guilds { get; set; }
-        [JsonProperty("private_channels")]
+        [JsonPropertyName("private_channels")]
         public Channel[] PrivateChannels { get; set; }
-        [JsonProperty("relationships")]
+        [JsonPropertyName("relationships")]
         public Relationship[] Relationships { get; set; }
-        [JsonProperty("application")]
+        [JsonPropertyName("application")]
         public PartialApplication Application { get; set; }
 
         //Ignored
-        /*[JsonProperty("user_settings")]
-        [JsonProperty("user_guild_settings")]
-        [JsonProperty("tutorial")]*/
+        /*[JsonPropertyName("user_settings")]
+        [JsonPropertyName("user_guild_settings")]
+        [JsonPropertyName("tutorial")]*/
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/RecipientEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/RecipientEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class RecipientEvent
     {
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public User User { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/RemoveAllReactionsEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/RemoveAllReactionsEvent.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class RemoveAllReactionsEvent
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("message_id")]
+        [JsonPropertyName("message_id")]
         public ulong MessageId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/RemoveAllReactionsForEmoteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/RemoveAllReactionsForEmoteEvent.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class RemoveAllReactionsForEmoteEvent
     {
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public Optional<ulong> GuildId { get; set; }
-        [JsonProperty("message_id")]
+        [JsonPropertyName("message_id")]
         public ulong MessageId { get; set; }
-        [JsonProperty("emoji")]
+        [JsonPropertyName("emoji")]
         public Emoji Emoji { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/RequestMembersParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/RequestMembersParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Discord.API.Gateway
@@ -6,12 +6,12 @@ namespace Discord.API.Gateway
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class RequestMembersParams
     {
-        [JsonProperty("query")]
+        [JsonPropertyName("query")]
         public string Query { get; set; }
-        [JsonProperty("limit")]
+        [JsonPropertyName("limit")]
         public int Limit { get; set; }
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public IEnumerable<ulong> GuildIds { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/ResumeParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ResumeParams.cs
@@ -1,15 +1,15 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class ResumeParams
     {
-        [JsonProperty("token")]
+        [JsonPropertyName("token")]
         public string Token { get; set; }
-        [JsonProperty("session_id")]
+        [JsonPropertyName("session_id")]
         public string SessionId { get; set; }
-        [JsonProperty("seq")]
+        [JsonPropertyName("seq")]
         public int Sequence { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/ResumedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ResumedEvent.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
-    internal class ResumedEvent 
-    { 
-        [JsonProperty("heartbeat_interval")]
+    internal class ResumedEvent
+    {
+        [JsonPropertyName("heartbeat_interval")]
         public int HeartbeatInterval { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/StatusUpdateParams.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
@@ -6,13 +6,13 @@ namespace Discord.API.Gateway
     internal class PresenceUpdateParams
 
     {
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public UserStatus Status { get; set; }
-        [JsonProperty("since", NullValueHandling = NullValueHandling.Include), Int53]
+        [JsonPropertyName("since", NullValueHandling = NullValueHandling.Include), Int53]
         public long? IdleSince { get; set; }
-        [JsonProperty("afk")]
+        [JsonPropertyName("afk")]
         public bool IsAFK { get; set; }
-        [JsonProperty("activities")]
+        [JsonPropertyName("activities")]
         public object[] Activities { get; set; } // TODO, change to interface later
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/ThreadListSyncEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ThreadListSyncEvent.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class ThreadListSyncEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
 
-        [JsonProperty("channel_ids")]
+        [JsonPropertyName("channel_ids")]
         public Optional<ulong[]> ChannelIds { get; set; }
 
-        [JsonProperty("threads")]
+        [JsonPropertyName("threads")]
         public Channel[] Threads { get; set; }
 
-        [JsonProperty("members")]
+        [JsonPropertyName("members")]
         public ThreadMember[] Members { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/ThreadMembersUpdate.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ThreadMembersUpdate.cs
@@ -1,22 +1,22 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class ThreadMembersUpdated
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public ulong Id { get; set; }
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
 
-        [JsonProperty("member_count")]
+        [JsonPropertyName("member_count")]
         public int MemberCount { get; set; }
 
-        [JsonProperty("added_members")]
+        [JsonPropertyName("added_members")]
         public Optional<ThreadMember[]> AddedMembers { get; set; }
 
-        [JsonProperty("removed_member_ids")]
+        [JsonPropertyName("removed_member_ids")]
         public Optional<ulong[]> RemovedMemberIds { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/TypingStartEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/TypingStartEvent.cs
@@ -1,18 +1,18 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class TypingStartEvent
     {
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong UserId { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("member")]
+        [JsonPropertyName("member")]
         public GuildMember Member { get; set; }
-        [JsonProperty("timestamp")]
+        [JsonPropertyName("timestamp")]
         public int Timestamp { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/VoiceServerUpdateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/VoiceServerUpdateEvent.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class VoiceServerUpdateEvent
 	{
-		[JsonProperty("guild_id")]
+		[JsonPropertyName("guild_id")]
 		public ulong GuildId { get; set; }
-        [JsonProperty("endpoint")]
+        [JsonPropertyName("endpoint")]
 		public string Endpoint { get; set; }
-        [JsonProperty("token")]
+        [JsonPropertyName("token")]
 		public string Token { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/VoiceStateUpdateParams.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/VoiceStateUpdateParams.cs
@@ -1,18 +1,18 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     internal class VoiceStateUpdateParams
     {
-        [JsonProperty("self_mute")]
+        [JsonPropertyName("self_mute")]
         public bool SelfMute { get; set; }
-        [JsonProperty("self_deaf")]
+        [JsonPropertyName("self_deaf")]
         public bool SelfDeaf { get; set; }
 
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong? GuildId { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong? ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/WebhookUpdateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/WebhookUpdateEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class WebhookUpdateEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/WebhooksUpdatedEvent.cs
@@ -1,13 +1,13 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Gateway
 {
     internal class WebhooksUpdatedEvent
     {
-        [JsonProperty("guild_id")]
+        [JsonPropertyName("guild_id")]
         public ulong GuildId { get; set; }
 
-        [JsonProperty("channel_id")]
+        [JsonPropertyName("channel_id")]
         public ulong ChannelId { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/SocketFrame.cs
+++ b/src/Discord.Net.WebSocket/API/SocketFrame.cs
@@ -1,16 +1,18 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API
 {
     internal class SocketFrame
     {
-        [JsonProperty("op")]
+        [JsonPropertyName("op")]
         public int Operation { get; set; }
-        [JsonProperty("t", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonPropertyName("t")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Type { get; set; }
-        [JsonProperty("s", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonPropertyName("s")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public int? Sequence { get; set; }
-        [JsonProperty("d")]
+        [JsonPropertyName("d")]
         public object Payload { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Voice/HelloEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/HelloEvent.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Voice
 {
     internal class HelloEvent
     {
-        [JsonProperty("heartbeat_interval")]
+        [JsonPropertyName("heartbeat_interval")]
         public int HeartbeatInterval { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Voice/IdentifyParams.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/IdentifyParams.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Voice
 {
     internal class IdentifyParams
     {
-        [JsonProperty("server_id")]
+        [JsonPropertyName("server_id")]
         public ulong GuildId { get; set; }
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong UserId { get; set; }
-        [JsonProperty("session_id")]
+        [JsonPropertyName("session_id")]
         public string SessionId { get; set; }
-        [JsonProperty("token")]
+        [JsonPropertyName("token")]
         public string Token { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Voice/ReadyEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/ReadyEvent.cs
@@ -1,19 +1,19 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Discord.API.Voice
 {
     internal class ReadyEvent
     {
-        [JsonProperty("ssrc")]
+        [JsonPropertyName("ssrc")]
         public uint SSRC { get; set; }
-        [JsonProperty("ip")]
+        [JsonPropertyName("ip")]
         public string Ip { get; set; }
-        [JsonProperty("port")]
+        [JsonPropertyName("port")]
         public ushort Port { get; set; }
-        [JsonProperty("modes")]
+        [JsonPropertyName("modes")]
         public string[] Modes { get; set; }
-        [JsonProperty("heartbeat_interval")]
+        [JsonPropertyName("heartbeat_interval")]
         [Obsolete("This field is erroneous and should not be used", true)]
         public int HeartbeatInterval { get; set; }
     }

--- a/src/Discord.Net.WebSocket/API/Voice/SelectProtocolParams.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/SelectProtocolParams.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Voice
 {
     internal class SelectProtocolParams
     {
-        [JsonProperty("protocol")]
+        [JsonPropertyName("protocol")]
         public string Protocol { get; set; }
-        [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public UdpProtocolInfo Data { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Voice/SessionDescriptionEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/SessionDescriptionEvent.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Voice
 {
     internal class SessionDescriptionEvent
     {
-        [JsonProperty("secret_key")]
+        [JsonPropertyName("secret_key")]
         public byte[] SecretKey { get; set; }
-        [JsonProperty("mode")]
+        [JsonPropertyName("mode")]
         public string Mode { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Voice/SpeakingEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/SpeakingEvent.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Voice
 {
     internal class SpeakingEvent
     {
-        [JsonProperty("user_id")]
+        [JsonPropertyName("user_id")]
         public ulong UserId { get; set; }
-        [JsonProperty("ssrc")]
+        [JsonPropertyName("ssrc")]
         public uint Ssrc { get; set; }
-        [JsonProperty("speaking")]
+        [JsonPropertyName("speaking")]
         public bool Speaking { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Voice/SpeakingParams.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/SpeakingParams.cs
@@ -1,12 +1,12 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Voice
 {
     internal class SpeakingParams
     {
-        [JsonProperty("speaking")]
+        [JsonPropertyName("speaking")]
         public bool IsSpeaking { get; set; }
-        [JsonProperty("delay")]
+        [JsonPropertyName("delay")]
         public int Delay { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/API/Voice/UdpProtocolInfo.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/UdpProtocolInfo.cs
@@ -1,14 +1,14 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Discord.API.Voice
 {
     internal class UdpProtocolInfo
     {
-        [JsonProperty("address")]
+        [JsonPropertyName("address")]
         public string Address { get; set; }
-        [JsonProperty("port")]
+        [JsonPropertyName("port")]
         public int Port { get; set; }
-        [JsonProperty("mode")]
+        [JsonPropertyName("mode")]
         public string Mode { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -1,5 +1,4 @@
 using Discord.Rest;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -118,7 +117,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     Collection of WebSocket-based users.
         /// </returns>
-        public IReadOnlyCollection<SocketUser> MentionedUsers => _userMentions; 
+        public IReadOnlyCollection<SocketUser> MentionedUsers => _userMentions;
         /// <inheritdoc />
         public DateTimeOffset Timestamp => DateTimeUtils.FromTicks(_timestampTicks);
 


### PR DESCRIPTION
# Switching to System.Text.Json
This is a very early draft to switch from Newtonsoft.Json to System.Text.Json

**Draft Roadmap:**

- [ ] Migrate data classes (Partly done. Some features like `MemberSerialization = MemberSerialization.OptIn` need to be migrated)
- [ ] Migrate Clients and API classes
- [ ] Tests

Help with migrating is appreciated!

--- 

### Why switch?
Over the years System.Text.Json has come a long way and improved a lot, even beyond Newtonsoft.Json. Some major reasons of switching to System.Text.Json include:
- A major increase in performance when serializing and deserializing Data
- Cutting down on a 3rd party library and replacing it with an official one
- More robust in terms of security and reliability
- Performance that is tailored towards the targeted framework

### Additions with switching
A lot of code will need to be migrated over to System.Text.Json, many things that used to be specified with attributes when using Newtonsoft.Json will now need to be added as a setting in the serializer/deserializer.

### Problems with switching
No problems should arise if everything is tested correctly after the code was migrated over.