### PR TITLE
[Fix] Remove outdated checks on thread creation

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -257,11 +257,6 @@ namespace Discord.Rest
         /// </param>
         /// <param name="autoArchiveDuration">
         ///     The duration on which this thread archives after.
-        ///     <para>
-        ///         <b>Note: </b> Options <see cref="ThreadArchiveDuration.OneWeek"/> and <see cref="ThreadArchiveDuration.ThreeDays"/>
-        ///         are only available for guilds that are boosted. You can check in the <see cref="IGuild.Features"/> to see if the
-        ///         guild has the <b>THREE_DAY_THREAD_ARCHIVE</b> and <b>SEVEN_DAY_THREAD_ARCHIVE</b>.
-        ///     </para>
         /// </param>
         /// <param name="message">The message which to start the thread from.</param>
         /// <param name="options">The options to be used when sending the request.</param>

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -14,16 +14,6 @@ namespace Discord.Rest
         public static async Task<Model> CreateThreadAsync(BaseDiscordClient client, ITextChannel channel, string name, ThreadType type = ThreadType.PublicThread,
             ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay, IMessage message = null, bool? invitable = null, int? slowmode = null, RequestOptions options = null)
         {
-            var features = channel.Guild.Features;
-            if (autoArchiveDuration == ThreadArchiveDuration.OneWeek && !features.HasFeature(GuildFeature.SevenDayThreadArchive))
-                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the SEVEN_DAY_THREAD_ARCHIVE feature!", nameof(autoArchiveDuration));
-
-            if (autoArchiveDuration == ThreadArchiveDuration.ThreeDays && !features.HasFeature(GuildFeature.ThreeDayThreadArchive))
-                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the THREE_DAY_THREAD_ARCHIVE feature!", nameof(autoArchiveDuration));
-
-            if (type == ThreadType.PrivateThread && !features.HasFeature(GuildFeature.PrivateThreads))
-                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the PRIVATE_THREADS feature!", nameof(type));
-
             if (channel is INewsChannel && type != ThreadType.NewsThread)
                 throw new ArgumentException($"{nameof(type)} must be a {ThreadType.NewsThread} in News channels");
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -107,11 +107,6 @@ namespace Discord.WebSocket
         /// </param>
         /// <param name="autoArchiveDuration">
         ///     The duration on which this thread archives after.
-        ///     <para>
-        ///         <b>Note: </b> Options <see cref="ThreadArchiveDuration.OneWeek"/> and <see cref="ThreadArchiveDuration.ThreeDays"/>
-        ///         are only available for guilds that are boosted. You can check in the <see cref="IGuild.Features"/> to see if the
-        ///         guild has the <b>THREE_DAY_THREAD_ARCHIVE</b> and <b>SEVEN_DAY_THREAD_ARCHIVE</b>.
-        ///     </para>
         /// </param>
         /// <param name="message">The message which to start the thread from.</param>
         /// <param name="options">The options to be used when sending the request.</param>


### PR DESCRIPTION
Since Discord has allowed creating private threads & threads with 3 and 7 day archive duration on all servers, D.Net does not need to checks for the features enabled in the guild.

### Changes
- remove outdated checks on thread creation & update xml docs