### PR TITLE
Add support for sending the guild in the PresenceUpdated event

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -531,12 +531,12 @@ namespace Discord.WebSocket
         #region Presence
 
         /// <summary> Fired when a users presence is updated. </summary>
-        public event Func<SocketUser, SocketPresence, SocketPresence, Task> PresenceUpdated
+        public event Func<SocketUser, SocketGuild, SocketPresence, SocketPresence, Task> PresenceUpdated
         {
             add { _presenceUpdated.Add(value); }
             remove { _presenceUpdated.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<SocketUser, SocketPresence, SocketPresence, Task>> _presenceUpdated = new AsyncEvent<Func<SocketUser, SocketPresence, SocketPresence, Task>>();
+        internal readonly AsyncEvent<Func<SocketUser, SocketGuild, SocketPresence, SocketPresence, Task>> _presenceUpdated = new AsyncEvent<Func<SocketUser, SocketGuild, SocketPresence, SocketPresence, Task>>();
 
         #endregion
 
@@ -907,7 +907,7 @@ namespace Discord.WebSocket
         internal readonly AsyncEvent<Func<SocketAuditLogEntry, SocketGuild, Task>> _auditLogCreated = new();
 
         #endregion
-        
+
         #region AutoModeration
 
         /// <summary>
@@ -949,7 +949,7 @@ namespace Discord.WebSocket
             remove => _autoModActionExecuted.Remove(value);
         }
         internal readonly AsyncEvent<Func<SocketGuild, AutoModRuleAction, AutoModActionExecutedData, Task>> _autoModActionExecuted = new ();
-        
+
         #endregion
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -460,7 +460,7 @@ namespace Discord.WebSocket
             client.UserBanned += (user, guild) => _userBannedEvent.InvokeAsync(user, guild);
             client.UserUnbanned += (user, guild) => _userUnbannedEvent.InvokeAsync(user, guild);
             client.UserUpdated += (oldUser, newUser) => _userUpdatedEvent.InvokeAsync(oldUser, newUser);
-            client.PresenceUpdated += (user, oldPresence, newPresence) => _presenceUpdated.InvokeAsync(user, oldPresence, newPresence);
+            client.PresenceUpdated += (user, guild, oldPresence, newPresence) => _presenceUpdated.InvokeAsync(user, guild, oldPresence, newPresence);
             client.GuildMemberUpdated += (oldUser, newUser) => _guildMemberUpdatedEvent.InvokeAsync(oldUser, newUser);
             client.UserVoiceStateUpdated += (user, oldVoiceState, newVoiceState) => _userVoiceStateUpdatedEvent.InvokeAsync(user, oldVoiceState, newVoiceState);
             client.VoiceServerUpdated += (server) => _voiceServerUpdatedEvent.InvokeAsync(server);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1975,12 +1975,13 @@ namespace Discord.WebSocket
                                     await _gatewayLogger.DebugAsync("Received Dispatch (PRESENCE_UPDATE)").ConfigureAwait(false);
 
                                     var data = (payload as JToken).ToObject<API.Presence>(_serializer);
+                                    SocketGuild guild = null;
 
                                     SocketUser user = null;
 
                                     if (data.GuildId.IsSpecified)
                                     {
-                                        var guild = State.GetGuild(data.GuildId.Value);
+                                        guild = State.GetGuild(data.GuildId.Value);
                                         if (guild == null)
                                         {
                                             await UnknownGuildAsync(type, data.GuildId.Value).ConfigureAwait(false);
@@ -2024,7 +2025,7 @@ namespace Discord.WebSocket
                                     var before = user.Presence?.Clone();
                                     user.Update(State, data.User);
                                     user.Update(data);
-                                    await TimedInvokeAsync(_presenceUpdated, nameof(PresenceUpdated), user, before, user.Presence).ConfigureAwait(false);
+                                    await TimedInvokeAsync(_presenceUpdated, nameof(PresenceUpdated), user, guild, before, user.Presence).ConfigureAwait(false);
                                 }
                                 break;
                             case "TYPING_START":
@@ -2904,7 +2905,7 @@ namespace Discord.WebSocket
                             }
                             break;
                             #endregion
-                            
+
                             #region Auto Moderation
 
                             case "AUTO_MODERATION_RULE_CREATE":


### PR DESCRIPTION
This PR adds the guild to the presenceupdated event to know which guild the presence updated event is fired from so you aren't left guessing.


# This is a breaking change