### PR TITLE
Avoid throwing on missing Application

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -902,7 +902,7 @@ namespace Discord.WebSocket
                                         var activities = _activity.IsSpecified ? ImmutableList.Create(_activity.Value) : null;
                                         currentUser.Presence = new SocketPresence(Status, null, activities);
                                         ApiClient.CurrentUserId = currentUser.Id;
-                                        ApiClient.CurrentApplicationId = data.Application.Id;
+                                        ApiClient.CurrentApplicationId = data.Application?.Id;
                                         Rest.CurrentUser = RestSelfUser.Create(this, data.User);
                                         int unavailableGuilds = 0;
                                         for (int i = 0; i < data.Guilds.Length; i++)


### PR DESCRIPTION
Fixes #2382

The `CurrentApplicationId` is already nullable, I don't see a reason to throw in this case.