### PR TITLE
[Feature] Missing invite properties

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuildScheduledEvent.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuildScheduledEvent.cs
@@ -17,6 +17,11 @@ namespace Discord
         IGuild Guild { get; }
 
         /// <summary>
+        ///     Gets the id of the guild this event is scheduled in.
+        /// </summary>
+        ulong GuildId { get; }
+
+        /// <summary>
         ///     Gets the optional channel id where this event will be hosted.
         /// </summary>
         ulong? ChannelId { get; }

--- a/src/Discord.Net.Core/Entities/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/IApplication.cs
@@ -60,5 +60,20 @@ namespace Discord
         /// </summary>
         public string PrivacyPolicy { get; }
 
+        /// <summary>
+        ///     Gets application's default custom authorization url. <see langword="null" /> if disabled.
+        /// </summary>
+        public string CustomInstallUrl { get; }
+
+        /// <summary>
+        ///     Gets the application's role connection verification entry point. <see langword="null" /> if not set.
+        /// </summary>
+        public string RoleConnectionsVerificationUrl { get; }
+
+        /// <summary>
+        ///     Gets the hex encoded key for verification in interactions.
+        /// </summary>
+        public string VerifyKey { get; }
+
     }
 }

--- a/src/Discord.Net.Core/Entities/Invites/IInvite.cs
+++ b/src/Discord.Net.Core/Entities/Invites/IInvite.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Discord
 {
     /// <summary>
@@ -80,7 +82,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     An <see cref="System.Int32" /> representing the approximated online member count of the guild that the
-        ///     invite points to; <c>null</c> if one cannot be obtained.
+        ///     invite points to; <see langword="null" /> if one cannot be obtained.
         /// </returns>
         int? PresenceCount { get; }
         /// <summary>
@@ -88,7 +90,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     An <see cref="System.Int32" /> representing the approximated total member count of the guild that the
-        ///     invite points to; <c>null</c> if one cannot be obtained.
+        ///     invite points to; <see langword="null" /> if one cannot be obtained.
         /// </returns>
         int? MemberCount { get; }
         /// <summary>
@@ -105,5 +107,19 @@ namespace Discord
         ///     The type of the linked user that is linked to this invite.
         /// </returns>
         TargetUserType TargetUserType { get; }
+
+        /// <summary>
+        ///     Gets the embedded application to open for this voice channel embedded application invite.
+        /// </summary>
+        /// <returns>
+        ///     A partial <see cref="IApplication"/> object. <see langword="null" /> if <see cref="TargetUserType"/>
+        ///     is not <see cref="TargetUserType.EmbeddedApplication"/>.
+        /// </returns>
+        IApplication Application { get; }
+
+        /// <summary>
+        ///     Gets the expiration date of this invite. <see langword="null" /> if the invite never expires.
+        /// </summary>
+        DateTimeOffset? ExpiresAt { get; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Application.cs
+++ b/src/Discord.Net.Rest/API/Common/Application.cs
@@ -32,5 +32,14 @@ namespace Discord.API
         public string TermsOfService { get; set; }
         [JsonProperty("privacy_policy_url")]
         public string PrivacyPolicy { get; set; }
+
+        [JsonProperty("custom_install_url")]
+        public Optional<string> CustomInstallUrl { get; set; }
+
+        [JsonProperty("role_connections_verification_url")]
+        public Optional<string> RoleConnectionsUrl { get; set; }
+
+        [JsonProperty("verify_key")]
+        public string VerifyKey { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Invite.cs
+++ b/src/Discord.Net.Rest/API/Common/Invite.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System;
 
 namespace Discord.API
 {
@@ -6,19 +7,35 @@ namespace Discord.API
     {
         [JsonProperty("code")]
         public string Code { get; set; }
+
         [JsonProperty("guild")]
         public Optional<InviteGuild> Guild { get; set; }
+
         [JsonProperty("channel")]
         public InviteChannel Channel { get; set; }
+
         [JsonProperty("inviter")]
         public Optional<User> Inviter { get; set; }
+
         [JsonProperty("approximate_presence_count")]
         public Optional<int?> PresenceCount { get; set; }
+
         [JsonProperty("approximate_member_count")]
         public Optional<int?> MemberCount { get; set; }
+
         [JsonProperty("target_user")]
         public Optional<User> TargetUser { get; set; }
-        [JsonProperty("target_user_type")]
+
+        [JsonProperty("target_type")]
         public Optional<TargetUserType> TargetUserType { get; set; }
+
+        [JsonProperty("target_application")]
+        public Optional<Application> Application { get; set; }
+
+        [JsonProperty("expires_at")]
+        public Optional<DateTimeOffset?> ExpiresAt { get; set; }
+
+        [JsonProperty("guild_scheduled_event")]
+        public Optional<GuildScheduledEvent> ScheduledEvent { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -52,10 +52,9 @@ namespace Discord.Rest
             return models.Select(model => RestConnection.Create(client, model)).ToImmutableArray();
         }
 
-        public static async Task<RestInviteMetadata> GetInviteAsync(BaseDiscordClient client,
-            string inviteId, RequestOptions options)
+        public static async Task<RestInviteMetadata> GetInviteAsync(BaseDiscordClient client, string inviteId, RequestOptions options, ulong? scheduledEventId = null)
         {
-            var model = await client.ApiClient.GetInviteAsync(inviteId, options).ConfigureAwait(false);
+            var model = await client.ApiClient.GetInviteAsync(inviteId, options, scheduledEventId).ConfigureAwait(false);
             if (model != null)
                 return RestInviteMetadata.Create(client, null, null, model);
             return null;

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1732,7 +1732,7 @@ namespace Discord.API
         #region Guild Invites
         /// <exception cref="ArgumentException"><paramref name="inviteId"/> cannot be blank.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="inviteId"/> must not be <see langword="null"/>.</exception>
-        public async Task<InviteMetadata> GetInviteAsync(string inviteId, RequestOptions options = null)
+        public async Task<InviteMetadata> GetInviteAsync(string inviteId, RequestOptions options = null, ulong? scheduledEventId = null)
         {
             Preconditions.NotNullOrEmpty(inviteId, nameof(inviteId));
             options = RequestOptions.CreateOrClone(options);
@@ -1745,9 +1745,13 @@ namespace Discord.API
             if (index >= 0)
                 inviteId = inviteId.Substring(index + 1);
 
+            var scheduledEventQuery = scheduledEventId is not null
+                ? $"&guild_scheduled_event_id={scheduledEventId}"
+                : string.Empty;
+
             try
             {
-                return await SendAsync<InviteMetadata>("GET", () => $"invites/{inviteId}?with_counts=true", new BucketIds(), options: options).ConfigureAwait(false);
+                return await SendAsync<InviteMetadata>("GET", () => $"invites/{inviteId}?with_counts=true&with_expiration=true{scheduledEventQuery}", new BucketIds(), options: options).ConfigureAwait(false);
             }
             catch (HttpException ex) when (ex.HttpCode == HttpStatusCode.NotFound) { return null; }
         }

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -182,8 +182,8 @@ namespace Discord.Rest
         public Task<IReadOnlyCollection<RestConnection>> GetConnectionsAsync(RequestOptions options = null)
             => ClientHelper.GetConnectionsAsync(this, options);
 
-        public Task<RestInviteMetadata> GetInviteAsync(string inviteId, RequestOptions options = null)
-            => ClientHelper.GetInviteAsync(this, inviteId, options);
+        public Task<RestInviteMetadata> GetInviteAsync(string inviteId, RequestOptions options = null, ulong? scheduledEventId = null)
+            => ClientHelper.GetInviteAsync(this, inviteId, options, scheduledEventId);
 
         public Task<RestGuild> GetGuildAsync(ulong id, RequestOptions options = null)
             => ClientHelper.GetGuildAsync(this, id, false, options);

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuildEvent.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuildEvent.cs
@@ -14,6 +14,9 @@ namespace Discord.Rest
         public IGuild Guild { get; private set; }
 
         /// <inheritdoc/>
+        public ulong GuildId { get; private set; }
+
+        /// <inheritdoc/>
         public ulong? ChannelId { get; private set; }
 
         /// <inheritdoc/>
@@ -102,6 +105,7 @@ namespace Discord.Rest
             Location = model.EntityMetadata?.Location.GetValueOrDefault();
             UserCount = model.UserCount.ToNullable();
             CoverImageId = model.Image;
+            GuildId = model.GuildId;
         }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Rest/Entities/Invites/RestInvite.cs
+++ b/src/Discord.Net.Rest/Entities/Invites/RestInvite.cs
@@ -38,6 +38,17 @@ namespace Discord.Rest
         /// </returns>
         public InviteGuild InviteGuild { get; private set; }
 
+        /// <inheritdoc cref="IInvite.Application" />
+        public RestApplication Application { get; private set; }
+
+        /// <inheritdoc />
+        public DateTimeOffset? ExpiresAt { get; private set; }
+
+        /// <summary>
+        ///     Gets guild scheduled event data. <see langword="null" /> if event id was invalid.
+        /// </summary>
+        public RestGuildEvent ScheduledEvent { get; private set; }
+
         internal IChannel Channel { get; }
 
         internal IGuild Guild { get; }
@@ -97,6 +108,14 @@ namespace Discord.Rest
                                     ch.EmojiId.IsSpecified ? ch.EmojiId.Value : null)).ToImmutableArray())
                         : null);
             }
