### PR TITLE
[Feature] Support for the new username system

### DIFF
--- a/src/Discord.Net.Commands/Readers/UserTypeReader.cs
+++ b/src/Discord.Net.Commands/Readers/UserTypeReader.cs
@@ -59,6 +59,17 @@ namespace Discord.Commands
                 }
             }
 
+            //By global (display) name
+            {
+                await channelUsers
+                    .Where(x => string.Equals(input, x.GlobalName, StringComparison.OrdinalIgnoreCase))
+                    .ForEachAsync(channelUser => AddResult(results, channelUser as T, channelUser.GlobalName == input ? 0.65f : 0.55f))
+                    .ConfigureAwait(false);
+
+                foreach (var guildUser in guildUsers.Where(x => string.Equals(input, x.GlobalName, StringComparison.OrdinalIgnoreCase)))
+                    AddResult(results, guildUser as T, guildUser.GlobalName == input ? 0.60f : 0.50f);
+            }
+
             //By Username (0.5-0.6)
             {
                 await channelUsers

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -72,6 +72,7 @@ namespace Discord
             string extension = FormatToExtension(format, bannerId);
             return $"{DiscordConfig.CDNUrl}banners/{userId}/{bannerId}.{extension}?size={size}";
         }
+
         /// <summary>
         ///     Returns the default user avatar URL.
         /// </summary>
@@ -83,6 +84,19 @@ namespace Discord
         {
             return $"{DiscordConfig.CDNUrl}embed/avatars/{discriminator % 5}.png";
         }
+
+        /// <summary>
+        ///     Returns the default user avatar URL.
+        /// </summary>
+        /// <param name="userId">The Id of a user.</param>
+        /// <returns>
+        ///     A URL pointing to the user's default avatar when one isn't set.
+        /// </returns>
+        public static string GetDefaultUserAvatarUrl(ulong userId)
+        {
+            return $"{DiscordConfig.CDNUrl}embed/avatars/{(userId >> 22) % 6}.png";
+        }
+
         /// <summary>
         ///     Returns an icon URL.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -47,11 +47,11 @@ namespace Discord
         /// </returns>
         string GetDefaultAvatarUrl();
         /// <summary>
-        ///     Gets the per-username unique ID for this user. This will return "0000" for users, who have migrated to new username system.
+        ///     Gets the per-username unique ID for this user. This will return "0000" for users who have migrated to new username system.
         /// </summary>
         string Discriminator { get; }
         /// <summary>
