### PR TITLE
[Feature]: ComponentBuilder component removal methods

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -82,6 +82,28 @@ namespace Discord
         }
 
         /// <summary>
+        ///     Removes all components of the given type from the <see cref="ComponentBuilder"/>.
+        /// </summary>
+        /// <param name="t">The <see cref="ComponentType"/> to remove.</param>
+        /// <returns>The current builder.</returns>
+        public ComponentBuilder RemoveComponentsOfType(ComponentType t)
+        {
+            this.ActionRows.ForEach(ar => ar.Components.RemoveAll(c => c.Type == t));
+            return this;
+        }
+
+        /// <summary>
+        ///     Removes a component from the <see cref="ComponentBuilder"/>.
+        /// </summary>
+        /// <param name="customId">The custom id of the component.</param>
+        /// <returns></returns>
+        public ComponentBuilder RemoveComponent(string customId)
+        {
+            this.ActionRows.ForEach(ar => ar.Components.RemoveAll(c => c.CustomId == customId));
+            return this;
+        }
+
+        /// <summary>
         ///     Adds a <see cref="SelectMenuBuilder"/> to the <see cref="ComponentBuilder"/> at the specific row.
         ///     If the row cannot accept the component then it will add it to a row that can.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -99,7 +99,7 @@ namespace Discord
         /// <returns>The current builder.</returns>
         public ComponentBuilder RemoveComponent(string customId)
         {
-            this.ActionRows.ForEach(ar => ar.Components.RemoveAll(c => c.CustomId == customId || (c is ButtonComponent b && b.Url == customId)));
+            this.ActionRows.ForEach(ar => ar.Components.RemoveAll(c => c.CustomId == customId));
             return this;
         }
 
@@ -108,7 +108,11 @@ namespace Discord
         /// </summary>
         /// <param name="url">The URL of the Link Button.</param>
         /// <returns>The current builder.</returns>
-        public ComponentBuilder RemoveButtonByURL(string url) => RemoveComponent(url);
+        public ComponentBuilder RemoveButtonByURL(string url)
+        {
+            this.ActionRows.ForEach(ar => ar.Components.RemoveAll(c => c is ButtonComponent b && b.Url == url));
+            return this;
+        }
 
         /// <summary>
         ///     Adds a <see cref="SelectMenuBuilder"/> to the <see cref="ComponentBuilder"/> at the specific row.

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -306,8 +306,8 @@ namespace Discord
                 throw new ArgumentException("TextInputComponents are not allowed in messages.", nameof(ActionRows));
 
             if (_actionRows?.Count > 0)
-                for (int i = 0; i < _actionRows.Count; i++)
-                    if (_actionRows[i].Components.Count == 0)
+                for (int i = 0; i < _actionRows?.Count; i++)
+                    if (_actionRows[i]?.Components?.Count == 0)
                         _actionRows.RemoveAt(i);
 
             return _actionRows != null

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -305,6 +305,11 @@ namespace Discord
             if (_actionRows?.SelectMany(x => x.Components)?.Any(x => x.Type == ComponentType.TextInput) ?? false)
                 throw new ArgumentException("TextInputComponents are not allowed in messages.", nameof(ActionRows));
 
+            if (_actionRows?.Count > 0)
+                for (int i = 0; i < _actionRows.Count; i++)
+                    if (_actionRows[i].Components.Count == 0)
+                        _actionRows.RemoveAt(i);
+
             return _actionRows != null
                 ? new MessageComponent(_actionRows.Select(x => x.Build()).ToList())
                 : MessageComponent.Empty;

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -96,12 +96,19 @@ namespace Discord
         ///     Removes a component from the <see cref="ComponentBuilder"/>.
         /// </summary>
         /// <param name="customId">The custom id of the component.</param>
-        /// <returns></returns>
+        /// <returns>The current builder.</returns>
         public ComponentBuilder RemoveComponent(string customId)
         {
-            this.ActionRows.ForEach(ar => ar.Components.RemoveAll(c => c.CustomId == customId));
+            this.ActionRows.ForEach(ar => ar.Components.RemoveAll(c => c.CustomId == customId || (c is ButtonComponent b && b.Url == customId)));
             return this;
         }
+
+        /// <summary>
+        ///     Removes a Link Button from the <see cref="ComponentBuilder"/> based on its URL.
+        /// </summary>
+        /// <param name="url">The URL of the Link Button.</param>
+        /// <returns>The current builder.</returns>
+        public ComponentBuilder RemoveButtonByURL(string url) => RemoveComponent(url);
 
         /// <summary>
         ///     Adds a <see cref="SelectMenuBuilder"/> to the <see cref="ComponentBuilder"/> at the specific row.


### PR DESCRIPTION
This PR adds two helper methods to ComponentBuilder to assist in the removal of components.

- `ComponentBuilder.RemoveComponent(customId)` will remove a component based on its custom id.
- `ComponentBuilder.RemoveComponentsOfType(componentType)` will remove all components of a given type (ie: button, menu, etc).

Build() will now automatically resolve empty ActionRows.

An example that will always remove the button that is clicked from a message:
```cs
[ComponentInteraction("testBtn:*", ignoreGroupNames: true)]
public async Task HandleButtonClick(string id) {
      ComponentBuilder comp = ComponentBuilder.FromMessage((Context.Interaction as IComponentInteraction).Message);
      comp.RemoveComponent($"testBtn:{id}");
      await (Context.Interaction as IComponentInteraction).UpdateAsync(m => { m.Components = comp.Build(); });
}
```