### PR TITLE
[Feature] Add Role & Attachment flags

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -14,7 +14,6 @@ public enum AttachmentFlags
     ///     Indicates that this attachment is a clip.
     /// </summary>
     IsClip = 1 << 0,
-    
 
     /// <summary>
     ///     Indicates that this attachment is a thumbnail.

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -11,14 +11,15 @@ public enum AttachmentFlags
     None = 0,
 
     /// <summary>
-    ///     Indicates that this attachment is a thumbnail.
-    /// </summary>
-    IsThumbnail = 1 << 0,
-    
-    /// <summary>
     ///     Indicates that this attachment is a clip.
     /// </summary>
-    IsClip = 1 << 1,
+    IsClip = 1 << 0,
+    
+
+    /// <summary>
+    ///     Indicates that this attachment is a thumbnail.
+    /// </summary>
+    IsThumbnail = 1 << 1,
     
     /// <summary>
     ///     Indicates that this attachment has been edited using the remix feature on mobile.

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Discord;
+
+[Flags]
+public enum AttachmentFlags
+{
+    /// <summary>
+    ///     The attachment has no flags.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///     Indicates that this attachment has been edited using the remix feature on mobile.
+    /// </summary>
+    Remix = 0,
+}

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -11,7 +11,17 @@ public enum AttachmentFlags
     None = 0,
 
     /// <summary>
+    ///     Indicates that this attachment is a thumbnail.
+    /// </summary>
+    IsThumbnail = 1 << 0,
+    
+    /// <summary>
+    ///     Indicates that this attachment is a clip.
+    /// </summary>
+    IsClip = 1 << 1,
+    
+    /// <summary>
     ///     Indicates that this attachment has been edited using the remix feature on mobile.
     /// </summary>
-    Remix = 1 << 2,
+    IsRemix = 1 << 2,
 }

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -13,5 +13,5 @@ public enum AttachmentFlags
     /// <summary>
     ///     Indicates that this attachment has been edited using the remix feature on mobile.
     /// </summary>
-    Remix = 0,
+    Remix = 1 << 2,
 }

--- a/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
@@ -80,5 +80,10 @@ namespace Discord
         ///     Gets the base64 encoded bytearray representing a sampled waveform. <see langword="null"/> if the attachment is not a voice message.
         /// </summary>
         public string Waveform { get; }
