### PR TITLE
[Fix] Update permissions & fix `ChannelPermissions.All()` exception

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
@@ -100,7 +100,7 @@ namespace Discord
         /// <summary>
         ///     Allows for using voice-activity-detection in a voice channel.
         /// </summary>
-        UseVAD = 25,
+        UseVAD = 1L << 25,
 
         /// <summary>
         ///     Allows for using priority speaker in a voice channel.

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermission.cs
@@ -10,141 +10,172 @@ namespace Discord
         /// <summary>
         ///     Allows creation of instant invites.
         /// </summary>
-        CreateInstantInvite = 0x00_00_00_00_01,
+        CreateInstantInvite = 1L << 0,
+
         /// <summary>
         ///     Allows management and editing of channels.
         /// </summary>
-        ManageChannels = 0x00_00_00_00_10,
+        ManageChannels = 1L << 4,
 
         // Text
         /// <summary>
         ///     Allows for the addition of reactions to messages.
         /// </summary>
-        AddReactions = 0x00_00_00_00_40,
+        AddReactions = 1L << 6,
+
         /// <summary>
         ///     Allows guild members to view a channel, which includes reading messages in text channels.
         /// </summary>
-        ViewChannel = 0x00_00_00_04_00,
+        ViewChannel = 1L << 10,
+
         /// <summary>
         ///     Allows for sending messages in a channel.
         /// </summary>
-        SendMessages = 0x00_00_00_08_00,
+        SendMessages = 1L << 11,
+
         /// <summary>
         ///     Allows for sending of text-to-speech messages.
         /// </summary>
-        SendTTSMessages = 0x00_00_00_10_00,
+        SendTTSMessages = 1L << 12,
+
         /// <summary>
         ///     Allows for deletion of other users messages.
         /// </summary>
-        ManageMessages = 0x00_00_00_20_00,
+        ManageMessages = 1L << 13,
+
         /// <summary>
         ///     Allows links sent by users with this permission will be auto-embedded.
         /// </summary>
-        EmbedLinks = 0x00_00_00_40_00,
+        EmbedLinks = 1L << 14,
+
         /// <summary>
         ///     Allows for uploading images and files.
         /// </summary>
-        AttachFiles = 0x00_00_00_80_00,
+        AttachFiles = 1L << 15,
+
         /// <summary>
         ///     Allows for reading of message history.
         /// </summary>
-        ReadMessageHistory = 0x00_00_01_00_00,
+        ReadMessageHistory = 1L << 16,
+
         /// <summary>
         ///     Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all
         ///     online users in a channel.
         /// </summary>
-        MentionEveryone = 0x00_00_02_00_00,
+        MentionEveryone = 1L << 17,
+
         /// <summary>
         ///     Allows the usage of custom emojis from other servers.
         /// </summary>
-        UseExternalEmojis = 0x00_00_04_00_00,
+        UseExternalEmojis = 1L << 18,
+
 
         // Voice
+
         /// <summary>
         ///     Allows for joining of a voice channel.
         /// </summary>
-        Connect = 0x00_00_10_00_00,
+        Connect = 1L << 20,
+
         /// <summary>
         ///     Allows for speaking in a voice channel.
         /// </summary>
-        Speak = 0x00_00_20_00_00,
+        Speak = 1L << 21,
+
         /// <summary>
         ///     Allows for muting members in a voice channel.
         /// </summary>
-        MuteMembers = 0x00_00_40_00_00,
+        MuteMembers = 1L << 22,
+
         /// <summary>
         ///     Allows for deafening of members in a voice channel.
         /// </summary>
-        DeafenMembers = 0x00_00_80_00_00,
+        DeafenMembers = 1L << 23,
+
         /// <summary>
         ///     Allows for moving of members between voice channels.
         /// </summary>
-        MoveMembers = 0x00_01_00_00_00,
+        MoveMembers = 1L << 24,
+
         /// <summary>
         ///     Allows for using voice-activity-detection in a voice channel.
         /// </summary>
-        UseVAD = 0x00_02_00_00_00,
+        UseVAD = 25,
 
         /// <summary>
         ///     Allows for using priority speaker in a voice channel.
         /// </summary>
-        PrioritySpeaker = 0x00_00_00_01_00,
+        PrioritySpeaker = 1L << 8,
 
         /// <summary>
         ///     Allows video streaming in a voice channel.
         /// </summary>
-        Stream = 0x00_00_00_02_00,
+        Stream = 1L << 9,
 
         // More General
         /// <summary>
         ///     Allows management and editing of roles.
         /// </summary>
-        ManageRoles = 0x00_10_00_00_00,
+        ManageRoles = 1L << 28,
+
         /// <summary>
         ///     Allows management and editing of webhooks.
         /// </summary>
-        ManageWebhooks = 0x00_20_00_00_00,
+        ManageWebhooks = 1L << 29,
 
         /// <summary>
         ///     Allows management and editing of emojis.
         /// </summary>
-        ManageEmojis = 0x00_40_00_00_00,
+        ManageEmojis = 1L << 30,
 
         /// <summary>
         ///     Allows members to use slash commands in text channels.
         /// </summary>
-        UseApplicationCommands = 0x00_80_00_00_00,
+        UseApplicationCommands = 1L << 31,
 
         /// <summary>
         ///     Allows for requesting to speak in stage channels. (This permission is under active development and may be changed or removed.)
         /// </summary>
-        RequestToSpeak = 0x01_00_00_00_00,
+        RequestToSpeak = 1L << 32,
 
         /// <summary>
         ///     Allows for deleting and archiving threads, and viewing all private threads
         /// </summary>
-        ManageThreads = 0x04_00_00_00_00,
+        ManageThreads = 1L << 34,
 
         /// <summary>
         ///     Allows for creating public threads.
         /// </summary>
-        CreatePublicThreads = 0x08_00_00_00_00,
+        CreatePublicThreads = 1L << 35,
+
         /// <summary>
         ///     Allows for creating private threads.
         /// </summary>
-        CreatePrivateThreads = 0x10_00_00_00_00,
+        CreatePrivateThreads = 1L << 36,
+
         /// <summary>
         ///     Allows the usage of custom stickers from other servers.
         /// </summary>
