### PR TITLE
[Fix] Allow creating stickers with no description

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -1088,7 +1088,7 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        Task<ICustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Image image, RequestOptions options = null);
+        Task<ICustomSticker> CreateStickerAsync(string name, Image image, IEnumerable<string> tags, string description = null, RequestOptions options = null);
 
         /// <summary>
         ///     Creates a new sticker in this guild.
@@ -1101,7 +1101,7 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        Task<ICustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, string path, RequestOptions options = null);
+        Task<ICustomSticker> CreateStickerAsync(string name, string path, IEnumerable<string> tags, string description = null, RequestOptions options = null);
 
         /// <summary>
         ///     Creates a new sticker in this guild.
@@ -1115,7 +1115,7 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        Task<ICustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Stream stream, string filename, RequestOptions options = null);
+        Task<ICustomSticker> CreateStickerAsync(string name, Stream stream, string filename, IEnumerable<string> tags, string description = null, RequestOptions options = null);
 
         /// <summary>
         ///     Gets a specific sticker within this guild.

--- a/src/Discord.Net.Rest/API/Rest/CreateStickerParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateStickerParams.cs
@@ -17,9 +17,13 @@ namespace Discord.API.Rest
             var d = new Dictionary<string, object>
             {
                 ["name"] = $"{Name}",
-                ["description"] = Description,
                 ["tags"] = Tags
             };
+
+            if (Description is not null)
+                d["description"] = Description;
+            else
+                d["description"] = string.Empty;
 
             string contentType;
             if (File is FileStream fileStream)

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -713,7 +713,7 @@ namespace Discord.Rest
             if (description is not null)
             {
                 Preconditions.AtLeast(description.Length, 2, nameof(description));
-                Preconditions.AtMost(description.Length, 100, nameof(name));
+                Preconditions.AtMost(description.Length, 100, nameof(description));
             }
 
             var tagString = string.Join(", ", tags);

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -718,8 +718,8 @@ namespace Discord.Rest
 
             var tagString = string.Join(", ", tags);
 
-            Preconditions.AtLeast(tagString.Length, 1, nameof(description));
-            Preconditions.AtMost(tagString.Length, 200, nameof(name));
+            Preconditions.AtLeast(tagString.Length, 1, nameof(tags));
+            Preconditions.AtMost(tagString.Length, 200, nameof(tags));
 
 
             Preconditions.AtLeast(name.Length, 2, nameof(name));
@@ -752,13 +752,13 @@ namespace Discord.Rest
             if (description is not null)
             {
                 Preconditions.AtLeast(description.Length, 2, nameof(description));
-                Preconditions.AtMost(description.Length, 100, nameof(name));
+                Preconditions.AtMost(description.Length, 100, nameof(description));
             }
             
             var tagString = string.Join(", ", tags);
 
-            Preconditions.AtLeast(tagString.Length, 1, nameof(description));
-            Preconditions.AtMost(tagString.Length, 200, nameof(name));
+            Preconditions.AtLeast(tagString.Length, 1, nameof(tags));
+            Preconditions.AtMost(tagString.Length, 200, nameof(tags));
 
             var apiArgs = new CreateStickerParams()
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -705,49 +705,67 @@ namespace Discord.Rest
         public static Task DeleteEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, RequestOptions options)
             => client.ApiClient.DeleteGuildEmoteAsync(guild.Id, id, options);
 
-        public static async Task<API.Sticker> CreateStickerAsync(BaseDiscordClient client, IGuild guild, string name, string description, IEnumerable<string> tags,
-            Image image, RequestOptions options = null)
+        public static async Task<API.Sticker> CreateStickerAsync(BaseDiscordClient client, IGuild guild, string name, Image image, IEnumerable<string> tags,
+            string description = null, RequestOptions options = null)
         {
             Preconditions.NotNull(name, nameof(name));
-            Preconditions.NotNull(description, nameof(description));
+
+            if (description is not null)
+            {
+                Preconditions.AtLeast(description.Length, 2, nameof(description));
+                Preconditions.AtMost(description.Length, 100, nameof(name));
+            }
+
+            var tagString = string.Join(", ", tags);
+
+            Preconditions.AtLeast(tagString.Length, 1, nameof(description));
+            Preconditions.AtMost(tagString.Length, 200, nameof(name));
+
 
             Preconditions.AtLeast(name.Length, 2, nameof(name));
-            Preconditions.AtLeast(description.Length, 2, nameof(description));
 
             Preconditions.AtMost(name.Length, 30, nameof(name));
-            Preconditions.AtMost(description.Length, 100, nameof(name));
 
             var apiArgs = new CreateStickerParams()
             {
                 Name = name,
                 Description = description,
                 File = image.Stream,
-                Tags = string.Join(", ", tags)
+                Tags = tagString
             };
 
             return await client.ApiClient.CreateGuildStickerAsync(apiArgs, guild.Id, options).ConfigureAwait(false);
         }
 
