### PR TITLE
[Feature] Interaction channel field support

### DIFF
--- a/src/Discord.Net.Rest/API/Common/Interaction.cs
+++ b/src/Discord.Net.Rest/API/Common/Interaction.cs
@@ -23,6 +23,9 @@ namespace Discord.API
         [JsonProperty("channel_id")]
         public Optional<ulong> ChannelId { get; set; }
 
+        [JsonProperty("channel")]
+        public Optional<Channel> Channel { get; set; }
+
         [JsonProperty("member")]
         public Optional<GuildMember> Member { get; set; }
 

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
@@ -116,8 +116,8 @@ namespace Discord.WebSocket
 
         internal virtual void Update(Model model)
         {
-            ChannelId = model.ChannelId.IsSpecified
-                ? model.ChannelId.Value
+            ChannelId = model.Channel.IsSpecified
+                ? model.Channel.Value.Id
                 : null;
 
             GuildId = model.GuildId.IsSpecified


### PR DESCRIPTION
[docs](https://github.com/discord/discord-api-docs/commit/af3308c1a365fa4783b8dc691dda38e93d15cbc0)

Discord's added `channel` field to `Interaction` object and may deprecate the `chanenl_id` field in future
This PR switches the D.Net to use the new field