-        UseExternalStickers = 0x20_00_00_00_00,
+        UseExternalStickers = 1L << 37,
+
         /// <summary>
         ///     Allows for sending messages in threads.
         /// </summary>
-        SendMessagesInThreads = 0x40_00_00_00_00,
+        SendMessagesInThreads = 1L << 38,
+
         /// <summary>
         ///     Allows for launching activities (applications with the EMBEDDED flag) in a voice channel.
         /// </summary>
-        StartEmbeddedActivities = 0x80_00_00_00_00
+        StartEmbeddedActivities = 1L << 39,
 
+        /// <summary>
+        ///     Allows for using the soundboard in a voice channel.
+        /// </summary>
+        UseSoundboard = 1L << 42,
+
+        /// <summary>
+        ///     Allows members to edit and cancel events in this channel.
+        /// </summary>
+        CreateEvents = 1L << 44,
     }
 }

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -18,17 +18,17 @@ namespace Discord
         /// <summary>
         ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for text channels.
         /// </summary>
-        public static readonly ChannelPermissions Text = new(0b0_11111_0101100_0000000_1111111110001_010001);
+        public static readonly ChannelPermissions Text = new(0b01_001111_110010_110011_111101_111111_111101_010001);
 
         /// <summary>
         ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for voice channels.
         /// </summary>
-        public static readonly ChannelPermissions Voice = new(0b1_11111_0101100_1111110_1111111111101_010001); // (0b1_00000_0000100_1111110_0000000011100_010001 (<- voice only perms) |= Text)
-
+        public static readonly ChannelPermissions Voice = new(0b01_001010_001010_110011_111101_111111_111101_010001); // (0b1_00000_0000100_1111110_0000000011100_010001 (<- voice only perms) |= Text)
+            
         /// <summary>
         ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for stage channels.
         /// </summary>
-        public static readonly ChannelPermissions Stage = new(0b0_00000_1000100_0111010_0000000010000_010001);
+        public static readonly ChannelPermissions Stage = new(0b0010_001110_010001_010101_111111_111001_010001);
 
         /// <summary>
         ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for category channels.
@@ -46,6 +46,11 @@ namespace Discord
         public static readonly ChannelPermissions Group = new(0b00000_1000110_0001101100000_000000);
 
         /// <summary>
+        ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for forum channels.
+        /// </summary>
+        public static readonly ChannelPermissions Forum = new(0b01_001110_010010_110011_111101_111111_111101_010001);
+
+        /// <summary>
         ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for a given channel type.
         /// </summary>
         /// <exception cref="ArgumentException">Unknown channel type.</exception>
@@ -59,6 +64,7 @@ namespace Discord
                 ICategoryChannel _ => Category,
                 IDMChannel _ => DM,
                 IGroupChannel _ => Group,
+                IForumChannel => Forum,
                 _ => throw new ArgumentException(message: "Unknown channel type.", paramName: nameof(channel)),
             };
         }
@@ -66,70 +72,74 @@ namespace Discord
         /// <summary> Gets a packed value representing all the permissions in this <see cref="ChannelPermissions"/>.</summary>
         public ulong RawValue { get; }
 
-        /// <summary> If <c>true</c>, a user may create invites.</summary>
+        /// <summary> If <see langword="true"/>, a user may create invites.</summary>
         public bool CreateInstantInvite => Permissions.GetValue(RawValue, ChannelPermission.CreateInstantInvite);
-        /// <summary> If <c>true</c>, a user may create, delete and modify this channel.</summary>
+        /// <summary> If <see langword="true"/>, a user may create, delete and modify this channel.</summary>
         public bool ManageChannel => Permissions.GetValue(RawValue, ChannelPermission.ManageChannels);
 
-        /// <summary> If <c>true</c>, a user may add reactions.</summary>
+        /// <summary> If <see langword="true"/>, a user may add reactions.</summary>
         public bool AddReactions => Permissions.GetValue(RawValue, ChannelPermission.AddReactions);
-        /// <summary> If <c>true</c>, a user may view channels.</summary>
+        /// <summary> If <see langword="true"/>, a user may view channels.</summary>
         public bool ViewChannel => Permissions.GetValue(RawValue, ChannelPermission.ViewChannel);
 
-        /// <summary> If <c>true</c>, a user may send messages.</summary>
+        /// <summary> If <see langword="true"/>, a user may send messages.</summary>
         public bool SendMessages => Permissions.GetValue(RawValue, ChannelPermission.SendMessages);
-        /// <summary> If <c>true</c>, a user may send text-to-speech messages.</summary>
+        /// <summary> If <see langword="true"/>, a user may send text-to-speech messages.</summary>
         public bool SendTTSMessages => Permissions.GetValue(RawValue, ChannelPermission.SendTTSMessages);
-        /// <summary> If <c>true</c>, a user may delete messages.</summary>
+        /// <summary> If <see langword="true"/>, a user may delete messages.</summary>
         public bool ManageMessages => Permissions.GetValue(RawValue, ChannelPermission.ManageMessages);
-        /// <summary> If <c>true</c>, Discord will auto-embed links sent by this user.</summary>
+        /// <summary> If <see langword="true"/>, Discord will auto-embed links sent by this user.</summary>
         public bool EmbedLinks => Permissions.GetValue(RawValue, ChannelPermission.EmbedLinks);
-        /// <summary> If <c>true</c>, a user may send files.</summary>
+        /// <summary> If <see langword="true"/>, a user may send files.</summary>
         public bool AttachFiles => Permissions.GetValue(RawValue, ChannelPermission.AttachFiles);
-        /// <summary> If <c>true</c>, a user may read previous messages.</summary>
+        /// <summary> If <see langword="true"/>, a user may read previous messages.</summary>
         public bool ReadMessageHistory => Permissions.GetValue(RawValue, ChannelPermission.ReadMessageHistory);
-        /// <summary> If <c>true</c>, a user may mention @everyone.</summary>
+        /// <summary> If <see langword="true"/>, a user may mention @everyone.</summary>
         public bool MentionEveryone => Permissions.GetValue(RawValue, ChannelPermission.MentionEveryone);
