### PR TITLE
Implemented ClientDisconnected event for audio client.

### DIFF
--- a/src/Discord.Net.Core/Audio/IAudioClient.cs
+++ b/src/Discord.Net.Core/Audio/IAudioClient.cs
@@ -13,6 +13,7 @@ namespace Discord.Audio
         event Func<ulong, AudioInStream, Task> StreamCreated;
         event Func<ulong, Task> StreamDestroyed;
         event Func<ulong, bool, Task> SpeakingUpdated;
+        event Func<ulong, Task> ClientDisconnected;
 
         /// <summary> Gets the current connection state of this client. </summary>
         ConnectionState ConnectionState { get; }

--- a/src/Discord.Net.WebSocket/API/Voice/ClientDisconnectEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Voice/ClientDisconnectEvent.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.API.Voice;
+internal class ClientDisconnectEvent
+{
+    [JsonProperty("user_id")]
+    public ulong UserId { get; set; }
+}

--- a/src/Discord.Net.WebSocket/Audio/AudioClient.Events.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.Events.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Discord.Audio
@@ -47,5 +47,11 @@ namespace Discord.Audio
             remove { _speakingUpdatedEvent.Remove(value); }
         }
         private readonly AsyncEvent<Func<ulong, bool, Task>> _speakingUpdatedEvent = new AsyncEvent<Func<ulong, bool, Task>>();
+        public event Func<ulong, Task> ClientDisconnected
+        {
+            add { _clientDisconnectedEvent.Add(value); }
+            remove { _clientDisconnectedEvent.Remove(value); }
+        }
+        private readonly AsyncEvent<Func<ulong, Task>> _clientDisconnectedEvent = new AsyncEvent<Func<ulong, Task>>();
     }
 }

--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
+using System.Collections.Generic; 
 
 namespace Discord.Audio
 {
@@ -277,6 +277,15 @@ namespace Discord.Audio
                             _ssrcMap[data.Ssrc] = data.UserId; //TODO: Memory Leak: SSRCs are never cleaned up
 
                             await _speakingUpdatedEvent.InvokeAsync(data.UserId, data.Speaking);
+                        }
+                        break;
+                    case VoiceOpCode.ClientDisconnect:
+                        {
+                            await _audioLogger.DebugAsync("Received ClientDisconnect").ConfigureAwait(false);
+
+                            var data = (payload as JToken).ToObject<ClientDisconnectEvent>(_serializer);
+
+                            await _clientDisconnectedEvent.InvokeAsync(data.UserId);
                         }
                         break;
                     default:


### PR DESCRIPTION
This PR adds the ClientDisconnected event to the AudioClient class and IAudioClient interface, which was otherwise defined as a VoiceOPCode but not implemented as a subscribable event.