### PR TITLE
[Feature] `IIntegrationChannel` & create webhooks in forums

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -7,7 +7,10 @@ using System.Threading.Tasks;
 
 namespace Discord
 {
-    public interface IForumChannel : IGuildChannel, IMentionable, INestedChannel
+    /// <summary>
+    ///     Represents a forum channel in a guild that can create posts.
+    /// </summary>
+    public interface IForumChannel : IMentionable, INestedChannel, IIntegrationChannel
     {
         /// <summary>
         ///     Gets a value that indicates whether the channel is NSFW.

--- a/src/Discord.Net.Core/Entities/Channels/IIntegrationChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IIntegrationChannel.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Discord;
+
+/// <summary>
+///     Represents a channel in a guild that can create webhooks.
+/// </summary>
+public interface IIntegrationChannel : IGuildChannel
+{
+    /// <summary>
+    ///     Creates a webhook in this channel.
+    /// </summary>
+    /// <param name="name">The name of the webhook.</param>
+    /// <param name="avatar">The avatar of the webhook.</param>
+    /// <param name="options">The options to be used when sending the request.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous creation operation. The task result contains the newly created
+    ///     webhook.
+    /// </returns>
+    Task<IWebhook> CreateWebhookAsync(string name, Stream avatar = null, RequestOptions options = null);
+
+    /// <summary>
+    ///     Gets a webhook available in this channel.
+    /// </summary>
+    /// <param name="id">The identifier of the webhook.</param>
+    /// <param name="options">The options to be used when sending the request.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous get operation. The task result contains a webhook associated
+    ///     with the identifier; <c>null</c> if the webhook is not found.
+    /// </returns>
+    Task<IWebhook> GetWebhookAsync(ulong id, RequestOptions options = null);
+
+    /// <summary>
+    ///     Gets the webhooks available in this channel.
+    /// </summary>
+    /// <param name="options">The options to be used when sending the request.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
+    ///     of webhooks that is available in this channel.
+    /// </returns>
+    Task<IReadOnlyCollection<IWebhook>> GetWebhooksAsync(RequestOptions options = null);
+}

--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -8,7 +8,7 @@ namespace Discord
     /// <summary>
     ///     Represents a generic channel in a guild that can send and receive messages.
     /// </summary>
-    public interface ITextChannel : IMessageChannel, IMentionable, INestedChannel
+    public interface ITextChannel : IMessageChannel, IMentionable, INestedChannel, IIntegrationChannel
     {
         /// <summary>
         ///     Gets a value that indicates whether the channel is NSFW.
@@ -94,37 +94,6 @@ namespace Discord
         /// </returns>
         /// <seealso cref="TextChannelProperties"/>
         Task ModifyAsync(Action<TextChannelProperties> func, RequestOptions options = null);
-        
-        /// <summary>
-        ///     Creates a webhook in this text channel.
-        /// </summary>
-        /// <param name="name">The name of the webhook.</param>
-        /// <param name="avatar">The avatar of the webhook.</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous creation operation. The task result contains the newly created
-        ///     webhook.
-        /// </returns>
-        Task<IWebhook> CreateWebhookAsync(string name, Stream avatar = null, RequestOptions options = null);
-        /// <summary>
-        ///     Gets a webhook available in this text channel.
-        /// </summary>
-        /// <param name="id">The identifier of the webhook.</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous get operation. The task result contains a webhook associated
-        ///     with the identifier; <c>null</c> if the webhook is not found.
-        /// </returns>
-        Task<IWebhook> GetWebhookAsync(ulong id, RequestOptions options = null);
-        /// <summary>
-        ///     Gets the webhooks available in this text channel.
-        /// </summary>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection
-        ///     of webhooks that is available in this channel.
-        /// </returns>
-        Task<IReadOnlyCollection<IWebhook>> GetWebhooksAsync(RequestOptions options = null);
 
         /// <summary>
         ///     Creates a thread within this <see cref="ITextChannel"/>.

--- a/src/Discord.Net.Core/Entities/Webhooks/IWebhook.cs
+++ b/src/Discord.Net.Core/Entities/Webhooks/IWebhook.cs
@@ -29,7 +29,7 @@ namespace Discord
         /// <summary>
         ///     Gets the channel for this webhook.
         /// </summary>
-        ITextChannel Channel { get; }
+        IIntegrationChannel Channel { get; }
         /// <summary>
         ///     Gets the ID of the channel for this webhook.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -568,7 +568,7 @@ namespace Discord.Rest
         #endregion
 
         #region Webhooks
-        public static async Task<RestWebhook> CreateWebhookAsync(ITextChannel channel, BaseDiscordClient client, string name, Stream avatar, RequestOptions options)
+        public static async Task<RestWebhook> CreateWebhookAsync(IIntegrationChannel channel, BaseDiscordClient client, string name, Stream avatar, RequestOptions options)
         {
             var args = new CreateWebhookParams { Name = name };
             if (avatar != null)
@@ -577,14 +577,14 @@ namespace Discord.Rest
             var model = await client.ApiClient.CreateWebhookAsync(channel.Id, args, options).ConfigureAwait(false);
             return RestWebhook.Create(client, channel, model);
         }
-        public static async Task<RestWebhook> GetWebhookAsync(ITextChannel channel, BaseDiscordClient client, ulong id, RequestOptions options)
+        public static async Task<RestWebhook> GetWebhookAsync(IIntegrationChannel channel, BaseDiscordClient client, ulong id, RequestOptions options)
         {
             var model = await client.ApiClient.GetWebhookAsync(id, options: options).ConfigureAwait(false);
             if (model == null)
                 return null;
             return RestWebhook.Create(client, channel, model);
         }
-        public static async Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(ITextChannel channel, BaseDiscordClient client, RequestOptions options)
+        public static async Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(IIntegrationChannel channel, BaseDiscordClient client, RequestOptions options)
         {
             var models = await client.ApiClient.GetChannelWebhooksAsync(channel.Id, options).ConfigureAwait(false);
             return models.Select(x => RestWebhook.Create(client, channel, x))

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -154,6 +154,18 @@ namespace Discord.Rest
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
             => ThreadHelper.GetPublicArchivedThreadsAsync(this, Discord, limit, before, options);
 
+        /// <inheritdoc cref="IIntegrationChannel.CreateWebhookAsync"/>
+        public Task<RestWebhook> CreateWebhookAsync(string name, Stream avatar = null, RequestOptions options = null)
+            => ChannelHelper.CreateWebhookAsync(this, Discord, name, avatar, options);
+
+        /// <inheritdoc cref="IIntegrationChannel.GetWebhookAsync"/>
+        public Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
+            => ChannelHelper.GetWebhookAsync(this, Discord, id, options);
+
+        /// <inheritdoc cref="IIntegrationChannel.GetWebhooksAsync"/>
+        public Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
+            => ChannelHelper.GetWebhooksAsync(this, Discord, options);
+
         #region IForumChannel
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetActiveThreadsAsync(RequestOptions options)
             => await GetActiveThreadsAsync(options).ConfigureAwait(false);
@@ -203,5 +215,20 @@ namespace Discord.Rest
         public Task SyncPermissionsAsync(RequestOptions options = null)
             => ChannelHelper.SyncPermissionsAsync(this, Discord, options);
         #endregion
+
+        #region IIntegrationChannel
+
+        /// <inheritdoc />
+        async Task<IWebhook> IIntegrationChannel.CreateWebhookAsync(string name, Stream avatar, RequestOptions options)
+            => await CreateWebhookAsync(name, avatar, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IWebhook> IIntegrationChannel.GetWebhookAsync(ulong id, RequestOptions options)
+            => await GetWebhookAsync(id, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IWebhook>> IIntegrationChannel.GetWebhooksAsync(RequestOptions options)
+            => await GetWebhooksAsync(options).ConfigureAwait(false);
+
+        #endregion
+
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -307,16 +307,21 @@ namespace Discord.Rest
         private string DebuggerDisplay => $"{Name} ({Id}, Text)";
         #endregion
 
-        #region ITextChannel
+        #region IIntegrationChannel
+
         /// <inheritdoc />
-        async Task<IWebhook> ITextChannel.CreateWebhookAsync(string name, Stream avatar, RequestOptions options)
+        async Task<IWebhook> IIntegrationChannel.CreateWebhookAsync(string name, Stream avatar, RequestOptions options)
             => await CreateWebhookAsync(name, avatar, options).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IWebhook> ITextChannel.GetWebhookAsync(ulong id, RequestOptions options)
+        async Task<IWebhook> IIntegrationChannel.GetWebhookAsync(ulong id, RequestOptions options)
             => await GetWebhookAsync(id, options).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IReadOnlyCollection<IWebhook>> ITextChannel.GetWebhooksAsync(RequestOptions options)
+        async Task<IReadOnlyCollection<IWebhook>> IIntegrationChannel.GetWebhooksAsync(RequestOptions options)
             => await GetWebhooksAsync(options).ConfigureAwait(false);
+
+        #endregion
+
+        #region ITextChannel
 
         async Task<IThreadChannel> ITextChannel.CreateThreadAsync(string name, ThreadType type, ThreadArchiveDuration autoArchiveDuration, IMessage message, bool? invitable, int? slowmode, RequestOptions options)
             => await CreateThreadAsync(name, type, autoArchiveDuration, message, invitable, slowmode, options);

--- a/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
+++ b/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
@@ -10,7 +10,7 @@ namespace Discord.Rest
     {
         #region RestWebhook
         internal IGuild Guild { get; private set; }
-        internal ITextChannel Channel { get; private set; }
+        internal IIntegrationChannel Channel { get; private set; }
 
         /// <inheritdoc />
         public string Token { get; }
@@ -38,7 +38,7 @@ namespace Discord.Rest
             Token = token;
             ChannelId = channelId;
         }
-        internal RestWebhook(BaseDiscordClient discord, ITextChannel channel, ulong id, string token, ulong channelId)
+        internal RestWebhook(BaseDiscordClient discord, IIntegrationChannel channel, ulong id, string token, ulong channelId)
             : this(discord, channel.Guild, id, token, channelId)
         {
             Channel = channel;
@@ -50,7 +50,7 @@ namespace Discord.Rest
             entity.Update(model);
             return entity;
         }
-        internal static RestWebhook Create(BaseDiscordClient discord, ITextChannel channel, Model model)
+        internal static RestWebhook Create(BaseDiscordClient discord, IIntegrationChannel channel, Model model)
         {
             var entity = new RestWebhook(discord, channel, model.Id, model.Token, model.ChannelId);
             entity.Update(model);
@@ -103,7 +103,7 @@ namespace Discord.Rest
         IGuild IWebhook.Guild 
             => Guild ?? throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
         /// <inheritdoc />
-        ITextChannel IWebhook.Channel 
+        IIntegrationChannel IWebhook.Channel 
             => Channel ?? throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
         /// <inheritdoc />
         Task IWebhook.ModifyAsync(Action<WebhookProperties> func, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -156,6 +156,35 @@ namespace Discord.WebSocket
         public Task<IReadOnlyCollection<RestThreadChannel>> GetPublicArchivedThreadsAsync(int? limit = null, DateTimeOffset? before = null, RequestOptions options = null)
             => ThreadHelper.GetPublicArchivedThreadsAsync(this, Discord, limit, before, options);
 
+        #region Webhooks
+
+        /// <inheritdoc cref="IIntegrationChannel.CreateWebhookAsync"/>
+        public Task<RestWebhook> CreateWebhookAsync(string name, Stream avatar = null, RequestOptions options = null)
+            => ChannelHelper.CreateWebhookAsync(this, Discord, name, avatar, options);
+
+        /// <inheritdoc cref="IIntegrationChannel.CreateWebhookAsync"/>
+        public Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
+            => ChannelHelper.GetWebhookAsync(this, Discord, id, options);
+
+        /// <inheritdoc cref="IIntegrationChannel.CreateWebhookAsync"/>
+        public Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
+            => ChannelHelper.GetWebhooksAsync(this, Discord, options);
+        #endregion
+
+        #region IIntegrationChannel
+
+        /// <inheritdoc />
+        async Task<IWebhook> IIntegrationChannel.CreateWebhookAsync(string name, Stream avatar, RequestOptions options)
+            => await CreateWebhookAsync(name, avatar, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IWebhook> IIntegrationChannel.GetWebhookAsync(ulong id, RequestOptions options)
+            => await GetWebhookAsync(id, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IWebhook>> IIntegrationChannel.GetWebhooksAsync(RequestOptions options)
+            => await GetWebhooksAsync(options).ConfigureAwait(false);
+        /// <inheritdoc />
+        #endregion
+
         #region IForumChannel
         async Task<IReadOnlyCollection<IThreadChannel>> IForumChannel.GetActiveThreadsAsync(RequestOptions options)
             => await GetActiveThreadsAsync(options).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -365,17 +365,21 @@ namespace Discord.WebSocket
         internal new SocketTextChannel Clone() => MemberwiseClone() as SocketTextChannel;
         #endregion
 
-        #region ITextChannel
+        #region IIntegrationChannel
+
         /// <inheritdoc />
-        async Task<IWebhook> ITextChannel.CreateWebhookAsync(string name, Stream avatar, RequestOptions options)
+        async Task<IWebhook> IIntegrationChannel.CreateWebhookAsync(string name, Stream avatar, RequestOptions options)
             => await CreateWebhookAsync(name, avatar, options).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IWebhook> ITextChannel.GetWebhookAsync(ulong id, RequestOptions options)
+        async Task<IWebhook> IIntegrationChannel.GetWebhookAsync(ulong id, RequestOptions options)
             => await GetWebhookAsync(id, options).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<IReadOnlyCollection<IWebhook>> ITextChannel.GetWebhooksAsync(RequestOptions options)
+        async Task<IReadOnlyCollection<IWebhook>> IIntegrationChannel.GetWebhooksAsync(RequestOptions options)
             => await GetWebhooksAsync(options).ConfigureAwait(false);
         /// <inheritdoc />
+        #endregion
+
+        #region ITextChannel
         async Task<IThreadChannel> ITextChannel.CreateThreadAsync(string name, ThreadType type, ThreadArchiveDuration autoArchiveDuration, IMessage message, bool? invitable, int? slowmode, RequestOptions options)
             => await CreateThreadAsync(name, type, autoArchiveDuration, message, invitable, slowmode, options);
         /// <inheritdoc />

--- a/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
+++ b/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
@@ -65,7 +65,7 @@ namespace Discord.Webhook
         private string DebuggerDisplay => $"Webhook: {Name} ({Id})";
 
         IUser IWebhook.Creator => null;
-        ITextChannel IWebhook.Channel => null;
+        IIntegrationChannel IWebhook.Channel => null;
         IGuild IWebhook.Guild => null;
     }
 }


### PR DESCRIPTION
This PR adds more abstraction to D.Net's channels - `IIntegrationChannel` interface, containing all webhook related methods instead of `ITextChannel` to bring support for webhooks in forum channels.

### Changes
- move webhook related methods from `ITextChannel` to `IIntegrationChannel`.
- add webhook related methods to forum channels.