### PR TITLE
[Refactor] Refactor some stuff

### DIFF
--- a/samples/BasicBot/_BasicBot.csproj
+++ b/samples/BasicBot/_BasicBot.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.WebSocket" Version="3.8.1"/>
+    <PackageReference Include="Discord.Net.WebSocket" Version="3.10.0"/>
   </ItemGroup>
 
 </Project>

--- a/samples/InteractionFramework/_InteractionFramework.csproj
+++ b/samples/InteractionFramework/_InteractionFramework.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Discord.Net.Interactions" Version="3.8.1" />
+    <PackageReference Include="Discord.Net.Interactions" Version="3.10.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ShardedClient/_ShardedClient.csproj
+++ b/samples/ShardedClient/_ShardedClient.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Discord.Net" Version="3.8.1" />
+    <PackageReference Include="Discord.Net" Version="3.10.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/TextCommandFramework/_TextCommandFramework.csproj
+++ b/samples/TextCommandFramework/_TextCommandFramework.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Discord.Net.Commands" Version="3.8.1" />
-    <PackageReference Include="Discord.Net.Websocket" Version="3.8.1" />
+    <PackageReference Include="Discord.Net.Commands" Version="3.10.0" />
+    <PackageReference Include="Discord.Net.Websocket" Version="3.10.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/WebhookClient/_WebhookClient.csproj
+++ b/samples/WebhookClient/_WebhookClient.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Webhook" Version="3.8.1" />
+    <PackageReference Include="Discord.Net.Webhook" Version="3.10.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Discord.Net.Commands/Attributes/PreconditionAttribute.cs
+++ b/src/Discord.Net.Commands/Attributes/PreconditionAttribute.cs
@@ -15,7 +15,7 @@ namespace Discord.Commands
         /// </summary>
         /// <remarks>
         ///     <see cref="Preconditions" /> of the same group require only one of the preconditions to pass in order to
-        ///     be successful (A || B). Specifying <see cref="Group" /> = <c>null</c> or not at all will
+        ///     be successful (A || B). Specifying <see cref="Group" /> = <see langword="null" /> or not at all will
         ///     require *all* preconditions to pass, just like normal (A &amp;&amp; B).
         /// </remarks>
         public string Group { get; set; } = null;

--- a/src/Discord.Net.Commands/CommandService.cs
+++ b/src/Discord.Net.Commands/CommandService.cs
@@ -163,7 +163,7 @@ namespace Discord.Commands
         ///     </code>
         /// </example>
         /// <typeparam name="T">The type of module.</typeparam>
-        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <c>null</c>.</param>
+        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <see langword="null" />.</param>
         /// <exception cref="ArgumentException">This module has already been added.</exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="ModuleInfo"/> fails to be built; an invalid type may have been provided.
@@ -178,7 +178,7 @@ namespace Discord.Commands
         ///     Adds a command module from a <see cref="Type" />.
         /// </summary>
         /// <param name="type">The type of module.</param>
-        /// <param name="services">The <see cref="IServiceProvider" /> for your dependency injection solution if using one; otherwise, pass <c>null</c> .</param>
+        /// <param name="services">The <see cref="IServiceProvider" /> for your dependency injection solution if using one; otherwise, pass <see langword="null" /> .</param>
         /// <exception cref="ArgumentException">This module has already been added.</exception>
         /// <exception cref="InvalidOperationException">
         /// The <see cref="ModuleInfo"/> fails to be built; an invalid type may have been provided.
@@ -217,7 +217,7 @@ namespace Discord.Commands
         ///     Add command modules from an <see cref="Assembly"/>.
         /// </summary>
         /// <param name="assembly">The <see cref="Assembly"/> containing command modules.</param>
-        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <c>null</c>.</param>
+        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <see langword="null" />.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation for adding the command modules. The task result
         ///     contains an enumerable collection of modules added.

--- a/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Commands/Extensions/MessageExtensions.cs
@@ -14,7 +14,7 @@ namespace Discord.Commands
         /// <param name="c">The char prefix.</param>
         /// <param name="argPos">References where the command starts.</param>
         /// <returns>
-        ///     <c>true</c> if the message begins with the char <paramref name="c"/>; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the message begins with the char <paramref name="c"/>; otherwise <see langword="false" />.
         /// </returns>
         public static bool HasCharPrefix(this IUserMessage msg, char c, ref int argPos)
         {

--- a/src/Discord.Net.Commands/ModuleBase.cs
+++ b/src/Discord.Net.Commands/ModuleBase.cs
@@ -34,7 +34,7 @@ namespace Discord.Commands
         /// <param name="embed">An embed to be displayed alongside the <paramref name="message"/>.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the <paramref name="message"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="options">The request options for this <see langword="async"/> request.</param>
         /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>

--- a/src/Discord.Net.Commands/Results/ExecuteResult.cs
+++ b/src/Discord.Net.Commands/Results/ExecuteResult.cs
@@ -76,7 +76,7 @@ namespace Discord.Commands
         ///     Gets a string that indicates the execution result.
         /// </summary>
         /// <returns>
-        ///     <c>Success</c> if <see cref="IsSuccess"/> is <c>true</c>; otherwise "<see cref="Error"/>: 
+        ///     <c>Success</c> if <see cref="IsSuccess"/> is <see langword="true" />; otherwise "<see cref="Error"/>: 
         ///     <see cref="ErrorReason"/>".
         /// </returns>
         public override string ToString() => IsSuccess ? "Success" : $"{Error}: {ErrorReason}";

--- a/src/Discord.Net.Commands/Results/IResult.cs
+++ b/src/Discord.Net.Commands/Results/IResult.cs
@@ -10,7 +10,7 @@ namespace Discord.Commands
         /// </summary>
         /// <returns>
         ///     A <see cref="CommandError" /> indicating the type of error that may have occurred during the operation; 
-        ///     <c>null</c> if the operation was successful.
+        ///     <see langword="null" /> if the operation was successful.
         /// </returns>
         CommandError? Error { get; }
         /// <summary>
@@ -24,7 +24,7 @@ namespace Discord.Commands
         ///     Indicates whether the operation was successful or not.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the result is positive; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the result is positive; otherwise <see langword="false" />.
         /// </returns>
         bool IsSuccess { get; }
     }

--- a/src/Discord.Net.Commands/Results/ParseResult.cs
+++ b/src/Discord.Net.Commands/Results/ParseResult.cs
@@ -23,7 +23,7 @@ namespace Discord.Commands
         /// </summary>
         /// <returns>
         ///     A <see cref="ParameterInfo" /> indicating the parameter info of the error that may have occurred during parsing; 
-        ///     <c>null</c> if the parsing was successful or the parsing error is not specific to a single parameter.
+        ///     <see langword="null" /> if the parsing was successful or the parsing error is not specific to a single parameter.
         /// </returns>
         public ParameterInfo ErrorParameter { get; }
 

--- a/src/Discord.Net.Commands/Results/RuntimeResult.cs
+++ b/src/Discord.Net.Commands/Results/RuntimeResult.cs
@@ -8,7 +8,7 @@ namespace Discord.Commands
         /// <summary>
         ///     Initializes a new <see cref="RuntimeResult" /> class with the type of error and reason.
         /// </summary>
-        /// <param name="error">The type of failure, or <c>null</c> if none.</param>
+        /// <param name="error">The type of failure, or <see langword="null" /> if none.</param>
         /// <param name="reason">The reason of failure.</param>
         protected RuntimeResult(CommandError? error, string reason)
         {

--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -170,7 +170,7 @@ namespace Discord
         ///     Gets or sets whether the initial log entry should be printed.
         /// </summary>
         /// <remarks>
-        ///     If set to <c>true</c>, the library will attempt to print the current version of the library, as well as
+        ///     If set to <see langword="true" />, the library will attempt to print the current version of the library, as well as
         ///     the API version it uses on startup.
         /// </remarks>
         internal bool DisplayInitialLog { get; set; } = true;
@@ -179,7 +179,7 @@ namespace Discord
         /// 	Gets or sets whether or not rate-limits should use the system clock.
         /// </summary>
         /// <remarks>
-        ///		If set to <c>false</c>, we will use the X-RateLimit-Reset-After header
+        ///		If set to <see langword="false" />, we will use the X-RateLimit-Reset-After header
         ///		to determine when a rate-limit expires, rather than comparing the
         ///		X-RateLimit-Reset timestamp to the system time.
         ///

--- a/src/Discord.Net.Core/Entities/Activities/GameAsset.cs
+++ b/src/Discord.Net.Core/Entities/Activities/GameAsset.cs
@@ -30,7 +30,7 @@ namespace Discord
         /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.</param>
         /// <param name="format">The format to return.</param>
         /// <returns>
-        ///     A string pointing to the image URL of the asset; <c>null</c> when the application ID does not exist.
+        ///     A string pointing to the image URL of the asset; <see langword="null" /> when the application ID does not exist.
         /// </returns>
         public string GetImageUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => ApplicationId.HasValue ? CDN.GetRichAssetUrl(ApplicationId.Value, ImageId, size, format) : null;

--- a/src/Discord.Net.Core/Entities/AuditLogs/IAuditLogEntry.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/IAuditLogEntry.cs
@@ -23,7 +23,7 @@ namespace Discord
         ///     Gets the data for this entry.
         /// </summary>
         /// <returns>
-        ///     An <see cref="IAuditLogData" /> for this audit log entry; <c>null</c> if no data is available.
+        ///     An <see cref="IAuditLogData" /> for this audit log entry; <see langword="null" /> if no data is available.
         /// </returns>
         IAuditLogData Data { get; }
 
@@ -39,7 +39,7 @@ namespace Discord
         ///     Gets the reason behind the change.
         /// </summary>
         /// <returns>
-        ///     A string containing the reason for the change; <c>null</c> if none is provided.
+        ///     A string containing the reason for the change; <see langword="null" /> if none is provided.
         /// </returns>
         string Reason { get; }
     }

--- a/src/Discord.Net.Core/Entities/Channels/IChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IChannel.cs
@@ -46,7 +46,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a user object that
-        ///     represents the found user; <c>null</c> if none is found.
+        ///     represents the found user; <see langword="null" /> if none is found.
         /// </returns>
         Task<IUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
     }

--- a/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IForumChannel.cs
@@ -16,7 +16,7 @@ namespace Discord
         ///     Gets a value that indicates whether the channel is NSFW.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the channel has the NSFW flag enabled; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the channel has the NSFW flag enabled; otherwise <see langword="false" />.
         /// </returns>
         bool IsNsfw { get; }
 
@@ -24,7 +24,7 @@ namespace Discord
         ///     Gets the current topic for this text channel.
         /// </summary>
         /// <returns>
-        ///     A string representing the topic set in the channel; <c>null</c> if none is set.
+        ///     A string representing the topic set in the channel; <see langword="null" /> if none is set.
         /// </returns>
         string Topic { get; }
 
@@ -103,7 +103,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
         /// <param name="stickers">A collection of stickers to send with the message.</param>
@@ -130,7 +130,7 @@ namespace Discord
         /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
         /// <param name="stickers">A collection of stickers to send with the file.</param>
@@ -159,7 +159,7 @@ namespace Discord
         /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
         /// <param name="stickers">A collection of stickers to send with the file.</param>
@@ -186,7 +186,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
         /// <param name="stickers">A collection of stickers to send with the file.</param>
@@ -212,7 +212,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
         /// <param name="stickers">A collection of stickers to send with the file.</param>

--- a/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IGuildChannel.cs
@@ -74,7 +74,7 @@ namespace Discord
         /// </summary>
         /// <param name="role">The role to get the overwrite from.</param>
         /// <returns>
-        ///     An overwrite object for the targeted role; <c>null</c> if none is set.
+        ///     An overwrite object for the targeted role; <see langword="null" /> if none is set.
         /// </returns>
         OverwritePermissions? GetPermissionOverwrite(IRole role);
         /// <summary>
@@ -82,7 +82,7 @@ namespace Discord
         /// </summary>
         /// <param name="user">The user to get the overwrite from.</param>
         /// <returns>
-        ///     An overwrite object for the targeted user; <c>null</c> if none is set.
+        ///     An overwrite object for the targeted user; <see langword="null" /> if none is set.
         /// </returns>
         OverwritePermissions? GetPermissionOverwrite(IUser user);
         /// <summary>
@@ -163,7 +163,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task representing the asynchronous get operation. The task result contains a guild user object that
-        ///     represents the user; <c>null</c> if none is found.
+        ///     represents the user; <see langword="null" /> if none is found.
         /// </returns>
         new Task<IGuildUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
     }

--- a/src/Discord.Net.Core/Entities/Channels/IIntegrationChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IIntegrationChannel.cs
@@ -28,7 +28,7 @@ public interface IIntegrationChannel : IGuildChannel
     /// <param name="options">The options to be used when sending the request.</param>
     /// <returns>
     ///     A task that represents the asynchronous get operation. The task result contains a webhook associated
-    ///     with the identifier; <c>null</c> if the webhook is not found.
+    ///     with the identifier; <see langword="null" /> if the webhook is not found.
     /// </returns>
     Task<IWebhook> GetWebhookAsync(ulong id, RequestOptions options = null);
 

--- a/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMessageChannel.cs
@@ -25,7 +25,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
@@ -67,7 +67,7 @@ namespace Discord
         /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
@@ -105,7 +105,7 @@ namespace Discord
         /// <param name="isSpoiler">Whether the message attachment should be hidden as a spoiler.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
@@ -135,7 +135,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
@@ -165,7 +165,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
@@ -186,7 +186,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous get operation for retrieving the message. The task result contains
-        ///     the retrieved message; <c>null</c> if no message is found with the specified identifier.
+        ///     the retrieved message; <see langword="null" /> if no message is found with the specified identifier.
         /// </returns>
         Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
 