-        ///     Gets the per-username unique ID for this user. This will return 0 for users, who have migrated to new username system.
+        ///     Gets the per-username unique ID for this user. This will return 0 for users who have migrated to new username system.
         /// </summary>
         ushort DiscriminatorValue { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -47,7 +47,7 @@ namespace Discord
         /// </returns>
         string GetDefaultAvatarUrl();
         /// <summary>
-        ///     Gets the per-username unique ID for this user. This will return 0 for users, who have migrated to new username system.
+        ///     Gets the per-username unique ID for this user. This will return "0000" for users, who have migrated to new username system.
         /// </summary>
         string Discriminator { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -47,11 +47,11 @@ namespace Discord
         /// </returns>
         string GetDefaultAvatarUrl();
         /// <summary>
-        ///     Gets the per-username unique ID for this user.
+        ///     Gets the per-username unique ID for this user. This will return 0 for users, who have migrated to new username system.
         /// </summary>
         string Discriminator { get; }
         /// <summary>
-        ///     Gets the per-username unique ID for this user.
+        ///     Gets the per-username unique ID for this user. This will return 0 for users, who have migrated to new username system.
         /// </summary>
         ushort DiscriminatorValue { get; }
         /// <summary>
@@ -86,6 +86,14 @@ namespace Discord
         ///     The value of public flags for this user.
         /// </returns>
         UserProperties? PublicFlags { get; }
+
+        /// <summary>
+        ///     Gets the user's display name, if it is set. For bots, this will get the application name.
+        /// </summary>
+        /// <remarks>
+        ///     This property will be <see langword="null"/> if user has no display name set.
+        /// </remarks>
+        string GlobalName { get; }
 
         /// <summary>
         ///     Creates the direct message channel of this user.

--- a/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/EmbedBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Discord
 
         /// <summary> Fills the embed author field with the provided user's full username and avatar URL. </summary>
         public static EmbedBuilder WithAuthor(this EmbedBuilder builder, IUser user) =>
-            builder.WithAuthor($"{user.Username}#{user.Discriminator}", user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl());
+            builder.WithAuthor(user.DiscriminatorValue != 0 ? $"{user.Username}#{user.Discriminator}" : user.Username, user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl());
 
         /// <summary> Converts a <see cref="EmbedType.Rich"/> <see cref="IEmbed"/> object to a <see cref="EmbedBuilder"/>. </summary>
         /// <exception cref="InvalidOperationException">The embed type is not <see cref="EmbedType.Rich"/>.</exception>

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -108,7 +108,7 @@ namespace Discord
         }
 
         /// <summary>
-        ///     Formats a user's username + discriminator. Returns the username if the user has migrated to new username system.
+        ///     Formats a user's username and optional discriminator.
         /// </summary>
         /// <param name="doBidirectional">To format the string in bidirectional unicode or not</param>
         /// <param name="user">The user whose username and discriminator to format</param>

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -108,16 +108,18 @@ namespace Discord
         }
 
         /// <summary>
-        ///     Formats a user's username + discriminator.
+        ///     Formats a user's username + discriminator. Returns the username if the user has migrated to new username system.
         /// </summary>
         /// <param name="doBidirectional">To format the string in bidirectional unicode or not</param>
         /// <param name="user">The user whose username and discriminator to format</param>
         /// <returns>The username + discriminator</returns>
         public static string UsernameAndDiscriminator(IUser user, bool doBidirectional)
         {
-            return doBidirectional
-                ? $"\u2066{user.Username}\u2069#{user.Discriminator}"
-                : $"{user.Username}#{user.Discriminator}";
+            if (user.DiscriminatorValue != 0)
+                return doBidirectional
+                    ? $"\u2066{user.Username}\u2069#{user.Discriminator}"
+                    : $"{user.Username}#{user.Discriminator}";
+            return user.Username;
         }
     }
 }

--- a/src/Discord.Net.Core/Format.cs
+++ b/src/Discord.Net.Core/Format.cs
@@ -112,7 +112,7 @@ namespace Discord
         /// </summary>
         /// <param name="doBidirectional">To format the string in bidirectional unicode or not</param>
         /// <param name="user">The user whose username and discriminator to format</param>
