### PR TITLE
Fixed syntax error in example AutocompleteHandler

### DIFF
--- a/docs/guides/int_framework/samples/autocompletion/autocomplete-example.cs
+++ b/docs/guides/int_framework/samples/autocompletion/autocomplete-example.cs
@@ -1,6 +1,6 @@
 // you need to add `Autocomplete` attribute before parameter to add autocompletion to it
 [SlashCommand("command_name", "command_description")]
-public async Task ExampleCommand([Summary("parameter_name"), Autocomplete(typeof(ExampleAutocompleteHandler))] string parameterWithAutocompletion)
+public async Task ExampleCommand([Summary("parameter_name"), [Autocomplete(typeof(ExampleAutocompleteHandler))] string parameterWithAutocompletion)
     => await RespondAsync($"Your choice: {parameterWithAutocompletion}");
 
 public class ExampleAutocompleteHandler : AutocompleteHandler


### PR DESCRIPTION
It only fix a syntax error in a code example in the docs -> https://discordnet.dev/guides/int_framework/autocompletion.html#creating-autocompletehandlers