### PR TITLE
[Feature] Application Role Connections Metadata support

### DIFF
--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
@@ -14,7 +14,7 @@ public class RoleConnection
     public string PlatformName { get; }
 
     /// <summary>
-    ///     Gets the username on the platform a bot has connected.
+    ///     Gets the username on the platform a bot has connected to.
     /// </summary>
     public string PlatformUsername { get; }
 

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Discord;
+
+public class RoleConnection
+{
+    /// <summary>
+    ///     Gets the vanity name of the platform a bot has connected.
+    /// </summary>
+    public string PlatformName { get; }
+
+    /// <summary>
+    ///     Gets the username on the platform a bot has connected.
+    /// </summary>
+    public string PlatformUsername { get; }
+
+    /// <summary>
+    ///     
+    /// </summary>
+    public IReadOnlyDictionary<string, object> Metadata { get; }
+
+    internal RoleConnection(string platformName, string platformUsername, IReadOnlyDictionary<string, object> metadata)
+    {
+        PlatformName = platformName;
+        PlatformUsername = platformUsername;
+        Metadata = metadata;
+    }
+}

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 
 namespace Discord;
 
+/// <summary>
+///     Represents the connection object that the user has attached.
+/// </summary>
 public class RoleConnection
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Discord;
@@ -18,14 +19,25 @@ public class RoleConnection
     public string PlatformUsername { get; }
 
     /// <summary>
-    ///     
+    ///     Gets the object mapping <see cref="RoleConnectionMetadata"/> keys to their string-ified values.
     /// </summary>
-    public IReadOnlyDictionary<string, object> Metadata { get; }
+    public IReadOnlyDictionary<string, string> Metadata { get; }
 
-    internal RoleConnection(string platformName, string platformUsername, IReadOnlyDictionary<string, object> metadata)
+    internal RoleConnection(string platformName, string platformUsername, IReadOnlyDictionary<string, string> metadata)
     {
         PlatformName = platformName;
         PlatformUsername = platformUsername;
         Metadata = metadata;
     }
+
+    /// <summary>
+    ///     Initializes a new <see cref="RoleConnectionProperties"/> with the data from this object.
+    /// </summary>
+    public RoleConnectionProperties ToRoleConnectionProperties()
+        => new()
+        {
+            PlatformName = PlatformName,
+            PlatformUsername = PlatformUsername,
+            Metadata = Metadata.ToDictionary()
+        };
 }

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnection.cs
@@ -9,7 +9,7 @@ namespace Discord;
 public class RoleConnection
 {
     /// <summary>
-    ///     Gets the vanity name of the platform a bot has connected.
+    ///     Gets the vanity name of the platform a bot has connected to.
     /// </summary>
     public string PlatformName { get; }
 

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
@@ -1,9 +1,11 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Discord;
 
+/// <summary>
+///     Represents the role connection metadata object.
+/// </summary>
 public class RoleConnectionMetadata
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -5,26 +6,58 @@ namespace Discord;
 
 public class RoleConnectionMetadata
 {
+    /// <summary>
+    ///     Gets the of metadata value.
+    /// </summary>
     public RoleConnectionMetadataType Type { get; }
 
+    /// <summary>
+    ///     Gets the dictionary key for the metadata field.
+    /// </summary>
     public string Key { get; }
 
-    public string Name{ get; }
+    /// <summary>
+    ///     Gets the name of the metadata field.
+    /// </summary>
+    public string Name { get; }
 
-    public Optional<IReadOnlyDictionary<string, string>> NameLocalizations { get; }
-
+    /// <summary>
+    ///     Gets the description of the metadata field.
+    /// </summary>
     public string Description { get; }
 
-    public Optional<IReadOnlyDictionary<string, string>> DescriptionLocalizations { get; }
+    /// <summary>
+    ///     Gets translations of the name. <see langword="null"/> if not set.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> NameLocalizations { get; }
+
+    /// <summary>
+    ///     Gets translations of the description. <see langword="null"/> if not set.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> DescriptionLocalizations { get; }
 
     internal RoleConnectionMetadata(RoleConnectionMetadataType type, string key, string name, string description,
-        Dictionary<string, string> nameLocalizations = null, Dictionary<string, string> descriptionLocalizations = null)
+        IDictionary<string, string> nameLocalizations = null, IDictionary<string, string> descriptionLocalizations = null)
     {
         Type = type;
         Key = key;
         Name = name;
         Description = description;
-        NameLocalizations = nameLocalizations.ToImmutableDictionary();
-        DescriptionLocalizations = descriptionLocalizations.ToImmutableDictionary();
+        NameLocalizations = nameLocalizations?.ToImmutableDictionary();
+        DescriptionLocalizations = descriptionLocalizations?.ToImmutableDictionary();
     }
+
+    /// <summary>
+    ///     Initializes a new <see cref="RoleConnectionMetadataProperties"/> with the data from this object.
+    /// </summary>
+    public RoleConnectionMetadataProperties ToRoleConnectionMetadataProperties()
+        => new()
+        {
+            Name = Name,
+            Description = Description,
+            Type = Type,
+            Key = Key,
+            NameLocalizations = NameLocalizations,
+            DescriptionLocalizations = DescriptionLocalizations
+        };
 }

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Discord;
 
