### PR TITLE
[Feature] Add missing VoiceChannel properties

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
@@ -27,6 +27,11 @@ namespace Discord
         int? UserLimit { get; }
 
         /// <summary>
+        ///     Gets the video quality mode for this channel.
+        /// </summary>
+        VideoQualityMode VideoQualityMode { get; }
+
+        /// <summary>
         ///     Bulk-deletes multiple messages.
         /// </summary>
         /// <example>

--- a/src/Discord.Net.Core/Entities/Channels/VideoQualityMode.cs
+++ b/src/Discord.Net.Core/Entities/Channels/VideoQualityMode.cs
@@ -1,0 +1,17 @@
+namespace Discord;
+
+/// <summary>
+///     Represents a video quality mode for voice channels.
+/// </summary>
+public enum VideoQualityMode
+{
+    /// <summary>
+    ///     Discord chooses the quality for optimal performance.
+    /// </summary>
+    Auto = 1,
+
+    /// <summary>
+    /// 	720p.
+    /// </summary>
+    Full = 2
+}

--- a/src/Discord.Net.Core/Entities/Channels/VoiceChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/VoiceChannelProperties.cs
@@ -17,5 +17,10 @@ namespace Discord
         ///     Gets or sets the channel voice region id, automatic when set to <see langword="null"/>.
         /// </summary>
         public Optional<string> RTCRegion { get; set; }
+
+        /// <summary>
+        ///     Get or sets the video quality mode for this channel.
+        /// </summary>
+        public Optional<VideoQualityMode> VideoQualityMode { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Channel.cs
+++ b/src/Discord.Net.Rest/API/Common/Channel.cs
@@ -43,6 +43,9 @@ namespace Discord.API
         [JsonProperty("rtc_region")]
         public Optional<string> RTCRegion { get; set; }
 
+        [JsonProperty("video_quality_mode")]
+        public Optional<VideoQualityMode> VideoQualityMode { get; set; }
+
         //PrivateChannel
         [JsonProperty("recipients")]
         public Optional<User[]> Recipients { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
@@ -31,6 +31,10 @@ namespace Discord.API.Rest
         public Optional<int> Bitrate { get; set; }
         [JsonProperty("user_limit")]
         public Optional<int?> UserLimit { get; set; }
+        [JsonProperty("video_quality_mode")]
+        public Optional<VideoQualityMode> VideoQuality { get; set; }
+        [JsonProperty("rtc_region")]
+        public Optional<string> RtcRegion { get; set; }
 
         //Forum channels
         [JsonProperty("default_reaction_emoji")]

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -26,6 +26,8 @@ namespace Discord.Rest
         public int? UserLimit { get; private set; }
         /// <inheritdoc/>
         public string RTCRegion { get; private set; }
+        /// <inheritdoc/>
+        public VideoQualityMode VideoQualityMode { get; private set; }
 
         internal RestVoiceChannel(BaseDiscordClient discord, IGuild guild, ulong id)
             : base(discord, guild, id)
@@ -47,6 +49,8 @@ namespace Discord.Rest
 
             if(model.UserLimit.IsSpecified)
                 UserLimit = model.UserLimit.Value != 0 ? model.UserLimit.Value : (int?)null;
+
+            VideoQualityMode = model.VideoQualityMode.GetValueOrDefault(VideoQualityMode.Auto);
 
             RTCRegion = model.RTCRegion.GetValueOrDefault(null);
         }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -285,6 +285,8 @@ namespace Discord.Rest
                         Deny = overwrite.Permissions.DenyValue.ToString()
                     }).ToArray()
                     : Optional.Create<API.Overwrite[]>(),
+                VideoQuality = props.VideoQualityMode,
+                RtcRegion = props.RTCRegion
             };
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
             return RestVoiceChannel.Create(client, guild, model);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketVoiceChannel.cs
@@ -34,6 +34,8 @@ namespace Discord.WebSocket
         public int? UserLimit { get; private set; }
         /// <inheritdoc />
         public string RTCRegion { get; private set; }
+        /// <inheritdoc/>
+        public VideoQualityMode VideoQualityMode { get; private set; }
 
         /// <summary>
         ///     Gets a collection of users that are currently connected to this voice channel.
@@ -60,6 +62,7 @@ namespace Discord.WebSocket
             base.Update(state, model);
             Bitrate = model.Bitrate.GetValueOrDefault(64000);
             UserLimit = model.UserLimit.GetValueOrDefault() != 0 ? model.UserLimit.Value : (int?)null;
+            VideoQualityMode = model.VideoQualityMode.GetValueOrDefault(VideoQualityMode.Auto);
             RTCRegion = model.RTCRegion.GetValueOrDefault(null);
         }
 

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
@@ -38,6 +38,8 @@ namespace Discord
 
         public ChannelFlags Flags => throw new NotImplementedException();
 
+        public VideoQualityMode VideoQualityMode => throw new NotImplementedException();
+
         public Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null) => throw new NotImplementedException();
         public Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null) => throw new NotImplementedException();
         public Task<IAudioClient> ConnectAsync(bool selfDeaf = false, bool selfMute = false, bool external = false) => throw new NotImplementedException();


### PR DESCRIPTION
This PR add missing `VideoQualityMode` property of Voice channels & fixes #2563 

### Changes
- add `VideoQualityMode` enum to voice channel objects
- fix `CreateVoiceChannelAsync` not setting `RTCRegion` property