### PR TITLE
[Refactor] Remove unnecessary `@everyone` role check

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1926,8 +1926,6 @@ namespace Discord.API
 
             bool isCurrentUser = userId == CurrentUserId;
 
-            if (args.RoleIds.IsSpecified)
-                Preconditions.NotEveryoneRole(args.RoleIds.Value, guildId, nameof(args.RoleIds));
             if (isCurrentUser && args.Nickname.IsSpecified)
             {
                 var nickArgs = new Rest.ModifyCurrentUserNickParams(args.Nickname.Value ?? "");


### PR DESCRIPTION
The check for adding `@everyone` role in `IGuildUser.ModifyAsync` is unnecessary as the API ignores it. Removing one lets developers simplify & optimize code flow.

### Changes
- remove check for adding `@everyone` role