### PR TITLE
#2536 Add RemoveModulesFromGuildAsync

### DIFF
--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -684,6 +684,14 @@ namespace Discord.Interactions
             }
         }
 
+        /// <summary>
+        ///     Unregister Application Commands from modules provided in <paramref name="modules"/> from a guild.
+        /// </summary>
+        /// <param name="guild">The target guild.</param>
+        /// <param name="modules">Modules to be deregistered from Discord.</param>
+        /// <returns>
+        ///     A task representing the command de-registration process. The task result contains the active application commands of the target guild.
+        /// </returns>
         public async Task<IReadOnlyCollection<RestGuildCommand>> RemoveModulesFromGuildAsync(IGuild guild, params ModuleInfo[] modules)
         {
             if (guild is null)
@@ -692,6 +700,14 @@ namespace Discord.Interactions
             return await RemoveModulesFromGuildAsync(guild.Id, modules).ConfigureAwait(false);
         }
 
+        /// <summary>
+        ///     Unregister Application Commands from modules provided in <paramref name="modules"/> from a guild.
+        /// </summary>
+        /// <param name="guildID">The target guild ID.</param>
+        /// <param name="modules">Modules to be deregistered from Discord.</param>
+        /// <returns>
+        ///     A task representing the command de-registration process. The task result contains the active application commands of the target guild.
+        /// </returns>
         public async Task<IReadOnlyCollection<RestGuildCommand>> RemoveModulesFromGuildAsync(ulong guildId, params ModuleInfo[] modules)
         {
             EnsureClientReady();

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -697,9 +697,9 @@ namespace Discord.Interactions
             EnsureClientReady();
 
             var exclude = modules.SelectMany(x => x.ToApplicationCommandProps(true)).ToList();
-            var existing = (await RestClient.GetGuildApplicationCommands(guildId).ConfigureAwait(false)).Select(x => x.ToApplicationCommandProps());
+            var existing = await RestClient.GetGuildApplicationCommands(guildId).ConfigureAwait(false);
 
-            var props = existing.Except(exclude);
+            var props = existing.Where(x => !exclude.Any(y => y.Name.IsSpecified && x.Name == y.Name.Value)).Select(x => x.ToApplicationCommandProps());
 
             return await RestClient.BulkOverwriteGuildCommands(props.ToArray(), guildId).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -684,6 +684,26 @@ namespace Discord.Interactions
             }
         }
 
+        public async Task<IReadOnlyCollection<RestGuildCommand>> RemoveModulesFromGuildAsync(IGuild guild, params ModuleInfo[] modules)
+        {
+            if (guild is null)
+                throw new ArgumentNullException(nameof(guild));
+
+            return await RemoveModulesFromGuildAsync(guild.Id, modules).ConfigureAwait(false);
+        }
+
+        public async Task<IReadOnlyCollection<RestGuildCommand>> RemoveModulesFromGuildAsync(ulong guildId, params ModuleInfo[] modules)
+        {
+            EnsureClientReady();
+
+            var exclude = modules.SelectMany(x => x.ToApplicationCommandProps(true)).ToList();
+            var existing = (await RestClient.GetGuildApplicationCommands(guildId).ConfigureAwait(false)).Select(x => x.ToApplicationCommandProps());
+
+            var props = existing.Except(exclude);
+
+            return await RestClient.BulkOverwriteGuildCommands(props.ToArray(), guildId).ConfigureAwait(false);
+        }
+
         private bool RemoveModuleInternal (ModuleInfo moduleInfo)
         {
             if (!_moduleDefs.Remove(moduleInfo))

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -703,7 +703,7 @@ namespace Discord.Interactions
         /// <summary>
         ///     Unregister Application Commands from modules provided in <paramref name="modules"/> from a guild.
         /// </summary>
-        /// <param name="guildID">The target guild ID.</param>
+        /// <param name="guildId">The target guild ID.</param>
         /// <param name="modules">Modules to be deregistered from Discord.</param>
         /// <returns>
         ///     A task representing the command de-registration process. The task result contains the active application commands of the target guild.


### PR DESCRIPTION
This is basically just the opposite of `AddModulesToGuildAsync`, as outlined in #2536.  Deregisters a module or multiple modules from a specific guild. Usage is identical to `AddModulesToGuildAsync` but without RemoveMissing since it doesn't really make sense in this context. 

## Use cases
This is useful any time you want to remove a module from a guild while the bot is live. This can be achieved manually as outlined in  #2536, but if the library can handle registering them automatically i don't see why it shouldn't be able to handle de-registering them automatically

## Breaking changes
No breaking changes, only adds new methods to existing service