-        /// <summary> If <c>true</c>, a user may use custom emoji from other guilds.</summary>
+        /// <summary> If <see langword="true"/>, a user may use custom emoji from other guilds.</summary>
         public bool UseExternalEmojis => Permissions.GetValue(RawValue, ChannelPermission.UseExternalEmojis);
 
-        /// <summary> If <c>true</c>, a user may connect to a voice channel.</summary>
+        /// <summary> If <see langword="true"/>, a user may connect to a voice channel.</summary>
         public bool Connect => Permissions.GetValue(RawValue, ChannelPermission.Connect);
-        /// <summary> If <c>true</c>, a user may speak in a voice channel.</summary>
+        /// <summary> If <see langword="true"/>, a user may speak in a voice channel.</summary>
         public bool Speak => Permissions.GetValue(RawValue, ChannelPermission.Speak);
-        /// <summary> If <c>true</c>, a user may mute users.</summary>
+        /// <summary> If <see langword="true"/>, a user may mute users.</summary>
         public bool MuteMembers => Permissions.GetValue(RawValue, ChannelPermission.MuteMembers);
-        /// <summary> If <c>true</c>, a user may deafen users.</summary>
+        /// <summary> If <see langword="true"/>, a user may deafen users.</summary>
         public bool DeafenMembers => Permissions.GetValue(RawValue, ChannelPermission.DeafenMembers);
-        /// <summary> If <c>true</c>, a user may move other users between voice channels.</summary>
+        /// <summary> If <see langword="true"/>, a user may move other users between voice channels.</summary>
         public bool MoveMembers => Permissions.GetValue(RawValue, ChannelPermission.MoveMembers);
-        /// <summary> If <c>true</c>, a user may use voice-activity-detection rather than push-to-talk.</summary>
+        /// <summary> If <see langword="true"/>, a user may use voice-activity-detection rather than push-to-talk.</summary>
         public bool UseVAD => Permissions.GetValue(RawValue, ChannelPermission.UseVAD);
-        /// <summary> If <c>true</c>, a user may use priority speaker in a voice channel.</summary>
+        /// <summary> If <see langword="true"/>, a user may use priority speaker in a voice channel.</summary>
         public bool PrioritySpeaker => Permissions.GetValue(RawValue, ChannelPermission.PrioritySpeaker);
-        /// <summary> If <c>true</c>, a user may stream video in a voice channel.</summary>
+        /// <summary> If <see langword="true"/>, a user may stream video in a voice channel.</summary>
         public bool Stream => Permissions.GetValue(RawValue, ChannelPermission.Stream);
 
-        /// <summary> If <c>true</c>, a user may adjust role permissions. This also implicitly grants all other permissions.</summary>
+        /// <summary> If <see langword="true"/>, a user may adjust role permissions. This also implicitly grants all other permissions.</summary>
         public bool ManageRoles => Permissions.GetValue(RawValue, ChannelPermission.ManageRoles);
-        /// <summary> If <c>true</c>, a user may edit the webhooks for this channel.</summary>
+        /// <summary> If <see langword="true"/>, a user may edit the webhooks for this channel.</summary>
         public bool ManageWebhooks => Permissions.GetValue(RawValue, ChannelPermission.ManageWebhooks);
-        /// <summary> If <c>true</c>, a user may use application commands in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user may use application commands in this guild.</summary>
         public bool UseApplicationCommands => Permissions.GetValue(RawValue, ChannelPermission.UseApplicationCommands);
-        /// <summary> If <c>true</c>, a user may request to speak in stage channels.</summary>
+        /// <summary> If <see langword="true"/>, a user may request to speak in stage channels.</summary>
         public bool RequestToSpeak => Permissions.GetValue(RawValue, ChannelPermission.RequestToSpeak);
-        /// <summary> If <c>true</c>, a user may manage threads in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user may manage threads in this guild.</summary>
         public bool ManageThreads => Permissions.GetValue(RawValue, ChannelPermission.ManageThreads);
-        /// <summary> If <c>true</c>, a user may create public threads in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user may create public threads in this guild.</summary>
         public bool CreatePublicThreads => Permissions.GetValue(RawValue, ChannelPermission.CreatePublicThreads);
-        /// <summary> If <c>true</c>, a user may create private threads in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user may create private threads in this guild.</summary>
         public bool CreatePrivateThreads => Permissions.GetValue(RawValue, ChannelPermission.CreatePrivateThreads);
-        /// <summary> If <c>true</c>, a user may use external stickers in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user may use external stickers in this guild.</summary>
         public bool UseExternalStickers => Permissions.GetValue(RawValue, ChannelPermission.UseExternalStickers);
-        /// <summary> If <c>true</c>, a user may send messages in threads in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user may send messages in threads in this guild.</summary>
         public bool SendMessagesInThreads => Permissions.GetValue(RawValue, ChannelPermission.SendMessagesInThreads);
-        /// <summary> If <c>true</c>, a user launch application activities in voice channels in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user launch application activities in voice channels in this guild.</summary>
         public bool StartEmbeddedActivities => Permissions.GetValue(RawValue, ChannelPermission.StartEmbeddedActivities);
+        /// <summary> If <see langword="true"/>, a user can use soundboard in a voice channel.</summary>
+        public bool UseSoundboard => Permissions.GetValue(RawValue, ChannelPermission.UseSoundboard);
+        /// <summary> If <see langword="true"/>, a user can edit and cancel events in this channel.</summary>
+        public bool CreateEvents => Permissions.GetValue(RawValue, ChannelPermission.CreateEvents);
 
         /// <summary> Creates a new <see cref="ChannelPermissions"/> with the provided packed value.</summary>
         public ChannelPermissions(ulong rawValue) { RawValue = rawValue; }
@@ -164,7 +174,9 @@ namespace Discord
             bool? createPrivateThreads = null,
             bool? useExternalStickers = null,
             bool? sendMessagesInThreads = null,
