### PR TITLE
[Bug] Fix GetEventCoverImageUrl by removing the GuildId in the Url string

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -218,7 +218,7 @@ namespace Discord
         /// <param name="size">The size of the image.</param>
         /// <returns></returns>
         public static string GetEventCoverImageUrl(ulong guildId, ulong eventId, string assetId, ImageFormat format = ImageFormat.Auto, ushort size = 1024)
-            => $"{DiscordConfig.CDNUrl}guild-events/{guildId}/{eventId}/{assetId}.{FormatToExtension(format, assetId)}?size={size}";
+            => $"{DiscordConfig.CDNUrl}guild-events/{eventId}/{assetId}.{FormatToExtension(format, assetId)}?size={size}";
 
         private static string FormatToExtension(StickerFormatType format)
         {


### PR DESCRIPTION
See https://github.com/discord-net/Discord.Net/issues/2576 for more information

GuildScheduledEvent cover image Urls don't include the related `{guildId}` in the Url, GuildScheduledEvent cover image Urls are stored on Discord and fetched by only their `{eventId}` and `{assetId}`

Invalid Uri: `guild-events/1068697076323602503/1069337361063878727/516b0a9fe85c696678d98750589aef5e.png?size=1024`
Valid Uri: `guild-events/1069337361063878727/516b0a9fe85c696678d98750589aef5e.png?size=1024`

Invalid Url: https://cdn.discordapp.com/guild-events/1068697076323602503/1069337361063878727/516b0a9fe85c696678d98750589aef5e.png?size=1024
Valid Url: https://cdn.discordapp.com/guild-events/1069337361063878727/516b0a9fe85c696678d98750589aef5e.png?size=1024

A temporary fix can be achieved by using `Replace` or any other string manipulation technique
```cpp
 var coverImageUrl = message.CoverImageId != null ? message.GetCoverImageUrl().Replace($"/{message.Guild.Id}", "") : null;
 ```

This closes https://github.com/discord-net/Discord.Net/issues/2576