-        /// <returns>The username + discriminator</returns>
+        /// <returns>The username + optional discriminator.</returns>
         public static string UsernameAndDiscriminator(IUser user, bool doBidirectional)
         {
             if (user.DiscriminatorValue != 0)

--- a/src/Discord.Net.Core/Utils/MentionUtils.cs
+++ b/src/Discord.Net.Core/Utils/MentionUtils.cs
@@ -12,14 +12,14 @@ namespace Discord
         private const char SanitizeChar = '\x200b';
 
         //If the system can't be positive a user doesn't have a nickname, assume useNickname = true (source: Jake)
-        internal static string MentionUser(string id, bool useNickname = true) => useNickname ? $"<@!{id}>" : $"<@{id}>";
+        internal static string MentionUser(string id) => $"<@{id}>";
         /// <summary>
         ///     Returns a mention string based on the user ID.
         /// </summary>
         /// <returns>
         ///     A user mention string (e.g. &lt;@80351110224678912&gt;).
         /// </returns>
-        public static string MentionUser(ulong id) => MentionUser(id.ToString(), true);
+        public static string MentionUser(ulong id) => MentionUser(id.ToString());
         internal static string MentionChannel(string id) => $"<#{id}>";
         /// <summary>
         ///     Returns a mention string based on the channel ID.
@@ -192,12 +192,12 @@ namespace Discord
                             return "";
                     case TagHandling.FullName:
                         if (user != null)
-                            return $"@{user.Username}#{user.Discriminator}";
+                            return user.DiscriminatorValue != 0 ? $"@{user.Username}#{user.Discriminator}" : user.Username;
                         else
                             return "";
                     case TagHandling.FullNameNoPrefix:
                         if (user != null)
-                            return $"{user.Username}#{user.Discriminator}";
+                            return user.DiscriminatorValue != 0 ? $"@{user.Username}#{user.Discriminator}" : user.Username;
                         else
                             return "";
                     case TagHandling.Sanitize:

--- a/src/Discord.Net.Core/Utils/MentionUtils.cs
+++ b/src/Discord.Net.Core/Utils/MentionUtils.cs
@@ -202,9 +202,9 @@ namespace Discord
                             return "";
                     case TagHandling.Sanitize:
                         if (guildUser != null && guildUser.Nickname == null)
-                            return MentionUser($"{SanitizeChar}{tag.Key}", false);
+                            return MentionUser($"{SanitizeChar}{tag.Key}");
                         else
-                            return MentionUser($"{SanitizeChar}{tag.Key}", true);
+                            return MentionUser($"{SanitizeChar}{tag.Key}");
                 }
             }
             return "";

--- a/src/Discord.Net.Rest/API/Common/User.cs
+++ b/src/Discord.Net.Rest/API/Common/User.cs
@@ -19,6 +19,9 @@ namespace Discord.API
         [JsonProperty("accent_color")]
         public Optional<uint?> AccentColor { get; set; }
 
+        [JsonProperty("global_name")]
+        public Optional<string> GlobalName { get; set; }
+
         //CurrentUser
         [JsonProperty("verified")]
         public Optional<bool> Verified { get; set; }

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -19,8 +19,10 @@ namespace Discord.Rest
         private long? _timedOutTicks;
         private long? _joinedAtTicks;
         private ImmutableArray<ulong> _roleIds;
-        /// <inheritdoc />
-        public string DisplayName => Nickname ?? Username;
+
+        /// <inheritdoc cref="IGuildUser.DisplayName"/>
+        public string DisplayName => Nickname ?? GlobalName ?? Username;
+
         /// <inheritdoc />
         public string Nickname { get; private set; }
         /// <inheritdoc/>

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -87,7 +87,7 @@ namespace Discord.Rest
             if (model.AccentColor.IsSpecified)
                 AccentColor = model.AccentColor.Value;
             if (model.Discriminator.IsSpecified)