-            bool? startEmbeddedActivities = null)
+            bool? startEmbeddedActivities = null,
+            bool? useSoundboard = null,
+            bool? createEvents = null)
         {
             ulong value = initialValue;
 
@@ -198,6 +210,8 @@ namespace Discord
             Permissions.SetValue(ref value, useExternalStickers, ChannelPermission.UseExternalStickers);
             Permissions.SetValue(ref value, sendMessagesInThreads, ChannelPermission.SendMessagesInThreads);
             Permissions.SetValue(ref value, startEmbeddedActivities, ChannelPermission.StartEmbeddedActivities);
+            Permissions.SetValue(ref value, useSoundboard, ChannelPermission.UseSoundboard);
+            Permissions.SetValue(ref value, createEvents, ChannelPermission.CreateEvents);
 
             RawValue = value;
         }
@@ -233,12 +247,14 @@ namespace Discord
             bool createPrivateThreads = false,
             bool useExternalStickers = false,
             bool sendMessagesInThreads = false,
-            bool startEmbeddedActivities = false)
+            bool startEmbeddedActivities = false,
+            bool useSoundboard = false,
+            bool createEvents = false)
             : this(0, createInstantInvite, manageChannel, addReactions, viewChannel, sendMessages, sendTTSMessages, manageMessages,
                 embedLinks, attachFiles, readMessageHistory, mentionEveryone, useExternalEmojis, connect,
                 speak, muteMembers, deafenMembers, moveMembers, useVoiceActivation, prioritySpeaker, stream, manageRoles, manageWebhooks,
                 useApplicationCommands, requestToSpeak, manageThreads, createPublicThreads, createPrivateThreads, useExternalStickers, sendMessagesInThreads,
-                startEmbeddedActivities)
+                startEmbeddedActivities, useSoundboard, createEvents)
         { }
 
         /// <summary> Creates a new <see cref="ChannelPermissions"/> from this one, changing the provided non-null permissions.</summary>
@@ -272,7 +288,9 @@ namespace Discord
             bool? createPrivateThreads = null,
             bool? useExternalStickers = null,
             bool? sendMessagesInThreads = null,
-            bool? startEmbeddedActivities = null)
+            bool? startEmbeddedActivities = null,
+            bool? useSoundboard = null,
+            bool? createEvents = null)
             => new ChannelPermissions(RawValue,
                 createInstantInvite,
                 manageChannel,
@@ -303,7 +321,9 @@ namespace Discord
                 createPrivateThreads,
                 useExternalStickers,
                 sendMessagesInThreads,
-                startEmbeddedActivities);
+                startEmbeddedActivities,
+                useSoundboard,
+                createEvents);
 
         public bool Has(ChannelPermission permission) => Permissions.GetValue(RawValue, permission);
 

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -10,7 +10,8 @@ namespace Discord
         /// <summary>
         ///     Allows creation of instant invites.
         /// </summary>
-        CreateInstantInvite = 0x00_00_00_01,
+        CreateInstantInvite = 1L << 0,
+
         /// <summary>
         ///     Allows kicking members.
         /// </summary>
@@ -18,7 +19,8 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        KickMembers = 0x00_00_00_02,
+        KickMembers = 1L << 1,
+
         /// <summary>
         ///     Allows banning members.
         /// </summary>
@@ -26,7 +28,8 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        BanMembers = 0x00_00_00_04,
+        BanMembers = 1L << 2,
+
         /// <summary>
         ///     Allows all permissions and bypasses channel permission overwrites.
         /// </summary>
@@ -34,7 +37,8 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        Administrator = 0x00_00_00_08,
+        Administrator = 1L << 3,
+
         /// <summary>
         ///     Allows management and editing of channels.
         /// </summary>
@@ -42,7 +46,8 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        ManageChannels = 0x00_00_00_10,
+        ManageChannels = 1L << 4,
+
         /// <summary>
         ///     Allows management and editing of the guild.
         /// </summary>
@@ -50,7 +55,8 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        ManageGuild = 0x00_00_00_20,
+        ManageGuild = 1L << 5,
+
         /// <summary>
         ///     Allows for viewing of guild insights
         /// </summary>
@@ -60,23 +66,28 @@ namespace Discord
         /// <summary>
         ///     Allows for the addition of reactions to messages.
         /// </summary>
-        AddReactions = 0x00_00_00_40,
+        AddReactions = 1L << 6,
+
         /// <summary>
         ///		Allows for viewing of audit logs.
         /// </summary>
-        ViewAuditLog = 0x00_00_00_80,
+        ViewAuditLog = 1L << 7,
+
         /// <summary>
         ///     Allows guild members to view a channel, which includes reading messages in text channels.
         /// </summary>
-        ViewChannel = 0x00_00_04_00,
+        ViewChannel = 1L << 10,
+
         /// <summary>
         ///     Allows for sending messages in a channel
         /// </summary>
-        SendMessages = 0x00_00_08_00,
+        SendMessages = 1L << 11,
+
         /// <summary>
         ///     Allows for sending of text-to-speech messages.
         /// </summary>
-        SendTTSMessages = 0x00_00_10_00,
+        SendTTSMessages = 1L << 12,
+
         /// <summary>
         ///     Allows for deletion of other users messages.
         /// </summary>
@@ -84,73 +95,83 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        ManageMessages = 0x00_00_20_00,
+        ManageMessages = 1L << 13,
         /// <summary>
         ///     Allows links sent by users with this permission will be auto-embedded.
         /// </summary>
-        EmbedLinks = 0x00_00_40_00,
+        EmbedLinks = 1L << 14,
+
         /// <summary>
         ///     Allows for uploading images and files.
         /// </summary>
-        AttachFiles = 0x00_00_80_00,
+        AttachFiles = 1L << 15,
+
         /// <summary>
         ///     Allows for reading of message history.
         /// </summary>
         ReadMessageHistory = 0x00_01_00_00,
+
         /// <summary>
         ///     Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all
         ///     online users in a channel.
         /// </summary>
         MentionEveryone = 0x00_02_00_00,
+
         /// <summary>
         ///     Allows the usage of custom emojis from other servers.
         /// </summary>
-        UseExternalEmojis = 0x00_04_00_00,
-
-
-        // Voice
+        UseExternalEmojis = 1L << 18,
+        
         /// <summary>
         ///     Allows for joining of a voice channel.
         /// </summary>
