### PR TITLE
Bearer token fixes

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -75,7 +75,8 @@ namespace Discord.API
             RestClient = _restClientProvider(baseUrl);
             RestClient.SetHeader("accept", "*/*");
             RestClient.SetHeader("user-agent", UserAgent);
-            RestClient.SetHeader("authorization", GetPrefixedToken(AuthTokenType, AuthToken));
+            if (!string.IsNullOrEmpty(AuthToken))
+                RestClient.SetHeader("authorization", GetPrefixedToken(AuthTokenType, AuthToken));
         }
         /// <exception cref="ArgumentException">Unknown OAuth token type.</exception>
         internal static string GetPrefixedToken(TokenType tokenType, string token)
@@ -83,7 +84,7 @@ namespace Discord.API
             return tokenType switch
             {
                 TokenType.Bot => $"Bot {token}",
-                TokenType.Bearer => $"Bearer {token}",
+                TokenType.Bearer => $"{token}",  // Bearer tokens are not prefixed
                 _ => throw new ArgumentException(message: "Unknown OAuth token type.", paramName: nameof(tokenType)),
             };
         }

--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -234,8 +234,16 @@ namespace Discord.API
                 {
                     if (!_isExplicitUrl && _gatewayUrl == null)
                     {
-                        var gatewayResponse = await GetBotGatewayAsync().ConfigureAwait(false);
-                        _gatewayUrl = FormatGatewayUrl(gatewayResponse.Url);
+                        if (AuthTokenType == TokenType.Bot)
+                        {
+                            var gatewayResponse = await GetBotGatewayAsync().ConfigureAwait(false);
+                            _gatewayUrl = FormatGatewayUrl(gatewayResponse.Url);
+                        }
+                        else
+                        {
+                            var gatewayResponse = await GetGatewayAsync().ConfigureAwait(false);
+                            _gatewayUrl = FormatGatewayUrl(gatewayResponse.Url);
+                        }
                     }
 
                     gatewayUrl = _gatewayUrl;

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -3006,6 +3006,10 @@ namespace Discord.WebSocket
         /// <exception cref="InvalidOperationException">Unexpected channel type is created.</exception>
         internal ISocketPrivateChannel AddPrivateChannel(API.Channel model, ClientState state)
         {
+            // don't add dead DMs
+            if (! (model.Recipients.GetValueOrDefault()?.Any() ?? false))
+                return null;
+
             var channel = SocketChannel.CreatePrivate(this, state, model);
             state.AddChannel(channel as SocketChannel);
             return channel;

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -315,14 +315,14 @@ namespace Discord.WebSocket
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override OverwritePermissions? GetPermissionOverwrite(IRole role)
-            => ParentChannel.GetPermissionOverwrite(role);
+            => ParentChannel?.GetPermissionOverwrite(role);
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override OverwritePermissions? GetPermissionOverwrite(IUser user)
-            => ParentChannel.GetPermissionOverwrite(user);
+            => ParentChannel?.GetPermissionOverwrite(user);
 
         /// <inheritdoc/>
         /// <remarks>


### PR DESCRIPTION
This attempts to fix a couple issues I ran into in testing with bearer tokens. The prefixed tokens were rejected with a 401 Unauthorized, and without the prefix the constructor of DiscordRestApiClient threw an exception due to the null token (which got set later).

In addition, if a DM involved a deleted user, the channel would show up as having no recipients. My quick fix for this was simply not to add the private channel.