### PR TITLE
[Feature] Optimize `Add/RemoveRolesAsync` methods

### DIFF
--- a/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Users/UserHelper.cs
@@ -81,14 +81,18 @@ namespace Discord.Rest
 
         public static async Task AddRolesAsync(IGuildUser user, BaseDiscordClient client, IEnumerable<ulong> roleIds, RequestOptions options)
         {
-            foreach (var roleId in roleIds)
-                await client.ApiClient.AddRoleAsync(user.Guild.Id, user.Id, roleId, options).ConfigureAwait(false);
+            await client.ApiClient.ModifyGuildMemberAsync(user.GuildId, user.Id, args: new()
+            {
+                RoleIds = user.RoleIds.Except(new[] { user.Guild.Id }).Concat(roleIds).Distinct().ToArray()
+            }, options);
         }
 
         public static async Task RemoveRolesAsync(IGuildUser user, BaseDiscordClient client, IEnumerable<ulong> roleIds, RequestOptions options)
         {
-            foreach (var roleId in roleIds)
-                await client.ApiClient.RemoveRoleAsync(user.Guild.Id, user.Id, roleId, options).ConfigureAwait(false);
+            await client.ApiClient.ModifyGuildMemberAsync(user.GuildId, user.Id, args: new()
+            {
+                RoleIds = user.RoleIds.Except(new[] { user.Guild.Id }).Except(roleIds).ToArray()
+            }, options);
         }
 
         public static async Task SetTimeoutAsync(IGuildUser user, BaseDiscordClient client, TimeSpan span, RequestOptions options)


### PR DESCRIPTION
This PR reworks `AddRolesAsync` and `RemoveRolesAsync` methods to use [`Modify Guild Member`](https://discord.com/developers/docs/resources/guild#modify-guild-member) endpoint instead of calling [`Add Guild Member Role`](https://discord.com/developers/docs/resources/guild#add-guild-member-role) and [`Remove Guild Member Role`](https://discord.com/developers/docs/resources/guild#remove-guild-member-role) for each role, which greatly optimizes methods' performance with large role sets.