### PR TITLE
Resolves issue #2466

### DIFF
--- a/src/Discord.Net.Interactions/TypeConverters/SlashCommands/EnumConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/SlashCommands/EnumConverter.cs
@@ -1,6 +1,7 @@
 using Discord.WebSocket;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -22,6 +23,7 @@ namespace Discord.Interactions
         {
             var names = Enum.GetNames(typeof(T));
             var members = names.SelectMany(x => typeof(T).GetMember(x)).Where(x => !x.IsDefined(typeof(HideAttribute), true));
+            var localizationManager = parameterInfo.Command.Module.CommandService.LocalizationManager;
 
             if (members.Count() <= 25)
             {
@@ -33,7 +35,8 @@ namespace Discord.Interactions
                     choices.Add(new ApplicationCommandOptionChoiceProperties
                     {
                         Name = displayValue,
-                        Value = member.Name
+                        Value = member.Name,
+                        NameLocalizations = localizationManager?.GetAllNames(parameterInfo.GetChoicePath(new ParameterChoice(displayValue.ToLower(), member.Name)), LocalizationTarget.Choice) ?? ImmutableDictionary<string, string>.Empty
                     });
                 }
                 properties.Choices = choices;

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
@@ -93,7 +93,8 @@ namespace Discord.API
             Choices = option.Choices?.Select(x => new ApplicationCommandOptionChoice
             {
                 Name = x.Name,
-                Value = x.Value
+                Value = x.Value,
+                NameLocalizations = x.NameLocalizations?.ToDictionary() ?? Optional<Dictionary<string, string>>.Unspecified,
             }).ToArray() ?? Optional<ApplicationCommandOptionChoice[]>.Unspecified;
 
             Options = option.Options?.Select(x => new ApplicationCommandOption(x)).ToArray() ?? Optional<ApplicationCommandOption[]>.Unspecified;


### PR DESCRIPTION
This pr fixes #2466

The problem was that the enum type converter was not adding also the localization and that the model creation was also not adding the naming localization property

It was tested with the json localization manager.

I added in Line 38 a toLower to follow conventions, but not sure if its practicable so feel free to correct me on this and further points. Thanks for looking up.