### PR TITLE
[Fix] Update modal's `DeferAsync` impl

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/Modals/IModalInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Modals/IModalInteraction.cs
@@ -31,5 +31,13 @@ namespace Discord
         ///     This method can be used only if the modal was created from a message component.
         /// </remarks>
         Task UpdateAsync(Action<MessageProperties> func, RequestOptions options = null);
+
+        /// <summary>
+        ///     Defers an interaction with the response type 5 (<see cref="InteractionResponseType.DeferredChannelMessageWithSource"/>).
+        /// </summary>
+        /// <param name="ephemeral"><see langword="true"/> to defer ephemerally, otherwise <see langword="false"/>.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>A task that represents the asynchronous operation of acknowledging the interaction.</returns>
+        Task DeferLoadingAsync(bool ephemeral = false, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
@@ -43,7 +43,8 @@ namespace Discord.Rest
         private object _lock = new object();
 
         /// <summary>
-        ///     Acknowledges this interaction with the <see cref="InteractionResponseType.DeferredChannelMessageWithSource"/>.
+        ///     Acknowledges this interaction with the <see cref="InteractionResponseType.DeferredUpdateMessage"/> if the modal was created
+        ///     in a response to a message component interaction, <see cref="InteractionResponseType.DeferredChannelMessageWithSource"/> otherwise.
         /// </summary>
         /// <returns>
         ///     A string that contains json to write back to the incoming http request.
@@ -55,7 +56,9 @@ namespace Discord.Rest
 
             var response = new API.InteractionResponse
             {
-                Type = InteractionResponseType.DeferredUpdateMessage,
+                Type = Message is not null
+                    ? InteractionResponseType.DeferredUpdateMessage
+                    : InteractionResponseType.DeferredChannelMessageWithSource,
                 Data = new API.InteractionCallbackData
                 {
                     Flags = ephemeral ? MessageFlags.Ephemeral : Optional<MessageFlags>.Unspecified

--- a/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
@@ -55,7 +55,7 @@ namespace Discord.Rest
 
             var response = new API.InteractionResponse
             {
-                Type = InteractionResponseType.DeferredChannelMessageWithSource,
+                Type = InteractionResponseType.DeferredUpdateMessage,
                 Data = new API.InteractionCallbackData
                 {
                     Flags = ephemeral ? MessageFlags.Ephemeral : Optional<MessageFlags>.Unspecified
@@ -77,6 +77,39 @@ namespace Discord.Rest
 
             return SerializePayload(response);
         }
+
+        /// <summary>
+        ///     Defers an interaction and responds with type 5 (<see cref="InteractionResponseType.DeferredChannelMessageWithSource"/>)
+        /// </summary>
+        /// <param name="ephemeral"><see langword="true"/> to send this message ephemerally, otherwise <see langword="false"/>.</param>
+        /// <param name="options">The request options for this <see langword="async"/> request.</param>
+        /// <returns>
+        ///     A string that contains json to write back to the incoming http request.
+        /// </returns>
+        public string DeferLoading(bool ephemeral = false, RequestOptions options = null)
+        {
+            if (!InteractionHelper.CanSendResponse(this))
+                throw new TimeoutException($"Cannot defer an interaction after {InteractionHelper.ResponseTimeLimit} seconds of no response/acknowledgement");
+
+            var response = new API.InteractionResponse
+            {
+                Type = InteractionResponseType.DeferredChannelMessageWithSource,
+                Data = ephemeral ? new API.InteractionCallbackData { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
+            };
+
+            lock (_lock)
+            {
+                if (HasResponded)
+                {
+                    throw new InvalidOperationException("Cannot respond or defer twice to the same interaction");
+                }
+
+                HasResponded = true;
+            }
+
+            return SerializePayload(response);
+        }
+
 
         /// <summary>
         ///     Sends a followup message for this interaction.
@@ -412,6 +445,10 @@ namespace Discord.Rest
         IUserMessage IModalInteraction.Message => Message;
 
         IModalInteractionData IModalInteraction.Data => Data;
+
+        /// <inheritdoc />
+        Task IModalInteraction.DeferLoadingAsync(bool ephemeral, RequestOptions options)
+            => Task.FromResult(DeferLoading(ephemeral, options));
 
         /// <inheritdoc/>
         public async Task UpdateAsync(Action<MessageProperties> func, RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Modals/SocketModal.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Modals/SocketModal.cs
@@ -376,6 +376,10 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc/>
+        /// <remarks>     
+        ///     Acknowledges this interaction with the <see cref="InteractionResponseType.DeferredUpdateMessage"/> if the modal was created
+        ///     in a response to a message component interaction, <see cref="InteractionResponseType.DeferredChannelMessageWithSource"/> otherwise.
+        /// </remarks>
         public override async Task DeferAsync(bool ephemeral = false, RequestOptions options = null)
         {
             if (!InteractionHelper.CanSendResponse(this))
@@ -383,7 +387,9 @@ namespace Discord.WebSocket
 
             var response = new API.InteractionResponse
             {
-                Type = InteractionResponseType.DeferredUpdateMessage,
+                Type = Message is not null
+                    ? InteractionResponseType.DeferredUpdateMessage
+                    : InteractionResponseType.DeferredChannelMessageWithSource,
                 Data = ephemeral ? new API.InteractionCallbackData { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
             };
 


### PR DESCRIPTION
Currently defer on modals responds with `InteractionResponseType.DeferredUpdateMessage` response type, while leaving no way of responding with `InteractionResponseType.DeferredChannelMessageWithSource` - basically making it impossible to defer a modal sent in response to a slash command interaction.
This PR adds the `DeferLoadingAsync` method to `IModalInteraction`. In a similar to `IComponentInteraction` way - it responds with `DeferredChannelMessageWithSource` type.

### Changes
- add `DeferLoadingAsync` to `IModalInteraction` and its inherited types
- update `Defer(Async)` to use `DeferredChannelMessageWithSource` if the `IModalInteraction.Message` is `null` (= interaction that triggered the modal was not a component interaction)

## Warning
- This PR changes the behavior of `RestModal.Defer` to respond with `DeferredUpdateMessage` type to equalize behavior with the `SocketModal.DeferAsync`
- In addition to the previous change - if the modal was sent in a response to a non component interaction - the `Defer(Async)` responds with `DeferredChannelMessageWithSource` type instead of `DeferredUpdateMessage`

fixes #2624