### PR TITLE
[Feature] Create forum posts with `DiscordWebhookClient`

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
@@ -42,6 +42,9 @@ namespace Discord.API.Rest
         [JsonProperty("file")]
         public Optional<MultipartFile> File { get; set; }
 
+        [JsonProperty("thread_name")]
+        public Optional<string> ThreadName { get; set; }
+
         public IReadOnlyDictionary<string, object> ToDictionary()
         {
             var d = new Dictionary<string, object>();
@@ -70,6 +73,8 @@ namespace Discord.API.Rest
                 payload["allowed_mentions"] = AllowedMentions.Value;
             if (Components.IsSpecified)
                 payload["components"] = Components.Value;
+            if (ThreadName.IsSpecified)
+                payload["thread_name"] = ThreadName.Value;
 
             var json = new StringBuilder();
             using (var text = new StringWriter(json))

--- a/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
@@ -22,6 +22,7 @@ namespace Discord.API.Rest
         public Optional<AllowedMentions> AllowedMentions { get; set; }
         public Optional<ActionRowComponent[]> MessageComponents { get; set; }
         public Optional<MessageFlags> Flags { get; set; }
+        public Optional<string> ThreadName { get; set; }
 
         public UploadWebhookFileParams(params FileAttachment[] files)
         {
@@ -51,6 +52,8 @@ namespace Discord.API.Rest
                 payload["allowed_mentions"] = AllowedMentions.Value;
             if (Flags.IsSpecified)
                 payload["flags"] = Flags.Value;
+            if (ThreadName.IsSpecified)
+                payload["thread_name"] = ThreadName.Value;
 
             List<object> attachments = new();
 

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -88,8 +88,8 @@ namespace Discord.Webhook
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendMessageAsync(string text = null, bool isTTS = false, IEnumerable<Embed> embeds = null,
             string username = null, string avatarUrl = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
-            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId);
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
+            => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId, threadName);
 
         /// <summary>
         ///     Modifies a message posted using this webhook.
@@ -125,35 +125,35 @@ namespace Discord.Webhook
         public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
             => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl,
-                allowedMentions, options, isSpoiler, components, flags, threadId);
+                allowedMentions, options, isSpoiler, components, flags, threadId, threadName);
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
             => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username,
-                avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId);
+                avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId, threadName);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFileAsync(FileAttachment attachment, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null,
-            MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
             => WebhookClientHelper.SendFileAsync(this, attachment, text, isTTS, embeds, username,
-                avatarUrl, allowedMentions, components, options, flags, threadId);
+                avatarUrl, allowedMentions, components, options, flags, threadId, threadName);
 
         /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
         /// <returns> Returns the ID of the created message. </returns>
         public Task<ulong> SendFilesAsync(IEnumerable<FileAttachment> attachments, string text, bool isTTS = false,
             IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
             RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null,
-            MessageFlags flags = MessageFlags.None, ulong? threadId = null)
+            MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
             => WebhookClientHelper.SendFilesAsync(this, attachments, text, isTTS, embeds, username, avatarUrl,
-                allowedMentions, components, options, flags, threadId);
+                allowedMentions, components, options, flags, threadId, threadName);
 
 
         /// <summary> Modifies the properties of this webhook. </summary>


### PR DESCRIPTION
This PR adds `threadName` property to `SendMessageAsync` & add `SendFile(s)Async` methods of `DiscordWebhookClient`, which allows creation of forum posts with the webhook.

closes #2553 