--- a/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/INestedChannel.cs
@@ -13,7 +13,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="ulong"/> representing the snowflake identifier of the parent of this channel;
-        ///     <c>null</c> if none is set.
+        ///     <see langword="null" /> if none is set.
         /// </returns>
         ulong? CategoryId { get; }
         /// <summary>
@@ -23,7 +23,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the category channel
-        ///     representing the parent of this channel; <c>null</c> if none is set.
+        ///     representing the parent of this channel; <see langword="null" /> if none is set.
         /// </returns>
         Task<ICategoryChannel> GetCategoryAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
 
@@ -46,10 +46,10 @@ namespace Discord
         ///     await guildChannel.CreateInviteAsync(maxAge: 43200, maxUses: 3);
         ///     </code>
         /// </example>
-        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
-        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
-        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
-        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
+        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <see langword="null" /> to never expire.</param>
+        /// <param name="maxUses">The max amount of times this invite may be used. Set to <see langword="null" /> to have unlimited uses.</param>
+        /// <param name="isTemporary">If <see langword="true" />, the user accepting this invite will be kicked from the guild after closing their client.</param>
+        /// <param name="isUnique">If <see langword="true" />, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous invite creation operation. The task result contains an invite
@@ -61,10 +61,10 @@ namespace Discord
         ///     Creates a new invite to this channel.
         /// </summary>
         /// <param name="applicationId">The id of the embedded application to open for this invite.</param>
-        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
-        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
-        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
-        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
+        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <see langword="null" /> to never expire.</param>
+        /// <param name="maxUses">The max amount of times this invite may be used. Set to <see langword="null" /> to have unlimited uses.</param>
+        /// <param name="isTemporary">If <see langword="true" />, the user accepting this invite will be kicked from the guild after closing their client.</param>
+        /// <param name="isUnique">If <see langword="true" />, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous invite creation operation. The task result contains an invite
@@ -76,10 +76,10 @@ namespace Discord
         ///     Creates a new invite to this channel.
         /// </summary>
         /// <param name="application">The application to open for this invite.</param>
-        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
-        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
-        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
-        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
+        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <see langword="null" /> to never expire.</param>
+        /// <param name="maxUses">The max amount of times this invite may be used. Set to <see langword="null" /> to have unlimited uses.</param>
+        /// <param name="isTemporary">If <see langword="true" />, the user accepting this invite will be kicked from the guild after closing their client.</param>
+        /// <param name="isUnique">If <see langword="true" />, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous invite creation operation. The task result contains an invite
@@ -98,10 +98,10 @@ namespace Discord
         ///     </code>
         /// </example>
         /// <param name="user">The id of the user whose stream to display for this invite.</param>
-        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <c>null</c> to never expire.</param>
-        /// <param name="maxUses">The max amount of times this invite may be used. Set to <c>null</c> to have unlimited uses.</param>
-        /// <param name="isTemporary">If <c>true</c>, the user accepting this invite will be kicked from the guild after closing their client.</param>
-        /// <param name="isUnique">If <c>true</c>, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
+        /// <param name="maxAge">The time (in seconds) until the invite expires. Set to <see langword="null" /> to never expire.</param>
+        /// <param name="maxUses">The max amount of times this invite may be used. Set to <see langword="null" /> to have unlimited uses.</param>
+        /// <param name="isTemporary">If <see langword="true" />, the user accepting this invite will be kicked from the guild after closing their client.</param>
+        /// <param name="isUnique">If <see langword="true" />, don't try to reuse a similar invite (useful for creating many unique one time use invites).</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous invite creation operation. The task result contains an invite

--- a/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ITextChannel.cs
@@ -14,7 +14,7 @@ namespace Discord
         ///     Gets a value that indicates whether the channel is NSFW.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the channel has the NSFW flag enabled; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the channel has the NSFW flag enabled; otherwise <see langword="false" />.
         /// </returns>
         bool IsNsfw { get; }
 
@@ -22,7 +22,7 @@ namespace Discord
         ///     Gets the current topic for this text channel.
         /// </summary>
         /// <returns>
-        ///     A string representing the topic set in the channel; <c>null</c> if none is set.
+        ///     A string representing the topic set in the channel; <see langword="null" /> if none is set.
         /// </returns>
         string Topic { get; }
 

--- a/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IVoiceChannel.cs
@@ -22,7 +22,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     An <see cref="int"/> representing the maximum number of users that are allowed to be connected to this
-        ///     channel at once; <c>null</c> if a limit is not set.
+        ///     channel at once; <see langword="null" /> if a limit is not set.
         /// </returns>
         int? UserLimit { get; }
 

--- a/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/TextChannelProperties.cs
@@ -13,7 +13,7 @@ namespace Discord
         ///     Gets or sets the topic of the channel.
         /// </summary>
         /// <remarks>
-        ///     Setting this value to any string other than <c>null</c> or <see cref="string.Empty"/> will set the
+        ///     Setting this value to any string other than <see langword="null" /> or <see cref="string.Empty"/> will set the
         ///     channel topic or description to the desired value.
         /// </remarks>
         public Optional<string> Topic { get; set; }
@@ -21,8 +21,8 @@ namespace Discord
         ///     Gets or sets whether this channel should be flagged as NSFW.
         /// </summary>
         /// <remarks>
-        ///     Setting this value to <c>true</c> will mark the channel as NSFW (Not Safe For Work) and will prompt the
-        ///     user about its possibly mature nature before they may view the channel; setting this value to <c>false</c> will
+        ///     Setting this value to <see langword="true" /> will mark the channel as NSFW (Not Safe For Work) and will prompt the
+        ///     user about its possibly mature nature before they may view the channel; setting this value to <see langword="false" /> will
         ///     remove the NSFW indicator.
         /// </remarks>
         public Optional<bool> IsNsfw { get; set; }

--- a/src/Discord.Net.Core/Entities/Channels/VoiceChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/VoiceChannelProperties.cs
@@ -12,7 +12,7 @@ public class VoiceChannelProperties : TextChannelProperties
     /// </summary>
     public Optional<int> Bitrate { get; set; }
     /// <summary>
-    ///     Gets or sets the maximum number of users that can be present in a channel, or <c>null</c> if none.
+    ///     Gets or sets the maximum number of users that can be present in a channel, or <see langword="null" /> if none.
     /// </summary>
     public Optional<int?> UserLimit { get; set; }
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/GuildEmote.cs
@@ -35,7 +35,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     An <see cref="ulong"/> snowflake identifier representing the user who created this emoji; 
-        ///     <c>null</c> if unknown.
+        ///     <see langword="null" /> if unknown.
         /// </returns>
         public ulong? CreatorId { get; }
 

--- a/src/Discord.Net.Core/Entities/Guilds/IBan.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IBan.cs
@@ -16,7 +16,7 @@ namespace Discord
         ///     Gets the reason why the user is banned if specified.
         /// </summary>
         /// <returns>
-        ///     A string containing the reason behind the ban; <c>null</c> if none is specified.
+        ///     A string containing the reason behind the ban; <see langword="null" /> if none is specified.
         /// </returns>
         string Reason { get; }
     }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -115,7 +115,7 @@ namespace Discord
         ///     This boolean is used to determine if the guild is currently connected to the WebSocket and is ready to be used/accessed.
         /// </remarks>
         /// <returns>
-        ///     <c>true</c> if this guild is currently connected and ready to be used; otherwise <see langword="false"/>.
+        ///     <see langword="true" /> if this guild is currently connected and ready to be used; otherwise <see langword="false"/>.
         /// </returns>
         bool Available { get; }
 
@@ -966,7 +966,7 @@ namespace Discord
         ///         This method removes all users that have not logged on in the provided number of <paramref name="days"/>.
         ///     </para>
         ///     <para>
-        ///         If <paramref name="simulate" /> is <c>true</c>, this method will only return the number of users that
+        ///         If <paramref name="simulate" /> is <see langword="true" />, this method will only return the number of users that
         ///         would be removed without kicking the users.
         ///     </para>
         /// </remarks>

--- a/src/Discord.Net.Core/Entities/Guilds/IUserGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IUserGuild.cs
@@ -7,11 +7,11 @@ namespace Discord
         /// </summary>
         string Name { get; }
         /// <summary>
-        ///     Gets the icon URL associated with this guild, or <c>null</c> if one is not set.
+        ///     Gets the icon URL associated with this guild, or <see langword="null" /> if one is not set.
         /// </summary>
         string IconUrl { get; }
         /// <summary>
-        ///     Returns <c>true</c> if the current user owns this guild.
+        ///     Returns <see langword="true" /> if the current user owns this guild.
         /// </summary>
         bool IsOwner { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IVoiceRegion.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IVoiceRegion.cs
@@ -23,28 +23,28 @@ namespace Discord
         ///     Gets a value that indicates whether or not this voice region is exclusive to partnered servers.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this voice region is exclusive to VIP accounts; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this voice region is exclusive to VIP accounts; otherwise <see langword="false" />.
         /// </returns>
         bool IsVip { get; }
         /// <summary>
         ///     Gets a value that indicates whether this voice region is optimal for your client in terms of latency.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this voice region is the closest to your machine; otherwise <c>false</c> .
+        ///     <see langword="true" /> if this voice region is the closest to your machine; otherwise <see langword="false" /> .
         /// </returns>
         bool IsOptimal { get; }
         /// <summary>
         ///     Gets a value that indicates whether this voice region is no longer being maintained.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this is a deprecated voice region; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this is a deprecated voice region; otherwise <see langword="false" />.
         /// </returns>
         bool IsDeprecated { get; }
         /// <summary>
         ///     Gets a value that indicates whether this voice region is custom-made for events.
         /// </summary>
         /// <returns> 
-        ///     <c>true</c> if this is a custom voice region (used for events/etc); otherwise <c>false</c>/
+        ///     <see langword="true" /> if this is a custom voice region (used for events/etc); otherwise <see langword="false" />/
         /// </returns>
         bool IsCustom { get; }
     }

--- a/src/Discord.Net.Core/Entities/Image.cs
+++ b/src/Discord.Net.Core/Entities/Image.cs
@@ -41,7 +41,7 @@ namespace Discord
         /// <paramref name="path" /> is a zero-length string, contains only white space, or contains one or more invalid
         /// characters as defined by <see cref="Path.GetInvalidPathChars"/>.
         /// </exception>
-        /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <see langword="null" />.</exception>
         /// <exception cref="PathTooLongException">
         /// The specified path, file name, or both exceed the system-defined maximum length. For example, on
         /// Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260

--- a/src/Discord.Net.Core/Entities/Integrations/IIntegration.cs
+++ b/src/Discord.Net.Core/Entities/Integrations/IIntegration.cs
@@ -33,7 +33,7 @@ namespace Discord
         ///     Gets a value that indicates whether this integration is enabled or not.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this integration is enabled; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this integration is enabled; otherwise <see langword="false" />.
         /// </returns>
         bool IsEnabled { get; }
         /// <summary>
@@ -44,7 +44,7 @@ namespace Discord
         ///     disabled will not. A user must manually choose when sync the integration if syncing is disabled.
         /// </remarks>
         /// <returns>