-        Connect = 0x00_10_00_00,
+        Connect = 1L << 20,
+
         /// <summary>
         ///     Allows for speaking in a voice channel.
         /// </summary>
-        Speak = 0x00_20_00_00,
+        Speak = 1L << 21,
+
         /// <summary>
         ///     Allows for muting members in a voice channel.
         /// </summary>
-        MuteMembers = 0x00_40_00_00,
+        MuteMembers = 1L << 22,
+
         /// <summary>
         ///     Allows for deafening of members in a voice channel.
         /// </summary>
-        DeafenMembers = 0x00_80_00_00,
+        DeafenMembers = 1L << 23,
+
         /// <summary>
         ///     Allows for moving of members between voice channels.
         /// </summary>
-        MoveMembers = 0x01_00_00_00,
+        MoveMembers = 1L << 24,
+
         /// <summary>
         ///     Allows for using voice-activity-detection in a voice channel.
         /// </summary>
-        UseVAD = 0x02_00_00_00,
+        UseVAD = 1L << 25,
+
         /// <summary>
         ///     Allows for using priority speaker in a voice channel.	
         /// </summary>
-        PrioritySpeaker = 0x00_00_01_00,
+        PrioritySpeaker = 1L << 8,
+
         /// <summary>
         ///     Allows video streaming in a voice channel.
         /// </summary>
-        Stream = 0x00_00_02_00,
-
+        Stream = 1L << 9,
+        
         // General 2
         /// <summary>
         ///     Allows for modification of own nickname.
         /// </summary>
-        ChangeNickname = 0x04_00_00_00,
+        ChangeNickname = 1L << 26,
+
         /// <summary>
         ///     Allows for modification of other users nicknames.
         /// </summary>
-        ManageNicknames = 0x08_00_00_00,
+        ManageNicknames = 1L << 27,
         /// <summary>
         ///     Allows management and editing of roles.
         /// </summary>
@@ -158,7 +179,8 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        ManageRoles = 0x10_00_00_00,
+        ManageRoles = 1L << 28,
+
         /// <summary>
         ///     Allows management and editing of webhooks.
         /// </summary>
@@ -166,7 +188,8 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        ManageWebhooks = 0x20_00_00_00,
+        ManageWebhooks = 1L << 29,
+
         /// <summary>
         ///     Allows management and editing of emojis and stickers.
         /// </summary>
@@ -174,19 +197,23 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        ManageEmojisAndStickers = 0x40_00_00_00,
+        ManageEmojisAndStickers = 1L << 30,
+
         /// <summary>
         ///     Allows members to use application commands like slash commands and context menus in text channels.	
         /// </summary>
-        UseApplicationCommands = 0x80_00_00_00,
+        UseApplicationCommands = 1L << 31,
+
         /// <summary>
         ///     Allows for requesting to speak in stage channels.
         /// </summary>
-        RequestToSpeak = 0x01_00_00_00_00,
+        RequestToSpeak = 1L << 32,
+
         /// <summary>
         ///     Allows for creating, editing, and deleting guild scheduled events.
         /// </summary>
-        ManageEvents = 0x02_00_00_00_00,
+        ManageEvents = 1L << 33,
+
         /// <summary>
         ///     Allows for deleting and archiving threads, and viewing all private threads.
         /// </summary>
@@ -194,30 +221,46 @@ namespace Discord
         ///     This permission requires the owner account to use two-factor
         ///     authentication when used on a guild that has server-wide 2FA enabled.
         /// </remarks>
-        ManageThreads = 0x04_00_00_00_00,
+        ManageThreads = 1L << 34,
+
         /// <summary>
         ///     Allows for creating public threads.
         /// </summary>
-        CreatePublicThreads = 0x08_00_00_00_00,
+        CreatePublicThreads = 1L << 35,
+
         /// <summary>
         ///     Allows for creating private threads.
         /// </summary>
-        CreatePrivateThreads = 0x10_00_00_00_00,
+        CreatePrivateThreads = 1L << 36,
+
         /// <summary>
         ///     Allows the usage of custom stickers from other servers.
         /// </summary>
-        UseExternalStickers = 0x20_00_00_00_00,
+        UseExternalStickers = 1L << 37,
+
         /// <summary>
         ///     Allows for sending messages in threads.
         /// </summary>
-        SendMessagesInThreads = 0x40_00_00_00_00,
+        SendMessagesInThreads = 1L << 38,
+
         /// <summary>
         ///     Allows for launching activities (applications with the EMBEDDED flag) in a voice channel.
         /// </summary>
-        StartEmbeddedActivities = 0x80_00_00_00_00,
+        StartEmbeddedActivities = 1L << 39,
+
         /// <summary>
         ///     Allows for timing out users.
         /// </summary>
-        ModerateMembers = 0x01_00_00_00_00_00
+        ModerateMembers = 1L << 40,
+
+        /// <summary>
+        ///     Allows for viewing role subscription insights.
+        /// </summary>
+        ViewMonetizationAnalytics = 1L << 41,
+
+        /// <summary>
+        ///     Allows for using the soundboard.
+        /// </summary>
+        UseSoundboard = 1L << 42,
     }
 }

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermission.cs
@@ -60,7 +60,7 @@ namespace Discord
         /// <summary>
         ///     Allows for viewing of guild insights
         /// </summary>
-        ViewGuildInsights = 0x00_08_00_00,
+        ViewGuildInsights = 1L << 19,
 
         // Text
         /// <summary>
@@ -109,13 +109,13 @@ namespace Discord
         /// <summary>
         ///     Allows for reading of message history.
         /// </summary>
-        ReadMessageHistory = 0x00_01_00_00,
+        ReadMessageHistory = 1 << 16,
 
         /// <summary>
         ///     Allows for using the @everyone tag to notify all users in a channel, and the @here tag to notify all
         ///     online users in a channel.
         /// </summary>
-        MentionEveryone = 0x00_02_00_00,
+        MentionEveryone = 1L << 17,
 
         /// <summary>
         ///     Allows the usage of custom emojis from other servers.

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -104,6 +104,11 @@ namespace Discord
         public bool StartEmbeddedActivities => Permissions.GetValue(RawValue, GuildPermission.StartEmbeddedActivities);
         /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
         public bool ModerateMembers => Permissions.GetValue(RawValue, GuildPermission.ModerateMembers);