+
+        /// <summary>
+        ///     Gets flags related to this to this attachment.
+        /// </summary>
+        public AttachmentFlags Flags { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -88,6 +88,11 @@ namespace Discord
         RoleTags Tags { get; }
 
         /// <summary>
+        ///     Gets flags related to this attachment.
+        /// </summary>
+        RoleFlags Flags { get; }
+
+        /// <summary>
         ///     Modifies this role.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -88,7 +88,7 @@ namespace Discord
         RoleTags Tags { get; }
 
         /// <summary>
-        ///     Gets flags related to this attachment.
+        ///     Gets flags related to this role.
         /// </summary>
         RoleFlags Flags { get; }
 

--- a/src/Discord.Net.Core/Entities/Roles/RoleFlags.cs
+++ b/src/Discord.Net.Core/Entities/Roles/RoleFlags.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Discord;
+
+[Flags]
+public enum RoleFlags
+{
+    /// <summary>
+    ///     The role has no flags.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///     Indicates that the role can be selected by members in an onboarding.
+    /// </summary>
+    InPrompt = 1 << 0,
+}

--- a/src/Discord.Net.Rest/API/Common/Attachment.cs
+++ b/src/Discord.Net.Rest/API/Common/Attachment.cs
@@ -1,32 +1,45 @@
 using Newtonsoft.Json;
 
-namespace Discord.API
+namespace Discord.API;
+
+internal class Attachment
 {
-    internal class Attachment
-    {
-        [JsonProperty("id")]
-        public ulong Id { get; set; }
-        [JsonProperty("filename")]
-        public string Filename { get; set; }
-        [JsonProperty("description")]
-        public Optional<string> Description { get; set; }
-        [JsonProperty("content_type")]
-        public Optional<string> ContentType { get; set; }
-        [JsonProperty("size")]
-        public int Size { get; set; }
-        [JsonProperty("url")]
-        public string Url { get; set; }
-        [JsonProperty("proxy_url")]
-        public string ProxyUrl { get; set; }
-        [JsonProperty("height")]
-        public Optional<int> Height { get; set; }
-        [JsonProperty("width")]
-        public Optional<int> Width { get; set; }
-        [JsonProperty("ephemeral")]
-        public Optional<bool> Ephemeral { get; set; }
-        [JsonProperty("duration_secs")]
-        public Optional<double> DurationSeconds { get; set; }
-        [JsonProperty("waveform")]
-        public Optional<string> Waveform { get; set; }
-    }
+    [JsonProperty("id")]
+    public ulong Id { get; set; }
+
+    [JsonProperty("filename")]
+    public string Filename { get; set; }
+
+    [JsonProperty("description")]
+    public Optional<string> Description { get; set; }
+
+    [JsonProperty("content_type")]
+    public Optional<string> ContentType { get; set; }
+
+    [JsonProperty("size")]
+    public int Size { get; set; }
+
+    [JsonProperty("url")]
+    public string Url { get; set; }
+
+    [JsonProperty("proxy_url")]
+    public string ProxyUrl { get; set; }
+
+    [JsonProperty("height")]
+    public Optional<int> Height { get; set; }
+
+    [JsonProperty("width")]
+    public Optional<int> Width { get; set; }
+
+    [JsonProperty("ephemeral")]
+    public Optional<bool> Ephemeral { get; set; }
+
+    [JsonProperty("duration_secs")]
+    public Optional<double> DurationSeconds { get; set; }
+
+    [JsonProperty("waveform")]
+    public Optional<string> Waveform { get; set; }
+
+    [JsonProperty("flags")]
+    public Optional<AttachmentFlags> Flags { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Common/Role.cs
+++ b/src/Discord.Net.Rest/API/Common/Role.cs
@@ -1,30 +1,42 @@
 using Newtonsoft.Json;
 
-namespace Discord.API
+namespace Discord.API;
+
+internal class Role
 {
-    internal class Role
-    {
-        [JsonProperty("id")]
-        public ulong Id { get; set; }
-        [JsonProperty("name")]
-        public string Name { get; set; }
-        [JsonProperty("icon")]
-        public Optional<string> Icon { get; set; }
-        [JsonProperty("unicode_emoji")]
-        public Optional<string> Emoji { get; set; }
-        [JsonProperty("color")]
-        public uint Color { get; set; }
-        [JsonProperty("hoist")]
-        public bool Hoist { get; set; }
-        [JsonProperty("mentionable")]
-        public bool Mentionable { get; set; }
-        [JsonProperty("position")]
-        public int Position { get; set; }
-        [JsonProperty("permissions"), Int53]
-        public string Permissions { get; set; }
-        [JsonProperty("managed")]
-        public bool Managed { get; set; }
-        [JsonProperty("tags")]
-        public Optional<RoleTags> Tags { get; set; }
-    }
+    [JsonProperty("id")]
+    public ulong Id { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("icon")]
+    public Optional<string> Icon { get; set; }
+
+    [JsonProperty("unicode_emoji")]
+    public Optional<string> Emoji { get; set; }
+
+    [JsonProperty("color")]
+    public uint Color { get; set; }
+
+    [JsonProperty("hoist")]
+    public bool Hoist { get; set; }
+
+    [JsonProperty("mentionable")]
+    public bool Mentionable { get; set; }
+
+    [JsonProperty("position")]
+    public int Position { get; set; }
+
+    [JsonProperty("permissions"), Int53]
+    public string Permissions { get; set; }
+
+    [JsonProperty("managed")]
+    public bool Managed { get; set; }
+
+    [JsonProperty("tags")]
+    public Optional<RoleTags> Tags { get; set; }
+
+    [JsonProperty("flags")]
+    public RoleFlags Flags { get; set; }
 }

--- a/src/Discord.Net.Rest/Entities/Messages/Attachment.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/Attachment.cs
@@ -32,8 +32,11 @@ namespace Discord
         /// <inheritdoc />
         public double? Duration { get; }
 
+        /// <inheritdoc />
+        public AttachmentFlags Flags { get; }
+
         internal Attachment(ulong id, string filename, string url, string proxyUrl, int size, int? height, int? width,
-            bool? ephemeral, string description, string contentType, double? duration, string waveform)
+            bool? ephemeral, string description, string contentType, double? duration, string waveform, AttachmentFlags flags)
         {
             Id = id;
             Filename = filename;
@@ -47,6 +50,7 @@ namespace Discord
             ContentType = contentType;
             Duration = duration;
             Waveform = waveform;
+            Flags = flags;
         }
         internal static Attachment Create(Model model)
         {
@@ -56,7 +60,8 @@ namespace Discord
                 model.Ephemeral.ToNullable(), model.Description.GetValueOrDefault(),
                 model.ContentType.GetValueOrDefault(),
                 model.DurationSeconds.IsSpecified ? model.DurationSeconds.Value : null,
-                model.Waveform.GetValueOrDefault(null));
+                model.Waveform.GetValueOrDefault(null),
+                model.Flags.GetValueOrDefault(AttachmentFlags.None));
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -35,6 +35,9 @@ namespace Discord.Rest
         public RoleTags Tags { get; private set; }
 
         /// <inheritdoc />
+        public RoleFlags Flags { get; private set; }
+
+        /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <summary>
         ///     Gets if this role is the @everyone role of the guild or not.
@@ -63,6 +66,8 @@ namespace Discord.Rest
             Position = model.Position;
             Color = new Color(model.Color);
             Permissions = new GuildPermissions(model.Permissions);
+            Flags = model.Flags;
+
             if (model.Tags.IsSpecified)
                 Tags = model.Tags.Value.ToEntity();
 

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -45,6 +45,9 @@ namespace Discord.WebSocket
         public RoleTags Tags { get; private set; }
 
         /// <inheritdoc />
+        public RoleFlags Flags { get; private set; }
+
+        /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <summary>
         ///     Returns a value that determines if the role is an @everyone role.
@@ -82,6 +85,8 @@ namespace Discord.WebSocket
             Position = model.Position;
             Color = new Color(model.Color);
             Permissions = new GuildPermissions(model.Permissions);
+            Flags = model.Flags;
+
             if (model.Tags.IsSpecified)
                 Tags = model.Tags.Value.ToEntity();
 


### PR DESCRIPTION
This PR adds `flags` properties to [Role](https://github.com/discord/discord-api-docs/pull/6269) & [Attachment](https://github.com/discord/discord-api-docs/pull/6272) entities