-                DiscriminatorValue = ushort.Parse(model.Discriminator.Value ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
+                DiscriminatorValue = ushort.Parse(model.Discriminator.GetValueOrDefault(null) ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
             if (model.Bot.IsSpecified)
                 IsBot = model.Bot.Value;
             if (model.Username.IsSpecified)

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -30,6 +30,8 @@ namespace Discord.Rest
         public Color? AccentColor { get; private set; }
         /// <inheritdoc />
         public UserProperties? PublicFlags { get; private set; }
+        /// <inheritdoc />
+        public string GlobalName { get; internal set; }
 
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
@@ -92,6 +94,8 @@ namespace Discord.Rest
                 Username = model.Username.Value;
             if (model.PublicFlags.IsSpecified)
                 PublicFlags = model.PublicFlags.Value;
+            if (model.GlobalName.IsSpecified)
+                GlobalName = model.GlobalName.Value;
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -125,7 +125,9 @@ namespace Discord.Rest
 
         /// <inheritdoc />
         public string GetDefaultAvatarUrl()
-            => CDN.GetDefaultUserAvatarUrl(DiscriminatorValue);
+            => DiscriminatorValue != 0
+                ? CDN.GetDefaultUserAvatarUrl(DiscriminatorValue)
+                : CDN.GetDefaultUserAvatarUrl(Id);
 
         /// <summary>
         ///     Gets the Username#Discriminator of the user.

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -87,7 +87,7 @@ namespace Discord.Rest
             if (model.AccentColor.IsSpecified)
                 AccentColor = model.AccentColor.Value;
             if (model.Discriminator.IsSpecified)
-                DiscriminatorValue = ushort.Parse(model.Discriminator.Value, NumberStyles.None, CultureInfo.InvariantCulture);
+                DiscriminatorValue = ushort.Parse(model.Discriminator.Value ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
             if (model.Bot.IsSpecified)
                 IsBot = model.Bot.Value;
             if (model.Username.IsSpecified)

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -201,7 +201,7 @@ namespace Discord.Rest
                             Username = command.User.Username,
                             Avatar = command.User.AvatarId,
                             Bot = command.User.IsBot,
-                            Discriminator = command.User.Discriminator,
+                            Discriminator = command.User.Discriminator == "0000" ? Optional<string>.Unspecified : command.User.Discriminator,
                             PublicFlags = command.User.PublicFlags.HasValue ? command.User.PublicFlags.Value : Optional<UserProperties>.Unspecified,
                             Id = command.User.Id,
                             GlobalName = command.User.GlobalName,

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -204,6 +204,7 @@ namespace Discord.Rest
                             Discriminator = command.User.Discriminator,
                             PublicFlags = command.User.PublicFlags.HasValue ? command.User.PublicFlags.Value : Optional<UserProperties>.Unspecified,
                             Id = command.User.Id,
+                            GlobalName = command.User.GlobalName,
                         }
                     };
                 }

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -140,7 +140,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     A generic WebSocket-based user; <c>null</c> when the user cannot be found.
         /// </returns>
-        public abstract SocketUser GetUser(string username, string discriminator);
+        public abstract SocketUser GetUser(string username, string discriminator = null);
         /// <summary>
         ///     Gets a channel.
         /// </summary>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -343,7 +343,7 @@ namespace Discord.WebSocket
             return null;
         }
         /// <inheritdoc />
-        public override SocketUser GetUser(string username, string discriminator)
+        public override SocketUser GetUser(string username, string discriminator = null)
         {
             for (int i = 0; i < _shards.Length; i++)
             {

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -425,8 +425,8 @@ namespace Discord.WebSocket
         public override SocketUser GetUser(ulong id)
             => State.GetUser(id);
         /// <inheritdoc />
-        public override SocketUser GetUser(string username, string discriminator)
-            => State.Users.FirstOrDefault(x => x.Discriminator == discriminator && x.Username == username);
+        public override SocketUser GetUser(string username, string discriminator = null)
+            => State.Users.FirstOrDefault(x => (discriminator is null || x.Discriminator == discriminator) && x.Username == username);
 
         /// <summary>
         ///     Gets a global application command.

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
@@ -48,7 +48,10 @@ namespace Discord.WebSocket
             }
         }
 
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Global)";
+        private string DebuggerDisplay => DiscriminatorValue != 0
+            ? $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Guild)"
+            : $"{Username} ({Id}{(IsBot ? ", Bot" : "")}, Guild)";
+
         internal new SocketGlobalUser Clone() => MemberwiseClone() as SocketGlobalUser;
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
@@ -48,7 +48,10 @@ namespace Discord.WebSocket
             return entity;
         }
 
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Group)";
+        private string DebuggerDisplay => DiscriminatorValue != 0
+            ? $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Group)"
+            : $"{Username} ({Id}{(IsBot ? ", Bot" : "")}, Group)";
+
         internal new SocketGroupUser Clone() => MemberwiseClone() as SocketGroupUser;
         #endregion
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -29,8 +29,10 @@ namespace Discord.WebSocket
         ///     Gets the guild the user is in.
         /// </summary>
         public SocketGuild Guild { get; }