@@ -10,11 +11,11 @@ public class RoleConnectionMetadata
 
     public string Name{ get; }
 
-    public Optional<Dictionary<string, string>> NameLocalizations { get; }
+    public Optional<IReadOnlyDictionary<string, string>> NameLocalizations { get; }
 
     public string Description { get; }
 
-    public Optional<Dictionary<string, string>> DescriptionLocalizations { get; }
+    public Optional<IReadOnlyDictionary<string, string>> DescriptionLocalizations { get; }
 
     internal RoleConnectionMetadata(RoleConnectionMetadataType type, string key, string name, string description,
         Dictionary<string, string> nameLocalizations = null, Dictionary<string, string> descriptionLocalizations = null)
@@ -23,7 +24,7 @@ public class RoleConnectionMetadata
         Key = key;
         Name = name;
         Description = description;
-        NameLocalizations = nameLocalizations;
-        DescriptionLocalizations = descriptionLocalizations;
+        NameLocalizations = nameLocalizations.ToImmutableDictionary();
+        DescriptionLocalizations = descriptionLocalizations.ToImmutableDictionary();
     }
 }

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadata.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Discord;
+
+public class RoleConnectionMetadata
+{
+    public RoleConnectionMetadataType Type { get; }
+
+    public string Key { get; }
+
+    public string Name{ get; }
+
+    public Optional<Dictionary<string, string>> NameLocalizations { get; }
+
+    public string Description { get; }
+
+    public Optional<Dictionary<string, string>> DescriptionLocalizations { get; }
+
+    internal RoleConnectionMetadata(RoleConnectionMetadataType type, string key, string name, string description,
+        Dictionary<string, string> nameLocalizations = null, Dictionary<string, string> descriptionLocalizations = null)
+    {
+        Type = type;
+        Key = key;
+        Name = name;
+        Description = description;
+        NameLocalizations = nameLocalizations;
+        DescriptionLocalizations = descriptionLocalizations;
+    }
+}

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataProperties.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataProperties.cs
@@ -120,5 +120,19 @@ public class RoleConnectionMetadataProperties
     ///     Initializes a new instance of <see cref="RoleConnectionMetadataProperties"/>.
     /// </summary>
     public RoleConnectionMetadataProperties() { }
+
+    /// <summary>
+    ///     Initializes a new <see cref="RoleConnectionMetadataProperties"/> with the data from provided <see cref="RoleConnectionMetadata"/>.
+    /// </summary>
+    public static RoleConnectionMetadataProperties FromRoleConnectionMetadata(RoleConnectionMetadata metadata)
+        => new()
+        {
+            Name = metadata.Name,
+            Description = metadata.Description,
+            Type = metadata.Type,
+            Key = metadata.Key,
+            NameLocalizations = metadata.NameLocalizations,
+            DescriptionLocalizations = metadata.DescriptionLocalizations
+        };
 }
 

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataProperties.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataProperties.cs
@@ -4,6 +4,9 @@ using System.Collections.Immutable;
 
 namespace Discord;
 