-        ///      <c>true</c> if this integration is syncing; otherwise <c>false</c>.
+        ///      <see langword="true" /> if this integration is syncing; otherwise <see langword="false" />.
         /// </returns>
         bool? IsSyncing { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Invites/IInviteMetadata.cs
+++ b/src/Discord.Net.Core/Entities/Invites/IInviteMetadata.cs
@@ -11,15 +11,15 @@ namespace Discord
         ///     Gets a value that indicates whether the invite is a temporary one.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if users accepting this invite will be removed from the guild when they log off; otherwise 
-        ///     <c>false</c>.
+        ///     <see langword="true" /> if users accepting this invite will be removed from the guild when they log off; otherwise 
+        ///     <see langword="false" />.
         /// </returns>
         bool IsTemporary { get; }
         /// <summary>
         ///     Gets the time (in seconds) until the invite expires.
         /// </summary>
         /// <returns>
-        ///     An <see cref="int"/> representing the time in seconds until this invite expires; <c>null</c> if this
+        ///     An <see cref="int"/> representing the time in seconds until this invite expires; <see langword="null" /> if this
         ///     invite never expires.
         /// </returns>
         int? MaxAge { get; }
@@ -28,7 +28,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     An <see cref="int"/> representing the number of uses this invite may be accepted until it is removed
-        ///     from the guild; <c>null</c> if none is set.
+        ///     from the guild; <see langword="null" /> if none is set.
         /// </returns>
         int? MaxUses { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AllowedMentions.cs
@@ -29,7 +29,7 @@ namespace Discord
         ///     The <see cref="AllowedMentionTypes.Users"/> flag is mutually exclusive with the <see cref="UserIds"/>
         ///     property, and the <see cref="AllowedMentionTypes.Roles"/> flag is mutually exclusive with the
         ///     <see cref="RoleIds"/> property.
-        ///     If <c>null</c>, only the ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
+        ///     If <see langword="null" />, only the ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
         /// </remarks>
         public AllowedMentionTypes? AllowedTypes { get; set; }
 
@@ -37,7 +37,7 @@ namespace Discord
         ///     Gets or sets the list of all role ids that will be mentioned.
         ///     This property is mutually exclusive with the <see cref="AllowedMentionTypes.Roles"/>
         ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
-        ///     must be <c>null</c> or empty.
+        ///     must be <see langword="null" /> or empty.
         /// </summary>
         public List<ulong> RoleIds { get; set; } = new List<ulong>();
 
@@ -45,7 +45,7 @@ namespace Discord
         ///     Gets or sets the list of all user ids that will be mentioned.
         ///     This property is mutually exclusive with the <see cref="AllowedMentionTypes.Users"/>
         ///     flag of the <see cref="AllowedTypes"/> property. If the flag is set, the value of this property
-        ///     must be <c>null</c> or empty.
+        ///     must be <see langword="null" /> or empty.
         /// </summary>
         public List<ulong> UserIds { get; set; } = new List<ulong>();
 
@@ -62,7 +62,7 @@ namespace Discord
         /// </summary>
         /// <param name="allowedTypes">
         ///     The types of mentions to parse from the message content.
-        ///     If <c>null</c>, only the ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
+        ///     If <see langword="null" />, only the ids specified in <see cref="UserIds"/> and <see cref="RoleIds"/> will be mentioned.
         /// </param>
         public AllowedMentions(AllowedMentionTypes? allowedTypes = null)
         {

--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -93,7 +93,7 @@ namespace Discord
 
         /// <summary> Gets or sets the list of <see cref="EmbedFieldBuilder"/> of an <see cref="Embed"/>. </summary>
         /// <exception cref="ArgumentNullException" accessor="set">An embed builder's fields collection is set to
-        /// <c>null</c>.</exception>
+        /// <see langword="null" />.</exception>
         /// <exception cref="ArgumentException" accessor="set">Fields count exceeds <see cref="MaxFieldCount"/>.
         /// </exception>
         /// <returns> The list of existing <see cref="EmbedFieldBuilder"/>.</returns>
@@ -114,28 +114,28 @@ namespace Discord
         ///     Gets or sets the timestamp of an <see cref="Embed"/>.
         /// </summary>
         /// <returns>
-        ///     The timestamp of the embed, or <c>null</c> if none is set.
+        ///     The timestamp of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         public DateTimeOffset? Timestamp { get; set; }
         /// <summary>
         ///     Gets or sets the sidebar color of an <see cref="Embed"/>.
         /// </summary>
         /// <returns>
-        ///     The color of the embed, or <c>null</c> if none is set.
+        ///     The color of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         public Color? Color { get; set; }
         /// <summary>
         ///     Gets or sets the <see cref="EmbedAuthorBuilder" /> of an <see cref="Embed"/>.
         /// </summary>
         /// <returns>
-        ///     The author field builder of the embed, or <c>null</c> if none is set.
+        ///     The author field builder of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         public EmbedAuthorBuilder Author { get; set; }
         /// <summary>
         ///     Gets or sets the <see cref="EmbedFooterBuilder" /> of an <see cref="Embed"/>.
         /// </summary>
         /// <returns>
-        ///     The footer field builder of the embed, or <c>null</c> if none is set.
+        ///     The footer field builder of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         public EmbedFooterBuilder Footer { get; set; }
 
@@ -556,7 +556,7 @@ namespace Discord
         ///     Gets or sets the field name.
         /// </summary>
         /// <exception cref="ArgumentException">
-        /// <para>Field name is <c>null</c>, empty or entirely whitespace.</para>
+        /// <para>Field name is <see langword="null" />, empty or entirely whitespace.</para>
         /// <para><c>- or -</c></para>
         /// <para>Field name length exceeds <see cref="MaxFieldNameLength"/>.</para>
         /// </exception>
@@ -580,7 +580,7 @@ namespace Discord
         ///     Gets or sets the field value.
         /// </summary>
         /// <exception cref="ArgumentException" accessor="set">
-        /// <para>Field value is <c>null</c>, empty or entirely whitespace.</para>
+        /// <para>Field value is <see langword="null" />, empty or entirely whitespace.</para>
         /// <para><c>- or -</c></para>
         /// <para>Field value length exceeds <see cref="MaxFieldValueLength"/>.</para>
         /// </exception>
@@ -648,7 +648,7 @@ namespace Discord
         ///     The current builder.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// <para><see cref="Name"/> or <see cref="Value"/> is <c>null</c>, empty or entirely whitespace.</para>
+        /// <para><see cref="Name"/> or <see cref="Value"/> is <see langword="null" />, empty or entirely whitespace.</para>
         /// <para><c>- or -</c></para>
         /// <para><see cref="Name"/> or <see cref="Value"/> exceeds the maximum length allowed by Discord.</para>
         /// </exception>

--- a/src/Discord.Net.Core/Entities/Messages/EmbedImage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedImage.cs
@@ -26,7 +26,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="int"/> representing the height of this image if it can be retrieved; otherwise 
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </returns>
         public int? Height { get; }
         /// <summary>
@@ -34,7 +34,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="int"/> representing the width of this image if it can be retrieved; otherwise 
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </returns>
         public int? Width { get; }
 

--- a/src/Discord.Net.Core/Entities/Messages/EmbedThumbnail.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedThumbnail.cs
@@ -26,7 +26,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="int"/> representing the height of this thumbnail if it can be retrieved; otherwise 
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </returns>
         public int? Height { get; }
         /// <summary>
@@ -34,7 +34,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="int"/> representing the width of this thumbnail if it can be retrieved; otherwise 
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </returns>
         public int? Width { get; }
 

--- a/src/Discord.Net.Core/Entities/Messages/EmbedVideo.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedVideo.cs
@@ -21,7 +21,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="int"/> representing the height of this video if it can be retrieved; otherwise 
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </returns>
         public int? Height { get; }
         /// <summary>
@@ -29,7 +29,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="int"/> representing the width of this video if it can be retrieved; otherwise 
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </returns>
         public int? Width { get; }
 

--- a/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
@@ -71,7 +71,7 @@ namespace Discord
         /// <paramref name="path" /> is a zero-length string, contains only white space, or contains one or more invalid
         /// characters as defined by <see cref="Path.GetInvalidPathChars"/>.
         /// </exception>
-        /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <see langword="null" />.</exception>
         /// <exception cref="PathTooLongException">
         /// The specified path, file name, or both exceed the system-defined maximum length. For example, on
         /// Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260

--- a/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
@@ -45,14 +45,14 @@ namespace Discord
         ///     Gets the height of this attachment.
         /// </summary>
         /// <returns>
-        ///     The height of this attachment if it is a picture; otherwise <c>null</c>.
+        ///     The height of this attachment if it is a picture; otherwise <see langword="null" />.
         /// </returns>
         int? Height { get; }
         /// <summary>
         ///     Gets the width of this attachment.
         /// </summary>
         /// <returns>
-        ///     The width of this attachment if it is a picture; otherwise <c>null</c>.
+        ///     The width of this attachment if it is a picture; otherwise <see langword="null" />.
         /// </returns>
         int? Width { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IEmbed.cs
@@ -41,56 +41,56 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="DateTimeOffset"/> based on the timestamp present at the bottom left of the embed, or 
-        ///     <c>null</c> if none is set.
+        ///     <see langword="null" /> if none is set.
         /// </returns>
         DateTimeOffset? Timestamp { get; }
         /// <summary>
         ///     Gets the color of this embed.
         /// </summary>
         /// <returns>
-        ///     The color of the embed present on the side of the embed, or <c>null</c> if none is set.
+        ///     The color of the embed present on the side of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         Color? Color { get; }
         /// <summary>
         ///     Gets the image of this embed.
         /// </summary>
         /// <returns>
-        ///     The image of the embed, or <c>null</c> if none is set.
+        ///     The image of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         EmbedImage? Image { get; }
         /// <summary>
         ///     Gets the video of this embed.
         /// </summary>
         /// <returns>
-        ///     The video of the embed, or <c>null</c> if none is set.
+        ///     The video of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         EmbedVideo? Video { get; }
         /// <summary>
         ///     Gets the author field of this embed.
         /// </summary>
         /// <returns>
-        ///     The author field of the embed, or <c>null</c> if none is set.
+        ///     The author field of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         EmbedAuthor? Author { get; }
         /// <summary>
         ///     Gets the footer field of this embed.
         /// </summary>
         /// <returns>
-        ///     The author field of the embed, or <c>null</c> if none is set.
+        ///     The author field of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         EmbedFooter? Footer { get; }
         /// <summary>
         ///     Gets the provider of this embed.
         /// </summary>
         /// <returns>
-        ///     The source of the embed, or <c>null</c> if none is set.
+        ///     The source of the embed, or <see langword="null" /> if none is set.
         /// </returns>
         EmbedProvider? Provider { get; }
         /// <summary>
         ///     Gets the thumbnail featured in this embed.
         /// </summary>
         /// <returns>
-        ///     The thumbnail featured in the embed, or <c>null</c> if none is set.
+        ///     The thumbnail featured in the embed, or <see langword="null" /> if none is set.
         /// </returns>
         EmbedThumbnail? Thumbnail { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Messages/IMessage.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IMessage.cs
@@ -21,28 +21,28 @@ namespace Discord
         ///     Gets the value that indicates whether this message was meant to be read-aloud by Discord.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this message was sent as a text-to-speech message; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this message was sent as a text-to-speech message; otherwise <see langword="false" />.
         /// </returns>
         bool IsTTS { get; }
         /// <summary>
         ///     Gets the value that indicates whether this message is pinned.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this message was added to its channel's pinned messages; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this message was added to its channel's pinned messages; otherwise <see langword="false" />.
         /// </returns>
         bool IsPinned { get; }
         /// <summary>
         ///     Gets the value that indicates whether or not this message's embeds are suppressed.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the embeds in this message have been suppressed (made invisible); otherwise <c>false</c>.
+        ///     <see langword="true" /> if the embeds in this message have been suppressed (made invisible); otherwise <see langword="false" />.
         /// </returns>
         bool IsSuppressed { get; }
         /// <summary>
         ///     Gets the value that indicates whether this message mentioned everyone.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this message mentioned everyone; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this message mentioned everyone; otherwise <see langword="false" />.
         /// </returns>
         bool MentionedEveryone { get; }
         /// <summary>
@@ -76,7 +76,7 @@ namespace Discord
         ///     Gets the time of this message's last edit.
         /// </summary>
         /// <returns>
-        ///     Time of when the message was last edited; <c>null</c> if the message is never edited.
+        ///     Time of when the message was last edited; <see langword="null" /> if the message is never edited.
         /// </returns>
         DateTimeOffset? EditedTimestamp { get; }
 

--- a/src/Discord.Net.Core/Entities/Messages/ReactionMetadata.cs
+++ b/src/Discord.Net.Core/Entities/Messages/ReactionMetadata.cs
@@ -17,7 +17,7 @@ namespace Discord
         ///     Gets a value that indicates whether the current user has reacted to this.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the user has reacted to the message; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the user has reacted to the message; otherwise <see langword="false" />.
         /// </returns>
         public bool IsMe { get; internal set; }
     }

--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -364,7 +364,7 @@ namespace Discord
         ///     in these permissions.
         /// </summary>
         /// <param name="permission">The permission value to check for.</param>
-        /// <returns><see langword="true"/> if the permission is enabled, <c>false</c> otherwise.</returns>
+        /// <returns><see langword="true"/> if the permission is enabled, <see langword="false" /> otherwise.</returns>
         public bool Has(GuildPermission permission) => Permissions.GetValue(RawValue, permission);
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/OverwritePermissions.cs
@@ -83,21 +83,21 @@ namespace Discord
         public PermValue ManageRoles => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ManageRoles);
         /// <summary> If True, a user may edit the webhooks for this channel. </summary>
         public PermValue ManageWebhooks => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ManageWebhooks);
-        /// <summary> If <c>true</c>, a user may use slash commands in this guild. </summary>
+        /// <summary> If <see langword="true" />, a user may use slash commands in this guild. </summary>
         public PermValue UseApplicationCommands => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.UseApplicationCommands);
-        /// <summary> If <c>true</c>, a user may request to speak in stage channels. </summary>
+        /// <summary> If <see langword="true" />, a user may request to speak in stage channels. </summary>
         public PermValue RequestToSpeak => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.RequestToSpeak);
-        /// <summary> If <c>true</c>, a user may manage threads in this guild. </summary>
+        /// <summary> If <see langword="true" />, a user may manage threads in this guild. </summary>
         public PermValue ManageThreads => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.ManageThreads);
-        /// <summary> If <c>true</c>, a user may create public threads in this guild. </summary>
+        /// <summary> If <see langword="true" />, a user may create public threads in this guild. </summary>
         public PermValue CreatePublicThreads => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.CreatePublicThreads);
-        /// <summary> If <c>true</c>, a user may create private threads in this guild. </summary>
+        /// <summary> If <see langword="true" />, a user may create private threads in this guild. </summary>
         public PermValue CreatePrivateThreads => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.CreatePrivateThreads);
-        /// <summary> If <c>true</c>, a user may use external stickers in this guild. </summary>
+        /// <summary> If <see langword="true" />, a user may use external stickers in this guild. </summary>
         public PermValue UseExternalStickers => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.UseExternalStickers);
-        /// <summary> If <c>true</c>, a user may send messages in threads in this guild. </summary>
+        /// <summary> If <see langword="true" />, a user may send messages in threads in this guild. </summary>
         public PermValue SendMessagesInThreads => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.SendMessagesInThreads);
-        /// <summary> If <c>true</c>, a user launch application activities in voice channels in this guild. </summary>
+        /// <summary> If <see langword="true" />, a user launch application activities in voice channels in this guild. </summary>
         public PermValue StartEmbeddedActivities => Permissions.GetValue(AllowValue, DenyValue, ChannelPermission.StartEmbeddedActivities);
 
         /// <summary> Creates a new OverwritePermissions with the provided allow and deny packed values. </summary>

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -27,21 +27,21 @@ namespace Discord
         ///     Gets a value that indicates whether the role can be separated in the user list.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if users of this role are separated in the user list; otherwise <c>false</c>.
