### PR TITLE
[Fix] Disconnecting socket client does not send close code

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketApiClient.cs
@@ -279,14 +279,16 @@ namespace Discord.API
                 return;
             ConnectionState = ConnectionState.Disconnecting;
 
-            try
-            { _connectCancelToken?.Cancel(false); }
-            catch { }
-
             if (ex is GatewayReconnectException)
                 await WebSocketClient.DisconnectAsync(4000).ConfigureAwait(false);
             else
                 await WebSocketClient.DisconnectAsync().ConfigureAwait(false);
+
+            try
+            {
+                _connectCancelToken?.Cancel(false);
+            }
+            catch { }
 
             ConnectionState = ConnectionState.Disconnected;
         }

--- a/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
@@ -120,16 +120,19 @@ namespace Discord.Net.WebSockets
                     {
                         await _client.CloseOutputAsync(status, "", new CancellationToken());
                     }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine(ex.ToString());
-                    }
+                    catch { }
                 }
+
                 try
-                { _client.Dispose(); }
+                {
+                    _client.Dispose();
+                }
                 catch { }
+
                 try
-                { _disconnectTokenSource.Cancel(false); }
+                {
+                    _disconnectTokenSource.Cancel(false);
+                }
                 catch { }
 
                 _client = null;

--- a/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
+++ b/src/Discord.Net.WebSocket/Net/DefaultWebSocketClient.cs
@@ -110,9 +110,6 @@ namespace Discord.Net.WebSockets
         {
             _isDisconnecting = true;
 
-            try
-            { _disconnectTokenSource.Cancel(false); }
-            catch { }
 
             if (_client != null)
             {
@@ -120,11 +117,19 @@ namespace Discord.Net.WebSockets
                 {
                     var status = (WebSocketCloseStatus)closeCode;
                     try
-                    { await _client.CloseOutputAsync(status, "", new CancellationToken()); }
-                    catch { }
+                    {
+                        await _client.CloseOutputAsync(status, "", new CancellationToken());
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex.ToString());
+                    }
                 }
                 try
                 { _client.Dispose(); }
+                catch { }
+                try
+                { _disconnectTokenSource.Cancel(false); }
                 catch { }
 
                 _client = null;


### PR DESCRIPTION
This PR fixes the `DiscordSocketClient` not sending close code on disconnect.

### Changes
- cancel tokens after sending close code