+/// <summary>
+///     Properties object used to create or modify <see cref="RoleConnectionMetadata"/> object.
+/// </summary>
 public class RoleConnectionMetadataProperties
 {
     private const int MaxKeyLength = 50;

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataProperties.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataProperties.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
+
+namespace Discord;
+
+public class RoleConnectionMetadataProperties
+{
+    private const int MaxKeyLength = 50;
+    private const int MaxNameLength = 100;
+    private const int MaxDescriptionLength = 200;
+
+    private string _key;
+    private string _name;
+    private string _description;
+
+    private IReadOnlyDictionary<string, string> _nameLocalizations;
+    private IReadOnlyDictionary<string, string> _descriptionLocalizations;
+
+    /// <summary>
+    ///     Gets or sets the of metadata value.
+    /// </summary>
+    public RoleConnectionMetadataType Type { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the dictionary key for the metadata field.
+    /// </summary>
+    public string Key
+    {
+        get => _key;
+        set
+        {
+            Preconditions.AtMost(value.Length, MaxKeyLength, nameof(Key), $"Key length must be less than or equal to {MaxKeyLength}");
+            _key = value;
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets the name of the metadata field.
+    /// </summary>
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            Preconditions.AtMost(value.Length, MaxNameLength, nameof(Name), $"Name length must be less than or equal to {MaxNameLength}");
+            _name = value;
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets the description of the metadata field.
+    /// </summary>
+    public string Description
+    {
+        get => _description;
+        set
+        {
+            Preconditions.AtMost(value.Length, MaxDescriptionLength, nameof(Description), $"Description length must be less than or equal to {MaxDescriptionLength}");
+            _description = value;
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets translations of the name. <see langword="null"/> if not set.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> NameLocalizations
+    {
+        get => _nameLocalizations;
+        set
+        {
+            if (value is not null)
+                foreach (var localization in value)
+                    if (localization.Value.Length > MaxNameLength)
+                        throw new ArgumentException($"Name localization length must be less than or equal to {MaxNameLength}. Locale '{localization}'");
+            _nameLocalizations = value;
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets translations of the description. <see langword="null"/> if not set.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> DescriptionLocalizations
+    {
+        get => _descriptionLocalizations;
+        set
+        {
+            if (value is not null)
+                foreach (var localization in value)
+                    if (localization.Value.Length > MaxDescriptionLength)
+                        throw new ArgumentException($"Description localization length must be less than or equal to {MaxDescriptionLength}. Locale '{localization}'");
+            _descriptionLocalizations = value;
+        }
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of <see cref="RoleConnectionMetadataProperties"/>.
+    /// </summary>
+    /// <param name="type">The type of the metadata value.</param>
+    /// <param name="key">The dictionary key for the metadata field. Max 50 characters.</param>
+    /// <param name="name">The name of the metadata visible in user profile. Max 100 characters.</param>
+    /// <param name="description">The description of the metadata visible in user profile. Max 200 characters.</param>
+    /// <param name="nameLocalizations">Translations for the name.</param>
+    /// <param name="descriptionLocalizations">Translations for the description.</param>
+    public RoleConnectionMetadataProperties(RoleConnectionMetadataType type, string key, string name, string description,
+        IDictionary<string, string> nameLocalizations = null, IDictionary<string, string> descriptionLocalizations = null)
+    {
+        Type = type;
+        Key = key;
+        Name = name;
+        Description = description;
+        NameLocalizations = nameLocalizations?.ToImmutableDictionary();
+        DescriptionLocalizations = descriptionLocalizations?.ToImmutableDictionary();
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of <see cref="RoleConnectionMetadataProperties"/>.
+    /// </summary>
+    public RoleConnectionMetadataProperties() { }
+}
+

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataType.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataType.cs
@@ -3,47 +3,47 @@ using System;
 namespace Discord;
 
 /// <summary>
-///     Represents the type of Application Role Connection Metadata
+///     Represents the type of Application Role Connection Metadata.
 /// </summary>
 public enum RoleConnectionMetadataType
 {
     /// <summary>
-    /// 	The metadata's integer value is less than or equal to the guild's configured value
+    /// 	The metadata's integer value is less than or equal to the guild's configured value.
     /// </summary>
     IntegerLessOrEqual = 1,
 
     /// <summary>
-    /// 	The metadata's integer value is greater than or equal to the guild's configured value
+    /// 	The metadata's integer value is greater than or equal to the guild's configured value.
     /// </summary>
     IntegerGreaterOrEqual = 2,
 
     /// <summary>
-    /// 	The metadata's integer value is equal to the guild's configured value
+    /// 	The metadata's integer value is equal to the guild's configured value.
     /// </summary>
     IntegerEqual = 3,
 
     /// <summary>
-    /// 	The metadata's integer value is not equal to the guild's configured value
+    /// 	The metadata's integer value is not equal to the guild's configured value.
     /// </summary>
     IntegerNotEqual = 4,
 
     /// <summary>
-    /// 	The metadata's ISO8601 string value is less or equal to the guild's configured value
+    /// 	The metadata's ISO8601 string value is less or equal to the guild's configured value.
     /// </summary>
     DateTimeLessOrEqual = 5,
 
     /// <summary>
-    /// 	The metadata's ISO8601 string value is greater to the guild's configured value
+    /// 	The metadata's ISO8601 string value is greater to the guild's configured value.
     /// </summary>
     DateTimeGreaterOrEqual = 6,
 
     /// <summary>
-    /// 	The metadata's integer value is equal to the guild's configured value
+    /// 	The metadata's integer value is equal to the guild's configured value.
     /// </summary>
     BoolEqual = 7,
 
     /// <summary>
-    /// 	The metadata's integer value is equal to the guild's configured value
+    /// 	The metadata's integer value is equal to the guild's configured value.
     /// </summary>
     BoolNotEqual = 8,
 }

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataType.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionMetadataType.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace Discord;
+
+/// <summary>
+///     Represents the type of Application Role Connection Metadata
+/// </summary>
+public enum RoleConnectionMetadataType
+{
+    /// <summary>
+    /// 	The metadata's integer value is less than or equal to the guild's configured value
+    /// </summary>
+    IntegerLessOrEqual = 1,
+
+    /// <summary>
+    /// 	The metadata's integer value is greater than or equal to the guild's configured value
+    /// </summary>
+    IntegerGreaterOrEqual = 2,
+
+    /// <summary>
+    /// 	The metadata's integer value is equal to the guild's configured value
+    /// </summary>
+    IntegerEqual = 3,
+
+    /// <summary>
+    /// 	The metadata's integer value is not equal to the guild's configured value
+    /// </summary>
+    IntegerNotEqual = 4,
+
+    /// <summary>
+    /// 	The metadata's ISO8601 string value is less or equal to the guild's configured value
+    /// </summary>
+    DateTimeLessOrEqual = 5,
+
+    /// <summary>
+    /// 	The metadata's ISO8601 string value is greater to the guild's configured value
+    /// </summary>
+    DateTimeGreaterOrEqual = 6,
+
+    /// <summary>
+    /// 	The metadata's integer value is equal to the guild's configured value
+    /// </summary>
+    BoolEqual = 7,
+
+    /// <summary>
+    /// 	The metadata's integer value is equal to the guild's configured value
+    /// </summary>
+    BoolNotEqual = 8,
+}

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionProperties.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionProperties.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+
+namespace Discord;
+
+/// <summary>
+///     Represents the properties used to modify user's <see cref="RoleConnection"/>.
+/// </summary>
+public class RoleConnectionProperties
+{
+    private const int MaxPlatformNameLength = 50;
+    private const int MaxPlatformUsernameLength = 100;
+    private const int MaxMetadataRecords = 100;
+
+    private string _platformName;
+    private string _platformUsername;
+    private Dictionary<string, string> _metadata;
+
+    /// <summary>
+    ///     Gets or sets the vanity name of the platform a bot has connected. Max 50 characters.
+    /// </summary>
+    public string PlatformName
+    {
+        get => _platformName;
+        set
+        {
+            if (value is not null)
+                Preconditions.AtMost(value.Length, MaxPlatformNameLength, nameof(PlatformName), $"Platform name length must be less or equal to {MaxPlatformNameLength}");
+            _platformName = value;
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets the username on the platform a bot has connected. Max 100 characters.
+    /// </summary>
+    public string PlatformUsername
+    {
+        get => _platformUsername;
+        set
+        {
+            if(value is not null)
+                Preconditions.AtMost(value.Length, MaxPlatformUsernameLength, nameof(PlatformUsername), $"Platform username length must be less or equal to {MaxPlatformUsernameLength}");
+            _platformUsername = value;
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets object mapping <see cref="RoleConnectionMetadata"/> keys to their string-ified values.
+    /// </summary>
+    public Dictionary<string, string> Metadata
+    {
+        get => _metadata;
+        set
+        {
+            if (value is not null)
+                Preconditions.AtMost(value.Count, MaxPlatformUsernameLength, nameof(Metadata), $"Metadata records count must be less or equal to {MaxMetadataRecords}");
+            _metadata = value;
+        }
+    }
+
+    /// <summary>
+    ///     Adds a metadata record with the provided key and value.
+    /// </summary>
+    /// <returns>The current <see cref="RoleConnectionProperties"/>.</returns>
+    public RoleConnectionProperties WithDate(string key, DateTimeOffset value)
+        => AddMetadataRecord(key, value.ToString("O"));
+
+    /// <summary>
+    ///     Adds a metadata record with the provided key and value.
+    /// </summary>
+    /// <returns>The current <see cref="RoleConnectionProperties"/>.</returns>
+    public RoleConnectionProperties WithBool(string key, bool value)
+        => AddMetadataRecord(key, value ? "1" : "0");
+
+    /// <summary>
+    ///     Adds a metadata record with the provided key and value.
+    /// </summary>
+    /// <returns>The current <see cref="RoleConnectionProperties"/>.</returns>
+    public RoleConnectionProperties WithNumber(string key, int value)
+        => AddMetadataRecord(key, value.ToString());
+
+    /// <summary>
+    ///     Adds a metadata record with the provided key and value.
+    /// </summary>
+    /// <returns>The current <see cref="RoleConnectionProperties"/>.</returns>
+    public RoleConnectionProperties WithNumber(string key, uint value)
+        => AddMetadataRecord(key, value.ToString());
+
+    /// <summary>
+    ///     Adds a metadata record with the provided key and value.
+    /// </summary>
+    /// <returns>The current <see cref="RoleConnectionProperties"/>.</returns>
+    public RoleConnectionProperties WithNumber(string key, long value)
+        => AddMetadataRecord(key, value.ToString());
+
+    /// <summary>
+    ///     Adds a metadata record with the provided key and value.
+    /// </summary>
+    /// <returns>The current <see cref="RoleConnectionProperties"/>.</returns>
+    public RoleConnectionProperties WithNumber(string key, ulong value)
+        => AddMetadataRecord(key, value.ToString());
+
+    internal RoleConnectionProperties AddMetadataRecord(string key, string value)
+    {
+        Metadata ??= new Dictionary<string, string>();
+        if(!Metadata.ContainsKey(key))
+            Preconditions.AtMost(Metadata.Count + 1, MaxPlatformUsernameLength, nameof(Metadata), $"Metadata records count must be less or equal to {MaxMetadataRecords}");
+
+        _metadata[key] = value;
+        return this;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of <see cref="RoleConnectionProperties"/>.
+    /// </summary>
+    /// <param name="platformName">The name of the platform a bot has connected.</param>s
+    /// <param name="platformUsername">Gets the username on the platform a bot has connected.</param>
+    /// <param name="metadata">Object mapping <see cref="RoleConnectionMetadata"/> keys to their values.</param>
+    public RoleConnectionProperties(string platformName, string platformUsername, IDictionary<string, string> metadata = null)
+    {
+        PlatformName = platformName;
+        PlatformUsername = platformUsername;
+        Metadata = metadata.ToDictionary();
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of <see cref="RoleConnectionProperties"/>.
+    /// </summary>
+    public RoleConnectionProperties() {}
+
+    /// <summary>
+    ///     Initializes a new <see cref="RoleConnectionProperties"/> with the data from provided <see cref="RoleConnection"/>.
+    /// </summary>
+    public static RoleConnectionProperties FromRoleConnection(RoleConnection roleConnection)
+        => new()
+        {
+            PlatformName = roleConnection.PlatformName,
+            PlatformUsername = roleConnection.PlatformUsername,
+            Metadata = roleConnection.Metadata.ToDictionary()
+        };
+}

--- a/src/Discord.Net.Rest/API/Common/RoleConnection.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleConnection.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Discord.API;
+
+public class RoleConnection
+{
+    [JsonProperty("platform_name")]
+    public Optional<string> PlatformName { get; set; }
+
+    [JsonProperty("platform_username")]
+    public Optional<string> PlatformUsername { get; set; }
+
+    [JsonProperty("metadata")]
+    public Optional<Dictionary<string, string>> Metadata { get; set; }
+}

--- a/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
@@ -18,8 +18,8 @@ public class RoleConnectionMetadata
     public string Description { get; set; }
 
     [JsonProperty("name_localizations")]
-    public Optional<IReadOnlyCollection<KeyValuePair<string, string>>> NameLocalizations { get; set; }
+    public Optional<Dictionary<string, string>> NameLocalizations { get; set; }
 
     [JsonProperty("description_localizations")]
-    public Optional<IReadOnlyCollection<KeyValuePair<string, string>>> DescriptionLocalizations { get; set; }
+    public Optional<Dictionary<string, string>> DescriptionLocalizations { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
@@ -18,8 +18,8 @@ public class RoleConnectionMetadata
     public string Description { get; set; }
 
     [JsonProperty("name_localizations")]
-    public Optional<IEnumerable<KeyValuePair<string, string>>> NameLocalizations { get; set; }
+    public Optional<IReadOnlyCollection<KeyValuePair<string, string>>> NameLocalizations { get; set; }
 
     [JsonProperty("description_localizations")]
-    public Optional<IEnumerable<KeyValuePair<string, string>>> DescriptionLocalizations { get; set; }
+    public Optional<IReadOnlyCollection<KeyValuePair<string, string>>> DescriptionLocalizations { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Discord.API;
+
+public class RoleConnectionMetadata
+{
+    [JsonProperty("type")]
+    public RoleConnectionMetadataType Type { get; set; }
+
+    [JsonProperty("key")]
+    public string Key { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("description")]
+    public string Description { get; set; }
+
+    [JsonProperty("name_localizations")]
+    public Optional<IEnumerable<KeyValuePair<string, string>>> NameLocalizations { get; set; }
+
+    [JsonProperty("description_localizations")]
+    public Optional<IEnumerable<KeyValuePair<string, string>>> DescriptionLocalizations { get; set; }
+}

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -264,5 +264,50 @@ namespace Discord.Rest
         public static Task RemoveRoleAsync(BaseDiscordClient client, ulong guildId, ulong userId, ulong roleId, RequestOptions options = null)
             => client.ApiClient.RemoveRoleAsync(guildId, userId, roleId, options);
         #endregion
+
+        #region Role Subscription Metadata
+
+        public static async Task<IReadOnlyCollection<RoleConnectionMetadata>> GetRoleConnectionMetadataRecordsAsync(BaseDiscordClient client, RequestOptions options = null)
+            => (await client.ApiClient.GetApplicationRoleConnectionMetadataRecordsAsync(options))
+                .Select(model
+                    => new RoleConnectionMetadata(
+                        model.Type,
+                        model.Key,
+                        model.Name,
+                        model.Description,
+                        model.NameLocalizations.IsSpecified
+                            ? model.NameLocalizations.Value?.ToImmutableDictionary()
+                            : null,
+                        model.DescriptionLocalizations.IsSpecified
+                            ? model.DescriptionLocalizations.Value?.ToImmutableDictionary()
+                            : null))
+                .ToImmutableArray();
+
+        public static async Task<IReadOnlyCollection<RoleConnectionMetadata>> ModifyRoleConnectionMetadataRecordsAsync(ICollection<RoleConnectionMetadataProperties> metadata, BaseDiscordClient client, RequestOptions options = null)
+            => (await client.ApiClient.UpdateApplicationRoleConnectionMetadataRecordsAsync(metadata
+                .Select(x => new API.RoleConnectionMetadata
+                {
+                    Name = x.Name,
+                    Description = x.Description,
+                    Key = x.Key,
+                    Type = x.Type,
+                    NameLocalizations = x.NameLocalizations?.ToDictionary(),
+                    DescriptionLocalizations = x.DescriptionLocalizations?.ToDictionary()
+                }).ToArray()))
+                .Select(model
+                    => new RoleConnectionMetadata(
+                        model.Type,
+                        model.Key,
+                        model.Name,
+                        model.Description,
+                        model.NameLocalizations.IsSpecified
+                            ? model.NameLocalizations.Value?.ToImmutableDictionary()
+                            : null,
+                        model.DescriptionLocalizations.IsSpecified
+                            ? model.DescriptionLocalizations.Value?.ToImmutableDictionary()
+                            : null))
+                .ToImmutableArray();
+
+        #endregion
     }
 }

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -265,7 +265,7 @@ namespace Discord.Rest
             => client.ApiClient.RemoveRoleAsync(guildId, userId, roleId, options);
         #endregion
 
-        #region Role Subscription Metadata
+        #region Role Connection Metadata
 
         public static async Task<IReadOnlyCollection<RoleConnectionMetadata>> GetRoleConnectionMetadataRecordsAsync(BaseDiscordClient client, RequestOptions options = null)
             => (await client.ApiClient.GetApplicationRoleConnectionMetadataRecordsAsync(options))
@@ -307,6 +307,33 @@ namespace Discord.Rest
                             ? model.DescriptionLocalizations.Value?.ToImmutableDictionary()
                             : null))
                 .ToImmutableArray();
+
+        public static async Task<RoleConnection> GetUserRoleConnectionAsync(ulong applicationId, BaseDiscordClient client, RequestOptions options = null)
+        {
+            var roleConnection = await client.ApiClient.GetUserApplicationRoleConnectionAsync(applicationId, options);
+
+            return new RoleConnection(roleConnection.PlatformName.GetValueOrDefault(null),
+                roleConnection.PlatformUsername.GetValueOrDefault(null),
+                roleConnection.Metadata.GetValueOrDefault());
+        }
+
+        public static async Task<RoleConnection> ModifyUserRoleConnectionAsync(ulong applicationId, RoleConnectionProperties roleConnection, BaseDiscordClient client, RequestOptions options = null)
+        {
+            var updatedConnection = await client.ApiClient.ModifyUserApplicationRoleConnectionAsync(applicationId,
+                new API.RoleConnection
+                {
+                    PlatformName = roleConnection.PlatformName,
+                    PlatformUsername = roleConnection.PlatformUsername,
+                    Metadata = roleConnection.Metadata
+                }, options);
+
+            return new RoleConnection(
+                updatedConnection.PlatformName.GetValueOrDefault(null),
+                updatedConnection.PlatformUsername.GetValueOrDefault(null),
+                updatedConnection.Metadata.GetValueOrDefault()?.ToImmutableDictionary()
+                );
+        }
+
 
         #endregion
     }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -2490,6 +2490,16 @@ namespace Discord.API
             return await SendJsonAsync<IEnumerable<RoleConnectionMetadata>>("PUT", $"/applications/{CurrentApplicationId}/role-connections/metadata", roleConnections, options: options).ConfigureAwait(false);
         }
 
+        public async Task<RoleConnection> GetUserApplicationRoleConnection(RequestOptions options = null)
+        {
+            return await SendAsync<RoleConnection>("GET", $"/users/@me/applications/{CurrentApplicationId}/role-connection", options: options);
+        }
+
+        public async Task<RoleConnection> GetUserApplicationRoleConnection(RoleConnection connection, RequestOptions options = null)
+        {
+            return await SendJsonAsync<RoleConnection>("PUT", $"/users/@me/applications/{CurrentApplicationId}/role-connection", connection, options: options);
+        }
+
         #endregion
     }
 }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -4,7 +4,9 @@ using Discord.Net;
 using Discord.Net.Converters;
 using Discord.Net.Queue;
 using Discord.Net.Rest;
+
 using Newtonsoft.Json;
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -2480,25 +2482,17 @@ namespace Discord.API
 
         #region Application Role Connections Metadata
 
-        public async Task<IEnumerable<RoleConnectionMetadata>> GetApplicationRoleConnectionMetadataRecordsAsync(RequestOptions options = null)
-        {
-            return await SendAsync<IEnumerable<RoleConnectionMetadata>>("GET", $"/applications/{CurrentApplicationId}/role-connections/metadata", options: options).ConfigureAwait(false);
-        }
+        public async Task<RoleConnectionMetadata[]> GetApplicationRoleConnectionMetadataRecordsAsync(RequestOptions options = null)
+            => await SendAsync<RoleConnectionMetadata[]>("GET", () => $"applications/{CurrentApplicationId}/role-connections/metadata", new BucketIds(), options: options).ConfigureAwait(false);
 
-        public async Task<IEnumerable<RoleConnectionMetadata>> UpdateApplicationRoleConnectionMetadataRecordsAsync(IEnumerable<RoleConnectionMetadata> roleConnections, RequestOptions options = null)
-        {
-            return await SendJsonAsync<IEnumerable<RoleConnectionMetadata>>("PUT", $"/applications/{CurrentApplicationId}/role-connections/metadata", roleConnections, options: options).ConfigureAwait(false);
-        }
+        public async Task<RoleConnectionMetadata[]> UpdateApplicationRoleConnectionMetadataRecordsAsync(RoleConnectionMetadata[] roleConnections, RequestOptions options = null)
+        => await SendJsonAsync <RoleConnectionMetadata[]>("PUT", () => $"applications/{CurrentApplicationId}/role-connections/metadata", roleConnections, new BucketIds(), options: options).ConfigureAwait(false);
 
         public async Task<RoleConnection> GetUserApplicationRoleConnection(RequestOptions options = null)
-        {
-            return await SendAsync<RoleConnection>("GET", $"/users/@me/applications/{CurrentApplicationId}/role-connection", options: options);
-        }
+        => await SendAsync<RoleConnection>("GET", () => $"users/@me/applications/{CurrentApplicationId}/role-connection", new BucketIds(), options: options);
 
         public async Task<RoleConnection> GetUserApplicationRoleConnection(RoleConnection connection, RequestOptions options = null)
-        {
-            return await SendJsonAsync<RoleConnection>("PUT", $"/users/@me/applications/{CurrentApplicationId}/role-connection", connection, options: options);
-        }
+        => await SendJsonAsync<RoleConnection>("PUT", () => $"users/@me/applications/{CurrentApplicationId}/role-connection", connection, new BucketIds(), options: options);
 
         #endregion
     }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -2473,6 +2474,20 @@ namespace Discord.API
                 querys.Add($"thread_id={threadId}");
 
             return $"{string.Join("&", querys)}";
+        }
+
+        #endregion
+
+        #region Application Role Connections Metadata
+
+        public async Task<IEnumerable<RoleConnectionMetadata>> GetApplicationRoleConnectionMetadataRecordsAsync(RequestOptions options = null)
+        {
+            return await SendAsync<IEnumerable<RoleConnectionMetadata>>("GET", $"/applications/{CurrentApplicationId}/role-connections/metadata", options: options).ConfigureAwait(false);
+        }
+
+        public async Task<IEnumerable<RoleConnectionMetadata>> UpdateApplicationRoleConnectionMetadataRecordsAsync(IEnumerable<RoleConnectionMetadata> roleConnections, RequestOptions options = null)
+        {
+            return await SendJsonAsync<IEnumerable<RoleConnectionMetadata>>("PUT", $"/applications/{CurrentApplicationId}/role-connections/metadata", roleConnections, options: options).ConfigureAwait(false);
         }
 
         #endregion

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -2488,11 +2488,11 @@ namespace Discord.API
         public async Task<RoleConnectionMetadata[]> UpdateApplicationRoleConnectionMetadataRecordsAsync(RoleConnectionMetadata[] roleConnections, RequestOptions options = null)
         => await SendJsonAsync <RoleConnectionMetadata[]>("PUT", () => $"applications/{CurrentApplicationId}/role-connections/metadata", roleConnections, new BucketIds(), options: options).ConfigureAwait(false);
 
-        public async Task<RoleConnection> GetUserApplicationRoleConnection(RequestOptions options = null)
-        => await SendAsync<RoleConnection>("GET", () => $"users/@me/applications/{CurrentApplicationId}/role-connection", new BucketIds(), options: options);
+        public async Task<RoleConnection> GetUserApplicationRoleConnectionAsync(ulong applicationId, RequestOptions options = null)
+        => await SendAsync<RoleConnection>("GET", () => $"users/@me/applications/{applicationId}/role-connection", new BucketIds(), options: options);
 
-        public async Task<RoleConnection> GetUserApplicationRoleConnection(RoleConnection connection, RequestOptions options = null)
-        => await SendJsonAsync<RoleConnection>("PUT", () => $"users/@me/applications/{CurrentApplicationId}/role-connection", connection, new BucketIds(), options: options);
+        public async Task<RoleConnection> ModifyUserApplicationRoleConnectionAsync(ulong applicationId, RoleConnection connection, RequestOptions options = null)
+        => await SendJsonAsync<RoleConnection>("PUT", () => $"users/@me/applications/{applicationId}/role-connection", connection, new BucketIds(), options: options);
 
         #endregion
     }

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -241,6 +241,12 @@ namespace Discord.Rest
             return ClientHelper.ModifyRoleConnectionMetadataRecordsAsync(metadata, this, options);
         }
 
+        public Task<RoleConnection> GetUserApplicationRoleConnectionAsync(ulong applicationId, RequestOptions options = null)
+            => ClientHelper.GetUserRoleConnectionAsync(applicationId, this, options);
+
+        public Task<RoleConnection> ModifyUserApplicationRoleConnectionAsync(ulong applicationId, RoleConnectionProperties roleConnection, RequestOptions options = null)
+            => ClientHelper.ModifyUserRoleConnectionAsync(applicationId, roleConnection, this, options);
+
         #endregion
 
         #region IDiscordClient

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -231,7 +231,17 @@ namespace Discord.Rest
             => MessageHelper.RemoveAllReactionsAsync(channelId, messageId, this, options);
         public Task RemoveAllReactionsForEmoteAsync(ulong channelId, ulong messageId, IEmote emote, RequestOptions options = null)
             => MessageHelper.RemoveAllReactionsForEmoteAsync(channelId, messageId, emote, this, options);
-#endregion
+
+        public Task<IReadOnlyCollection<RoleConnectionMetadata>> GetRoleConnectionMetadataRecordsAsync(RequestOptions options = null)
+            => ClientHelper.GetRoleConnectionMetadataRecordsAsync(this, options);
+
+        public Task<IReadOnlyCollection<RoleConnectionMetadata>> ModifyRoleConnectionMetadataRecordsAsync(ICollection<RoleConnectionMetadataProperties> metadata, RequestOptions options = null)
+        {
+            Preconditions.AtMost(metadata.Count, 5, nameof(metadata), "An application can have a maximum of 5 metadata records.");
+            return ClientHelper.ModifyRoleConnectionMetadataRecordsAsync(metadata, this, options);
+        }
+
+        #endregion
 
         #region IDiscordClient
         /// <inheritdoc />


### PR DESCRIPTION
This PR adds support for the [Application Role Connections Metadata](https://discord.com/developers/docs/resources/application-role-connection-metadata)

### Changes
- [x] add data models
- [x] implement api methods