+        /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
+        public bool UseSoundboard => Permissions.GetValue(RawValue, GuildPermission.UseSoundboard);
+        /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
+        public bool ViewMonetizationAnalytics => Permissions.GetValue(RawValue, GuildPermission.ViewMonetizationAnalytics);
+
         /// <summary> Creates a new <see cref="GuildPermissions"/> with the provided packed value. </summary>
         public GuildPermissions(ulong rawValue) { RawValue = rawValue; }
 
@@ -151,7 +156,9 @@ namespace Discord
             bool? useExternalStickers = null,
             bool? sendMessagesInThreads = null,
             bool? startEmbeddedActivities = null,
-            bool? moderateMembers = null)
+            bool? moderateMembers = null,
+            bool? useSoundboard = null,
+            bool? viewMonetizationAnalytics = null)
         {
             ulong value = initialValue;
 
@@ -196,6 +203,8 @@ namespace Discord
             Permissions.SetValue(ref value, sendMessagesInThreads, GuildPermission.SendMessagesInThreads);
             Permissions.SetValue(ref value, startEmbeddedActivities, GuildPermission.StartEmbeddedActivities);
             Permissions.SetValue(ref value, moderateMembers, GuildPermission.ModerateMembers);
+            Permissions.SetValue(ref value, useSoundboard, GuildPermission.UseSoundboard);
+            Permissions.SetValue(ref value, viewMonetizationAnalytics, GuildPermission.ViewMonetizationAnalytics);
 
             RawValue = value;
         }
@@ -242,7 +251,9 @@ namespace Discord
             bool useExternalStickers = false,
             bool sendMessagesInThreads = false,
             bool startEmbeddedActivities = false,
-            bool moderateMembers = false)
+            bool moderateMembers = false,
+            bool useSoundboard = false,
+            bool viewMonetizationAnalytics = false)
             : this(0,
                 createInstantInvite: createInstantInvite,
                 manageRoles: manageRoles,
@@ -284,7 +295,9 @@ namespace Discord
                 useExternalStickers: useExternalStickers,
                 sendMessagesInThreads: sendMessagesInThreads,
                 startEmbeddedActivities: startEmbeddedActivities,
-                moderateMembers: moderateMembers)
+                moderateMembers: moderateMembers,
+                useSoundboard: useSoundboard,
+                viewMonetizationAnalytics: viewMonetizationAnalytics)
         { }
 
         /// <summary> Creates a new <see cref="GuildPermissions"/> from this one, changing the provided non-null permissions. </summary>
@@ -329,13 +342,15 @@ namespace Discord
             bool? useExternalStickers = null,
             bool? sendMessagesInThreads = null,
             bool? startEmbeddedActivities = null,
-            bool? moderateMembers = null)
+            bool? moderateMembers = null,
+            bool? useSoundboard = null,
+            bool? viewMonetizationAnalytics = null)
             => new GuildPermissions(RawValue, createInstantInvite, kickMembers, banMembers, administrator, manageChannels, manageGuild, addReactions,
                 viewAuditLog, viewGuildInsights, viewChannel, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
                 readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers,
                 useVoiceActivation, prioritySpeaker, stream, changeNickname, manageNicknames, manageRoles, manageWebhooks, manageEmojisAndStickers,
                 useApplicationCommands, requestToSpeak, manageEvents, manageThreads, createPublicThreads, createPrivateThreads, useExternalStickers, sendMessagesInThreads,
-                startEmbeddedActivities, moderateMembers);
+                startEmbeddedActivities, moderateMembers, useSoundboard, viewMonetizationAnalytics);
 
         /// <summary>
         ///     Returns a value that indicates if a specific <see cref="GuildPermission"/> is enabled

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -104,7 +104,7 @@ namespace Discord
         public bool StartEmbeddedActivities => Permissions.GetValue(RawValue, GuildPermission.StartEmbeddedActivities);
         /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
         public bool ModerateMembers => Permissions.GetValue(RawValue, GuildPermission.ModerateMembers);
-        /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user can use soundboard in this guild.</summary>
         public bool UseSoundboard => Permissions.GetValue(RawValue, GuildPermission.UseSoundboard);
         /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
         public bool ViewMonetizationAnalytics => Permissions.GetValue(RawValue, GuildPermission.ViewMonetizationAnalytics);

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -18,95 +18,95 @@ namespace Discord
         /// <summary> Gets a packed value representing all the permissions in this <see cref="GuildPermissions"/>. </summary>
         public ulong RawValue { get; }
 
-        /// <summary> If <c>true</c>, a user may create invites. </summary>
+        /// <summary> If <see langword="true"/>, a user may create invites. </summary>
         public bool CreateInstantInvite => Permissions.GetValue(RawValue, GuildPermission.CreateInstantInvite);
-        /// <summary> If <c>true</c>, a user may ban users from the guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may ban users from the guild. </summary>
         public bool BanMembers => Permissions.GetValue(RawValue, GuildPermission.BanMembers);
-        /// <summary> If <c>true</c>, a user may kick users from the guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may kick users from the guild. </summary>
         public bool KickMembers => Permissions.GetValue(RawValue, GuildPermission.KickMembers);
-        /// <summary> If <c>true</c>, a user is granted all permissions, and cannot have them revoked via channel permissions. </summary>
+        /// <summary> If <see langword="true"/>, a user is granted all permissions, and cannot have them revoked via channel permissions. </summary>
         public bool Administrator => Permissions.GetValue(RawValue, GuildPermission.Administrator);
-        /// <summary> If <c>true</c>, a user may create, delete and modify channels. </summary>
+        /// <summary> If <see langword="true"/>, a user may create, delete and modify channels. </summary>
         public bool ManageChannels => Permissions.GetValue(RawValue, GuildPermission.ManageChannels);
-        /// <summary> If <c>true</c>, a user may adjust guild properties. </summary>
+        /// <summary> If <see langword="true"/>, a user may adjust guild properties. </summary>
         public bool ManageGuild => Permissions.GetValue(RawValue, GuildPermission.ManageGuild);
 