-        public static async Task<API.Sticker> CreateStickerAsync(BaseDiscordClient client, IGuild guild, string name, string description, IEnumerable<string> tags,
-            Stream file, string filename, RequestOptions options = null)
+        public static async Task<API.Sticker> CreateStickerAsync(BaseDiscordClient client, IGuild guild, string name, Stream file, string filename, IEnumerable<string> tags,
+            string description = null, RequestOptions options = null)
         {
             Preconditions.NotNull(name, nameof(name));
-            Preconditions.NotNull(description, nameof(description));
             Preconditions.NotNull(file, nameof(file));
             Preconditions.NotNull(filename, nameof(filename));
 
             Preconditions.AtLeast(name.Length, 2, nameof(name));
-            Preconditions.AtLeast(description.Length, 2, nameof(description));
 
             Preconditions.AtMost(name.Length, 30, nameof(name));
-            Preconditions.AtMost(description.Length, 100, nameof(name));
+
+
+            if (description is not null)
+            {
+                Preconditions.AtLeast(description.Length, 2, nameof(description));
+                Preconditions.AtMost(description.Length, 100, nameof(name));
+            }
+            
+            var tagString = string.Join(", ", tags);
+
+            Preconditions.AtLeast(tagString.Length, 1, nameof(description));
+            Preconditions.AtMost(tagString.Length, 200, nameof(name));
 
             var apiArgs = new CreateStickerParams()
             {
                 Name = name,
                 Description = description,
                 File = file,
-                Tags = string.Join(", ", tags),
+                Tags = tagString,
                 FileName = filename
             };
 

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -1042,9 +1042,9 @@ namespace Discord.Rest
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        public async Task<CustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Image image, RequestOptions options = null)
+        public async Task<CustomSticker> CreateStickerAsync(string name, Image image, IEnumerable<string> tags, string description = null, RequestOptions options = null)
         {
-            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, description, tags, image, options).ConfigureAwait(false);
+            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, image, tags, description, options).ConfigureAwait(false);
 
             return CustomSticker.Create(Discord, model, this, model.User.IsSpecified ? model.User.Value.Id : null);
         }
@@ -1059,11 +1059,11 @@ namespace Discord.Rest
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        public Task<CustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, string path,
+        public Task<CustomSticker> CreateStickerAsync(string name,  string path, IEnumerable<string> tags, string description = null,
             RequestOptions options = null)
         {
             var fs = File.OpenRead(path);
-            return CreateStickerAsync(name, description, tags, fs, Path.GetFileName(fs.Name), options);
+            return CreateStickerAsync(name, fs, Path.GetFileName(fs.Name), tags,  description,options);
         }
         /// <summary>
         ///     Creates a new sticker in this guild
@@ -1077,10 +1077,10 @@ namespace Discord.Rest
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        public async Task<CustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Stream stream,
-            string filename, RequestOptions options = null)
+        public async Task<CustomSticker> CreateStickerAsync(string name,  Stream stream, string filename, IEnumerable<string> tags,
+             string description = null, RequestOptions options = null)
         {
-            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, description, tags, stream, filename, options).ConfigureAwait(false);
+            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, stream, filename, tags, description, options).ConfigureAwait(false);
 
             return CustomSticker.Create(Discord, model, this, model.User.IsSpecified ? model.User.Value.Id : null);
         }
@@ -1518,14 +1518,14 @@ namespace Discord.Rest
         async Task<IReadOnlyCollection<IApplicationCommand>> IGuild.GetApplicationCommandsAsync(bool withLocalizations, string locale, RequestOptions options)
             => await GetApplicationCommandsAsync(withLocalizations, locale, options).ConfigureAwait(false);
         /// <inheritdoc />
-        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, string description, IEnumerable<string> tags, Image image, RequestOptions options)
-            => await CreateStickerAsync(name, description, tags, image, options);
+        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name,  Image image, IEnumerable<string> tags, string description, RequestOptions options)
+            => await CreateStickerAsync(name, image, tags, description, options);
         /// <inheritdoc />