-        /// <inheritdoc />
-        public string DisplayName => Nickname ?? Username;
+
+        /// <inheritdoc cref="IGuildUser.DisplayName"/>
+        public string DisplayName => Nickname ?? GlobalName ?? Username;
+
         /// <inheritdoc />
         public string Nickname { get; private set; }
         /// <inheritdoc/>
@@ -265,7 +267,9 @@ namespace Discord.WebSocket
         public string GetGuildAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
             => CDN.GetGuildUserAvatarUrl(Id, Guild.Id, GuildAvatarId, size, format);
 
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Guild)";
+        private string DebuggerDisplay => DiscriminatorValue != 0
+            ? $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Guild)"
+            : $"{Username} ({Id}{(IsBot ? ", Bot" : "")}, Guild)";
 
         internal new SocketGuildUser Clone()
         {

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
@@ -91,7 +91,10 @@ namespace Discord.WebSocket
         public Task ModifyAsync(Action<SelfUserProperties> func, RequestOptions options = null)
             => UserHelper.ModifyAsync(this, Discord, func, options);
 
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Self)";
+        private string DebuggerDisplay => DiscriminatorValue != 0
+            ? $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Self)"
+            : $"{Username} ({Id}{(IsBot ? ", Bot" : "")}, Self)";
+
         internal new SocketSelfUser Clone() => MemberwiseClone() as SocketSelfUser;
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -31,7 +31,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc/>
         public string DisplayName
