### PR TITLE
Update XML documentation for `IDiscordInteraction.RespondAsync`

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
@@ -103,8 +103,7 @@ namespace Discord
         /// <param name="embed">A single embed to send with this response. If this is passed alongside an array of embeds, the single embed will be ignored.</param>
         /// <param name="options">The request options for this response.</param>
         /// <returns>
-        ///     A task that represents an asynchronous send operation for delivering the message. The task result
-        ///     contains the sent message.
+        ///     A task that represents an asynchronous send operation for delivering the message.
         /// </returns>
         Task RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false,
             bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null);


### PR DESCRIPTION
`IDiscordInteraction.RespondAsync` had a mistake in the XML documentation, which claimed it returned the sent message inside the Task, but it doesn't.

I've talked to Misha133 on the Discord server, and it seems it is not supposed to return it, so I've changed the XML docs to reflect it correctly.