-        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, string description, IEnumerable<string> tags, Stream stream, string filename, RequestOptions options)
-            => await CreateStickerAsync(name, description, tags, stream, filename, options);
+        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name,  Stream stream, string filename, IEnumerable<string> tags, string description, RequestOptions options)
+            => await CreateStickerAsync(name, stream, filename, tags, description, options);
         /// <inheritdoc />
-        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, string description, IEnumerable<string> tags, string path, RequestOptions options)
-            => await CreateStickerAsync(name, description, tags, path, options);
+        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name,  string path, IEnumerable<string> tags, string description, RequestOptions options)
+            => await CreateStickerAsync(name, path, tags, description, options);
         /// <inheritdoc />
         async Task<ICustomSticker> IGuild.GetStickerAsync(ulong id, CacheMode mode, RequestOptions options)
         {

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1516,10 +1516,10 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        public async Task<SocketCustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Image image,
+        public async Task<SocketCustomSticker> CreateStickerAsync(string name,  Image image, IEnumerable<string> tags, string description = null,
             RequestOptions options = null)
         {
-            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, description, tags, image, options).ConfigureAwait(false);
+            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, image, tags, description, options).ConfigureAwait(false);
 
             return AddOrUpdateSticker(model);
         }
@@ -1534,11 +1534,11 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        public Task<SocketCustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, string path,
+        public Task<SocketCustomSticker> CreateStickerAsync(string name,  string path, IEnumerable<string> tags, string description = null,
             RequestOptions options = null)
         {
             var fs = File.OpenRead(path);
-            return CreateStickerAsync(name, description, tags, fs, Path.GetFileName(fs.Name), options);
+            return CreateStickerAsync(name,  fs, Path.GetFileName(fs.Name), tags, description, options);
         }
         /// <summary>
         ///     Creates a new sticker in this guild
@@ -1552,10 +1552,10 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A task that represents the asynchronous creation operation. The task result contains the created sticker.
         /// </returns>
-        public async Task<SocketCustomSticker> CreateStickerAsync(string name, string description, IEnumerable<string> tags, Stream stream,
-            string filename, RequestOptions options = null)
+        public async Task<SocketCustomSticker> CreateStickerAsync(string name, Stream stream, string filename, IEnumerable<string> tags, string description = null,
+             RequestOptions options = null)
         {
-            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, description, tags, stream, filename, options).ConfigureAwait(false);
+            var model = await GuildHelper.CreateStickerAsync(Discord, this, name, stream, filename, tags, description, options).ConfigureAwait(false);
 
             return AddOrUpdateSticker(model);
         }
@@ -2085,15 +2085,14 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IApplicationCommand>> IGuild.GetApplicationCommandsAsync(bool withLocalizations, string locale, RequestOptions options)
             => await GetApplicationCommandsAsync(withLocalizations, locale, options).ConfigureAwait(false);
+        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, Image image, IEnumerable<string> tags, string description, RequestOptions options)
+            => await CreateStickerAsync(name, image, tags, description, options);
         /// <inheritdoc />
-        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, string description, IEnumerable<string> tags, Image image, RequestOptions options)
-            => await CreateStickerAsync(name, description, tags, image, options);
+        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, Stream stream, string filename, IEnumerable<string> tags, string description, RequestOptions options)
+            => await CreateStickerAsync(name, stream, filename, tags, description, options);
         /// <inheritdoc />
-        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, string description, IEnumerable<string> tags, Stream stream, string filename, RequestOptions options)
-            => await CreateStickerAsync(name, description, tags, stream, filename, options);
-        /// <inheritdoc />
-        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, string description, IEnumerable<string> tags, string path, RequestOptions options)
-            => await CreateStickerAsync(name, description, tags, path, options);
+        async Task<ICustomSticker> IGuild.CreateStickerAsync(string name, string path, IEnumerable<string> tags, string description, RequestOptions options)
+            => await CreateStickerAsync(name, path, tags, description, options);
         /// <inheritdoc />
         async Task<ICustomSticker> IGuild.GetStickerAsync(ulong id, CacheMode mode, RequestOptions options)
             => await GetStickerAsync(id, mode, options);


### PR DESCRIPTION
This PR allows creating custom stickers without a description

###Changes
- **BREAKING** make `description` parameter optional in `CreateStickerAsync` methods