### PR TITLE
[feature-ish] Fix `GetActiveThreadsAsync` & add it to `ITextChannel`

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -160,5 +160,15 @@ namespace Discord
         /// </returns>
         Task<IThreadChannel> CreateThreadAsync(string name, ThreadType type = ThreadType.PublicThread, ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay,
             IMessage message = null, bool? invitable = null, int? slowmode = null, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a collection of active threads within this channel.
+        /// </summary>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents an asynchronous get operation for retrieving the threads. The task result contains
+        ///     a collection of active threads.
+        /// </returns>
+        Task<IReadOnlyCollection<IThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -134,9 +134,9 @@ namespace Discord.Rest
             MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
             => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
-        /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
+        /// <inheritdoc cref="ITextChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsAsync(Guild, Discord, options);
+            => ThreadHelper.GetActiveThreadsAsync(Guild, Id, Discord, options);
 
         /// <inheritdoc cref="IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -288,6 +288,10 @@ namespace Discord.Rest
         /// <inheritdoc />
         public Task SyncPermissionsAsync(RequestOptions options = null)
             => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
+
+        /// <inheritdoc cref="ITextChannel.GetActiveThreadsAsync(RequestOptions)"/>
+        public virtual Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => ThreadHelper.GetActiveThreadsAsync(Guild, Id, Discord, options);
         #endregion
 
         #region Invites
@@ -321,6 +325,10 @@ namespace Discord.Rest
 
         async Task<IThreadChannel> ITextChannel.CreateThreadAsync(string name, ThreadType type, ThreadArchiveDuration autoArchiveDuration, IMessage message, bool? invitable, int? slowmode, RequestOptions options)
             => await CreateThreadAsync(name, type, autoArchiveDuration, message, invitable, slowmode, options);
+
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IThreadChannel>> ITextChannel.GetActiveThreadsAsync(RequestOptions options)
+            => await GetActiveThreadsAsync(options);
         #endregion
 
         #region IMessageChannel

--- a/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
@@ -241,5 +241,9 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public Task RemoveUserAsync(IGuildUser user, RequestOptions options = null)
             => Discord.ApiClient.RemoveThreadMemberAsync(Id, user.Id, options);
+
+        /// <inheritdoc/> <exception cref="NotSupportedException">This method is not supported in threads.</exception>
+        public override Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => throw new NotSupportedException("This method is not supported in threads.");
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -234,6 +234,10 @@ namespace Discord.Rest
             return base.TriggerTypingAsync(options);
         }
 
+        /// <inheritdoc/> <exception cref="NotSupportedException">Threads are not supported in voice channels</exception>
+        public override Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => throw new NotSupportedException("Threads are not supported in voice channels");
+
         #endregion
 
 

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -68,10 +68,10 @@ namespace Discord.Rest
             return await client.ApiClient.ModifyThreadAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }
 
-        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(IGuild guild, BaseDiscordClient client, RequestOptions options)
+        public static async Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(IGuild guild, ulong channelId, BaseDiscordClient client, RequestOptions options)
         {
             var result = await client.ApiClient.GetActiveThreadsAsync(guild.Id, options).ConfigureAwait(false);
-            return result.Threads.Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
+            return result.Threads.Where(x => x.CategoryId == channelId).Select(x => RestThreadChannel.Create(client, guild, x)).ToImmutableArray();
         }
 
         public static async Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(IGuildChannel channel, BaseDiscordClient client, int? limit = null,

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -135,9 +135,9 @@ namespace Discord.WebSocket
             MessageComponent components = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None, ForumTag[] tags = null)
             => ThreadHelper.CreatePostAsync(this, Discord, title, attachments, archiveDuration, slowmode, text, embed, options, allowedMentions, components, stickers, embeds, flags, tags?.Select(tag => tag.Id).ToArray());
 
