### PR TITLE
[Fix] Forum channel related issues.

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
@@ -31,7 +31,7 @@ public class ForumChannelProperties : TextChannelProperties
     /// <summary>
     /// Gets or sets a collection of tags inside of this forum channel.
     /// </summary>
-    public Optional<IEnumerable<ForumTagProperties>> Tags { get; set; }
+    public Optional<IEnumerable<IForumTag>> Tags { get; set; }
 
     /// <summary>
     /// Gets or sets a new default reaction emoji in this forum channel.

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTag.cs
@@ -1,67 +1,62 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 #nullable enable
 
-namespace Discord
+namespace Discord;
+
+/// <summary>
+///     A struct representing a forum channel tag.
+/// </summary>
+public readonly struct ForumTag : ISnowflakeEntity, IForumTag
 {
-    /// <summary>
-    ///     A struct representing a forum channel tag.
-    /// </summary>
-    public struct ForumTag : ISnowflakeEntity, IForumTag
+    /// <inheritdoc/>
+    public ulong Id { get; }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public IEmote? Emoji { get; }
+
+    /// <inheritdoc/>
+    public bool IsModerated { get; }
+
+    /// <inheritdoc/>
+    public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
+
+    internal ForumTag(ulong id, string name, ulong? emojiId = null, string? emojiName = null, bool moderated = false)
     {
-        /// <summary>
-        ///     Gets the Id of the tag.
-        /// </summary>
-        public ulong Id { get; }
+        if (emojiId.HasValue && emojiId.Value != 0)
+            Emoji = new Emote(emojiId.Value, null, false);
+        else if (emojiName != null)
+            Emoji = new Emoji(emojiName);
+        else
+            Emoji = null;
 
-        /// <inheritdoc/>
-        public string Name { get; }
-
-        /// <inheritdoc/>
-        public IEmote? Emoji { get; }
-
-        /// <inheritdoc/>
-        public bool IsModerated { get; }
-
-        /// <inheritdoc/>
-        public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
-
-        internal ForumTag(ulong id, string name, ulong? emojiId = null, string? emojiName = null, bool moderated = false)
-        {
-            if (emojiId.HasValue && emojiId.Value != 0)
-                Emoji = new Emote(emojiId.Value, null, false);
-            else if (emojiName != null)
-                Emoji = new Emoji(emojiName);
-            else
-                Emoji = null;
-
-            Id = id;
-            Name = name;
-            IsModerated = moderated;
-        }
-
-        public override int GetHashCode() => (Id, Name, Emoji, IsModerated).GetHashCode();
-
-        public override bool Equals(object? obj)
-            => obj is ForumTag tag && Equals(tag);
-
-        /// <summary>
-        /// Gets whether supplied tag is equals to the current one.
-        /// </summary>
-        public bool Equals(ForumTag tag)
-            => Id == tag.Id &&
-               Name == tag.Name &&
-               (Emoji is Emoji emoji && tag.Emoji is Emoji otherEmoji && emoji.Equals(otherEmoji) ||
-                Emoji is Emote emote && tag.Emoji is Emote otherEmote && emote.Equals(otherEmote)) &&
-               IsModerated == tag.IsModerated;
-
-        public static bool operator ==(ForumTag? left, ForumTag? right)
-            => left?.Equals(right) ?? right is null;
-
-        public static bool operator !=(ForumTag? left, ForumTag? right) => !(left == right);
+        Id = id;
+        Name = name;
+        IsModerated = moderated;
     }
+
+    public override int GetHashCode() => (Id, Name, Emoji, IsModerated).GetHashCode();
+
+    public override bool Equals(object? obj)
+        => obj is ForumTag tag && Equals(tag);
+
+    /// <summary>
+    /// Gets whether supplied tag is equals to the current one.
+    /// </summary>
+    public bool Equals(ForumTag tag)
+        => Id == tag.Id &&
+           Name == tag.Name &&
+           (Emoji is Emoji emoji && tag.Emoji is Emoji otherEmoji && emoji.Equals(otherEmoji) ||
+            Emoji is Emote emote && tag.Emoji is Emote otherEmote && emote.Equals(otherEmote)) &&
+           IsModerated == tag.IsModerated;
+
+    public static bool operator ==(ForumTag? left, ForumTag? right)
+        => left?.Equals(right) ?? right is null;
+
+    public static bool operator !=(ForumTag? left, ForumTag? right) => !(left == right);
+
+    /// <inheritdoc/>
+    readonly ulong? IForumTag.Id => Id;
 }

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagBuilder.cs
@@ -124,8 +124,8 @@ public class ForumTagBuilder
     public ForumTagProperties Build()
     {
         if (_name is null)
-            throw new ArgumentNullException(nameof(Name), "Name must be set to build the tag");
-        return new ForumTagProperties(_name!, _emoji, _moderated);
+            throw new ArgumentNullException(nameof(Name), "Name must be set to build the tag.");
+        return new ForumTagProperties(_id, _name, _emoji, _moderated);
     }
 
     /// <summary>