-            => GuildUser.Nickname ?? GuildUser.Username;
+            => GuildUser.Nickname ?? GuildUser.GlobalName ?? GuildUser.Username;
 
         /// <inheritdoc/>
         public string Nickname

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
@@ -42,7 +42,10 @@ namespace Discord.WebSocket
             return entity;
         }
 
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Unknown)";
+        private string DebuggerDisplay => DiscriminatorValue != 0
+            ? $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Unknown)"
+            : $"{Username} ({Id}{(IsBot ? ", Bot" : "")}, Unknown)";
+
         internal new SocketUnknownUser Clone() => MemberwiseClone() as SocketUnknownUser;
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -71,10 +71,10 @@ namespace Discord.WebSocket
             }
             if (model.Discriminator.IsSpecified)
             {
-                var newVal = ushort.Parse(model.Discriminator.Value ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
+                var newVal = ushort.Parse(model.Discriminator.GetValueOrDefault(null) ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
                 if (newVal != DiscriminatorValue)
                 {
-                    DiscriminatorValue = ushort.Parse(model.Discriminator.Value ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
+                    DiscriminatorValue = ushort.Parse(model.Discriminator.GetValueOrDefault(null) ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
                     hasChanges = true;
                 }
             }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -33,6 +33,9 @@ namespace Discord.WebSocket
         internal abstract SocketPresence Presence { get; set; }
 
         /// <inheritdoc />
+        public string GlobalName { get; internal set; }
+
+        /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string Discriminator => DiscriminatorValue.ToString("D4");
@@ -88,6 +91,11 @@ namespace Discord.WebSocket
             if (model.PublicFlags.IsSpecified && model.PublicFlags.Value != PublicFlags)
             {
                 PublicFlags = model.PublicFlags.Value;
+                hasChanges = true;
+            }
+            if (model.GlobalName.IsSpecified)
+            {
+                GlobalName = model.GlobalName.Value;
                 hasChanges = true;
             }
             return hasChanges;

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -71,10 +71,10 @@ namespace Discord.WebSocket
             }
             if (model.Discriminator.IsSpecified)
             {
-                var newVal = ushort.Parse(model.Discriminator.Value, NumberStyles.None, CultureInfo.InvariantCulture);
+                var newVal = ushort.Parse(model.Discriminator.Value ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
                 if (newVal != DiscriminatorValue)
                 {
-                    DiscriminatorValue = ushort.Parse(model.Discriminator.Value, NumberStyles.None, CultureInfo.InvariantCulture);
+                    DiscriminatorValue = ushort.Parse(model.Discriminator.Value ?? "0", NumberStyles.None, CultureInfo.InvariantCulture);
                     hasChanges = true;
                 }
             }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -117,7 +117,9 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public string GetDefaultAvatarUrl()
-            => CDN.GetDefaultUserAvatarUrl(DiscriminatorValue);
+            => DiscriminatorValue != 0
+                ? CDN.GetDefaultUserAvatarUrl(DiscriminatorValue)
+                : CDN.GetDefaultUserAvatarUrl(Id);
 
         /// <summary>
         ///     Gets the full name of the user (e.g. Example#0001).

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -49,7 +49,10 @@ namespace Discord.WebSocket
             return entity;
         }
 
-        private string DebuggerDisplay => $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Webhook)";
+        private string DebuggerDisplay => DiscriminatorValue != 0
+            ? $"{Username}#{Discriminator} ({Id}{(IsBot ? ", Bot" : "")}, Webhook)"
+            : $"{Username} ({Id}{(IsBot ? ", Bot" : "")}, Webhook)";
+
         internal new SocketWebhookUser Clone() => MemberwiseClone() as SocketWebhookUser;
         #endregion
 

--- a/test/Discord.Net.Tests.Unit/MentionUtilsTests.cs
+++ b/test/Discord.Net.Tests.Unit/MentionUtilsTests.cs
@@ -16,10 +16,9 @@ namespace Discord
         [Fact]
         public void MentionUser()
         {
-            Assert.Equal("<@!123>", MentionUtils.MentionUser(123u));
-            Assert.Equal("<@!123>", MentionUtils.MentionUser("123"));
-            Assert.Equal("<@!123>", MentionUtils.MentionUser("123", true));
-            Assert.Equal("<@123>", MentionUtils.MentionUser("123", false));
+            Assert.Equal("<@123>", MentionUtils.MentionUser(123u));
+            Assert.Equal("<@123>", MentionUtils.MentionUser("123"));
+            Assert.Equal("<@123>", MentionUtils.MentionUser("123"));
         }
         /// <summary>
         ///     Tests <see cref="MentionUtils.MentionChannel(string)"/>

--- a/test/Discord.Net.Tests.Unit/MentionUtilsTests.cs
+++ b/test/Discord.Net.Tests.Unit/MentionUtilsTests.cs
@@ -18,7 +18,6 @@ namespace Discord
         {
             Assert.Equal("<@123>", MentionUtils.MentionUser(123u));
             Assert.Equal("<@123>", MentionUtils.MentionUser("123"));
-            Assert.Equal("<@123>", MentionUtils.MentionUser("123"));
         }
         /// <summary>
         ///     Tests <see cref="MentionUtils.MentionChannel(string)"/>


### PR DESCRIPTION
This PR brings support for the new username system introduced by discord.

### Changes
- update all `ToString()` methods of user entities & their debugger display properties to use the new unique username instead of `username#discriminator` pattern if discriminator value is equals to 0 - the placeholder value.
- made `discriminator` parameter of `BaseSocketClient.GetUser()` method optional
- update `EmbedBuilderExtensions.WithAuthor()`
- update `MentionUtils`
- Add `GlobalName` property to user entities
- Add a new CDN method with support for new default avatar calculation
- Update `UserTypeReader` in `Discord.Commands` to search for `GlobalName`
#### Misc
- update `MentionUtils` to use `<@id>` user mention syntax instead of deprecated `<@!id>` ([docs](https://discord.com/developers/docs/reference#message-formatting-formats))


- closes #2693

*P.S. I think I've found all places that need to be updated for the new system, pls correct me if I missed any*