-        /// <summary> If <c>true</c>, a user may add reactions. </summary>
+        /// <summary> If <see langword="true"/>, a user may add reactions. </summary>
         public bool AddReactions => Permissions.GetValue(RawValue, GuildPermission.AddReactions);
-        /// <summary> If <c>true</c>, a user may view the audit log. </summary>
+        /// <summary> If <see langword="true"/>, a user may view the audit log. </summary>
         public bool ViewAuditLog => Permissions.GetValue(RawValue, GuildPermission.ViewAuditLog);
-        /// <summary> If <c>true</c>, a user may view the guild insights. </summary>
+        /// <summary> If <see langword="true"/>, a user may view the guild insights. </summary>
         public bool ViewGuildInsights => Permissions.GetValue(RawValue, GuildPermission.ViewGuildInsights);
 
         /// <summary> If True, a user may view channels. </summary>
         public bool ViewChannel => Permissions.GetValue(RawValue, GuildPermission.ViewChannel);
         /// <summary> If True, a user may send messages. </summary>
         public bool SendMessages => Permissions.GetValue(RawValue, GuildPermission.SendMessages);
-        /// <summary> If <c>true</c>, a user may send text-to-speech messages. </summary>
+        /// <summary> If <see langword="true"/>, a user may send text-to-speech messages. </summary>
         public bool SendTTSMessages => Permissions.GetValue(RawValue, GuildPermission.SendTTSMessages);
-        /// <summary> If <c>true</c>, a user may delete messages. </summary>
+        /// <summary> If <see langword="true"/>, a user may delete messages. </summary>
         public bool ManageMessages => Permissions.GetValue(RawValue, GuildPermission.ManageMessages);
-        /// <summary> If <c>true</c>, Discord will auto-embed links sent by this user. </summary>
+        /// <summary> If <see langword="true"/>, Discord will auto-embed links sent by this user. </summary>
         public bool EmbedLinks => Permissions.GetValue(RawValue, GuildPermission.EmbedLinks);
-        /// <summary> If <c>true</c>, a user may send files. </summary>
+        /// <summary> If <see langword="true"/>, a user may send files. </summary>
         public bool AttachFiles => Permissions.GetValue(RawValue, GuildPermission.AttachFiles);
-        /// <summary> If <c>true</c>, a user may read previous messages. </summary>
+        /// <summary> If <see langword="true"/>, a user may read previous messages. </summary>
         public bool ReadMessageHistory => Permissions.GetValue(RawValue, GuildPermission.ReadMessageHistory);
-        /// <summary> If <c>true</c>, a user may mention @everyone. </summary>
+        /// <summary> If <see langword="true"/>, a user may mention @everyone. </summary>
         public bool MentionEveryone => Permissions.GetValue(RawValue, GuildPermission.MentionEveryone);
-        /// <summary> If <c>true</c>, a user may use custom emoji from other guilds. </summary>
+        /// <summary> If <see langword="true"/>, a user may use custom emoji from other guilds. </summary>
         public bool UseExternalEmojis => Permissions.GetValue(RawValue, GuildPermission.UseExternalEmojis);
 
-        /// <summary> If <c>true</c>, a user may connect to a voice channel. </summary>
+        /// <summary> If <see langword="true"/>, a user may connect to a voice channel. </summary>
         public bool Connect => Permissions.GetValue(RawValue, GuildPermission.Connect);
-        /// <summary> If <c>true</c>, a user may speak in a voice channel. </summary>
+        /// <summary> If <see langword="true"/>, a user may speak in a voice channel. </summary>
         public bool Speak => Permissions.GetValue(RawValue, GuildPermission.Speak);
-        /// <summary> If <c>true</c>, a user may mute users. </summary>
+        /// <summary> If <see langword="true"/>, a user may mute users. </summary>
         public bool MuteMembers => Permissions.GetValue(RawValue, GuildPermission.MuteMembers);
-        /// <summary> If <c>true</c>, a user may deafen users. </summary>
+        /// <summary> If <see langword="true"/>, a user may deafen users. </summary>
         public bool DeafenMembers => Permissions.GetValue(RawValue, GuildPermission.DeafenMembers);
-        /// <summary> If <c>true</c>, a user may move other users between voice channels. </summary>
+        /// <summary> If <see langword="true"/>, a user may move other users between voice channels. </summary>
         public bool MoveMembers => Permissions.GetValue(RawValue, GuildPermission.MoveMembers);
-        /// <summary> If <c>true</c>, a user may use voice-activity-detection rather than push-to-talk. </summary>
+        /// <summary> If <see langword="true"/>, a user may use voice-activity-detection rather than push-to-talk. </summary>
         public bool UseVAD => Permissions.GetValue(RawValue, GuildPermission.UseVAD);
         /// <summary> If True, a user may use priority speaker in a voice channel. </summary>
         public bool PrioritySpeaker => Permissions.GetValue(RawValue, GuildPermission.PrioritySpeaker);
         /// <summary> If True, a user may stream video in a voice channel. </summary>
         public bool Stream => Permissions.GetValue(RawValue, GuildPermission.Stream);
 
-        /// <summary> If <c>true</c>, a user may change their own nickname. </summary>
+        /// <summary> If <see langword="true"/>, a user may change their own nickname. </summary>
         public bool ChangeNickname => Permissions.GetValue(RawValue, GuildPermission.ChangeNickname);
-        /// <summary> If <c>true</c>, a user may change the nickname of other users. </summary>
+        /// <summary> If <see langword="true"/>, a user may change the nickname of other users. </summary>
         public bool ManageNicknames => Permissions.GetValue(RawValue, GuildPermission.ManageNicknames);
-        /// <summary> If <c>true</c>, a user may adjust roles. </summary>
+        /// <summary> If <see langword="true"/>, a user may adjust roles. </summary>
         public bool ManageRoles => Permissions.GetValue(RawValue, GuildPermission.ManageRoles);
-        /// <summary> If <c>true</c>, a user may edit the webhooks for this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may edit the webhooks for this guild. </summary>
         public bool ManageWebhooks => Permissions.GetValue(RawValue, GuildPermission.ManageWebhooks);