-        /// <inheritdoc cref="IForumChannel.GetActiveThreadsAsync(RequestOptions)"/>
+        /// <inheritdoc cref="ITextChannel.GetActiveThreadsAsync(RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
-            => ThreadHelper.GetActiveThreadsAsync(Guild, Discord, options);
+            => ThreadHelper.GetActiveThreadsAsync(Guild, Id, Discord, options);
 
         /// <inheritdoc cref="IForumChannel.GetJoinedPrivateArchivedThreadsAsync(int?, DateTimeOffset?, RequestOptions)"/>
         public Task<IReadOnlyCollection<RestThreadChannel>> GetJoinedPrivateArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -130,7 +130,12 @@ namespace Discord.WebSocket
 
             return thread;
         }
-#endregion
+
+        /// <inheritdoc cref="ITextChannel.GetActiveThreadsAsync(RequestOptions)"/>
+        public virtual Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => ThreadHelper.GetActiveThreadsAsync(Guild, Id, Discord, options);
+
+        #endregion
 
         #region Messages
         /// <inheritdoc />
@@ -378,6 +383,9 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         async Task<IThreadChannel> ITextChannel.CreateThreadAsync(string name, ThreadType type, ThreadArchiveDuration autoArchiveDuration, IMessage message, bool? invitable, int? slowmode, RequestOptions options)
             => await CreateThreadAsync(name, type, autoArchiveDuration, message, invitable, slowmode, options);
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IThreadChannel>> ITextChannel.GetActiveThreadsAsync(RequestOptions options)
+            => await GetActiveThreadsAsync(options);
         #endregion
 
         #region IGuildChannel

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -374,6 +374,10 @@ namespace Discord.WebSocket
         public override Task SyncPermissionsAsync(RequestOptions options = null)
             => throw new NotSupportedException("This method is not supported in threads.");
 
+        /// <inheritdoc/> <exception cref="NotSupportedException">This method is not supported in threads.</exception>
+        public override Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => throw new NotSupportedException("This method is not supported in threads.");
+
         string IChannel.Name => Name;
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -296,6 +296,10 @@ namespace Discord.WebSocket
             return base.TriggerTypingAsync(options);
         }
 
+        /// <inheritdoc/> <exception cref="NotSupportedException">Threads are not supported in voice channels</exception>
+        public override Task<IReadOnlyCollection<RestThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null)
+            => throw new NotSupportedException("Threads are not supported in voice channels");
+
         #endregion
 
         private string DebuggerDisplay => $"{Name} ({Id}, Voice)";

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
@@ -214,11 +214,12 @@ namespace Discord
         {
             throw new NotImplementedException();
         }
-
+        
         public Task<IUserMessage> SendFileAsync(FileAttachment attachment, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, MessageComponent component = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None) => throw new NotImplementedException();
         public Task<IUserMessage> SendFilesAsync(IEnumerable<FileAttachment> attachments, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null, MessageReference messageReference = null, MessageComponent component = null, ISticker[] stickers = null, Embed[] embeds = null, MessageFlags flags = MessageFlags.None) => throw new NotImplementedException();
         public Task<IThreadChannel> CreateThreadAsync(string name, ThreadType type = ThreadType.PublicThread, ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay, IMessage message = null, bool? invitable = null, int? slowmode = null, RequestOptions options = null, MessageFlags flags = MessageFlags.None) => throw new NotImplementedException();
         public Task<IInviteMetadata> CreateInviteToApplicationAsync(DefaultApplications application, int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null) => throw new NotImplementedException();
         public Task<IThreadChannel> CreateThreadAsync(string name, ThreadType type = ThreadType.PublicThread, ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay, IMessage message = null, bool? invitable = null, int? slowmode = null, RequestOptions options = null) => throw new NotImplementedException();
+        public Task<IReadOnlyCollection<IThreadChannel>> GetActiveThreadsAsync(RequestOptions options = null) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
`IForumChannel.GetActiveThreadsAsync` was not working in a way its description said... so I reworked it a bit

### Changes
- `GetActiveThreadsAsync` actually does what it should - gets threads **only from the channel this method is called on**
- Add `GetActiveThreadsAsync` to `ITextChannel` 

This PR fixes #2427 