### PR TITLE
[Fix] Threads not getting removed from cache on `THREAD_DELETE`

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -2584,7 +2584,7 @@ namespace Discord.WebSocket
                                         return;
                                     }
 
-                                    var thread = (SocketThreadChannel)guild.GetChannel(data.Id);
+                                    var thread = (SocketThreadChannel)guild.RemoveChannel(State, data.Id);
 
                                     var cacheable = new Cacheable<SocketThreadChannel, ulong>(thread, data.Id, thread != null, null);
 


### PR DESCRIPTION
This PR fixes the issue of threads not getting removed from cache on `THREAD_DELETE` event and thus fixes a memory leak

### Changes
- remove threads from cache on `THREAD_DELETE` event