+
+            if(model.Application.IsSpecified)
+                Application = RestApplication.Create(Discord, model.Application.Value);
+
+            ExpiresAt = model.ExpiresAt.IsSpecified ? model.ExpiresAt.Value : null;
+
+            if(model.ScheduledEvent.IsSpecified)
+                ScheduledEvent = RestGuildEvent.Create(Discord, Guild, model.ScheduledEvent.Value);
         }
 
         /// <inheritdoc />
@@ -117,6 +136,8 @@ namespace Discord.Rest
         /// </returns>
         public override string ToString() => Url;
         private string DebuggerDisplay => $"{Url} ({GuildName} / {ChannelName})";
+
+        #region IInvite
 
         /// <inheritdoc />
         IGuild IInvite.Guild
@@ -140,5 +161,10 @@ namespace Discord.Rest
                 throw new InvalidOperationException("Unable to return this entity's parent unless it was fetched through that object.");
             }
         }
+
+        /// <inheritdoc />
+        IApplication IInvite.Application => Application;
+        
+        #endregion
     }
 }

--- a/src/Discord.Net.Rest/Entities/RestApplication.cs
+++ b/src/Discord.Net.Rest/Entities/RestApplication.cs
@@ -35,6 +35,14 @@ namespace Discord.Rest
         public string TermsOfService { get; private set; }
         /// <inheritdoc />
         public string PrivacyPolicy { get; private set; }
