### PR TITLE
[Fix] Creating post in threads with required tags

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -148,7 +148,7 @@ namespace Discord.Rest
                 throw new ArgumentException("The only valid MessageFlags are SuppressEmbeds and none.", nameof(flags));
 
             if (channel.Flags.HasFlag(ChannelFlags.RequireTag))
-                throw new ArgumentException($"The channel {channel.Name} requires posts to have at least one tag.");
+                Preconditions.AtLeast(tagIds?.Length ?? 0, 1, nameof(tagIds), $"The channel {channel.Name} requires posts to have at least one tag.");
 
             var args = new CreatePostParams()
             {


### PR DESCRIPTION
Apparently I made some oversights in #2469 PR which went unnoticed until now

### Changes
- fix throwing exception on thread creation in forums that require posts to have at least 1 tag