-        /// <summary> If <c>true</c>, a user may edit the emojis and stickers for this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may edit the emojis and stickers for this guild. </summary>
         public bool ManageEmojisAndStickers => Permissions.GetValue(RawValue, GuildPermission.ManageEmojisAndStickers);
-        /// <summary> If <c>true</c>, a user may use slash commands in this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may use slash commands in this guild. </summary>
         public bool UseApplicationCommands => Permissions.GetValue(RawValue, GuildPermission.UseApplicationCommands);
-        /// <summary> If <c>true</c>, a user may request to speak in stage channels. </summary>
+        /// <summary> If <see langword="true"/>, a user may request to speak in stage channels. </summary>
         public bool RequestToSpeak => Permissions.GetValue(RawValue, GuildPermission.RequestToSpeak);
-        /// <summary> If <c>true</c>, a user may create, edit, and delete events. </summary>
+        /// <summary> If <see langword="true"/>, a user may create, edit, and delete events. </summary>
         public bool ManageEvents => Permissions.GetValue(RawValue, GuildPermission.ManageEvents);
-        /// <summary> If <c>true</c>, a user may manage threads in this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may manage threads in this guild. </summary>
         public bool ManageThreads => Permissions.GetValue(RawValue, GuildPermission.ManageThreads);
-        /// <summary> If <c>true</c>, a user may create public threads in this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may create public threads in this guild. </summary>
         public bool CreatePublicThreads => Permissions.GetValue(RawValue, GuildPermission.CreatePublicThreads);
-        /// <summary> If <c>true</c>, a user may create private threads in this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may create private threads in this guild. </summary>
         public bool CreatePrivateThreads => Permissions.GetValue(RawValue, GuildPermission.CreatePrivateThreads);
-        /// <summary> If <c>true</c>, a user may use external stickers in this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may use external stickers in this guild. </summary>
         public bool UseExternalStickers => Permissions.GetValue(RawValue, GuildPermission.UseExternalStickers);
-        /// <summary> If <c>true</c>, a user may send messages in threads in this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user may send messages in threads in this guild. </summary>
         public bool SendMessagesInThreads => Permissions.GetValue(RawValue, GuildPermission.SendMessagesInThreads);
-        /// <summary> If <c>true</c>, a user launch application activities in voice channels in this guild. </summary>
+        /// <summary> If <see langword="true"/>, a user launch application activities in voice channels in this guild. </summary>
         public bool StartEmbeddedActivities => Permissions.GetValue(RawValue, GuildPermission.StartEmbeddedActivities);
-        /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user can timeout other users in this guild.</summary>
         public bool ModerateMembers => Permissions.GetValue(RawValue, GuildPermission.ModerateMembers);
         /// <summary> If <see langword="true"/>, a user can use soundboard in this guild.</summary>
         public bool UseSoundboard => Permissions.GetValue(RawValue, GuildPermission.UseSoundboard);
-        /// <summary> If <c>true</c>, a user can timeout other users in this guild.</summary>
+        /// <summary> If <see langword="true"/>, a user can view monetization analytics in this guild.</summary>
         public bool ViewMonetizationAnalytics => Permissions.GetValue(RawValue, GuildPermission.ViewMonetizationAnalytics);
 
         /// <summary> Creates a new <see cref="GuildPermissions"/> with the provided packed value. </summary>
@@ -357,7 +357,7 @@ namespace Discord
         ///     in these permissions.
         /// </summary>
         /// <param name="permission">The permission value to check for.</param>
-        /// <returns><c>true</c> if the permission is enabled, <c>false</c> otherwise.</returns>
+        /// <returns><see langword="true"/> if the permission is enabled, <c>false</c> otherwise.</returns>
         public bool Has(GuildPermission permission) => Permissions.GetValue(RawValue, permission);
 
         /// <summary>

--- a/test/Discord.Net.Tests.Unit/ChannelPermissionsTests.cs
+++ b/test/Discord.Net.Tests.Unit/ChannelPermissionsTests.cs
@@ -89,10 +89,13 @@ namespace Discord
             AssertFlag(() => new ChannelPermissions(createPrivateThreads: true), ChannelPermission.CreatePrivateThreads);
             AssertFlag(() => new ChannelPermissions(createPublicThreads: true), ChannelPermission.CreatePublicThreads);
             AssertFlag(() => new ChannelPermissions(sendMessagesInThreads: true), ChannelPermission.SendMessagesInThreads);
+            AssertFlag(() => new ChannelPermissions(startEmbeddedActivities: true), ChannelPermission.StartEmbeddedActivities);
+            AssertFlag(() => new ChannelPermissions(useSoundboard: true), ChannelPermission.UseSoundboard);
+            AssertFlag(() => new ChannelPermissions(createEvents: true), ChannelPermission.CreateEvents);
         }
 
         /// <summary>
-        ///     Tests the behavior of <see cref="Discord.ChannelPermissions.Modify(bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?, bool?)"/>
+        ///     Tests the behavior of <see cref="Discord.ChannelPermissions.Modify"/>
         ///     with each of the parameters.
         /// </summary>
         [Fact]

--- a/test/Discord.Net.Tests.Unit/GuildPermissionsTests.cs
+++ b/test/Discord.Net.Tests.Unit/GuildPermissionsTests.cs
@@ -100,6 +100,8 @@ namespace Discord
             AssertFlag(() => new GuildPermissions(createPrivateThreads: true), GuildPermission.CreatePrivateThreads);
             AssertFlag(() => new GuildPermissions(useExternalStickers: true), GuildPermission.UseExternalStickers);
             AssertFlag(() => new GuildPermissions(moderateMembers: true), GuildPermission.ModerateMembers);
+            AssertFlag(() => new GuildPermissions(viewMonetizationAnalytics: true), GuildPermission.ViewMonetizationAnalytics);
+            AssertFlag(() => new GuildPermissions(useSoundboard: true), GuildPermission.UseSoundboard);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds missing guild & channel permissions and resolves #2643

### Changes
- Refactor permission enums
- Add missing perms
- fix `ChannelPermissions.All()` throwing on `IForumChannel`
- update permission sets for text, voice & stage channels