+
+        /// <inheritdoc />
+        public string VerifyKey { get; private set; }
+        /// <inheritdoc />
+        public string CustomInstallUrl { get; private set; }
+        /// <inheritdoc />
+        public string RoleConnectionsVerificationUrl { get; private set; }
+
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
@@ -74,6 +82,10 @@ namespace Discord.Rest
                 Owner = RestUser.Create(Discord, model.Owner.Value);
             if (model.Team != null)
                 Team = RestTeam.Create(Discord, model.Team);
+
+            CustomInstallUrl = model.CustomInstallUrl.IsSpecified ? model.CustomInstallUrl.Value : null;
+            RoleConnectionsVerificationUrl = model.RoleConnectionsUrl.IsSpecified ? model.RoleConnectionsUrl.Value : null;
+            VerifyKey = model.VerifyKey;
         }
 
         /// <exception cref="InvalidOperationException">Unable to update this object from a different application token.</exception>

--- a/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/InviteCreateEvent.cs
@@ -21,11 +21,17 @@ namespace Discord.API.Gateway
         public int MaxUses { get; set; }
         [JsonProperty("target_user")]
         public Optional<User> TargetUser { get; set; }
-        [JsonProperty("target_user_type")]
+        [JsonProperty("target_type")]
         public Optional<TargetUserType> TargetUserType { get; set; }
         [JsonProperty("temporary")]
         public bool Temporary { get; set; }
         [JsonProperty("uses")]
         public int Uses { get; set; }
