### PR TITLE
Update ip discovery to send 74 bytes

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -306,7 +306,7 @@ namespace Discord.Audio
             {
                 if (_connection.State == ConnectionState.Connecting)
                 {
-                    if (packet.Length != 70)
+                    if (packet.Length != 74)
                     {
                         await _audioLogger.DebugAsync("Malformed Packet").ConfigureAwait(false);
                         return;
@@ -315,8 +315,8 @@ namespace Discord.Audio
                     int port;
                     try
                     {
-                        ip = Encoding.UTF8.GetString(packet, 4, 70 - 6).TrimEnd('\0');
-                        port = (packet[69] << 8) | packet[68];
+                        ip = Encoding.UTF8.GetString(packet, 8, 74 - 10).TrimEnd('\0');
+                        port = (packet[73] << 8) | packet[72];
                     }
                     catch (Exception ex)
                     {

--- a/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
@@ -228,12 +228,14 @@ namespace Discord.Audio
         #region Udp
         public async Task SendDiscoveryAsync(uint ssrc)
         {
-            var packet = new byte[70];
-            packet[0] = (byte)(ssrc >> 24);
-            packet[1] = (byte)(ssrc >> 16);
-            packet[2] = (byte)(ssrc >> 8);
-            packet[3] = (byte)(ssrc >> 0);
-            await SendAsync(packet, 0, 70).ConfigureAwait(false);
+            var packet = new byte[74];
+            packet[1] = 1;
+            packet[3] = 70;
+            packet[4] = (byte)(ssrc >> 24);
+            packet[5] = (byte)(ssrc >> 16);
+            packet[6] = (byte)(ssrc >> 8);
+            packet[7] = (byte)(ssrc >> 0);
+            await SendAsync(packet, 0, 74).ConfigureAwait(false);
             await _sentDiscoveryEvent.InvokeAsync().ConfigureAwait(false);
         }
         public async Task<ulong> SendKeepaliveAsync()


### PR DESCRIPTION
> IP Discovery Upcoming Change
﻿
We recently pushed out a change related to Voice Connections that broke apps sending 70-byte UDP packets to the voice server when using IP Discovery. While the documentation and deprecation were updated in December 2019, there wasn't communication around the the change starting to roll out so we've temporarily reverted the change to give developers more time to handle the breaking change.
﻿
﻿⚠️﻿ Starting 15 March 2023, all apps with Voice Connections using IP Discovery must send 74-byte UDP packets. IP Discovery requests sending the deprecated 70-byte packet will no longer receive a response.
﻿
Some 3rd party libraries may be needed to be updated to support this change, so if your app uses Voice Connections and a 3rd party library, check with the maintainer(s) to see if it sends the updated packet and/or whether you need to update the library version you're using.
﻿
﻿📰﻿ Read the IP Discovery documentation for more information about the UDP packet to send: https://discord.com/developers/docs/topics/voice-connections#ip-discovery