### PR TITLE
Fix duplicated members of DiscordErrorCode

### DIFF
--- a/src/Discord.Net.Core/DiscordErrorCode.cs
+++ b/src/Discord.Net.Core/DiscordErrorCode.cs
@@ -94,10 +94,10 @@ namespace Discord
         MaxNumberOfDailyApplicationCommandCreatesHasBeenReached = 30034,
         MaximumBansForNonGuildMembersReached = 30035,
         MaximumBanFetchesReached = 30037,
-        MaximumUncompleteGuildScheduledEvents = 30038,
+        MaximumUncompletedGuildScheduledEvents = 30038,
         MaximumStickersReached = 30039,
         MaximumPruneRequestReached = 30040,
-        MaximumGuildWigitsReached = 30042,
+        MaximumGuildWidgetsReached = 30042,
         #endregion
 
         #region General Request Errors (40XXX)
@@ -128,12 +128,12 @@ namespace Discord
         MissingPermissions = 50001,
         InvalidAccountType = 50002,
         CannotExecuteForDM = 50003,
-        GuildWigitDisabled = 50004,
+        GuildWidgetDisabled = 50004,
         CannotEditOtherUsersMessage = 50005,
         CannotSendEmptyMessage = 50006,
         CannotSendMessageToUser = 50007,
         CannotSendMessageToVoiceChannel = 50008,
-        ChannelVerificationTooHight = 50009,
+        ChannelVerificationTooHigh = 50009,
         OAuth2ApplicationDoesntHaveBot = 50010,
         OAuth2ApplicationLimitReached = 50011,
         InvalidOAuth2State = 50012,
@@ -172,9 +172,8 @@ namespace Discord
         ServerRequiresMonetization = 50097,
         ServerRequiresBoosts = 50101,
         RequestBodyContainsInvalidJSON = 50109,
-        FailedToResizeAssetBelowTheMaximumSize = 50138,
         OwnershipCannotBeTransferredToABotUser = 50132,
-        AssetResizeBelowTheMaximumSize= 50138,
+        FailedToResizeAssetBelowTheMaximumSize = 50138,
         UploadedFileNotFound = 50146,
         MissingPermissionToSendThisSticker = 50600,
         #endregion
@@ -213,8 +212,8 @@ namespace Discord
         LottieCantContainRasters = 170002,
         StickerMaximumFramerateExceeded = 170003,
         StickerMaximumFrameCountExceeded = 170004,
-        LottieMaximumDimentionsExceeded = 170005,
-        StickerFramerateBoundsExceeed = 170006,
+        LottieMaximumDimensionsExceeded = 170005,
+        StickerFramerateBoundsExceeded = 170006,
         StickerAnimationDurationTooLong = 170007,
         #endregion
 
@@ -222,7 +221,7 @@ namespace Discord
         CannotUpdateFinishedEvent = 180000,
         FailedStageCreation = 180002,
         #endregion
-     
+
         #region Forum & Automod
         MessageWasBlockedByAutomaticModeration = 200000,
         TitleWasBlockedByAutomaticModeration = 200001,


### PR DESCRIPTION
[This commit](https://github.com/discord-net/Discord.Net/commit/1b01fed86767ead46ef2fc74b44deaef8a49effd) introduced duplicated enum members of DiscordErrorCode. `FailedToResizeAssetBelowTheMaximumSize` should be a replacement of `AssetResizeBelowTheMaximumSize` instead of additional enum member.

Additionally, this pull request fixes these typos in DiscordErrorCode:
 - Maximum**Uncomplete**GuildScheduledEvents -> Maximum**Uncompleted**GuildScheduledEvents
 - MaximumGuild**Wigits**Reached -> MaximumGuild**Widgets**Reached
 - Guild**Wigit**Disabled -> Guild**Widget**Disabled
 - ChannelVerificationToo**Hight** -> ChannelVerificationToo**High**
 - LottieMaximum**Dimentions**Exceeded -> LottieMaximum**Dimensions**Exceeded
 - StickerFramerateBounds**Exceeed** -> StickerFramerateBounds**Exceeded**