+
+        [JsonProperty("target_application")]
+        public Optional<Application> Application { get; set; }
+
+        [JsonProperty("expires_at")]
+        public Optional<DateTimeOffset?> ExpiresAt { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -268,11 +268,12 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="inviteId">The invitation identifier.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="scheduledEventId">The id of the guild scheduled event to include with the invite.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the invite information.
         /// </returns>
-        public Task<RestInviteMetadata> GetInviteAsync(string inviteId, RequestOptions options = null)
-            => ClientHelper.GetInviteAsync(this, inviteId, options ?? RequestOptions.Default);
+        public Task<RestInviteMetadata> GetInviteAsync(string inviteId, RequestOptions options = null, ulong? scheduledEventId = null)
+            => ClientHelper.GetInviteAsync(this, inviteId, options ?? RequestOptions.Default, scheduledEventId);
         /// <summary>
         ///     Gets a sticker.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuildEvent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuildEvent.cs
@@ -19,6 +19,9 @@ namespace Discord.WebSocket
         /// </summary>
         public SocketGuild Guild { get; private set; }
 
+        /// <inheritdoc/>
+        public ulong GuildId { get; private set; }
+
         /// <summary>
         ///     Gets the channel of the event.
         /// </summary>
@@ -113,6 +116,7 @@ namespace Discord.WebSocket
             Status = model.Status;
             UserCount = model.UserCount.ToNullable();
             CoverImageId = model.Image;
+            GuildId = model.GuildId;
         }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -90,6 +90,12 @@ namespace Discord.WebSocket
         /// </summary>
         public TargetUserType TargetUserType { get; private set; }
 
+        /// <inheritdoc cref="IInvite.Application" />
+        public RestApplication Application { get; private set; }
+
+        /// <inheritdoc />
+        public DateTimeOffset? ExpiresAt { get; private set; }
+        
         /// <inheritdoc />
         public string Code => Id;
         /// <inheritdoc />
@@ -119,6 +125,8 @@ namespace Discord.WebSocket
             Uses = model.Uses;
             _createdAtTicks = model.CreatedAt.UtcTicks;
             TargetUserType = model.TargetUserType.IsSpecified ? model.TargetUserType.Value : TargetUserType.Undefined;
+            ExpiresAt = model.ExpiresAt.IsSpecified ? model.ExpiresAt.Value : null;
+            Application = model.Application.IsSpecified ? RestApplication.Create(Discord, model.Application.Value) : null;
         }
 
         /// <inheritdoc />
@@ -134,6 +142,8 @@ namespace Discord.WebSocket
         public override string ToString() => Url;
         private string DebuggerDisplay => $"{Url} ({Guild?.Name} / {Channel.Name})";
 
+        #region IInvite
+
         /// <inheritdoc />
         IGuild IInvite.Guild => Guild;
         /// <inheritdoc />
@@ -142,5 +152,10 @@ namespace Discord.WebSocket
         IUser IInvite.Inviter => Inviter;
         /// <inheritdoc />
         IUser IInvite.TargetUser => TargetUser;
+
+        /// <inheritdoc />
+        IApplication IInvite.Application => Application;
+        
+        #endregion
     }
 }


### PR DESCRIPTION
This PR adds missing properties of `invite` & some related objects

### Changes
- add `with_expiration=true` & add `ExpiresAt` property to `IInvite` (resolves #2586)
- add missing properties to `IApplication`
- add `GuildId` property to `IGuildScheduledEvent`
- add `scheduledEventId` parameter to `GetInviteAsync` methods