### PR TITLE
[Fix] Missing DebuggerDisplay attribute or properties

### DIFF
--- a/src/Discord.Net.Commands/Results/MatchResult.cs
+++ b/src/Discord.Net.Commands/Results/MatchResult.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 
 namespace Discord.Commands
 {
+    [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class MatchResult : IResult
     {
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
@@ -27,6 +27,8 @@ namespace Discord.Rest
         }
         public override int SlowModeInterval => throw new NotSupportedException("News channels do not support Slow Mode.");
 
+        private string DebuggerDisplay => $"{Name} ({Id}, News)";
+
         /// <inheritdoc />
         public Task<ulong> FollowAnnouncementChannelAsync(ulong channelId, RequestOptions options = null)
             => ChannelHelper.FollowAnnouncementChannelAsync(this, channelId, Discord, options);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs
@@ -37,6 +37,8 @@ namespace Discord.WebSocket
         public override int SlowModeInterval
             => throw new NotSupportedException("News channels do not support Slow Mode.");
 
+        private string DebuggerDisplay => $"{Name} ({Id}, News)";
+
         /// <inheritdoc cref="INewsChannel.FollowAnnouncementChannelAsync"/>
         public Task<ulong> FollowAnnouncementChannelAsync(ITextChannel channel, RequestOptions options = null)
             => FollowAnnouncementChannelAsync(channel.Id, options);


### PR DESCRIPTION
This PR tries to fix two incorrect usages of DebuggerDisplay.

- [MatchResult] has a private `DebuggerDisplay` get-only property, but the `DebuggerDisplayAttribute` is not attached to this class.
- [RestNewsChannel] and [SocketNewsChannel] have attached `DebuggerDisplayAttribute`s, but their `DebuggerDisplay` get-only properties are not overridden.

[MatchResult]: https://github.com/discord-net/Discord.Net/blob/66e6329b9df0f9401008f17263fbdebbd5dd0a77/src/Discord.Net.Commands/Results/MatchResult.cs#L44
[RestNewsChannel]: https://github.com/discord-net/Discord.Net/blob/66e6329b9df0f9401008f17263fbdebbd5dd0a77/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs#L15
[SocketNewsChannel]: https://github.com/discord-net/Discord.Net/blob/66e6329b9df0f9401008f17263fbdebbd5dd0a77/src/Discord.Net.WebSocket/Entities/Channels/SocketNewsChannel.cs#L18