### PR TITLE
[Feature] RespondWithModal() which accepts an IModal instance as template

### DIFF
--- a/src/Discord.Net.Interactions/Builders/Modals/Inputs/IInputComponentBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Modals/Inputs/IInputComponentBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Discord.Interactions.Builders
 {
@@ -37,6 +38,11 @@ namespace Discord.Interactions.Builders
         ///     Get the reference type of this input component.
         /// </summary>
         Type Type { get; }
+
+        /// <summary>
+        ///     Get the <see cref="PropertyInfo"/> of this component's property.
+        /// </summary>
+        PropertyInfo PropertyInfo { get; }
 
         /// <summary>
         ///     Get the <see cref="ComponentTypeConverter"/> assigned to this input.

--- a/src/Discord.Net.Interactions/Builders/Modals/Inputs/InputComponentBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Modals/Inputs/InputComponentBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Discord.Interactions.Builders
 {
@@ -32,6 +33,9 @@ namespace Discord.Interactions.Builders
 
         /// <inheritdoc/>
         public Type Type { get; private set; }
+
+        /// <inheritdoc/>
+        public PropertyInfo PropertyInfo { get; internal set; }
 
         /// <inheritdoc/>
         public ComponentTypeConverter TypeConverter { get; private set; }

--- a/src/Discord.Net.Interactions/Builders/Modals/ModalBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Modals/ModalBuilder.cs
@@ -37,6 +37,8 @@ namespace Discord.Interactions.Builders
             if (!typeof(IModal).IsAssignableFrom(type))
                 throw new ArgumentException($"Must be an implementation of {nameof(IModal)}", nameof(type));
 
+            Type = type;
+
             _interactionService = interactionService;
             _components = new();
         }

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -596,6 +596,7 @@ namespace Discord.Interactions.Builders
             builder.Label = propertyInfo.Name;
             builder.DefaultValue = defaultValue;
             builder.WithType(propertyInfo.PropertyType);
+            builder.PropertyInfo = propertyInfo;
 
             foreach(var attribute in attributes)
             {

--- a/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
+++ b/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
@@ -45,12 +45,12 @@ namespace Discord.Interactions
         }
 
         /// <summary>
-        ///     Respond to an interaction with a <see cref="IModal"/> and fills the value fields of the modal using the property values of the provided
+        ///     Respond to an interaction with an <see cref="IModal"/> and fills the value fields of the modal using the property values of the provided
         ///     instance.
         /// </summary>
         /// <typeparam name="T">Type of the <see cref="IModal"/> implementation.</typeparam>
         /// <param name="interaction">The interaction to respond to.</param>
-        /// <param name="modal"><see cref="IModal"/> instance to get field values from.</param>
+        /// <param name="modal">The <see cref="IModal"/> instance to get field values from.</param>
         /// <param name="options">The request options for this <see langword="async"/> request.</param>
         /// <param name="modifyModal">Delegate that can be used to modify the modal.</param>
         /// <returns></returns>

--- a/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
+++ b/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
@@ -44,6 +44,44 @@ namespace Discord.Interactions
             await SendModalResponseAsync(interaction, customId, modalInfo, options, modifyModal);
         }
 
