### PR TITLE
Fixed typo in the code example on the documentation page about ephemeral responses.

### DIFF
--- a/docs/guides/int_basics/application-commands/slash-commands/responding-ephemerally.md
+++ b/docs/guides/int_basics/application-commands/slash-commands/responding-ephemerally.md
@@ -15,7 +15,7 @@ When responding with either `FollowupAsync` or `RespondAsync` you can pass in an
 Let's use this in our list role command.
 
 ```cs
-await command.RespondAsync(embed: embedBuiler.Build(), ephemeral: true);
+await command.RespondAsync(embed: embedBuilder.Build(), ephemeral: true);
 ```
 
 Running the command now only shows the message to us!


### PR DESCRIPTION
Corrected "embedBuiler" to "embedBuilder" on this [page](https://discordnet.dev/guides/int_basics/application-commands/slash-commands/responding-ephemerally.html).