### PR TITLE
[Feature] Default thread ratelimit in guild text channels 

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
@@ -28,21 +28,6 @@ public class ForumChannelProperties : TextChannelProperties
     /// <exception cref="ArgumentOutOfRangeException">Thrown if the value does not fall within [0, 21600].</exception>
     public Optional<int> ThreadCreationInterval { get; set; }
 
-
-    /// <summary>
-    /// Gets or sets the default slow-mode for threads in this channel.
-    /// </summary>
-    /// <remarks>
-    ///     Setting this value to anything above zero will require each user to wait X seconds before
-    ///     sending another message; setting this value to <c>0</c> will disable slow-mode for child threads.
-    ///     <note>
-    ///         Users with <see cref="Discord.ChannelPermission.ManageMessages"/> or 
-    ///         <see cref="ChannelPermission.ManageChannels"/> will be exempt from slow-mode.
-    ///     </note>
-    /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value does not fall within [0, 21600].</exception>
-    public Optional<int> DefaultSlowModeInterval { get; set; }
-
     /// <summary>
     /// Gets or sets a collection of tags inside of this forum channel.
     /// </summary>

--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -36,6 +36,15 @@ namespace Discord
         int SlowModeInterval { get; }
 
         /// <summary>
+        /// Gets the current default slow-mode delay for threads in this channel.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="int"/> representing the time in seconds required before the user can send another
+        ///     message; <c>0</c> if disabled.
+        /// </returns>
+        int DefaultSlowModeInterval { get; }
+
+        /// <summary>
         ///     Gets the default auto-archive duration for client-created threads in this channel.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
@@ -45,5 +45,19 @@ namespace Discord
         /// </summary>
         public Optional<ThreadArchiveDuration> AutoArchiveDuration { get; set; }
 
+        /// <summary>
+        /// Gets or sets the default slow-mode for threads in this channel.
+        /// </summary>
+        /// <remarks>
+        ///     Setting this value to anything above zero will require each user to wait X seconds before
+        ///     sending another message; setting this value to <c>0</c> will disable slow-mode for child threads.
+        ///     <note>
+        ///         Users with <see cref="Discord.ChannelPermission.ManageMessages"/> or 
+        ///         <see cref="ChannelPermission.ManageChannels"/> will be exempt from slow-mode.
+        ///     </note>
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the value does not fall within [0, 21600].</exception>
+        public Optional<int> DefaultSlowModeInterval { get; set; }
+
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyForumChannelParams.cs
@@ -9,9 +9,6 @@ internal class ModifyForumChannelParams : ModifyTextChannelParams
     [JsonProperty("available_tags")]
     public Optional<ModifyForumTagParams[]> Tags { get; set; }
 
-    [JsonProperty("default_thread_rate_limit_per_user")]
-    public Optional<int> DefaultSlowModeInterval { get; set; }
-
     [JsonProperty("rate_limit_per_user")]
     public Optional<int> ThreadCreationInterval { get; set; }
 

--- a/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyTextChannelParams.cs
@@ -7,9 +7,14 @@ namespace Discord.API.Rest
     {
         [JsonProperty("topic")]
         public Optional<string> Topic { get; set; }
+
         [JsonProperty("nsfw")]
         public Optional<bool> IsNsfw { get; set; }
+
         [JsonProperty("rate_limit_per_user")]
         public Optional<int> SlowModeInterval { get; set; }
+
+        [JsonProperty("default_thread_rate_limit_per_user")]
+        public Optional<int> DefaultSlowModeInterval { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -65,6 +65,7 @@ namespace Discord.Rest
                         Deny = overwrite.Permissions.DenyValue.ToString()
                     }).ToArray()
                     : Optional.Create<API.Overwrite[]>(),
+                DefaultSlowModeInterval = args.DefaultSlowModeInterval
             };
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -27,6 +27,8 @@ namespace Discord.Rest
         public bool IsNsfw { get; private set; }
         /// <inheritdoc />
         public ThreadArchiveDuration DefaultArchiveDuration { get; private set; }
+        /// <inheritdoc />
+        public int DefaultSlowModeInterval { get; private set; }
 
         internal RestTextChannel(BaseDiscordClient discord, IGuild guild, ulong id)
             : base(discord, guild, id)
@@ -52,6 +54,8 @@ namespace Discord.Rest
                 DefaultArchiveDuration = model.AutoArchiveDuration.Value;
             else
                 DefaultArchiveDuration = ThreadArchiveDuration.OneDay;
+
+            DefaultSlowModeInterval = model.ThreadRateLimitPerUser.GetValueOrDefault(0);
             // basic value at channel creation. Shouldn't be called since guild text channels always have this property
         }
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -25,6 +25,8 @@ namespace Discord.WebSocket
         public virtual int SlowModeInterval { get; private set; }
         /// <inheritdoc />
         public ulong? CategoryId { get; private set; }
+        /// <inheritdoc />
+        public int DefaultSlowModeInterval { get; private set; }
         /// <summary>
         ///     Gets the parent (category) of this channel in the guild's channel list.
         /// </summary>
@@ -81,6 +83,8 @@ namespace Discord.WebSocket
                 DefaultArchiveDuration = model.AutoArchiveDuration.Value;
             else
                 DefaultArchiveDuration = ThreadArchiveDuration.OneDay;
+
+            DefaultSlowModeInterval = model.ThreadRateLimitPerUser.GetValueOrDefault(0);
             // basic value at channel creation. Shouldn't be called since guild text channels always have this property
         }
 

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedTextChannel.cs
@@ -10,6 +10,8 @@ namespace Discord
     {
         public bool IsNsfw => throw new NotImplementedException();
 
+        public int DefaultSlowModeInterval => throw new NotImplementedException();
+
         public ThreadArchiveDuration DefaultArchiveDuration => throw new NotImplementedException();
 
         public string Topic => throw new NotImplementedException();

--- a/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
+++ b/test/Discord.Net.Tests.Unit/MockedEntities/MockedVoiceChannel.cs
@@ -9,6 +9,8 @@ namespace Discord
 {
     internal sealed class MockedVoiceChannel : IVoiceChannel
     {
+        public int DefaultSlowModeInterval => throw new NotImplementedException();
+
         public int Bitrate => throw new NotImplementedException();
 
         public int? UserLimit => throw new NotImplementedException();


### PR DESCRIPTION
This PR add support for `default_thread_rate_limit_per_user` in guild text channels (https://github.com/discord/discord-api-docs/pull/5978)

### Changes
- add `DefaultSlowModeInterval` property to `ITextChannel`