+        /// <summary>
+        ///     Respond to an interaction with a <see cref="IModal"/> and fills the value fields of the modal using the property values of the provided
+        ///     instance.
+        /// </summary>
+        /// <typeparam name="T">Type of the <see cref="IModal"/> implementation.</typeparam>
+        /// <param name="interaction">The interaction to respond to.</param>
+        /// <param name="modal"><see cref="IModal"/> instance to get field values from.</param>
+        /// <param name="options">The request options for this <see langword="async"/> request.</param>
+        /// <param name="modifyModal">Delegate that can be used to modify the modal.</param>
+        /// <returns></returns>
+        public static async Task RespondWithModalAsync<T>(this IDiscordInteraction interaction, string customId, T modal, RequestOptions options = null,
+            Action<ModalBuilder> modifyModal = null)
+            where T : class, IModal
+        {
+            if (!ModalUtils.TryGet<T>(out var modalInfo))
+                throw new ArgumentException($"{typeof(T).FullName} isn't referenced by any registered Modal Interaction Command and doesn't have a cached {typeof(ModalInfo)}");
+
+            var builder = new ModalBuilder(modal.Title, customId);
+
+            foreach (var input in modalInfo.Components)
+                switch (input)
+                {
+                    case TextInputComponentInfo textComponent:
+                        {
+                            builder.AddTextInput(textComponent.Label, textComponent.CustomId, textComponent.Style, textComponent.Placeholder, textComponent.IsRequired ? textComponent.MinLength : null,
+                            textComponent.MaxLength, textComponent.IsRequired, textComponent.Getter(modal) as string);
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException($"{input.GetType().FullName} isn't a valid component info class");
+                }
+
+            if (modifyModal is not null)
+                modifyModal(builder);
+
+            await interaction.RespondWithModalAsync(builder.Build(), options).ConfigureAwait(false);
+        }
+
         private static async Task SendModalResponseAsync(IDiscordInteraction interaction, string customId, ModalInfo modalInfo, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
         {
             var builder = new ModalBuilder(modalInfo.Title, customId);

--- a/src/Discord.Net.Interactions/Info/InputComponents/InputComponentInfo.cs
+++ b/src/Discord.Net.Interactions/Info/InputComponents/InputComponentInfo.cs
@@ -44,6 +44,9 @@ namespace Discord.Interactions
         /// </summary>
         public Type Type { get; }
 
+        /// <summary>
+        ///     Gets the property linked to this component.
+        /// </summary>
         public PropertyInfo PropertyInfo { get; }
 
         /// <summary>

--- a/src/Discord.Net.Interactions/Info/InputComponents/InputComponentInfo.cs
+++ b/src/Discord.Net.Interactions/Info/InputComponents/InputComponentInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Reflection;
 
 namespace Discord.Interactions
 {
@@ -9,6 +10,10 @@ namespace Discord.Interactions
     /// </summary>
     public abstract class InputComponentInfo
     {
+        private Lazy<Func<object, object>> _getter;
+        internal Func<object, object> Getter => _getter.Value;
+
+
         /// <summary>
         ///     Gets the parent modal of this component.
         /// </summary>
@@ -39,6 +44,8 @@ namespace Discord.Interactions
         /// </summary>
         public Type Type { get; }
 
+        public PropertyInfo PropertyInfo { get; }
+
         /// <summary>
         ///     Gets the <see cref="ComponentTypeConverter"/> assigned to this component.
         /// </summary>
@@ -62,9 +69,12 @@ namespace Discord.Interactions
             IsRequired = builder.IsRequired;
             ComponentType = builder.ComponentType;
             Type = builder.Type;
+            PropertyInfo = builder.PropertyInfo;
             TypeConverter = builder.TypeConverter;
             DefaultValue = builder.DefaultValue;
             Attributes = builder.Attributes.ToImmutableArray();
+
+            _getter = new(() => ReflectionUtils<object>.CreateLambdaPropertyGetter(Modal.Type, PropertyInfo));
         }
     }
 }

--- a/src/Discord.Net.Interactions/Utilities/ReflectionUtils.cs
+++ b/src/Discord.Net.Interactions/Utilities/ReflectionUtils.cs
@@ -10,7 +10,6 @@ namespace Discord.Interactions
     internal static class ReflectionUtils<T>
     {
         private static readonly TypeInfo ObjectTypeInfo = typeof(object).GetTypeInfo();
-
         internal static T CreateObject (TypeInfo typeInfo, InteractionService commandService, IServiceProvider services = null) =>
             CreateBuilder(typeInfo, commandService)(services);
 
@@ -164,6 +163,21 @@ namespace Discord.Interactions
             var assign = Expression.Assign(prop, Expression.Convert(valueParam, propertyInfo.PropertyType));
 
             return Expression.Lambda<Action<T, object>>(assign, instanceParam, valueParam).Compile();
+        }
+
+        internal static Func<T, object> CreateLambdaPropertyGetter(PropertyInfo propertyInfo)
+        {
+            var instanceParam = Expression.Parameter(typeof(T), "instance");
+            var prop = Expression.Property(instanceParam, propertyInfo);
+            return Expression.Lambda<Func<T, object>>(prop, instanceParam).Compile();
+        }
+
+        internal static Func<T, object> CreateLambdaPropertyGetter(Type type, PropertyInfo propertyInfo)
+        {
+            var instanceParam = Expression.Parameter(typeof(T), "instance");
+            var instanceAccess = Expression.Convert(instanceParam, type);
+            var prop = Expression.Property(instanceAccess, propertyInfo);
+            return Expression.Lambda<Func<T, object>>(prop, instanceParam).Compile();
         }
 
         internal static Func<object[], object[], T> CreateLambdaMemberInit(TypeInfo typeInfo, ConstructorInfo constructor, Predicate<PropertyInfo> propertySelect = null)


### PR DESCRIPTION
Example usage:
```csharp
[SlashCommand("summon-modal", "desc")]
public async Task SummonModalAsync()
{
    Context.Interaction.RespondWithModal("modal_id", new TestModal
    {
        FirstField = "Initial Value1",
        SecondField = "Initial Value2"
    });
}
```