+        ///     <see langword="true" /> if users of this role are separated in the user list; otherwise <see langword="false" />.
         /// </returns>
         bool IsHoisted { get; }
         /// <summary>
         ///     Gets a value that indicates whether the role is managed by Discord.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this role is automatically managed by Discord; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this role is automatically managed by Discord; otherwise <see langword="false" />.
         /// </returns>
         bool IsManaged { get; }
         /// <summary>
         ///     Gets a value that indicates whether the role is mentionable.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this role may be mentioned in messages; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this role may be mentioned in messages; otherwise <see langword="false" />.
         /// </returns>
         bool IsMentionable { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/AddGuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/AddGuildUserProperties.cs
@@ -12,7 +12,7 @@ namespace Discord
         ///     Gets or sets the user's nickname.
         /// </summary>
         /// <remarks>
-        ///     To clear the user's nickname, this value can be set to <c>null</c> or
+        ///     To clear the user's nickname, this value can be set to <see langword="null" /> or
         ///     <see cref="string.Empty"/>.
         /// </remarks>
         public Optional<string> Nickname { get; set; }
@@ -20,14 +20,14 @@ namespace Discord
         ///     Gets or sets whether the user should be muted in a voice channel.
         /// </summary>
         /// <remarks>
-        ///     If this value is set to <c>true</c>, no user will be able to hear this user speak in the guild.
+        ///     If this value is set to <see langword="true" />, no user will be able to hear this user speak in the guild.
         /// </remarks>
         public Optional<bool> Mute { get; set; }
         /// <summary>
         ///     Gets or sets whether the user should be deafened in a voice channel.
         /// </summary>
         /// <remarks>
-        ///     If this value is set to <c>true</c>, this user will not be able to hear anyone speak in the guild.
+        ///     If this value is set to <see langword="true" />, this user will not be able to hear anyone speak in the guild.
         /// </remarks>
         public Optional<bool> Deaf { get; set; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
+++ b/src/Discord.Net.Core/Entities/Users/GuildUserProperties.cs
@@ -13,21 +13,21 @@ namespace Discord
         ///     Gets or sets whether the user should be muted in a voice channel.
         /// </summary>
         /// <remarks>
-        ///     If this value is set to <c>true</c>, no user will be able to hear this user speak in the guild.
+        ///     If this value is set to <see langword="true" />, no user will be able to hear this user speak in the guild.
         /// </remarks>
         public Optional<bool> Mute { get; set; }
         /// <summary>
         ///     Gets or sets whether the user should be deafened in a voice channel.
         /// </summary>
         /// <remarks>
-        ///     If this value is set to <c>true</c>, this user will not be able to hear anyone speak in the guild.
+        ///     If this value is set to <see langword="true" />, this user will not be able to hear anyone speak in the guild.
         /// </remarks>
         public Optional<bool> Deaf { get; set; }
         /// <summary>
         ///     Gets or sets the user's nickname.
         /// </summary>
         /// <remarks>
-        ///     To clear the user's nickname, this value can be set to <c>null</c> or
+        ///     To clear the user's nickname, this value can be set to <see langword="null" /> or
         ///     <see cref="string.Empty"/>.
         /// </remarks>
         public Optional<string> Nickname { get; set; }
@@ -60,7 +60,7 @@ namespace Discord
         /// </remarks>
         public Optional<IEnumerable<ulong>> RoleIds { get; set; }
         /// <summary>
-        ///     Moves a user to a voice channel. If <c>null</c>, this user will be disconnected from their current voice channel.
+        ///     Moves a user to a voice channel. If <see langword="null" />, this user will be disconnected from their current voice channel.
         /// </summary>
         /// <remarks>
         ///     This user MUST already be in a <see cref="IVoiceChannel"/> for this to work.
@@ -68,7 +68,7 @@ namespace Discord
         /// </remarks>
         public Optional<IVoiceChannel> Channel { get; set; }
         /// <summary>
-        ///     Moves a user to a voice channel. Set <see cref="Channel"/> to <c>null</c> to disconnect this user from their current voice channel.
+        ///     Moves a user to a voice channel. Set <see cref="Channel"/> to <see langword="null" /> to disconnect this user from their current voice channel.
         /// </summary>
         /// <remarks>
         ///     This user MUST already be in a <see cref="IVoiceChannel"/> for this to work.

--- a/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IGuildUser.cs
@@ -14,7 +14,7 @@ namespace Discord
         /// </summary>
         /// <returns>
         ///     A <see cref="DateTimeOffset"/> representing the time of which the user has joined the guild; 
-        ///     <c>null</c> when it cannot be obtained.
+        ///     <see langword="null" /> when it cannot be obtained.
         /// </returns>
         DateTimeOffset? JoinedAt { get; }
         /// <summary>
@@ -28,7 +28,7 @@ namespace Discord
         ///     Gets the nickname for this user.
         /// </summary>
         /// <returns>
-        ///     A string representing the nickname of the user; <c>null</c> if none is set.
+        ///     A string representing the nickname of the user; <see langword="null" /> if none is set.
         /// </returns>
         string Nickname { get; }
         /// <summary>
@@ -73,7 +73,7 @@ namespace Discord
         ///     Gets the date and time for when this user's guild boost began.
         /// </summary>
         /// <returns>
-        ///     A <see cref="DateTimeOffset"/> for when the user began boosting this guild; <c>null</c> if they are not boosting the guild.
+        ///     A <see cref="DateTimeOffset"/> for when the user began boosting this guild; <see langword="null" /> if they are not boosting the guild.
         /// </returns>
         DateTimeOffset? PremiumSince { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/ISelfUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/ISelfUser.cs
@@ -16,14 +16,14 @@ namespace Discord
         ///     Indicates whether or not this user has their email verified.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this user's email has been verified; <c>false</c> if not.
+        ///     <see langword="true" /> if this user's email has been verified; <see langword="false" /> if not.
         /// </returns>
         bool IsVerified { get; }
         /// <summary>
         ///     Indicates whether or not this user has MFA enabled on their account.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this user has enabled multi-factor authentication on their account; <c>false</c> if not.
+        ///     <see langword="true" /> if this user has enabled multi-factor authentication on their account; <see langword="false" /> if not.
         /// </returns>
         bool IsMfaEnabled { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -16,7 +16,7 @@ namespace Discord
         /// </summary>
         /// <remarks>
         ///     This property retrieves a URL for this user's avatar. In event that the user does not have a valid avatar
-        ///     (i.e. their avatar identifier is not set), this method will return <c>null</c>. If you wish to
+        ///     (i.e. their avatar identifier is not set), this method will return <see langword="null" />. If you wish to
         ///     retrieve the default avatar for this user, consider using <see cref="IUser.GetDefaultAvatarUrl"/> (see
         ///     example).
         /// </remarks>
@@ -31,7 +31,7 @@ namespace Discord
         /// <param name="size">The size of the image to return in. This can be any power of two between 16 and 2048.
         /// </param>
         /// <returns>
-        ///     A string representing the user's avatar URL; <c>null</c> if the user does not have an avatar in place.
+        ///     A string representing the user's avatar URL; <see langword="null" /> if the user does not have an avatar in place.
         /// </returns>
         string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128);
         /// <summary>
@@ -62,14 +62,14 @@ namespace Discord
         ///     (indicated by the blue BOT tag within the official chat client).
         /// </remarks>
         /// <returns>
-        ///     <c>true</c> if the user is a bot application; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the user is a bot application; otherwise <see langword="false" />.
         /// </returns>
         bool IsBot { get; }
         /// <summary>
         ///     Gets a value that indicates whether this user is a webhook user.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the user is a webhook; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the user is a webhook; otherwise <see langword="false" />.
         /// </returns>
         bool IsWebhook { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/IVoiceState.cs
+++ b/src/Discord.Net.Core/Entities/Users/IVoiceState.cs
@@ -11,8 +11,8 @@ namespace Discord
         ///     Gets a value that indicates whether this user is deafened by the guild.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the user is deafened (i.e. not permitted to listen to or speak to others) by the guild;
-        ///     otherwise <c>false</c>.
+        ///     <see langword="true" /> if the user is deafened (i.e. not permitted to listen to or speak to others) by the guild;
+        ///     otherwise <see langword="false" />.
         /// </returns>
         bool IsDeafened { get; }
         /// <summary>
@@ -20,14 +20,14 @@ namespace Discord
         ///     guild.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this user is muted by the guild; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this user is muted by the guild; otherwise <see langword="false" />.
         /// </returns>
         bool IsMuted { get; }
         /// <summary>
         ///     Gets a value that indicates whether this user has marked themselves as deafened.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this user has deafened themselves (i.e. not permitted to listen to or speak to others); otherwise <c>false</c>.
+        ///     <see langword="true" /> if this user has deafened themselves (i.e. not permitted to listen to or speak to others); otherwise <see langword="false" />.
         /// </returns>
         bool IsSelfDeafened { get; }
         /// <summary>
@@ -35,21 +35,21 @@ namespace Discord
         ///     speak via voice).
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this user has muted themselves; otherwise <c>false</c>.
+        ///     <see langword="true" /> if this user has muted themselves; otherwise <see langword="false" />.
         /// </returns>
         bool IsSelfMuted { get; }
         /// <summary>
         ///     Gets a value that indicates whether the user is muted by the current user.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the guild is temporarily blocking audio to/from this user; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the guild is temporarily blocking audio to/from this user; otherwise <see langword="false" />.
         /// </returns>
         bool IsSuppressed { get; }
         /// <summary>
         ///     Gets the voice channel this user is currently in.
         /// </summary>
         /// <returns>
-        ///     A generic voice channel object representing the voice channel that the user is currently in; <c>null</c>
+        ///     A generic voice channel object representing the voice channel that the user is currently in; <see langword="null" />
         ///     if none.
         /// </returns>
         IVoiceChannel VoiceChannel { get; }
@@ -61,14 +61,14 @@ namespace Discord
         ///     Gets a value that indicates if this user is streaming in a voice channel.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the user is streaming; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the user is streaming; otherwise <see langword="false" />.
         /// </returns>
         bool IsStreaming { get; }
         /// <summary>
         ///     Gets a value that indicates if the user is videoing in a voice channel.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the user has their camera turned on; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the user has their camera turned on; otherwise <see langword="false" />.
         /// </returns>
         bool IsVideoing { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/MessageExtensions.cs
@@ -84,7 +84,7 @@ namespace Discord
         /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>

--- a/src/Discord.Net.Core/Extensions/UserExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/UserExtensions.cs
@@ -31,7 +31,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <param name="allowedMentions">
         ///     Specifies if notifications are sent for mentioned users and roles in the message <paramref name="text"/>.
-        ///     If <c>null</c>, all mentioned roles and users will be notified.
+        ///     If <see langword="null" />, all mentioned roles and users will be notified.
         /// </param>
         /// <param name="components">The message components to be included with this message. Used for interactions.</param>
         /// <param name="embeds">A array of <see cref="Embed"/>s to send with this response. Max 10.</param>

--- a/src/Discord.Net.Core/IDiscordClient.cs
+++ b/src/Discord.Net.Core/IDiscordClient.cs
@@ -76,7 +76,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the channel associated
-        ///     with the snowflake identifier; <c>null</c> when the channel cannot be found.
+        ///     with the snowflake identifier; <see langword="null" /> when the channel cannot be found.
         /// </returns>
         Task<IChannel> GetChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -192,7 +192,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the guild associated
-        ///     with the snowflake identifier; <c>null</c> when the guild cannot be found.
+        ///     with the snowflake identifier; <see langword="null" /> when the guild cannot be found.
         /// </returns>
         Task<IGuild> GetGuildAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -248,7 +248,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the user associated with
-        ///     the snowflake identifier; <c>null</c> if the user is not found.
+        ///     the snowflake identifier; <see langword="null" /> if the user is not found.
         /// </returns>
         Task<IUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
         /// <summary>
@@ -266,7 +266,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the user associated with
-        ///     the name and the discriminator; <c>null</c> if the user is not found.
+        ///     the name and the discriminator; <see langword="null" /> if the user is not found.
         /// </returns>
         Task<IUser> GetUserAsync(string username, string discriminator, RequestOptions options = null);
 
@@ -293,7 +293,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the voice region
-        ///     associated with the identifier; <c>null</c> if the voice region is not found.
+        ///     associated with the identifier; <see langword="null" /> if the voice region is not found.
         /// </returns>
         Task<IVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options = null);
 
@@ -304,7 +304,7 @@ namespace Discord
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a webhook associated
-        ///     with the identifier; <c>null</c> if the webhook is not found.
+        ///     with the identifier; <see langword="null" /> if the webhook is not found.
         /// </returns>
         Task<IWebhook> GetWebhookAsync(ulong id, RequestOptions options = null);
 

--- a/src/Discord.Net.Core/Logging/LogMessage.cs
+++ b/src/Discord.Net.Core/Logging/LogMessage.cs
@@ -33,7 +33,7 @@ namespace Discord
         ///     Gets the exception of this log entry.
         /// </summary>
         /// <returns>
-        ///     An <see cref="Discord.LogMessage.Exception" /> object associated with an incident; otherwise <c>null</c>.
+        ///     An <see cref="Discord.LogMessage.Exception" /> object associated with an incident; otherwise <see langword="null" />.
         /// </returns>
         public Exception Exception { get; }
 

--- a/src/Discord.Net.Core/Net/HttpException.cs
+++ b/src/Discord.Net.Core/Net/HttpException.cs
@@ -25,7 +25,7 @@ namespace Discord.Net
         /// <returns>
         ///     A 
         ///     <see href="https://discord.com/developers/docs/topics/opcodes-and-status-codes#json">JSON error code</see>
-        ///     from Discord, or <c>null</c> if none.
+        ///     from Discord, or <see langword="null" /> if none.
         /// </returns>
         public DiscordErrorCode? DiscordCode { get; }
         /// <summary>

--- a/src/Discord.Net.Core/RequestOptions.cs
+++ b/src/Discord.Net.Core/RequestOptions.cs
@@ -21,7 +21,7 @@ namespace Discord
         /// </summary>
         /// <remarks>
         ///     Gets or set the max time, in milliseconds, to wait for this request to complete. If
-        ///     <c>null</c>, a request will not time out. If a rate limit has been triggered for this request's bucket
+        ///     <see langword="null" />, a request will not time out. If a rate limit has been triggered for this request's bucket
         ///     and will not be unpaused in time, this request will fail immediately.
         /// </remarks>
         /// <returns>
@@ -50,7 +50,7 @@ namespace Discord
         public string AuditLogReason { get; set; }
         /// <summary>
         ///		Gets or sets whether or not this request should use the system
-        ///		clock for rate-limiting. Defaults to <c>true</c>.
+        ///		clock for rate-limiting. Defaults to <see langword="true" />.
         /// </summary>
         /// <remarks>
         ///		This property can also be set in <see cref="DiscordConfig"/>.

--- a/src/Discord.Net.Core/Utils/Cacheable.cs
+++ b/src/Discord.Net.Core/Utils/Cacheable.cs
@@ -25,7 +25,7 @@ namespace Discord
         /// </summary>
         /// <remarks>
         ///     This value is not guaranteed to be set; in cases where the entity cannot be pulled from cache, it is
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </remarks>
         public TEntity Value { get; }
         private Func<Task<TEntity>> DownloadFunc { get; }
@@ -81,7 +81,7 @@ namespace Discord
         /// </summary>
         /// <remarks>
         ///     This value is not guaranteed to be set; in cases where the entity cannot be pulled from cache, it is
-        ///     <c>null</c>.
+        ///     <see langword="null" />.
         /// </remarks>
         public TCachedEntity Value { get; }
         private Func<Task<TDownloadableEntity>> DownloadFunc { get; }

--- a/src/Discord.Net.Core/Utils/ConcurrentHashSet.cs
+++ b/src/Discord.Net.Core/Utils/ConcurrentHashSet.cs
@@ -157,7 +157,7 @@ namespace Discord
             : this(collection, EqualityComparer<T>.Default) { }
         public ConcurrentHashSet(IEqualityComparer<T> comparer)
             : this(DefaultConcurrencyLevel, DefaultCapacity, true, comparer) { }
-        /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <see langword="null" /></exception>
         public ConcurrentHashSet(IEnumerable<T> collection, IEqualityComparer<T> comparer)
             : this(comparer)
         {
@@ -166,7 +166,7 @@ namespace Discord
             InitializeFromCollection(collection);
         }
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="collection" /> or <paramref name="comparer" /> is <c>null</c>
+        /// <paramref name="collection" /> or <paramref name="comparer" /> is <see langword="null" />
         /// </exception>
         public ConcurrentHashSet(int concurrencyLevel, IEnumerable<T> collection, IEqualityComparer<T> comparer)
             : this(concurrencyLevel, DefaultCapacity, false, comparer)
@@ -217,7 +217,7 @@ namespace Discord
             if (_budget == 0)
                 _budget = _tables._buckets.Length / _tables._locks.Length;
         }
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null" /></exception>
         public bool ContainsKey(T value)
         {
             if (value == null)
@@ -242,7 +242,7 @@ namespace Discord
             return false;
         }
 
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null" /></exception>
         public bool TryAdd(T value)
         {
             if (value == null)
@@ -294,7 +294,7 @@ namespace Discord
             }
         }
 
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null" /></exception>
         public bool TryRemove(T value)
         {
             if (value == null)

--- a/src/Discord.Net.Core/Utils/TokenUtils.cs
+++ b/src/Discord.Net.Core/Utils/TokenUtils.cs
@@ -144,7 +144,7 @@ namespace Discord
         /// </summary>
         /// <param name="tokenType"> The type of token to validate. </param>
         /// <param name="token"> The token value to validate. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when the supplied token string is <c>null</c>, empty, or contains only whitespace.</exception>
+        /// <exception cref="ArgumentNullException"> Thrown when the supplied token string is <see langword="null" />, empty, or contains only whitespace.</exception>
         /// <exception cref="ArgumentException"> Thrown when the supplied <see cref="TokenType"/> or token value is invalid. </exception>
         public static void ValidateToken(TokenType tokenType, string token)
         {

--- a/src/Discord.Net.Interactions/Attributes/PreconditionAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/PreconditionAttribute.cs
@@ -15,7 +15,7 @@ namespace Discord.Interactions
         /// </summary>
         /// <remarks>
         ///     <see cref="Preconditions" /> of the same group require only one of the preconditions to pass in order to
-        ///     be successful (A || B). Specifying <see cref="Group" /> = <c>null</c> or not at all will
+        ///     be successful (A || B). Specifying <see cref="Group" /> = <see langword="null" /> or not at all will
         ///     require *all* preconditions to pass, just like normal (A &amp;&amp; B).
         /// </remarks>
         public string Group { get; set; } = null;

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -250,7 +250,7 @@ namespace Discord.Interactions
         ///     Create and loads a <see cref="ModuleInfo"/> using a builder factory.
         /// </summary>
         /// <param name="name">Name of the module.</param>
-        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <c>null</c>.</param>
+        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <see langword="null" />.</param>
         /// <param name="buildFunc">Module builder factory.</param>
         /// <returns>
         ///     A task representing the operation for adding modules. The task result contains the built module instance.
@@ -280,7 +280,7 @@ namespace Discord.Interactions
         ///     Discover and load command modules from an <see cref="Assembly"/>.
         /// </summary>
         /// <param name="assembly"><see cref="Assembly"/> the command modules are defined in.</param>
-        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <c>null</c>.</param>
+        /// <param name="services">The <see cref="IServiceProvider"/> for your dependency injection solution if using one; otherwise, pass <see langword="null" />.</param>
         /// <returns>
         ///     A task representing the operation for adding modules. The task result contains a collection of the modules added.
         /// </returns>
@@ -312,7 +312,7 @@ namespace Discord.Interactions
         ///     Add a command module from a <see cref="Type"/>.
         /// </summary>
         /// <typeparam name="T">Type of the module.</typeparam>
-        /// <param name="services">The <see cref="IServiceProvider" /> for your dependency injection solution if using one; otherwise, pass <c>null</c> .</param>
+        /// <param name="services">The <see cref="IServiceProvider" /> for your dependency injection solution if using one; otherwise, pass <see langword="null" /> .</param>
         /// <returns>
         ///     A task representing the operation for adding the module. The task result contains the built module.
         /// </returns>
@@ -329,7 +329,7 @@ namespace Discord.Interactions
         ///     Add a command module from a <see cref="Type"/>.
         /// </summary>
         /// <param name="type">Type of the module.</param>
-        /// <param name="services">The <see cref="IServiceProvider" /> for your dependency injection solution if using one; otherwise, pass <c>null</c> .</param>
+        /// <param name="services">The <see cref="IServiceProvider" /> for your dependency injection solution if using one; otherwise, pass <see langword="null" /> .</param>
         /// <returns>
         ///     A task representing the operation for adding the module. The task result contains the built module.
         /// </returns>

--- a/src/Discord.Net.Interactions/Results/AutocompletionResult.cs
+++ b/src/Discord.Net.Interactions/Results/AutocompletionResult.cs
@@ -91,7 +91,7 @@ namespace Discord.Interactions
         ///     Gets a string that indicates the autocompletion result.
         /// </summary>
         /// <returns>
-        ///     <c>Success</c> if <see cref="IsSuccess"/> is <c>true</c>; otherwise "<see cref="Error"/>: 
+        ///     <c>Success</c> if <see cref="IsSuccess"/> is <see langword="true" />; otherwise "<see cref="Error"/>: 
         ///     <see cref="ErrorReason"/>".
         /// </returns>
         public override string ToString() => IsSuccess ? "Success" : $"{Error}: {ErrorReason}";

--- a/src/Discord.Net.Interactions/Results/RuntimeResult.cs
+++ b/src/Discord.Net.Interactions/Results/RuntimeResult.cs
@@ -17,7 +17,7 @@ namespace Discord.Interactions
         /// <summary>
         ///     Initializes a new <see cref="RuntimeResult" /> class with the type of error and reason.
         /// </summary>
-        /// <param name="error">The type of failure, or <c>null</c> if none.</param>
+        /// <param name="error">The type of failure, or <see langword="null" /> if none.</param>
         /// <param name="reason">The reason of failure.</param>
         protected RuntimeResult(InteractionCommandError? error, string reason)
         {
@@ -29,7 +29,7 @@ namespace Discord.Interactions
         ///     Gets a string that indicates the runtime result.
         /// </summary>
         /// <returns>
-        ///     <c>Success</c> if <see cref="IsSuccess"/> is <c>true</c>; otherwise "<see cref="Error"/>: 
+        ///     <c>Success</c> if <see cref="IsSuccess"/> is <see langword="true" />; otherwise "<see cref="Error"/>: 
         ///     <see cref="ErrorReason"/>".
         /// </returns>
         public override string ToString() => ErrorReason ?? (IsSuccess ? "Successful" : "Unsuccessful");

--- a/src/Discord.Net.Rest/API/AuditLogs/GuildInfoAuditLogModel.cs
+++ b/src/Discord.Net.Rest/API/AuditLogs/GuildInfoAuditLogModel.cs
@@ -2,7 +2,7 @@ using Discord.Rest;
 
 namespace Discord.API.AuditLogs;
 
-public class GuildInfoAuditLogModel : IAuditLogInfoModel
+internal class GuildInfoAuditLogModel : IAuditLogInfoModel
 {
     [JsonField("name")]
     public string Name { get; set; }

--- a/src/Discord.Net.Rest/API/Common/ForumReactionEmoji.cs
+++ b/src/Discord.Net.Rest/API/Common/ForumReactionEmoji.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Discord.API;
 
-public class ForumReactionEmoji
+internal class ForumReactionEmoji
 {
     [JsonProperty("emoji_id")]
     public ulong? EmojiId { get; set; }

--- a/src/Discord.Net.Rest/API/Common/InviteVanity.cs
+++ b/src/Discord.Net.Rest/API/Common/InviteVanity.cs
@@ -5,7 +5,7 @@ namespace Discord.API
     /// <summary>
     /// Represents a vanity invite.
     /// </summary>
-    public class InviteVanity
+    internal class InviteVanity
     {
         /// <summary>
         /// The unique code for the invite link.

--- a/src/Discord.Net.Rest/API/Common/MessageActivity.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageActivity.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Discord.API
 {
-    public class MessageActivity
+    internal class MessageActivity
     {
         [JsonProperty("type")]
         public Optional<MessageActivityType> Type { get; set; }

--- a/src/Discord.Net.Rest/API/Common/MessageApplication.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageApplication.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Discord.API
 {
-    public class MessageApplication
+    internal class MessageApplication
     {
         /// <summary>
         ///     Gets the snowflake ID of the application.

--- a/src/Discord.Net.Rest/API/Common/RoleConnection.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleConnection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Discord.API;
 
-public class RoleConnection
+internal class RoleConnection
 {
     [JsonProperty("platform_name")]
     public Optional<string> PlatformName { get; set; }

--- a/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleConnectionMetadata.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Discord.API;
 
-public class RoleConnectionMetadata
+internal class RoleConnectionMetadata
 {
     [JsonProperty("type")]
     public RoleConnectionMetadataType Type { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateGuildChannelParams.cs
@@ -46,7 +46,7 @@ namespace Discord.API.Rest
         [JsonProperty("default_sort_order")]
         public Optional<ForumSortOrder?> DefaultSortOrder { get; set; }
 
-        [JsonProperty("default_forum_layout ")]
+        [JsonProperty("default_forum_layout")]
         public Optional<ForumLayout> DefaultLayout { get; set; }
 
         public CreateGuildChannelParams(string name, ChannelType type)

--- a/src/Discord.Net.Rest/API/Rest/ModifyForumReactionEmojiParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyForumReactionEmojiParams.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 namespace Discord.API;
 
 [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
-public class ModifyForumReactionEmojiParams
+internal class ModifyForumReactionEmojiParams
 {
     [JsonProperty("emoji_id")]
     public Optional<ulong?> EmojiId { get; set; }

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1471,7 +1471,8 @@ namespace Discord.API
         {
             if ((!args.Embeds.IsSpecified || args.Embeds.Value == null || args.Embeds.Value.Length == 0)
                 && (!args.Content.IsSpecified || args.Content.Value is null || string.IsNullOrWhiteSpace(args.Content.Value))
-                && (!args.Components.IsSpecified || args.Components.Value is null || args.Components.Value.Length == 0))
+                && (!args.Components.IsSpecified || args.Components.Value is null || args.Components.Value.Length == 0)
+                && (!args.File.IsSpecified))
             {
                 throw new ArgumentException("At least one of 'Content', 'Embeds', 'File' or 'Components' must be specified.", nameof(args));
             }
@@ -1494,7 +1495,8 @@ namespace Discord.API
         {
             if ((!args.Embeds.IsSpecified || args.Embeds.Value == null || args.Embeds.Value.Length == 0)
                 && (!args.Content.IsSpecified || args.Content.Value is null || string.IsNullOrWhiteSpace(args.Content.Value))
-                && (!args.MessageComponents.IsSpecified || args.MessageComponents.Value is null || args.MessageComponents.Value.Length == 0))
+                && (!args.MessageComponents.IsSpecified || args.MessageComponents.Value is null || args.MessageComponents.Value.Length == 0)
+                && (args.Files.Length == 0))
             {
                 throw new ArgumentException("At least one of 'Content', 'Embeds', 'Files' or 'Components' must be specified.", nameof(args));
             }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelCreateAuditLogData.cs
@@ -92,7 +92,7 @@ public class ChannelCreateAuditLogData : IAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
 
@@ -100,8 +100,8 @@ public class ChannelCreateAuditLogData : IAuditLogData
     ///     Gets the value that indicates whether the created channel is NSFW.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if the created channel has the NSFW flag enabled; otherwise <c>false</c>.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if the created channel has the NSFW flag enabled; otherwise <see langword="false" />.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? IsNsfw { get; }
 
@@ -111,7 +111,7 @@ public class ChannelCreateAuditLogData : IAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the bit-rate (bps) that the created voice channel defines and requests the
     ///     client(s) to use.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? Bitrate { get; }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelDeleteAuditLogData.cs
@@ -93,15 +93,15 @@ public class ChannelDeleteAuditLogData : IAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
     /// <summary>
     ///     Gets the value that indicates whether the deleted channel was NSFW.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this channel had the NSFW flag enabled; otherwise <c>false</c>.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if this channel had the NSFW flag enabled; otherwise <see langword="false" />.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? IsNsfw { get; }
     /// <summary>
@@ -109,7 +109,7 @@ public class ChannelDeleteAuditLogData : IAuditLogData
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the bit-rate set of the voice channel.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? Bitrate { get; }
     /// <summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ChannelInfo.cs
@@ -67,15 +67,15 @@ namespace Discord.Rest
         /// <returns>
         ///     An <see cref="int"/> representing the time in seconds required before the user can send another
         ///     message; <c>0</c> if disabled.
-        ///     <c>null</c> if this is not mentioned in this entry.
+        ///     <see langword="null" /> if this is not mentioned in this entry.
         /// </returns>
         public int? SlowModeInterval { get; }
         /// <summary>
         ///     Gets the value that indicates whether this channel is NSFW.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if this channel has the NSFW flag enabled; otherwise <c>false</c>.
-        ///     <c>null</c> if this is not mentioned in this entry.
+        ///     <see langword="true" /> if this channel has the NSFW flag enabled; otherwise <see langword="false" />.
+        ///     <see langword="null" /> if this is not mentioned in this entry.
         /// </returns>
         public bool? IsNsfw { get; }
         /// <summary>
@@ -83,14 +83,14 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>
         ///     An <see cref="int"/> representing the bit-rate set for the voice channel;
-        ///     <c>null</c> if this is not mentioned in this entry.
+        ///     <see langword="null" /> if this is not mentioned in this entry.
         /// </returns>
         public int? Bitrate { get; }
         /// <summary>
         ///     Gets the type of this channel.
         /// </summary>
         /// <returns>
-        ///     The channel type of this channel; <c>null</c> if not applicable.
+        ///     The channel type of this channel; <see langword="null" /> if not applicable.
         /// </returns>
         public ChannelType? ChannelType { get; }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/GuildInfo.cs
@@ -123,7 +123,7 @@ public struct GuildInfo
     /// <returns>
     ///     An <see cref="int"/> representing the amount of time in seconds for a user to be marked as inactive
     ///     and moved into the AFK voice channel.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? AfkTimeout { get; }
     /// <summary>
@@ -131,14 +131,14 @@ public struct GuildInfo
     /// </summary>
     /// <returns>
     ///     The default message notifications setting of this guild.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public DefaultMessageNotifications? DefaultMessageNotifications { get; }
     /// <summary>
     ///     Gets the ID of the AFK voice channel for this guild.
     /// </summary>
     /// <returns>
-    ///     A <see cref="ulong"/> representing the snowflake identifier of the AFK voice channel; <c>null</c> if
+    ///     A <see cref="ulong"/> representing the snowflake identifier of the AFK voice channel; <see langword="null" /> if
     ///     none is set.
     /// </returns>
     public ulong? AfkChannelId { get; }
@@ -157,7 +157,7 @@ public struct GuildInfo
     ///     Gets the ID of this guild's icon.
     /// </summary>
     /// <returns>
-    ///     A string containing the identifier for the splash image; <c>null</c> if none is set.
+    ///     A string containing the identifier for the splash image; <see langword="null" /> if none is set.
     /// </returns>
     public string IconHash { get; }
     /// <summary>
@@ -165,7 +165,7 @@ public struct GuildInfo
     /// </summary>
     /// <returns>
     ///     The level of requirements.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public VerificationLevel? VerificationLevel { get; }
     /// <summary>
@@ -181,7 +181,7 @@ public struct GuildInfo
     /// </summary>
     /// <returns>
     ///     The level of MFA requirement.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public MfaLevel? MfaLevel { get; }
     /// <summary>
@@ -196,7 +196,7 @@ public struct GuildInfo
     /// </summary>
     /// <returns>
     ///     A <see cref="ulong"/> representing the snowflake identifier of the channel where system
-    ///     messages are sent; <c>null</c> if none is set.
+    ///     messages are sent; <see langword="null" /> if none is set.
     /// </returns>
     public ulong? SystemChannelId { get; }
     /// <summary>
@@ -204,15 +204,15 @@ public struct GuildInfo
     /// </summary>
     /// <returns>
     ///     A <see cref="ulong"/> representing the snowflake identifier of the embedded channel found within the
-    ///     widget settings of this guild; <c>null</c> if none is set.
+    ///     widget settings of this guild; <see langword="null" /> if none is set.
     /// </returns>
     public ulong? EmbedChannelId { get; }
     /// <summary>
     ///     Gets a value that indicates whether this guild is embeddable (i.e. can use widget).
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this guild can be embedded via widgets; otherwise <c>false</c>.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if this guild can be embedded via widgets; otherwise <see langword="false" />.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? IsEmbeddable { get; }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteCreateAuditLogData.cs
@@ -59,8 +59,8 @@ public class InviteCreateAuditLogData : IAuditLogData
     ///     Gets a value that determines whether the invite is a temporary one.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if users accepting this invite will be removed from the guild when they log off; otherwise
-    ///     <c>false</c>.
+    ///     <see langword="true" /> if users accepting this invite will be removed from the guild when they log off; otherwise
+    ///     <see langword="false" />.
     /// </returns>
     public bool Temporary { get; }
 
@@ -96,7 +96,7 @@ public class InviteCreateAuditLogData : IAuditLogData
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the number of uses this invite may be accepted until it is removed
-    ///     from the guild; <c>null</c> if none is set.
+    ///     from the guild; <see langword="null" /> if none is set.
     /// </returns>
     public int MaxUses { get; }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteDeleteAuditLogData.cs
@@ -59,8 +59,8 @@ public class InviteDeleteAuditLogData : IAuditLogData
     ///     Gets a value that indicates whether the invite is a temporary one.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if users accepting this invite will be removed from the guild when they log off; otherwise
-    ///     <c>false</c>.
+    ///     <see langword="true" /> if users accepting this invite will be removed from the guild when they log off; otherwise
+    ///     <see langword="false" />.
     /// </returns>
     public bool Temporary { get; }
 
@@ -96,7 +96,7 @@ public class InviteDeleteAuditLogData : IAuditLogData
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the number of uses this invite may be accepted until it is removed
-    ///     from the guild; <c>null</c> if none is set.
+    ///     from the guild; <see langword="null" /> if none is set.
     /// </returns>
     public int MaxUses { get; }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/InviteInfo.cs
@@ -21,7 +21,7 @@ public struct InviteInfo
     ///     Gets the time (in seconds) until the invite expires.
     /// </summary>
     /// <returns>
-    ///     An <see cref="int"/> representing the time in seconds until this invite expires; <c>null</c> if this
+    ///     An <see cref="int"/> representing the time in seconds until this invite expires; <see langword="null" /> if this
     ///     invite never expires or not specified.
     /// </returns>
     public int? MaxAge { get; }
@@ -38,8 +38,8 @@ public struct InviteInfo
     ///     Gets a value that indicates whether the invite is a temporary one.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if users accepting this invite will be removed from the guild when they log off, 
-    ///     <c>false</c> if not; <c>null</c> if not specified.
+    ///     <see langword="true" /> if users accepting this invite will be removed from the guild when they log off, 
+    ///     <see langword="false" /> if not; <see langword="null" /> if not specified.
     /// </returns>
     public bool? Temporary { get; }
 
@@ -48,7 +48,7 @@ public struct InviteInfo
     /// </summary>
     /// <returns>
     ///     A <see cref="ulong"/> representing the channel snowflake identifier that the invite points to; 
-    ///     <c>null</c> if not specified.
+    ///     <see langword="null" /> if not specified.
     /// </returns>
     public ulong? ChannelId { get; }
 
@@ -57,7 +57,7 @@ public struct InviteInfo
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the number of uses this invite may be accepted until it is removed
-    ///     from the guild; <c>null</c> if none is specified.
+    ///     from the guild; <see langword="null" /> if none is specified.
     /// </returns>
     public int? MaxUses { get; }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleEditInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/MemberRoleEditInfo.cs
@@ -32,7 +32,7 @@ public struct MemberRoleEditInfo
     ///     Gets a value that indicates whether the role was added to the user.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if the role was added to the user; otherwise <c>false</c>.
+    ///     <see langword="true" /> if the role was added to the user; otherwise <see langword="false" />.
     /// </returns>
     public bool Added { get; }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
@@ -30,7 +30,7 @@ public struct RoleEditInfo
     ///     Gets the color of this role.
     /// </summary>
     /// <returns>
-    ///     A color object representing the color assigned to this role; <c>null</c> if this role does not have a
+    ///     A color object representing the color assigned to this role; <see langword="null" /> if this role does not have a
     ///     color.
     /// </returns>
     public Color? Color { get; }
@@ -39,8 +39,8 @@ public struct RoleEditInfo
     ///     Gets a value that indicates whether this role is mentionable.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if other members can mention this role in a text channel; otherwise <c>false</c>; 
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if other members can mention this role in a text channel; otherwise <see langword="false" />; 
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? Mentionable { get; }
 
@@ -49,8 +49,8 @@ public struct RoleEditInfo
     ///     section on the user list).
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this role's members will appear in a separate section in the user list; otherwise 
-    ///     <c>false</c>; <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if this role's members will appear in a separate section in the user list; otherwise 
+    ///     <see langword="false" />; <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? Hoist { get; }
 
@@ -66,7 +66,7 @@ public struct RoleEditInfo
     ///     Gets the permissions assigned to this role.
     /// </summary>
     /// <returns>
-    ///     A guild permissions object representing the permissions that have been assigned to this role; <c>null</c>
+    ///     A guild permissions object representing the permissions that have been assigned to this role; <see langword="null" />
     ///     if no permissions have been assigned.
     /// </returns>
     public GuildPermissions? Permissions { get; }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
@@ -43,7 +43,7 @@ public class ThreadCreateAuditLogData : IAuditLogData
     ///     Gets the thread that was created if it still exists.
     /// </summary>
     /// <returns>
-    ///     A thread object representing the thread that was created if it still exists, otherwise returns <c>null</c>.
+    ///     A thread object representing the thread that was created if it still exists, otherwise returns <see langword="null" />.
     /// </returns>
     public IThreadChannel Thread { get; }
 
@@ -75,7 +75,7 @@ public class ThreadCreateAuditLogData : IAuditLogData
     ///     Gets the value that indicates whether the thread is archived.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread has the Archived flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread has the Archived flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsArchived { get; }
 
@@ -91,7 +91,7 @@ public class ThreadCreateAuditLogData : IAuditLogData
     ///     Gets the value that indicates whether the thread is locked.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread has the Locked flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread has the Locked flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsLocked { get; }
 
@@ -101,7 +101,7 @@ public class ThreadCreateAuditLogData : IAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadDeleteAuditLogData.cs
@@ -63,7 +63,7 @@ public class ThreadDeleteAuditLogData : IAuditLogData
     ///     Gets the value that indicates whether the deleted thread was archived.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread had the Archived flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread had the Archived flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsArchived { get; }
 
@@ -79,7 +79,7 @@ public class ThreadDeleteAuditLogData : IAuditLogData
     ///     Gets the value that indicates whether the deleted thread was locked.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread had the Locked flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread had the Locked flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsLocked { get; }
 
@@ -89,7 +89,7 @@ public class ThreadDeleteAuditLogData : IAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
@@ -37,7 +37,7 @@ public class ThreadUpdateAuditLogData : IAuditLogData
     ///     Gets the thread that was created if it still exists.
     /// </summary>
     /// <returns>
-    ///     A thread object representing the thread that was created if it still exists, otherwise returns <c>null</c>.
+    ///     A thread object representing the thread that was created if it still exists, otherwise returns <see langword="null" />.
     /// </returns>
     public IThreadChannel Thread { get; }
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/WebhookCreateAuditLogData.cs
@@ -39,7 +39,7 @@ public class WebhookCreateAuditLogData : IAuditLogData
     ///     Gets the webhook that was created if it still exists.
     /// </summary>
     /// <returns>
-    ///     A webhook object representing the webhook that was created if it still exists, otherwise returns <c>null</c>.
+    ///     A webhook object representing the webhook that was created if it still exists, otherwise returns <see langword="null" />.
     /// </returns>
     public IWebhook Webhook { get; }
 

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -329,7 +329,7 @@ namespace Discord.Rest
         /// invalid characters as defined by <see cref="System.IO.Path.GetInvalidPathChars"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="filePath" /> is <c>null</c>.
+        /// <paramref name="filePath" /> is <see langword="null" />.
         /// </exception>
         /// <exception cref="PathTooLongException">
         /// The specified path, file name, or both exceed the system-defined maximum length. For example, on

--- a/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/IRestMessageChannel.cs
@@ -35,7 +35,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous get operation for retrieving the message. The task result contains
-        ///     the retrieved message; <c>null</c> if no message is found with the specified identifier.
+        ///     the retrieved message; <see langword="null" /> if no message is found with the specified identifier.
         /// </returns>
         Task<RestMessage> GetMessageAsync(ulong id, RequestOptions options = null);
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -64,7 +64,7 @@ namespace Discord.Rest
         /// </summary>
         /// <param name="id">The snowflake identifier of the user.</param>
         /// <returns>
-        ///     A <see cref="RestUser"/> object that is a recipient of this channel; otherwise <c>null</c>.
+        ///     A <see cref="RestUser"/> object that is a recipient of this channel; otherwise <see langword="null" />.
         /// </returns>
         public RestUser GetUser(ulong id)
         {
@@ -107,7 +107,7 @@ namespace Discord.Rest
         /// invalid characters as defined by <see cref="System.IO.Path.GetInvalidPathChars"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="filePath" /> is <c>null</c>.
+        /// <paramref name="filePath" /> is <see langword="null" />.
         /// </exception>
         /// <exception cref="PathTooLongException">
         /// The specified path, file name, or both exceed the system-defined maximum length. For example, on

--- a/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGroupChannel.cs
@@ -117,7 +117,7 @@ namespace Discord.Rest
         /// invalid characters as defined by <see cref="System.IO.Path.GetInvalidPathChars"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="filePath" /> is <c>null</c>.
+        /// <paramref name="filePath" /> is <see langword="null" />.
         /// </exception>
         /// <exception cref="PathTooLongException">
         /// The specified path, file name, or both exceed the system-defined maximum length. For example, on

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -90,7 +90,7 @@ namespace Discord.Rest
         /// </summary>
         /// <param name="user">The user to get the overwrite from.</param>
         /// <returns>
-        ///     An overwrite object for the targeted user; <c>null</c> if none is set.
+        ///     An overwrite object for the targeted user; <see langword="null" /> if none is set.
         /// </returns>
         public virtual OverwritePermissions? GetPermissionOverwrite(IUser user)
         {
@@ -107,7 +107,7 @@ namespace Discord.Rest
         /// </summary>
         /// <param name="role">The role to get the overwrite from.</param>
         /// <returns>
-        ///     An overwrite object for the targeted role; <c>null</c> if none is set.
+        ///     An overwrite object for the targeted role; <see langword="null" /> if none is set.
         /// </returns>
         public virtual OverwritePermissions? GetPermissionOverwrite(IRole role)
         {

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -76,7 +76,7 @@ namespace Discord.Rest
         /// </exception>
         /// <returns>
         ///     A task representing the asynchronous get operation. The task result contains a guild user object that
-        ///     represents the user; <c>null</c> if none is found.
+        ///     represents the user; <see langword="null" /> if none is found.
         /// </returns>
         public Task<RestGuildUser> GetUserAsync(ulong id, RequestOptions options = null)
             => ChannelHelper.GetUserAsync(this, Guild, Discord, id, options);
@@ -127,7 +127,7 @@ namespace Discord.Rest
         /// invalid characters as defined by <see cref="System.IO.Path.GetInvalidPathChars"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="filePath" /> is <c>null</c>.
+        /// <paramref name="filePath" /> is <see langword="null" />.
         /// </exception>
         /// <exception cref="PathTooLongException">
         /// The specified path, file name, or both exceed the system-defined maximum length. For example, on
@@ -227,7 +227,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a webhook associated
-        ///     with the identifier; <c>null</c> if the webhook is not found.
+        ///     with the identifier; <see langword="null" /> if the webhook is not found.
         /// </returns>
         public virtual Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => ChannelHelper.GetWebhookAsync(this, Discord, id, options);
@@ -280,7 +280,7 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the category channel
-        ///     representing the parent of this channel; <c>null</c> if none is set.
+        ///     representing the parent of this channel; <see langword="null" /> if none is set.
         /// </returns>
         public virtual Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
             => ChannelHelper.GetCategoryAsync(this, Discord, options);

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -16,7 +16,7 @@ namespace Discord.Rest
     internal static class GuildHelper
     {
         #region General
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null" />.</exception>
         public static async Task<Model> ModifyAsync(IGuild guild, BaseDiscordClient client,
             Action<GuildProperties> func, RequestOptions options)
         {
@@ -90,7 +90,7 @@ namespace Discord.Rest
 
             return await client.ApiClient.ModifyGuildAsync(guild.Id, apiArgs, options).ConfigureAwait(false);
         }
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null" />.</exception>
         public static async Task<WidgetModel> ModifyWidgetAsync(IGuild guild, BaseDiscordClient client,
             Action<GuildWidgetProperties> func, RequestOptions options)
         {
@@ -230,7 +230,7 @@ namespace Discord.Rest
             var models = await client.ApiClient.GetGuildChannelsAsync(guild.Id, options).ConfigureAwait(false);
             return models.Select(x => RestGuildChannel.Create(client, guild, x)).ToImmutableArray();
         }
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
         public static async Task<RestTextChannel> CreateTextChannelAsync(IGuild guild, BaseDiscordClient client,
             string name, RequestOptions options, Action<TextChannelProperties> func = null)
         {
@@ -261,7 +261,7 @@ namespace Discord.Rest
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
             return RestTextChannel.Create(client, guild, model);
         }
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
         public static async Task<RestVoiceChannel> CreateVoiceChannelAsync(IGuild guild, BaseDiscordClient client,
             string name, RequestOptions options, Action<VoiceChannelProperties> func = null)
         {
@@ -320,7 +320,7 @@ namespace Discord.Rest
             var model = await client.ApiClient.CreateGuildChannelAsync(guild.Id, args, options).ConfigureAwait(false);
             return RestStageChannel.Create(client, guild, model);
         }
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
         public static async Task<RestCategoryChannel> CreateCategoryChannelAsync(IGuild guild, BaseDiscordClient client,
             string name, RequestOptions options, Action<GuildChannelProperties> func = null)
         {
@@ -348,7 +348,7 @@ namespace Discord.Rest
             return RestCategoryChannel.Create(client, guild, model);
         }
 
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
         public static async Task<RestForumChannel> CreateForumChannelAsync(IGuild guild, BaseDiscordClient client,
             string name, RequestOptions options, Action<ForumChannelProperties> func = null)
         {
@@ -466,7 +466,7 @@ namespace Discord.Rest
         #endregion
 
         #region Roles
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
         public static async Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
             string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options)
         {
@@ -685,7 +685,7 @@ namespace Discord.Rest
             var emote = await client.ApiClient.CreateGuildEmoteAsync(guild.Id, apiargs, options).ConfigureAwait(false);
             return emote.ToEntity();
         }
-        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null" />.</exception>
         public static async Task<GuildEmote> ModifyEmoteAsync(IGuild guild, BaseDiscordClient client, ulong id, Action<EmoteProperties> func,
             RequestOptions options)
         {

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -873,7 +873,7 @@ namespace Discord.Rest
         ///         This method removes all users that have not logged on in the provided number of <paramref name="days"/>.
         ///     </para>
         ///     <para>
-        ///         If <paramref name="simulate" /> is <c>true</c>, this method will only return the number of users that
+        ///         If <paramref name="simulate" /> is <see langword="true" />, this method will only return the number of users that
         ///         would be removed without kicking the users.
         ///     </para>
         /// </remarks>

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -102,7 +102,7 @@ namespace Discord.WebSocket
         /// <remarks>
         ///     This method gets the user present in the WebSocket cache with the given condition.
         ///     <note type="warning">
-        ///         Sometimes a user may return <c>null</c> due to Discord not sending offline users in large guilds
+        ///         Sometimes a user may return <see langword="null" /> due to Discord not sending offline users in large guilds
         ///         (i.e. guild with 100+ members) actively. To download users on startup and to see more information
         ///         about this subject, see <see cref="Discord.WebSocket.DiscordSocketConfig.AlwaysDownloadUsers" />.
         ///     </note>
@@ -114,7 +114,7 @@ namespace Discord.WebSocket
         ///     </note>
         /// </remarks>
         /// <returns>
-        ///     A generic WebSocket-based user; <c>null</c> when the user cannot be found.
+        ///     A generic WebSocket-based user; <see langword="null" /> when the user cannot be found.
         /// </returns>
         public abstract SocketUser GetUser(ulong id);
 
@@ -124,7 +124,7 @@ namespace Discord.WebSocket
         /// <remarks>
         ///     This method gets the user present in the WebSocket cache with the given condition.
         ///     <note type="warning">
-        ///         Sometimes a user may return <c>null</c> due to Discord not sending offline users in large guilds
+        ///         Sometimes a user may return <see langword="null" /> due to Discord not sending offline users in large guilds
         ///         (i.e. guild with 100+ members) actively. To download users on startup and to see more information
         ///         about this subject, see <see cref="Discord.WebSocket.DiscordSocketConfig.AlwaysDownloadUsers" />.
         ///     </note>
@@ -138,7 +138,7 @@ namespace Discord.WebSocket
         /// <param name="username">The name of the user.</param>
         /// <param name="discriminator">The discriminator value of the user.</param>
         /// <returns>
-        ///     A generic WebSocket-based user; <c>null</c> when the user cannot be found.
+        ///     A generic WebSocket-based user; <see langword="null" /> when the user cannot be found.
         /// </returns>
         public abstract SocketUser GetUser(string username, string discriminator);
         /// <summary>
@@ -147,7 +147,7 @@ namespace Discord.WebSocket
         /// <param name="id">The snowflake identifier of the channel (e.g. `381889909113225237`).</param>
         /// <returns>
         ///     A generic WebSocket-based channel object (voice, text, category, etc.) associated with the identifier;
-        ///     <c>null</c> when the channel cannot be found.
+        ///     <see langword="null" /> when the channel cannot be found.
         /// </returns>
         public abstract SocketChannel GetChannel(ulong id);
         /// <summary>
@@ -155,7 +155,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="id">The guild snowflake identifier.</param>
         /// <returns>
-        ///     A WebSocket-based guild associated with the snowflake identifier; <c>null</c> when the guild cannot be
+        ///     A WebSocket-based guild associated with the snowflake identifier; <see langword="null" /> when the guild cannot be
         ///     found.
         /// </returns>
         public abstract SocketGuild GetGuild(ulong id);
@@ -173,7 +173,7 @@ namespace Discord.WebSocket
         /// <param name="id">The identifier of the voice region (e.g. <c>eu-central</c> ).</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     A task that contains a REST-based voice region associated with the identifier; <c>null</c> if the
+        ///     A task that contains a REST-based voice region associated with the identifier; <see langword="null" /> if the
         ///     voice region is not found.
         /// </returns>
         public abstract ValueTask<RestVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options = null);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -390,7 +390,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the channel associated
-        ///     with the snowflake identifier; <c>null</c> when the channel cannot be found.
+        ///     with the snowflake identifier; <see langword="null" /> when the channel cannot be found.
         /// </returns>
         public async ValueTask<IChannel> GetChannelAsync(ulong id, RequestOptions options = null)
             => GetChannel(id) ?? (IChannel)await ClientHelper.GetChannelAsync(this, id, options).ConfigureAwait(false);
@@ -408,7 +408,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains the user associated with
-        ///     the snowflake identifier; <c>null</c> if the user is not found.
+        ///     the snowflake identifier; <see langword="null" /> if the user is not found.
         /// </returns>
         public async ValueTask<IUser> GetUserAsync(ulong id, RequestOptions options = null)
             => await ((IDiscordClient)this).GetUserAsync(id, CacheMode.AllowDownload, options).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketConfig.cs
@@ -31,7 +31,7 @@ namespace Discord.WebSocket
         public const string GatewayEncoding = "json";
 
         /// <summary>
-        ///     Gets or sets the WebSocket host to connect to. If <c>null</c>, the client will use the
+        ///     Gets or sets the WebSocket host to connect to. If <see langword="null" />, the client will use the
         ///     /gateway endpoint.
         /// </summary>
         public string GatewayHost { get; set; } = null;
@@ -136,7 +136,7 @@ namespace Discord.WebSocket
 
         /// <summary>
         ///     Gets or sets the timeout for event handlers, in milliseconds, after which a warning will be logged.
-        ///     Setting this property to <c>null</c>disables this check.
+        ///     Setting this property to <see langword="null" />disables this check.
         /// </summary>
         public int? HandlerTimeout { get; set; } = 3000;
 

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketChannelCreateAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketChannelCreateAuditLogData.cs
@@ -90,7 +90,7 @@ public class SocketChannelCreateAuditLogData : ISocketAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
 
@@ -98,8 +98,8 @@ public class SocketChannelCreateAuditLogData : ISocketAuditLogData
     ///     Gets the value that indicates whether the created channel is NSFW.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if the created channel has the NSFW flag enabled; otherwise <c>false</c>.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if the created channel has the NSFW flag enabled; otherwise <see langword="false" />.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? IsNsfw { get; }
 
@@ -109,7 +109,7 @@ public class SocketChannelCreateAuditLogData : ISocketAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the bit-rate (bps) that the created voice channel defines and requests the
     ///     client(s) to use.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? Bitrate { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketChannelDeleteAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketChannelDeleteAuditLogData.cs
@@ -96,7 +96,7 @@ public class SocketChannelDeleteAuditLogData : ISocketAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
 
@@ -104,8 +104,8 @@ public class SocketChannelDeleteAuditLogData : ISocketAuditLogData
     ///     Gets the value that indicates whether the deleted channel was NSFW.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this channel had the NSFW flag enabled; otherwise <c>false</c>.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if this channel had the NSFW flag enabled; otherwise <see langword="false" />.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? IsNsfw { get; }
 
@@ -114,7 +114,7 @@ public class SocketChannelDeleteAuditLogData : ISocketAuditLogData
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the bit-rate set of the voice channel.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? Bitrate { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketChannelInfo.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketChannelInfo.cs
@@ -81,7 +81,7 @@ public struct SocketChannelInfo
     ///     Gets the type of this channel.
     /// </summary>
     /// <returns>
-    ///     The channel type of this channel; <c>null</c> if not applicable.
+    ///     The channel type of this channel; <see langword="null" /> if not applicable.
     /// </returns>
     public ChannelType? ChannelType { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketInviteCreateAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketInviteCreateAuditLogData.cs
@@ -67,8 +67,8 @@ public class SocketInviteCreateAuditLogData : ISocketAuditLogData
     ///     Gets a value that determines whether the invite is a temporary one.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if users accepting this invite will be removed from the guild when they log off; otherwise
-    ///     <c>false</c>.
+    ///     <see langword="true" /> if users accepting this invite will be removed from the guild when they log off; otherwise
+    ///     <see langword="false" />.
     /// </returns>
     public bool Temporary { get; }
 
@@ -104,7 +104,7 @@ public class SocketInviteCreateAuditLogData : ISocketAuditLogData
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the number of uses this invite may be accepted until it is removed
-    ///     from the guild; <c>null</c> if none is set.
+    ///     from the guild; <see langword="null" /> if none is set.
     /// </returns>
     public int MaxUses { get; }
 }

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketInviteDeleteAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketInviteDeleteAuditLogData.cs
@@ -66,8 +66,8 @@ public class SocketInviteDeleteAuditLogData : ISocketAuditLogData
     ///     Gets a value that indicates whether the invite is a temporary one.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if users accepting this invite will be removed from the guild when they log off; otherwise
-    ///     <c>false</c>.
+    ///     <see langword="true" /> if users accepting this invite will be removed from the guild when they log off; otherwise
+    ///     <see langword="false" />.
     /// </returns>
     public bool Temporary { get; }
 
@@ -103,7 +103,7 @@ public class SocketInviteDeleteAuditLogData : ISocketAuditLogData
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the number of uses this invite may be accepted until it is removed
-    ///     from the guild; <c>null</c> if none is set.
+    ///     from the guild; <see langword="null" /> if none is set.
     /// </returns>
     public int MaxUses { get; }
 }

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketInviteInfo.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketInviteInfo.cs
@@ -21,7 +21,7 @@ public struct SocketInviteInfo
     ///     Gets the time (in seconds) until the invite expires.
     /// </summary>
     /// <returns>
-    ///     An <see cref="int"/> representing the time in seconds until this invite expires; <c>null</c> if this
+    ///     An <see cref="int"/> representing the time in seconds until this invite expires; <see langword="null" /> if this
     ///     invite never expires or not specified.
     /// </returns>
     public int? MaxAge { get; }
@@ -38,8 +38,8 @@ public struct SocketInviteInfo
     ///     Gets a value that indicates whether the invite is a temporary one.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if users accepting this invite will be removed from the guild when they log off, 
-    ///     <c>false</c> if not; <c>null</c> if not specified.
+    ///     <see langword="true" /> if users accepting this invite will be removed from the guild when they log off, 
+    ///     <see langword="false" /> if not; <see langword="null" /> if not specified.
     /// </returns>
     public bool? Temporary { get; }
 
@@ -48,7 +48,7 @@ public struct SocketInviteInfo
     /// </summary>
     /// <returns>
     ///     A <see cref="ulong"/> representing the channel snowflake identifier that the invite points to; 
-    ///     <c>null</c> if not specified.
+    ///     <see langword="null" /> if not specified.
     /// </returns>
     public ulong? ChannelId { get; }
 
@@ -57,7 +57,7 @@ public struct SocketInviteInfo
     /// </summary>
     /// <returns>
     ///     An <see cref="int"/> representing the number of uses this invite may be accepted until it is removed
-    ///     from the guild; <c>null</c> if none is specified.
+    ///     from the guild; <see langword="null" /> if none is specified.
     /// </returns>
     public int? MaxUses { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketMemberRoleEditInfo.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketMemberRoleEditInfo.cs
@@ -30,7 +30,7 @@ public struct SocketMemberRoleEditInfo
     ///     Gets a value that indicates whether the role was added to the user.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if the role was added to the user; otherwise <c>false</c>.
+    ///     <see langword="true" /> if the role was added to the user; otherwise <see langword="false" />.
     /// </returns>
     public bool Added { get; }
 }

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
@@ -30,7 +30,7 @@ public struct SocketRoleEditInfo
     ///     Gets the color of this role.
     /// </summary>
     /// <returns>
-    ///     A color object representing the color assigned to this role; <c>null</c> if this role does not have a
+    ///     A color object representing the color assigned to this role; <see langword="null" /> if this role does not have a
     ///     color.
     /// </returns>
     public Color? Color { get; }
@@ -39,8 +39,8 @@ public struct SocketRoleEditInfo
     ///     Gets a value that indicates whether this role is mentionable.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if other members can mention this role in a text channel; otherwise <c>false</c>;
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if other members can mention this role in a text channel; otherwise <see langword="false" />;
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? Mentionable { get; }
 
@@ -49,8 +49,8 @@ public struct SocketRoleEditInfo
     ///     section on the user list).
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this role's members will appear in a separate section in the user list; otherwise
-    ///     <c>false</c>; <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="true" /> if this role's members will appear in a separate section in the user list; otherwise
+    ///     <see langword="false" />; <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? Hoist { get; }
 
@@ -66,7 +66,7 @@ public struct SocketRoleEditInfo
     ///     Gets the permissions assigned to this role.
     /// </summary>
     /// <returns>
-    ///     A guild permissions object representing the permissions that have been assigned to this role; <c>null</c>
+    ///     A guild permissions object representing the permissions that have been assigned to this role; <see langword="null" />
     ///     if no permissions have been assigned.
     /// </returns>
     public GuildPermissions? Permissions { get; }

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketThreadCreateAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketThreadCreateAuditLogData.cs
@@ -61,7 +61,7 @@ public class SocketThreadCreateAuditLogData : ISocketAuditLogData
     ///     Gets the value that indicates whether the thread is archived.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread has the Archived flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread has the Archived flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsArchived { get; }
 
@@ -77,7 +77,7 @@ public class SocketThreadCreateAuditLogData : ISocketAuditLogData
     ///     Gets the value that indicates whether the thread is locked.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread has the Locked flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread has the Locked flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsLocked { get; }
 
@@ -87,7 +87,7 @@ public class SocketThreadCreateAuditLogData : ISocketAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketThreadDeleteAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketThreadDeleteAuditLogData.cs
@@ -63,7 +63,7 @@ public class SocketThreadDeleteAuditLogData : ISocketAuditLogData
     ///     Gets the value that indicates whether the deleted thread was archived.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread had the Archived flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread had the Archived flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsArchived { get; }
 
@@ -79,7 +79,7 @@ public class SocketThreadDeleteAuditLogData : ISocketAuditLogData
     ///     Gets the value that indicates whether the deleted thread was locked.
     /// </summary>
     /// <returns>
-    ///     <c>true</c> if this thread had the Locked flag enabled; otherwise <c>false</c>.
+    ///     <see langword="true" /> if this thread had the Locked flag enabled; otherwise <see langword="false" />.
     /// </returns>
     public bool IsLocked { get; }
 
@@ -89,7 +89,7 @@ public class SocketThreadDeleteAuditLogData : ISocketAuditLogData
     /// <returns>
     ///     An <see cref="int"/> representing the time in seconds required before the user can send another
     ///     message; <c>0</c> if disabled.
-    ///     <c>null</c> if this is not mentioned in this entry.
+    ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public int? SlowModeInterval { get; }
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/ISocketMessageChannel.cs
@@ -54,7 +54,7 @@ namespace Discord.WebSocket
         /// <remarks>
         ///     <note type="warning">
         ///         This method requires the use of cache, which is not enabled by default; if caching is not enabled,
-        ///         this method will always return <c>null</c>. Please refer to
+        ///         this method will always return <see langword="null" />. Please refer to
         ///         <see cref="Discord.WebSocket.DiscordSocketConfig.MessageCacheSize" /> for more details.
         ///     </note>
         ///     <para>
@@ -64,7 +64,7 @@ namespace Discord.WebSocket
         /// </remarks>
         /// <param name="id">The snowflake identifier of the message.</param>
         /// <returns>
-        ///     A WebSocket-based message object; <c>null</c> if it does not exist in the cache or if caching is not
+        ///     A WebSocket-based message object; <see langword="null" /> if it does not exist in the cache or if caching is not
         ///     enabled.
         /// </returns>
         SocketMessage GetCachedMessage(ulong id);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketDMChannel.cs
@@ -71,7 +71,7 @@ namespace Discord.WebSocket
         /// <param name="id">TThe ID of the message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     The message gotten from either the cache or the download, or <c>null</c> if none is found.
+        ///     The message gotten from either the cache or the download, or <see langword="null" /> if none is found.
         /// </returns>
         public async Task<IMessage> GetMessageAsync(ulong id, RequestOptions options = null)
         {
@@ -215,7 +215,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="id">The snowflake identifier of the user.</param>
         /// <returns>
-        ///     A <see cref="SocketUser"/> object that is a recipient of this channel; otherwise <c>null</c>.
+        ///     A <see cref="SocketUser"/> object that is a recipient of this channel; otherwise <see langword="null" />.
         /// </returns>
         public new SocketUser GetUser(ulong id)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketForumChannel.cs
@@ -52,7 +52,7 @@ namespace Discord.WebSocket
         ///     Gets the parent (category) of this channel in the guild's channel list.
         /// </summary>
         /// <returns>
-        ///     An <see cref="ICategoryChannel"/> representing the parent of this channel; <c>null</c> if none is set.
+        ///     An <see cref="ICategoryChannel"/> representing the parent of this channel; <see langword="null" /> if none is set.
         /// </returns>
         public ICategoryChannel Category
             => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGroupChannel.cs
@@ -107,7 +107,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous get operation for retrieving the message. The task result contains
-        ///     the retrieved message; <c>null</c> if no message is found with the specified identifier.
+        ///     the retrieved message; <see langword="null" /> if no message is found with the specified identifier.
         /// </returns>
         public async Task<IMessage> GetMessageAsync(ulong id, RequestOptions options = null)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -93,7 +93,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="user">The user to get the overwrite from.</param>
         /// <returns>
-        ///     An overwrite object for the targeted user; <c>null</c> if none is set.
+        ///     An overwrite object for the targeted user; <see langword="null" /> if none is set.
         /// </returns>
         public virtual OverwritePermissions? GetPermissionOverwrite(IUser user)
         {
@@ -109,7 +109,7 @@ namespace Discord.WebSocket
         /// </summary>
         /// <param name="role">The role to get the overwrite from.</param>
         /// <returns>
-        ///     An overwrite object for the targeted role; <c>null</c> if none is set.
+        ///     An overwrite object for the targeted role; <see langword="null" /> if none is set.
         /// </returns>
         public virtual OverwritePermissions? GetPermissionOverwrite(IRole role)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketTextChannel.cs
@@ -31,7 +31,7 @@ namespace Discord.WebSocket
         ///     Gets the parent (category) of this channel in the guild's channel list.
         /// </summary>
         /// <returns>
-        ///     An <see cref="ICategoryChannel"/> representing the parent of this channel; <c>null</c> if none is set.
+        ///     An <see cref="ICategoryChannel"/> representing the parent of this channel; <see langword="null" /> if none is set.
         /// </returns>
         public ICategoryChannel Category
             => CategoryId.HasValue ? Guild.GetChannel(CategoryId.Value) as ICategoryChannel : null;
@@ -151,7 +151,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents an asynchronous get operation for retrieving the message. The task result contains
-        ///     the retrieved message; <c>null</c> if no message is found with the specified identifier.
+        ///     the retrieved message; <see langword="null" /> if no message is found with the specified identifier.
         /// </returns>
         public virtual async Task<IMessage> GetMessageAsync(ulong id, RequestOptions options = null)
         {
@@ -332,7 +332,7 @@ namespace Discord.WebSocket
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous get operation. The task result contains a webhook associated
-        ///     with the identifier; <c>null</c> if the webhook is not found.
+        ///     with the identifier; <see langword="null" /> if the webhook is not found.
         /// </returns>
         public virtual Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => ChannelHelper.GetWebhookAsync(this, Discord, id, options);

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -50,7 +50,7 @@ namespace Discord.WebSocket
         ///     Returns a value that determines if the role is an @everyone role.
         /// </summary>
         /// <returns>
-        ///     <c>true</c> if the role is @everyone; otherwise <c>false</c>.
+        ///     <see langword="true" /> if the role is @everyone; otherwise <see langword="false" />.
         /// </returns>
         public bool IsEveryone => Id == Guild.Id;
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -82,7 +82,7 @@ namespace Discord.WebSocket
         public IReadOnlyCollection<SocketRole> Roles
             => _roleIds.Select(id => Guild.GetRole(id)).Where(x => x != null).ToReadOnlyCollection(() => _roleIds.Length);
         /// <summary>
-        ///     Returns the voice channel the user is in, or <c>null</c> if none.
+        ///     Returns the voice channel the user is in, or <see langword="null" /> if none.
         /// </summary>
         public SocketVoiceChannel VoiceChannel => VoiceState?.VoiceChannel;
         /// <inheritdoc />
@@ -91,7 +91,7 @@ namespace Discord.WebSocket
         ///     Gets the voice connection status of the user if any.
         /// </summary>
         /// <returns>
-        ///     A <see cref="SocketVoiceState" /> representing the user's voice status; <c>null</c> if the user is not
+        ///     A <see cref="SocketVoiceState" /> representing the user's voice status; <see langword="null" /> if the user is not
         ///     connected to a voice channel.
         /// </returns>
         public SocketVoiceState? VoiceState => Guild.GetVoiceState(Id);

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketVoiceState.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketVoiceState.cs
@@ -11,7 +11,7 @@ namespace Discord.WebSocket
     public struct SocketVoiceState : IVoiceState
     {
         /// <summary>
-        ///     Initializes a default <see cref="SocketVoiceState"/> with everything set to <c>null</c> or <c>false</c>.
+        ///     Initializes a default <see cref="SocketVoiceState"/> with everything set to <see langword="null" /> or <see langword="false" />.
         /// </summary>
         public static readonly SocketVoiceState Default = new SocketVoiceState(null, null, null, false, false, false, false, false, false, false);
 
@@ -31,7 +31,7 @@ namespace Discord.WebSocket
         private readonly Flags _voiceStates;
 
         /// <summary>
-        ///     Gets the voice channel that the user is currently in; or <c>null</c> if none.
+        ///     Gets the voice channel that the user is currently in; or <see langword="null" /> if none.
         /// </summary>
         public SocketVoiceChannel VoiceChannel { get; }
         /// <inheritdoc />


### PR DESCRIPTION
This PR brings some minor QoL improvements to the library

### Changes
- switch all XMLdoc comments to use `<see langword="word" />` statement instead of `<c>word</c>` workaround for `null`, `true` and `false`
- changed some classes in `Discord.API` namespace to `internal` as they should be
- bump library version in samples