### PR TITLE
[Feature] Refactor stage instance implementation

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IStageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IStageChannel.cs
@@ -9,22 +9,9 @@ namespace Discord
     public interface IStageChannel : IVoiceChannel
     {
         /// <summary>
-        ///     Gets the <see cref="StagePrivacyLevel"/> of the current stage.
+        ///     Gets the stage instance currently running in the channel. <see langword="null" /> if no instance is running.
         /// </summary>
-        /// <remarks>
-        ///     If the stage isn't live then this property will be set to <see langword="null"/>.
-        /// </remarks>
-        StagePrivacyLevel? PrivacyLevel { get; }
-
-        /// <summary>
-        ///     Gets whether or not stage discovery is disabled. 
-        /// </summary>
-        bool? IsDiscoverableDisabled { get; }
-
-        /// <summary>
-        ///     Gets whether or not the stage is live.
-        /// </summary>
-        bool IsLive { get; }
+        IStageInstance StageInstance { get; }
 
         /// <summary>
         ///     Starts the stage, creating a stage instance.
@@ -32,10 +19,12 @@ namespace Discord
         /// <param name="topic">The topic for the stage/</param>
         /// <param name="privacyLevel">The privacy level of the stage.</param>
         /// <param name="options">The options to be used when sending the request.</param>
+        /// <param name="sendStartNotification">Notify @everyone that a Stage instance has started</param>
         /// <returns>
         ///     A task that represents the asynchronous start operation.
         /// </returns>
-        Task StartStageAsync(string topic, StagePrivacyLevel privacyLevel = StagePrivacyLevel.GuildOnly, RequestOptions options = null);
+        Task<IStageInstance> StartStageAsync(string topic, StagePrivacyLevel privacyLevel = StagePrivacyLevel.GuildOnly, bool sendStartNotification = false,
+            RequestOptions options = null);
 
         /// <summary>
         ///     Modifies the current stage instance.

--- a/src/Discord.Net.Core/Entities/Guilds/IStageInstance.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IStageInstance.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Discord;
+
+/// <summary>
+///     Represents a stage instance.
+/// </summary>
+public interface IStageInstance : ISnowflakeEntity
+{
+    /// <summary>
+    ///     Gets the guild id of the associated Stage channel.
+    /// </summary>
+    public ulong GuildId { get; }
+
+    /// <summary>
+    ///     Gets the id of the associated Stage channel.
+    /// </summary>
+    public ulong ChannelId { get; }
+
+    /// <summary>
+    ///     Gets the topic of the Stage instance.
+    /// </summary>
+    public string Topic { get; }
+
+    /// <summary>
+    ///     Gets the privacy level of the Stage instance.
+    /// </summary>
+    public StagePrivacyLevel PrivacyLevel { get; }
+    
+    /// <summary>
+    ///     Gets the id of the scheduled event for this Stage instance.
+    /// </summary>
+    public ulong? ScheduledEventId { get; }
+
+    /// <summary>
+    ///     Modifies the stage instance.
+    /// </summary>
+    Task ModifyAsync(Action<StageInstanceProperties> func, RequestOptions options = null);
+
+    /// <summary>
+    ///     Stops the stage instance.
+    /// </summary>
+    Task StopAsync(RequestOptions options = null);
+}

--- a/src/Discord.Net.Rest/API/Common/StageInstance.cs
+++ b/src/Discord.Net.Rest/API/Common/StageInstance.cs
@@ -1,25 +1,27 @@
 using Newtonsoft.Json;
 
-namespace Discord.API
+namespace Discord.API;
+
+internal class StageInstance
 {
-    internal class StageInstance
-    {
-        [JsonProperty("id")]
-        public ulong Id { get; set; }
+    [JsonProperty("id")]
+    public ulong Id { get; set; }
 
-        [JsonProperty("guild_id")]
-        public ulong GuildId { get; set; }
+    [JsonProperty("guild_id")]
+    public ulong GuildId { get; set; }
 
-        [JsonProperty("channel_id")]
-        public ulong ChannelId { get; set; }
+    [JsonProperty("channel_id")]
+    public ulong ChannelId { get; set; }
 
-        [JsonProperty("topic")]
-        public string Topic { get; set; }
+    [JsonProperty("topic")]
+    public string Topic { get; set; }
 
-        [JsonProperty("privacy_level")]
-        public StagePrivacyLevel PrivacyLevel { get; set; }
+    [JsonProperty("privacy_level")]
+    public StagePrivacyLevel PrivacyLevel { get; set; }
 
-        [JsonProperty("discoverable_disabled")]
-        public bool DiscoverableDisabled { get; set; }
-    }
+    [JsonProperty("discoverable_disabled")]
+    public bool DiscoverableDisabled { get; set; }
+
+    [JsonProperty("guild_scheduled_event_id")]
+    public Optional<ulong> ScheduledEventId { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Common/StageInstance.cs
+++ b/src/Discord.Net.Rest/API/Common/StageInstance.cs
@@ -23,5 +23,5 @@ internal class StageInstance
     public bool DiscoverableDisabled { get; set; }
 
     [JsonProperty("guild_scheduled_event_id")]
-    public Optional<ulong> ScheduledEventId { get; set; }
+    public ulong? ScheduledEventId { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateStageInstanceParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateStageInstanceParams.cs
@@ -1,16 +1,18 @@
 using Newtonsoft.Json;
 
-namespace Discord.API.Rest
+namespace Discord.API.Rest;
+
+internal class CreateStageInstanceParams
 {
-    internal class CreateStageInstanceParams
-    {
-        [JsonProperty("channel_id")]
-        public ulong ChannelId { get; set; }
+    [JsonProperty("channel_id")]
+    public ulong ChannelId { get; set; }
 
-        [JsonProperty("topic")]
-        public string Topic { get; set; }
+    [JsonProperty("topic")]
+    public string Topic { get; set; }
 
-        [JsonProperty("privacy_level")]
-        public Optional<StagePrivacyLevel> PrivacyLevel { get; set; }
-    }
+    [JsonProperty("privacy_level")]
+    public Optional<StagePrivacyLevel> PrivacyLevel { get; set; }
+
+    [JsonProperty("send_start_notification")]
+    public Optional<bool> SendNotification { get; set; }
 }

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -45,6 +45,8 @@ namespace Discord.Rest
             }, options);
         }
 
+        #endregion
+
         public static async Task<RestChannel> GetChannelAsync(BaseDiscordClient client,
             ulong id, RequestOptions options)
         {
@@ -290,7 +292,12 @@ namespace Discord.Rest
 
         public static Task RemoveRoleAsync(BaseDiscordClient client, ulong guildId, ulong userId, ulong roleId, RequestOptions options = null)
             => client.ApiClient.RemoveRoleAsync(guildId, userId, roleId, options);
-        #endregion
+
+        public static async Task<RestStageInstance> GetStageInstanceAsync(BaseDiscordClient client, ulong channelId, RequestOptions options = null)
+        {
+            var model = await client.ApiClient.GetStageInstanceAsync(channelId, options);
+            return model is null ? null : RestStageInstance.Create(client, model);
+        }
 
         #region Role Connection Metadata
 

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -721,7 +721,7 @@ namespace Discord.API
 
             try
             {
-                return await SendAsync<StageInstance>("POST", () => $"stage-instances/{channelId}", bucket, options: options).ConfigureAwait(false);
+                return await SendAsync<StageInstance>("GET", () => $"stage-instances/{channelId}", bucket, options: options).ConfigureAwait(false);
             }
             catch (HttpException httpEx) when (httpEx.HttpCode == HttpStatusCode.NotFound)
             {

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -278,6 +278,9 @@ namespace Discord.Rest
         public Task<RoleConnection> ModifyUserApplicationRoleConnectionAsync(ulong applicationId, RoleConnectionProperties roleConnection, RequestOptions options = null)
             => ClientHelper.ModifyUserRoleConnectionAsync(applicationId, roleConnection, this, options);
 
+        public Task<RestStageInstance> GetStageInstanceAsync(ulong channelId, RequestOptions options = null)
+            => ClientHelper.GetStageInstanceAsync(this, channelId, options);
+
         #endregion
 
         #region IDiscordClient

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -98,7 +98,7 @@ namespace Discord.Rest
             return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
         }
 
-        public static async Task<StageInstance> ModifyAsync(IStageChannel channel, BaseDiscordClient client,
+        public static async Task<StageInstance> ModifyStageAsync(IStageChannel channel, BaseDiscordClient client,
             Action<StageInstanceProperties> func, RequestOptions options = null)
         {
             var args = new StageInstanceProperties();

--- a/src/Discord.Net.Rest/Entities/Guilds/RestStageInstance.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestStageInstance.cs
@@ -1,0 +1,77 @@
+using Discord.API.Rest;
+
+using System;
+using System.Threading.Tasks;
+
+using Model = Discord.API.StageInstance;
+
+namespace Discord.Rest;
+
+public class RestStageInstance : RestEntity<ulong>, IStageInstance
+{
+    private IStageChannel _channel;
+
+    /// <inheritdoc />
+    public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
+
+    internal RestStageInstance(BaseDiscordClient discord, ulong id) : base(discord, id)
+    {
+    }
+
+    internal static RestStageInstance Create(BaseDiscordClient discord, Model model, IStageChannel channel = null)
+    {
+        var stage = new RestStageInstance(discord, model.Id)
+        {
+            _channel = channel
+        };
+        stage.Update(model);
+        return stage;
+    }
+
+    internal void Update(Model model)
+    {
+        GuildId = model.GuildId;
+        ChannelId = model.ChannelId;
+        Topic = model.Topic;
+        PrivacyLevel = model.PrivacyLevel;
+        ScheduledEventId = model.ScheduledEventId;
+    }
+
+    /// <inheritdoc />
+    public ulong GuildId { get; internal set; }
+
+    /// <inheritdoc />
+    public ulong ChannelId { get; internal set; }
+
+    /// <inheritdoc />
+    public string Topic { get; internal set; }
+
+    /// <inheritdoc />
+    public StagePrivacyLevel PrivacyLevel { get; internal set; }
+
+    /// <inheritdoc />
+    public ulong? ScheduledEventId { get; internal set; }
+
+    /// <inheritdoc />
+    public async Task ModifyAsync(Action<StageInstanceProperties> func, RequestOptions options = null)
+    {
+        var args = new StageInstanceProperties();
+        func(args);
+
+        var model = await Discord.ApiClient.ModifyStageInstanceAsync(ChannelId, new ModifyStageInstanceParams()
+        {
+            PrivacyLevel = args.PrivacyLevel,
+            Topic = args.Topic,
+        }, options);
+
+        Update(model);
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(RequestOptions options = null)
+    {
+        return _channel is not null
+            ? _channel.StopStageAsync()
+            : Discord.ApiClient.DeleteStageInstanceAsync(ChannelId);
+    }
+}

--- a/src/Discord.Net.WebSocket/API/Gateway/ExtendedGuild.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ExtendedGuild.cs
@@ -31,5 +31,8 @@ namespace Discord.API.Gateway
 
         [JsonProperty("guild_scheduled_events")]
         public GuildScheduledEvent[] GuildScheduledEvents { get; set; }
+
+        [JsonProperty("stage_instances")]
+        public StageInstance[] StageInstances { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -790,32 +790,32 @@ namespace Discord.WebSocket
         /// <summary>
         ///     Fired when a stage is started.
         /// </summary>
-        public event Func<SocketStageChannel, Task> StageStarted
+        public event Func<SocketStageInstance, Task> StageStarted
         {
             add { _stageStarted.Add(value); }
             remove { _stageStarted.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<SocketStageChannel, Task>> _stageStarted = new AsyncEvent<Func<SocketStageChannel, Task>>();
+        internal readonly AsyncEvent<Func<SocketStageInstance, Task>> _stageStarted = new ();
 
         /// <summary>
         ///     Fired when a stage ends.
         /// </summary>
-        public event Func<SocketStageChannel, Task> StageEnded
+        public event Func<SocketStageInstance, Task> StageEnded
         {
             add { _stageEnded.Add(value); }
             remove { _stageEnded.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<SocketStageChannel, Task>> _stageEnded = new AsyncEvent<Func<SocketStageChannel, Task>>();
+        internal readonly AsyncEvent<Func<SocketStageInstance, Task>> _stageEnded = new ();
 
         /// <summary>
         ///     Fired when a stage is updated.
         /// </summary>
-        public event Func<SocketStageChannel, SocketStageChannel, Task> StageUpdated
+        public event Func<SocketStageInstance, SocketStageInstance, Task> StageUpdated
         {
             add { _stageUpdated.Add(value); }
             remove { _stageUpdated.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<SocketStageChannel, SocketStageChannel, Task>> _stageUpdated = new AsyncEvent<Func<SocketStageChannel, SocketStageChannel, Task>>();
+        internal readonly AsyncEvent<Func<SocketStageInstance, SocketStageInstance, Task>> _stageUpdated = new ();
 
         /// <summary>
         ///     Fired when a user requests to speak within a stage channel.

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -374,6 +374,19 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override SocketChannel GetChannel(ulong id)
             => State.GetChannel(id);
+
+        /// <summary>
+        ///     Gets a stage instance from cache. Returns <see langword="null" /> if the stage instance could not be found.
+        /// </summary>
+        public SocketStageInstance GetStageInstance(ulong channelId)
+            => State.GetChannel(channelId) is SocketStageChannel channel ? channel.StageInstance : null;
+
+        /// <summary>
+        ///     Gets a stage instance from cache or does a rest request if unavailable. Returns <see langword="null" /> if the stage instance could not be found.
+        /// </summary>
+        public async Task<IStageInstance> GetStageInstanceAsync(ulong channelId, RequestOptions options = null)
+            => GetStageInstance(channelId) ?? (IStageInstance)await Rest.GetStageInstanceAsync(channelId, options);
+
         /// <summary>
         ///     Gets a generic channel from the cache or does a rest request if unavailable.
         /// </summary>

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
@@ -1,11 +1,12 @@
 using Discord.Rest;
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Model = Discord.API.Channel;
-using StageInstance = Discord.API.StageInstance;
 
 namespace Discord.WebSocket
 {
@@ -50,7 +51,7 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc cref="IStageChannel.StartStageAsync" />
-        public async Task<RestStageInstance> StartStageAsync(string topic, StagePrivacyLevel privacyLevel = StagePrivacyLevel.GuildOnly, bool sendStartNotification = false, 
+        public async Task<RestStageInstance> StartStageAsync(string topic, StagePrivacyLevel privacyLevel = StagePrivacyLevel.GuildOnly, bool sendStartNotification = false,
             RequestOptions options = null)
         {
             var args = new API.Rest.CreateStageInstanceParams
@@ -62,21 +63,17 @@ namespace Discord.WebSocket
             };
 
             var model = await Discord.ApiClient.CreateStageInstanceAsync(args, options).ConfigureAwait(false);
-            
+
             return RestStageInstance.Create(Discord, model);
         }
 
         /// <inheritdoc/>
-        public async Task ModifyInstanceAsync(Action<StageInstanceProperties> func, RequestOptions options = null)
-        {
-            var model = await ChannelHelper.ModifyStageAsync(this, Discord, func, options);
-        }
+        public Task ModifyInstanceAsync(Action<StageInstanceProperties> func, RequestOptions options = null)
+            => ChannelHelper.ModifyStageAsync(this, Discord, func, options);
 
         /// <inheritdoc/>
-        public async Task StopStageAsync(RequestOptions options = null)
-        {
-            await Discord.ApiClient.DeleteStageInstanceAsync(Id, options);
-        }
+        public Task StopStageAsync(RequestOptions options = null)
+            => Discord.ApiClient.DeleteStageInstanceAsync(Id, options);
 
         /// <inheritdoc/>
         public Task RequestToSpeakAsync(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketStageInstance.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketStageInstance.cs
@@ -1,0 +1,96 @@
+using Discord.API.Rest;
+
+using System;
+using System.Threading.Tasks;
+
+using Model = Discord.API.StageInstance;
+
+namespace Discord.WebSocket;
+
+public class SocketStageInstance : SocketEntity<ulong>, IStageInstance
+{
+    /// <inheritdoc />
+    public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
+
+    internal SocketStageInstance(DiscordSocketClient discord, ulong id) : base(discord, id)
+    {
+    }
+
+    internal static SocketStageInstance Create(DiscordSocketClient discord, Model model)
+    {
+        var stage = new SocketStageInstance(discord, model.Id);
+        stage.Update(model);
+        return stage;
+    }
+
+    internal void Update(Model model)
+    {
+        GuildId = model.GuildId;
+        ChannelId = model.ChannelId;
+        Topic = model.Topic;
+        PrivacyLevel = model.PrivacyLevel;
+        ScheduledEventId = model.ScheduledEventId;
+
+        Guild = Discord.GetGuild(model.GuildId);
+        Channel = Discord.GetChannel(model.ChannelId) as SocketStageChannel;
+        if (Guild is not null && model.ScheduledEventId is not null)
+            ScheduledEvent = Guild.GetEvent(model.ScheduledEventId.Value);
+        else
+            ScheduledEvent = null;
+    }
+
+    /// <inheritdoc />
+    public ulong GuildId { get; internal set; }
+
+    /// <summary>
+    ///     Gets the guild of the associated Stage channel 
+    /// </summary>
+    public SocketGuild Guild { get; internal set; }
+
+    /// <inheritdoc />
+    public ulong ChannelId { get; internal set; }
+
+    /// <summary>
+    ///     Gets the associated Stage channel.
+    /// </summary>
+    public SocketStageChannel Channel { get; internal set; }
+
+    /// <inheritdoc />
+    public string Topic { get; internal set; }
+
+    /// <inheritdoc />
+    public StagePrivacyLevel PrivacyLevel { get; internal set; }
+
+    /// <inheritdoc />
+    public ulong? ScheduledEventId { get; internal set; }
+
+    /// <summary>
+    ///     Gets the scheduled event for this Stage instance.
+    /// </summary>
+    public SocketGuildEvent ScheduledEvent { get; internal set; }
+
+    /// <inheritdoc />
+    public async Task ModifyAsync(Action<StageInstanceProperties> func, RequestOptions options = null)
+    {
+        var args = new StageInstanceProperties();
+        func(args);
+
+        var model = await Discord.ApiClient.ModifyStageInstanceAsync(ChannelId, new ModifyStageInstanceParams()
+        {
+            PrivacyLevel = args.PrivacyLevel,
+            Topic = args.Topic,
+        }, options);
+
+        Update(model);
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(RequestOptions options = null)
+    {
+        return Channel is not null
+            ? Channel.StopStageAsync()
+            : Discord.ApiClient.DeleteStageInstanceAsync(ChannelId);
+    }
+
+    internal SocketStageInstance Clone() => MemberwiseClone() as SocketStageInstance;
+}


### PR DESCRIPTION
This PR improves D.Net's stage instance implementation

### Changes:
- switch `GetStageInstance` api method from `POST` to `GET` request (lol)
- add `IStageInstance`, `RestStageInstance` & `SocketStageInstance`
- add stage instance cache to `SocketGuild`
- remove `discoverable_disabled` proprtiy, as one is deprecated [docs](https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-stage-instance-structure)
- remove stage instance properties from `IStageChannel`    **BREAKING**
- add `IStageInstance` property to `IStageChannel`
- add `GetStageInstance(Async)` methods to socket & rest clients
- change `SocketStageChannel` to `SocketStageInstance` in `StageStarted`, `Updated` & `Ended` events    **BREAKING**