--- a/src/Discord.Net.Core/Entities/ForumTags/ForumTagProperties.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/ForumTagProperties.cs
@@ -7,7 +7,7 @@ public class ForumTagProperties : IForumTag
     /// <summary>
     ///     Gets the Id of the tag.
     /// </summary>
-    public ulong Id { get; }
+    public ulong? Id { get; }
 
     /// <inheritdoc/>
     public string Name { get; }
@@ -18,11 +18,12 @@ public class ForumTagProperties : IForumTag
     /// <inheritdoc/>
     public bool IsModerated { get; }
 
-    internal ForumTagProperties(string name, IEmote? emoji = null, bool isMmoderated = false)
+    internal ForumTagProperties(ulong? id, string name, IEmote? emoji = null, bool isModerated = false)
     {
+        Id = id;
         Name = name;
         Emoji = emoji;
-        IsModerated = isMmoderated;
+        IsModerated = isModerated;
     }
 
     public override int GetHashCode() => (Id, Name, Emoji, IsModerated).GetHashCode();

--- a/src/Discord.Net.Core/Entities/ForumTags/IForumTag.cs
+++ b/src/Discord.Net.Core/Entities/ForumTags/IForumTag.cs
@@ -8,6 +8,14 @@ namespace Discord;
 public interface IForumTag
 {
     /// <summary>
+    ///     Gets the Id of the tag.
+    ///</summary>
+    /// <remarks>
+    ///     This property may be <see langword="null"/> if the object is <see cref="ForumTagProperties"/>.
+    /// </remarks>
+    ulong? Id { get; }
+
+    /// <summary>
     ///     Gets the name of the tag.
     /// </summary>
     string Name { get; }

--- a/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
@@ -46,6 +46,8 @@ namespace Discord.API.Rest
 
             if (Slowmode.IsSpecified)
                 payload["rate_limit_per_user"] = Slowmode.Value;
+            if (TagIds.IsSpecified)
+                payload["applied_tags"] = TagIds.Value;
 
             // message
             if (Content.IsSpecified)
@@ -60,8 +62,6 @@ namespace Discord.API.Rest
                 message["sticker_ids"] = Stickers.Value;
             if (Flags.IsSpecified)
                 message["flags"] = Flags.Value;
-            if (TagIds.IsSpecified)
-                message["applied_tags"] = TagIds.Value;
 
             List<object> attachments = new();
 

--- a/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
@@ -15,7 +15,7 @@ internal static class ForumHelper
         var args = new ForumChannelProperties();
         func(args);
 
-        Preconditions.AtMost(args.Tags.IsSpecified ? args.Tags.Value.Count() : 0, 5, nameof(args.Tags), "Forum channel can have max 20 tags.");
+        Preconditions.AtMost(args.Tags.IsSpecified ? args.Tags.Value.Count() : 0, 20, nameof(args.Tags), "Forum channel can have max 20 tags.");
 
         var apiArgs = new API.Rest.ModifyForumChannelParams()
         {
@@ -36,6 +36,7 @@ internal static class ForumHelper
             Tags = args.Tags.IsSpecified
                 ? args.Tags.Value.Select(tag => new API.ModifyForumTagParams
                 {
+                    Id = tag.Id ?? Optional<ulong>.Unspecified,
                     Name = tag.Name,
                     EmojiId = tag.Emoji is Emote emote
                         ? emote.Id

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -229,7 +229,8 @@ namespace Discord.Rest
                 MessageComponent = components?.Components?.Any() ?? false ? components.Components.Select(x => new API.ActionRowComponent(x)).ToArray() : Optional<API.ActionRowComponent[]>.Unspecified,
                 Slowmode = slowmode,
                 Stickers = stickers?.Any() ?? false ? stickers.Select(x => x.Id).ToArray() : Optional<ulong[]>.Unspecified,
-                Title = title
+                Title = title,
+                TagIds = tagIds
             };
 
             var model = await client.ApiClient.CreatePostAsync(channel.Id, args, options);

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -376,7 +376,7 @@ namespace Discord.Rest
                 AvailableTags = props.Tags.GetValueOrDefault(Array.Empty<ForumTagProperties>()).Select(
                     x => new ModifyForumTagParams
                     {
-                        Id = x.Id,
+                        Id = x.Id ?? Optional<ulong>.Unspecified,
                         Name = x.Name,
                         EmojiId = x.Emoji is Emote emote
                             ? emote.Id


### PR DESCRIPTION
This PR fixes #2718.

### Changes
- abstract `IForumTag.Id`, so existing tags can be reused when modifying a forum channel.
- - change `Optional<IEnumerable<ForumTagProperties>> Tags` in `ForumChannelProperties` to use a collection of `IForumTag` instead

### Fixes
- fix `ForumTagBuilder` ignoring provided `Id`
- fix `CreatePostWithFile(s)Async` not setting applied tags
- update max forum tag count