### PR TITLE
Allow more than 1 action to be registered per automod rule

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -1100,7 +1100,7 @@ namespace Discord.Rest
             if (!args.Name.IsSpecified || string.IsNullOrWhiteSpace(args.Name.Value))
                 throw new ArgumentException("Name of the rule must not be empty", paramName: nameof(args.Name));
 
-            Preconditions.AtLeast(1, args.Actions.GetValueOrDefault(Array.Empty<AutoModRuleActionProperties>()).Length, nameof(args.Actions), "Auto moderation rule must have at least 1 action");
+            Preconditions.AtLeast(args.Actions.GetValueOrDefault(Array.Empty<AutoModRuleActionProperties>()).Length, 1, nameof(args.Actions), "Auto moderation rule must have at least 1 action");
 
             if (args.RegexPatterns.IsSpecified)
             {


### PR DESCRIPTION
Fixes issue #2686 

Swaps the 1st and 2nd parameter around to allow more than 1 action to be registered per rule (And prevents any attempts to register 0 actions per rule)