### PR TITLE
Fix ModuleBuilder.AddSlashCommand/AddAutocompleteCommand typo

### DIFF
--- a/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
@@ -367,7 +367,7 @@ namespace Discord.Interactions.Builders
         /// <returns>
         ///     The builder instance.
         /// </returns>
-        public ModuleBuilder AddSlashCommand(string name, ExecuteCallback callback, Action<AutocompleteCommandBuilder> configure)
+        public ModuleBuilder AddAutocompleteCommand(string name, ExecuteCallback callback, Action<AutocompleteCommandBuilder> configure)
         {
             var command = new AutocompleteCommandBuilder(this, name, callback);
             configure(command);


### PR DESCRIPTION
Method name was typo'ed, probably when it was created