### PR TITLE
[Feature] Media channel support

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/ChannelFlags.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ChannelFlags.cs
@@ -16,7 +16,12 @@ public enum ChannelFlags
     Pinned = 1 << 1,
 
     /// <summary>
-    ///     Flag given to a forum channel that requires people to select tags when posting.
+    ///     Flag given to a forum or media channel that requires people to select tags when posting.
     /// </summary>
-    RequireTag = 1 << 4
+    RequireTag = 1 << 4,
+
+    /// <summary>
+    ///     Flag given to a media channel that hides the embedded media download options.
+    /// </summary>
+    HideMediaDownloadOption = 1 << 15,
 }

--- a/src/Discord.Net.Core/Entities/Channels/ChannelType.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ChannelType.cs
@@ -1,33 +1,75 @@
-namespace Discord
+namespace Discord;
+
+/// <summary> Defines the types of channels. </summary>
+public enum ChannelType
 {
-    /// <summary> Defines the types of channels. </summary>
-    public enum ChannelType
-    {
-        /// <summary> The channel is a text channel. </summary>
-        Text = 0,
-        /// <summary> The channel is a Direct Message channel. </summary>
-        DM = 1,
-        /// <summary> The channel is a voice channel. </summary>
-        Voice = 2,
-        /// <summary> The channel is a group channel. </summary>
-        Group = 3,
-        /// <summary> The channel is a category channel. </summary>
-        Category = 4,
-        /// <summary> The channel is a news channel. </summary>
-        News = 5,
-        /// <summary> The channel is a store channel. </summary>
-        Store = 6,
-        /// <summary> The channel is a temporary thread channel under a news channel. </summary>
-        NewsThread = 10,
-        /// <summary> The channel is a temporary thread channel under a text channel.  </summary>
-        PublicThread = 11,
-        /// <summary> The channel is a private temporary thread channel under a text channel.  </summary>
-        PrivateThread = 12,
-        /// <summary> The channel is a stage voice channel. </summary>
-        Stage = 13,
-        /// <summary> The channel is a guild directory used in hub servers. (Unreleased)</summary>
-        GuildDirectory = 14,
-        /// <summary> The channel is a forum channel containing multiple threads. </summary>
-        Forum = 15
-    }
+    /// <summary>
+    ///     The channel is a text channel.
+    /// </summary>
+    Text = 0,
+
+    /// <summary>
+    ///     The channel is a Direct Message channel.
+    /// </summary>
+    DM = 1,
+
+    /// <summary>
+    ///     The channel is a voice channel.
+    /// </summary>
+    Voice = 2,
+
+    /// <summary>
+    ///     The channel is a group channel.
+    /// </summary>
+    Group = 3,
+
+    /// <summary>
+    ///     The channel is a category channel.
+    /// </summary>
+    Category = 4,
+
+    /// <summary>
+    ///     The channel is a news channel.
+    /// </summary>
+    News = 5,
+
+    /// <summary>
+    ///     The channel is a store channel.
+    /// </summary>
+    Store = 6,
+
+    /// <summary>
+    ///     The channel is a temporary thread channel under a news channel.
+    /// </summary>
+    NewsThread = 10,
+
+    /// <summary>
+    ///     The channel is a temporary thread channel under a text channel.
+    /// </summary>
+    PublicThread = 11,
+
+    /// <summary>
+    ///     The channel is a private temporary thread channel under a text channel.
+    /// </summary>
+    PrivateThread = 12,
+
+    /// <summary>
+    ///     The channel is a stage voice channel.
+    /// </summary>
+    Stage = 13,
+
+    /// <summary>
+    ///     The channel is a guild directory used in hub servers. (Unreleased)
+    /// </summary>
+    GuildDirectory = 14,
+
+    /// <summary>
+    ///     The channel is a forum channel containing multiple threads.
+    /// </summary>
+    Forum = 15,
+
+    /// <summary>
+    ///     The channel is a media channel containing multiple threads.
+    /// </summary>
+    Media = 16,
 }

--- a/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ForumChannelProperties.cs
@@ -29,22 +29,25 @@ public class ForumChannelProperties : TextChannelProperties
     public Optional<int> ThreadCreationInterval { get; set; }
 
     /// <summary>
-    /// Gets or sets a collection of tags inside of this forum channel.
+    ///     Gets or sets a collection of tags inside of this forum channel.
     /// </summary>
     public Optional<IEnumerable<ForumTagProperties>> Tags { get; set; }
 
     /// <summary>
-    /// Gets or sets a new default reaction emoji in this forum channel.
+    ///     Gets or sets a new default reaction emoji in this forum channel.
     /// </summary>
     public Optional<IEmote> DefaultReactionEmoji { get; set; }
 
     /// <summary>
-    /// Gets or sets the rule used to order posts in forum channels.
+    ///     Gets or sets the rule used to order posts in forum channels.
     /// </summary>
     public Optional<ForumSortOrder> DefaultSortOrder { get; set; }
 
     /// <summary>
-    /// Gets or sets the rule used to display posts in a forum channel.
+    ///     Gets or sets the rule used to display posts in a forum channel.
     /// </summary>
+    /// <remarks>
+    ///     This property cannot be changed in media channels.
+    /// </remarks>
     public Optional<ForumLayout> DefaultLayout { get; set; }
 }

--- a/src/Discord.Net.Core/Entities/Channels/IMediaChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IMediaChannel.cs
@@ -1,0 +1,9 @@
+namespace Discord;
+
+/// <summary>
+///     Represents a media channel in a guild that can create posts.
+/// </summary>
+public interface IMediaChannel : IForumChannel
+{
+    
+}

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -729,6 +729,52 @@ namespace Discord
         Task<IReadOnlyCollection<IThreadChannel>> GetThreadChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
 
         /// <summary>
+        ///     Gets a forum channel in this guild.
+        /// </summary>
+        /// <param name="id">The snowflake identifier for the stage channel.</param>
+        /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains the stage channel associated
+        ///     with the specified <paramref name="id"/>; <see langword="null" /> if none is found.
+        /// </returns>
+        Task<IForumChannel> GetForumChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a collection of all forum channels in this guild.
+        /// </summary>
+        /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection of
+        ///     forum channels found within this guild.
+        /// </returns>
+        Task<IReadOnlyCollection<IForumChannel>> GetForumChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a forum channel in this guild.
+        /// </summary>
+        /// <param name="id">The snowflake identifier for the stage channel.</param>
+        /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains the stage channel associated
+        ///     with the specified <paramref name="id"/>; <see langword="null" /> if none is found.
+        /// </returns>
+        Task<IMediaChannel> GetMediaChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets a collection of all forum channels in this guild.
+        /// </summary>
+        /// <param name="mode">The <see cref="CacheMode"/> that determines whether the object should be fetched from cache.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection of
+        ///     media channels found within this guild.
+        /// </returns>
+        Task<IReadOnlyCollection<IMediaChannel>> GetMediaChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null);
+
+        /// <summary>
         ///     Creates a new text channel in this guild.
         /// </summary>
         /// <example>
@@ -789,6 +835,18 @@ namespace Discord
         ///     forum channel.
         /// </returns>
         Task<IForumChannel> CreateForumChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null);
+
+        /// <summary>
+        ///     Creates a new media channel in this guild.
+        /// </summary>
+        /// <param name="name">The new name for the media channel.</param>
+        /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous creation operation. The task result contains the newly created
+        ///     forum channel.
+        /// </returns>
+        Task<IMediaChannel> CreateMediaChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null);
 
         /// <summary>
         ///     Gets a collection of all the voice regions this guild can access.

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -14,7 +14,6 @@ public enum AttachmentFlags
     ///     Indicates that this attachment is a clip.
     /// </summary>
     IsClip = 1 << 0,
-    
 
     /// <summary>
     ///     Indicates that this attachment is a thumbnail.

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -11,14 +11,15 @@ public enum AttachmentFlags
     None = 0,
 
     /// <summary>
-    ///     Indicates that this attachment is a thumbnail.
-    /// </summary>
-    IsThumbnail = 1 << 0,
-    
-    /// <summary>
     ///     Indicates that this attachment is a clip.
     /// </summary>
-    IsClip = 1 << 1,
+    IsClip = 1 << 0,
+    
+
+    /// <summary>
+    ///     Indicates that this attachment is a thumbnail.
+    /// </summary>
+    IsThumbnail = 1 << 1,
     
     /// <summary>
     ///     Indicates that this attachment has been edited using the remix feature on mobile.

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Discord;
+
+[Flags]
+public enum AttachmentFlags
+{
+    /// <summary>
+    ///     The attachment has no flags.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///     Indicates that this attachment has been edited using the remix feature on mobile.
+    /// </summary>
+    Remix = 0,
+}

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -11,7 +11,17 @@ public enum AttachmentFlags
     None = 0,
 
     /// <summary>
+    ///     Indicates that this attachment is a thumbnail.
+    /// </summary>
+    IsThumbnail = 1 << 0,
+    
+    /// <summary>
+    ///     Indicates that this attachment is a clip.
+    /// </summary>
+    IsClip = 1 << 1,
+    
+    /// <summary>
     ///     Indicates that this attachment has been edited using the remix feature on mobile.
     /// </summary>
-    Remix = 1 << 2,
+    IsRemix = 1 << 2,
 }

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -13,5 +13,5 @@ public enum AttachmentFlags
     /// <summary>
     ///     Indicates that this attachment has been edited using the remix feature on mobile.
     /// </summary>
-    Remix = 0,
+    Remix = 1 << 2,
 }

--- a/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/FileAttachment.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -26,6 +22,11 @@ namespace Discord
         /// </summary>
         public bool IsSpoiler { get; set; }
 
+        /// <summary>
+        ///     Gets or sets if this file should be a thumbnail for a media channel post.
+        /// </summary>
+        public bool IsThumbnail { get; set; }
+
 #pragma warning disable IDISP008
         /// <summary>
         ///     Gets the stream containing the file content.
@@ -42,12 +43,14 @@ namespace Discord
         /// <param name="fileName">The name of the attachment.</param>
         /// <param name="description">The description of the attachment.</param>
         /// <param name="isSpoiler">Whether or not the attachment is a spoiler.</param>
-        public FileAttachment(Stream stream, string fileName, string description = null, bool isSpoiler = false)
+        /// <param name="isThumbnail">Whether or not this attachment should be a thumbnail for a media channel post.</param>
+        public FileAttachment(Stream stream, string fileName, string description = null, bool isSpoiler = false, bool isThumbnail = false)
         {
             _isDisposed = false;
             FileName = fileName;
             Description = description;
             Stream = stream;
+            IsThumbnail = isThumbnail;
             try
             {
                 Stream.Position = 0;
@@ -67,6 +70,7 @@ namespace Discord
         /// <param name="fileName">The name of the attachment.</param>
         /// <param name="description">The description of the attachment.</param>
         /// <param name="isSpoiler">Whether or not the attachment is a spoiler.</param>
+        /// <param name="isThumbnail">Whether or not this attachment should be a thumbnail for a media channel post.</param>
         /// <exception cref="System.ArgumentException">
         /// <paramref name="path" /> is a zero-length string, contains only white space, or contains one or more invalid
         /// characters as defined by <see cref="Path.GetInvalidPathChars"/>.
@@ -87,13 +91,14 @@ namespace Discord
         /// <exception cref="FileNotFoundException">The file specified in <paramref name="path" /> was not found.
         /// </exception>
         /// <exception cref="IOException">An I/O error occurred while opening the file. </exception>
-        public FileAttachment(string path, string fileName = null, string description = null, bool isSpoiler = false)
+        public FileAttachment(string path, string fileName = null, string description = null, bool isSpoiler = false, bool isThumbnail = false)
         {
             _isDisposed = false;
             Stream = File.OpenRead(path);
             FileName = fileName ?? Path.GetFileName(path);
             Description = description;
             IsSpoiler = isSpoiler;
+            IsThumbnail = isThumbnail;
         }
 
         public void Dispose()

--- a/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
+++ b/src/Discord.Net.Core/Entities/Messages/IAttachment.cs
@@ -80,5 +80,10 @@ namespace Discord
         ///     Gets the base64 encoded bytearray representing a sampled waveform. <see langword="null"/> if the attachment is not a voice message.
         /// </summary>
         public string Waveform { get; }
+
+        /// <summary>
+        ///     Gets flags related to this to this attachment.
+        /// </summary>
+        public AttachmentFlags Flags { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ChannelPermissions.cs
@@ -51,6 +51,11 @@ namespace Discord
         public static readonly ChannelPermissions Forum = new(0b01_001110_010010_110011_111101_111111_111101_010001);
 
         /// <summary>
+        ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for media channels.
+        /// </summary>
+        public static readonly ChannelPermissions Media = new(0b01_001110_010010_110011_111101_111111_111101_010001);
+
+        /// <summary>
         ///     Gets a <see cref="ChannelPermissions"/> that grants all permissions for a given channel type.
         /// </summary>
         /// <exception cref="ArgumentException">Unknown channel type.</exception>
@@ -64,6 +69,7 @@ namespace Discord
                 ICategoryChannel _ => Category,
                 IDMChannel _ => DM,
                 IGroupChannel _ => Group,
+                IMediaChannel _ => Media,
                 IForumChannel => Forum,
                 _ => throw new ArgumentException(message: "Unknown channel type.", paramName: nameof(channel)),
             };

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -88,6 +88,11 @@ namespace Discord
         RoleTags Tags { get; }
 
         /// <summary>
+        ///     Gets flags related to this attachment.
+        /// </summary>
+        RoleFlags Flags { get; }
+
+        /// <summary>
         ///     Modifies this role.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -88,7 +88,7 @@ namespace Discord
         RoleTags Tags { get; }
 
         /// <summary>
-        ///     Gets flags related to this attachment.
+        ///     Gets flags related to this role.
         /// </summary>
         RoleFlags Flags { get; }
 

--- a/src/Discord.Net.Core/Entities/Roles/RoleFlags.cs
+++ b/src/Discord.Net.Core/Entities/Roles/RoleFlags.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Discord;
+
+[Flags]
+public enum RoleFlags
+{
+    /// <summary>
+    ///     The role has no flags.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///     Indicates that the role can be selected by members in an onboarding.
+    /// </summary>
+    InPrompt = 1 << 0,
+}

--- a/src/Discord.Net.Core/Extensions/ChannelExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/ChannelExtensions.cs
@@ -47,6 +47,9 @@ namespace Discord
                 case ITextChannel:
                     return ChannelType.Text;
 
+                case IMediaChannel:
+                    return ChannelType.Media;
+
                 case IForumChannel:
                     return ChannelType.Forum;
             }

--- a/src/Discord.Net.Core/Utils/ChannelTypeUtils.cs
+++ b/src/Discord.Net.Core/Utils/ChannelTypeUtils.cs
@@ -9,6 +9,6 @@ public static class ChannelTypeUtils
         {
             ChannelType.Forum, ChannelType.Category, ChannelType.DM, ChannelType.Group, ChannelType.GuildDirectory,
             ChannelType.News, ChannelType.NewsThread, ChannelType.PrivateThread, ChannelType.PublicThread,
-            ChannelType.Stage, ChannelType.Store, ChannelType.Text, ChannelType.Voice
+            ChannelType.Stage, ChannelType.Store, ChannelType.Text, ChannelType.Voice, ChannelType.Media
         };
 }

--- a/src/Discord.Net.Interactions/TypeConverters/SlashCommands/DefaultEntityTypeConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/SlashCommands/DefaultEntityTypeConverter.cs
@@ -69,6 +69,12 @@ namespace Discord.Interactions
                 _ when typeof(ITextChannel).IsAssignableFrom(type)
                     => new List<ChannelType> { ChannelType.Text },
 
+                _ when typeof(IMediaChannel).IsAssignableFrom(type)
+                    => new List<ChannelType> { ChannelType.Media },
+
+                _ when typeof(IForumChannel).IsAssignableFrom(type)
+                    => new List<ChannelType> { ChannelType.Forum },
+
                 _ => null
             };
         }

--- a/src/Discord.Net.Rest/API/Common/Attachment.cs
+++ b/src/Discord.Net.Rest/API/Common/Attachment.cs
@@ -1,32 +1,45 @@
 using Newtonsoft.Json;
 
-namespace Discord.API
+namespace Discord.API;
+
+internal class Attachment
 {
-    internal class Attachment
-    {
-        [JsonProperty("id")]
-        public ulong Id { get; set; }
-        [JsonProperty("filename")]
-        public string Filename { get; set; }
-        [JsonProperty("description")]
-        public Optional<string> Description { get; set; }
-        [JsonProperty("content_type")]
-        public Optional<string> ContentType { get; set; }
-        [JsonProperty("size")]
-        public int Size { get; set; }
-        [JsonProperty("url")]
-        public string Url { get; set; }
-        [JsonProperty("proxy_url")]
-        public string ProxyUrl { get; set; }
-        [JsonProperty("height")]
-        public Optional<int> Height { get; set; }
-        [JsonProperty("width")]
-        public Optional<int> Width { get; set; }
-        [JsonProperty("ephemeral")]
-        public Optional<bool> Ephemeral { get; set; }
-        [JsonProperty("duration_secs")]
-        public Optional<double> DurationSeconds { get; set; }
-        [JsonProperty("waveform")]
-        public Optional<string> Waveform { get; set; }
-    }
+    [JsonProperty("id")]
+    public ulong Id { get; set; }
+
+    [JsonProperty("filename")]
+    public string Filename { get; set; }
+
+    [JsonProperty("description")]
+    public Optional<string> Description { get; set; }
+
+    [JsonProperty("content_type")]
+    public Optional<string> ContentType { get; set; }
+
+    [JsonProperty("size")]
+    public int Size { get; set; }
+
+    [JsonProperty("url")]
+    public string Url { get; set; }
+
+    [JsonProperty("proxy_url")]
+    public string ProxyUrl { get; set; }
+
+    [JsonProperty("height")]
+    public Optional<int> Height { get; set; }
+
+    [JsonProperty("width")]
+    public Optional<int> Width { get; set; }
+
+    [JsonProperty("ephemeral")]
+    public Optional<bool> Ephemeral { get; set; }
+
+    [JsonProperty("duration_secs")]
+    public Optional<double> DurationSeconds { get; set; }
+
+    [JsonProperty("waveform")]
+    public Optional<string> Waveform { get; set; }
+
+    [JsonProperty("flags")]
+    public Optional<AttachmentFlags> Flags { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Common/Role.cs
+++ b/src/Discord.Net.Rest/API/Common/Role.cs
@@ -1,30 +1,42 @@
 using Newtonsoft.Json;
 
-namespace Discord.API
+namespace Discord.API;
+
+internal class Role
 {
-    internal class Role
-    {
-        [JsonProperty("id")]
-        public ulong Id { get; set; }
-        [JsonProperty("name")]
-        public string Name { get; set; }
-        [JsonProperty("icon")]
-        public Optional<string> Icon { get; set; }
-        [JsonProperty("unicode_emoji")]
-        public Optional<string> Emoji { get; set; }
-        [JsonProperty("color")]
-        public uint Color { get; set; }
-        [JsonProperty("hoist")]
-        public bool Hoist { get; set; }
-        [JsonProperty("mentionable")]
-        public bool Mentionable { get; set; }
-        [JsonProperty("position")]
-        public int Position { get; set; }
-        [JsonProperty("permissions"), Int53]
-        public string Permissions { get; set; }
-        [JsonProperty("managed")]
-        public bool Managed { get; set; }
-        [JsonProperty("tags")]
-        public Optional<RoleTags> Tags { get; set; }
-    }
+    [JsonProperty("id")]
+    public ulong Id { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("icon")]
+    public Optional<string> Icon { get; set; }
+
+    [JsonProperty("unicode_emoji")]
+    public Optional<string> Emoji { get; set; }
+
+    [JsonProperty("color")]
+    public uint Color { get; set; }
+
+    [JsonProperty("hoist")]
+    public bool Hoist { get; set; }
+
+    [JsonProperty("mentionable")]
+    public bool Mentionable { get; set; }
+
+    [JsonProperty("position")]
+    public int Position { get; set; }
+
+    [JsonProperty("permissions"), Int53]
+    public string Permissions { get; set; }
+
+    [JsonProperty("managed")]
+    public bool Managed { get; set; }
+
+    [JsonProperty("tags")]
+    public Optional<RoleTags> Tags { get; set; }
+
+    [JsonProperty("flags")]
+    public RoleFlags Flags { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateMultipartPostAsync.cs
@@ -78,7 +78,8 @@ namespace Discord.API.Rest
                 {
                     id = (ulong)n,
                     filename = filename,
-                    description = attachment.Description ?? Optional<string>.Unspecified
+                    description = attachment.Description ?? Optional<string>.Unspecified,
+                    is_thumbnail = attachment.IsThumbnail,
                 });
             }
 

--- a/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ForumHelper.cs
@@ -56,8 +56,7 @@ internal static class ForumHelper
                         emoji.Name : Optional<string>.Unspecified
                 }
                 : Optional<ModifyForumReactionEmojiParams>.Unspecified,
-            DefaultSortOrder = args.DefaultSortOrder,
-            DefaultLayout = args.DefaultLayout,
+            DefaultSortOrder = args.DefaultSortOrder
         };
         return await client.ApiClient.ModifyGuildChannelAsync(channel.Id, apiArgs, options).ConfigureAwait(false);
     }

--- a/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestChannel.cs
@@ -50,7 +50,8 @@ namespace Discord.Rest
                 ChannelType.NewsThread or
                 ChannelType.PrivateThread or
                 ChannelType.PublicThread or
-                ChannelType.Forum
+                ChannelType.Forum or
+                ChannelType.Media
                     => RestGuildChannel.Create(discord, guild, model),
                 ChannelType.DM or ChannelType.Group => CreatePrivate(discord, model) as RestChannel,
                 ChannelType.Category => RestCategoryChannel.Create(discord, guild, model),

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -42,6 +42,7 @@ namespace Discord.Rest
                 ChannelType.Text => RestTextChannel.Create(discord, guild, model),
                 ChannelType.Voice => RestVoiceChannel.Create(discord, guild, model),
                 ChannelType.Stage => RestStageChannel.Create(discord, guild, model),
+                ChannelType.Media => RestMediaChannel.Create(discord, guild, model),
                 ChannelType.Forum => RestForumChannel.Create(discord, guild, model),
                 ChannelType.Category => RestCategoryChannel.Create(discord, guild, model),
                 ChannelType.PublicThread or ChannelType.PrivateThread or ChannelType.NewsThread => RestThreadChannel.Create(discord, guild, model),

--- a/src/Discord.Net.Rest/Entities/Channels/RestMediaChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestMediaChannel.cs
@@ -1,0 +1,24 @@
+using Model = Discord.API.Channel;
+
+namespace Discord.Rest;
+
+public class RestMediaChannel : RestForumChannel, IMediaChannel
+{
+    internal RestMediaChannel(BaseDiscordClient client, IGuild guild, ulong id)
+        : base(client, guild, id)
+    {
+
+    }
+
+    internal new static RestMediaChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
+    {
+        var entity = new RestMediaChannel(discord, guild, model.Id);
+        entity.Update(model);
+        return entity;
+    }
+
+    internal override void Update(Model model)
+    {
+        base.Update(model);
+    }
+}

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -418,9 +418,9 @@ namespace Discord.Rest
             var props = new ForumChannelProperties();
             func?.Invoke(props);
 
-            Preconditions.AtMost(props.Tags.IsSpecified ? props.Tags.Value.Count() : 0, 5, nameof(props.Tags), "Forum channel can have max 20 tags.");
+            Preconditions.AtMost(props.Tags.IsSpecified ? props.Tags.Value.Count() : 0, 20, nameof(props.Tags), "Media channel can have max 20 tags.");
 
-            var args = new CreateGuildChannelParams(name, ChannelType.Forum)
+            var args = new CreateGuildChannelParams(name, ChannelType.Media)
             {
                 Position = props.Position,
                 Overwrites = props.PermissionOverwrites.IsSpecified

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -447,6 +447,64 @@ namespace Discord.Rest
         }
 
         /// <summary>
+        ///     Gets a forum channel in this guild.
+        /// </summary>
+        /// <param name="id">The snowflake identifier for the forum channel.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains the text channel
+        ///     associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
+        /// </returns>
+        public async Task<RestForumChannel> GetForumChannelAsync(ulong id, RequestOptions options = null)
+        {
+            var channel = await GuildHelper.GetChannelAsync(this, Discord, id, options).ConfigureAwait(false);
+            return channel as RestForumChannel;
+        }
+
+        /// <summary>
+        ///     Gets a collection of all forum channels in this guild.
+        /// </summary>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection of
+        ///     forum channels found within this guild.
+        /// </returns>
+        public async Task<IReadOnlyCollection<RestForumChannel>> GetForumChannelsAsync(RequestOptions options = null)
+        {
+            var channels = await GuildHelper.GetChannelsAsync(this, Discord, options).ConfigureAwait(false);
+            return channels.OfType<RestForumChannel>().ToImmutableArray();
+        }
+
+        /// <summary>
+        ///     Gets a media channel in this guild.
+        /// </summary>
+        /// <param name="id">The snowflake identifier for the text channel.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains the media channel
+        ///     associated with the specified <paramref name="id"/>; <see langword="null"/> if none is found.
+        /// </returns>
+        public async Task<RestMediaChannel> GetMediaChannelAsync(ulong id, RequestOptions options = null)
+        {
+            var channel = await GuildHelper.GetChannelAsync(this, Discord, id, options).ConfigureAwait(false);
+            return channel as RestMediaChannel;
+        }
+
+        /// <summary>
+        ///     Gets a collection of all media channels in this guild.
+        /// </summary>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous get operation. The task result contains a read-only collection of
+        ///     media channels found within this guild.
+        /// </returns>
+        public async Task<IReadOnlyCollection<RestMediaChannel>> GetMediaChannelsAsync(RequestOptions options = null)
+        {
+            var channels = await GuildHelper.GetChannelsAsync(this, Discord, options).ConfigureAwait(false);
+            return channels.OfType<RestMediaChannel>().ToImmutableArray();
+        }
+
+        /// <summary>
         ///     Gets a thread channel in this guild.
         /// </summary>
         /// <param name="id">The snowflake identifier for the thread channel.</param>
@@ -726,10 +784,23 @@ namespace Discord.Rest
         /// <param name="options">The options to be used when sending the request.</param>
         /// <exception cref="ArgumentNullException"><paramref name="name" /> is <see langword="null"/>.</exception>
         /// <returns>
-        ///     The created category channel.
+        ///     The created forum channel.
         /// </returns>
         public Task<RestForumChannel> CreateForumChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null)
             => GuildHelper.CreateForumChannelAsync(this, Discord, name, options, func);
+
+        /// <summary>
+        ///     Creates a new media channel in this guild.
+        /// </summary>
+        /// <param name="name">The new name for the media channel.</param>
+        /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous creation operation. The task result contains the newly created
+        ///     media channel.
+        /// </returns>
+        public Task<RestMediaChannel> CreateMediaChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null)
+            => GuildHelper.CreateMediaChannelAsync(this, Discord, name, options, func);
 
         /// <summary>
         ///     Gets a collection of all the voice regions this guild can access.
@@ -1316,6 +1387,43 @@ namespace Discord.Rest
             else
                 return null;
         }
+
+        /// <inheritdoc />
+        async Task<IForumChannel> IGuild.GetForumChannelAsync(ulong id, CacheMode mode, RequestOptions options)
+        {
+            if (mode == CacheMode.AllowDownload)
+                return await GetForumChannelAsync(id, options).ConfigureAwait(false);
+            else
+                return null;
+        }
+
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IForumChannel>> IGuild.GetForumChannelsAsync(CacheMode mode, RequestOptions options)
+        {
+            if (mode == CacheMode.AllowDownload)
+                return await GetForumChannelsAsync(options).ConfigureAwait(false);
+            else
+                return null;
+        }
+
+        /// <inheritdoc />
+        async Task<IMediaChannel> IGuild.GetMediaChannelAsync(ulong id, CacheMode mode, RequestOptions options)
+        {
+            if (mode == CacheMode.AllowDownload)
+                return await GetMediaChannelAsync(id, options).ConfigureAwait(false);
+            else
+                return null;
+        }
+
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IMediaChannel>> IGuild.GetMediaChannelsAsync(CacheMode mode, RequestOptions options)
+        {
+            if (mode == CacheMode.AllowDownload)
+                return await GetMediaChannelsAsync(options).ConfigureAwait(false);
+            else
+                return null;
+        }
+
         /// <inheritdoc />
         async Task<IThreadChannel> IGuild.GetThreadChannelAsync(ulong id, CacheMode mode, RequestOptions options)
         {
@@ -1435,6 +1543,10 @@ namespace Discord.Rest
         /// <inheritdoc />
         async Task<IForumChannel> IGuild.CreateForumChannelAsync(string name, Action<ForumChannelProperties> func, RequestOptions options)
             => await CreateForumChannelAsync(name, func, options).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        async Task<IMediaChannel> IGuild.CreateMediaChannelAsync(string name, Action<ForumChannelProperties> func, RequestOptions options)
+            => await CreateMediaChannelAsync(name, func, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IVoiceRegion>> IGuild.GetVoiceRegionsAsync(RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -777,7 +777,7 @@ namespace Discord.Rest
             => GuildHelper.CreateCategoryChannelAsync(this, Discord, name, options, func);
 
         /// <summary>
-        ///     Creates a category channel with the provided name.
+        ///     Creates a new forum channel with the provided name.
         /// </summary>
         /// <param name="name">The name of the new channel.</param>
         /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>

--- a/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestInteraction.cs
@@ -196,7 +196,9 @@ namespace Discord.Rest
                                 ChannelType.Stage or
                                 ChannelType.NewsThread or
                                 ChannelType.PrivateThread or
-                                ChannelType.PublicThread
+                                ChannelType.PublicThread or
+                                ChannelType.Media or
+                                ChannelType.Forum
                                     => RestGuildChannel.Create(discord, Guild, model.Channel.Value) as IRestMessageChannel,
                                 ChannelType.DM => RestDMChannel.Create(discord, model.Channel.Value),
                                 ChannelType.Group => RestGroupChannel.Create(discord, model.Channel.Value),

--- a/src/Discord.Net.Rest/Entities/Messages/Attachment.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/Attachment.cs
@@ -32,8 +32,11 @@ namespace Discord
         /// <inheritdoc />
         public double? Duration { get; }
 
+        /// <inheritdoc />
+        public AttachmentFlags Flags { get; }
+
         internal Attachment(ulong id, string filename, string url, string proxyUrl, int size, int? height, int? width,
-            bool? ephemeral, string description, string contentType, double? duration, string waveform)
+            bool? ephemeral, string description, string contentType, double? duration, string waveform, AttachmentFlags flags)
         {
             Id = id;
             Filename = filename;
@@ -47,6 +50,7 @@ namespace Discord
             ContentType = contentType;
             Duration = duration;
             Waveform = waveform;
+            Flags = flags;
         }
         internal static Attachment Create(Model model)
         {
@@ -56,7 +60,8 @@ namespace Discord
                 model.Ephemeral.ToNullable(), model.Description.GetValueOrDefault(),
                 model.ContentType.GetValueOrDefault(),
                 model.DurationSeconds.IsSpecified ? model.DurationSeconds.Value : null,
-                model.Waveform.GetValueOrDefault(null));
+                model.Waveform.GetValueOrDefault(null),
+                model.Flags.GetValueOrDefault(AttachmentFlags.None));
         }
 
         /// <summary>

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -35,6 +35,9 @@ namespace Discord.Rest
         public RoleTags Tags { get; private set; }
 
         /// <inheritdoc />
+        public RoleFlags Flags { get; private set; }
+
+        /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <summary>
         ///     Gets if this role is the @everyone role of the guild or not.
@@ -63,6 +66,8 @@ namespace Discord.Rest
             Position = model.Position;
             Color = new Color(model.Color);
             Permissions = new GuildPermissions(model.Permissions);
+            Flags = model.Flags;
+
             if (model.Tags.IsSpecified)
                 Tags = model.Tags.Value.ToEntity();
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketGuildChannel.cs
@@ -63,6 +63,7 @@ namespace Discord.WebSocket
                 ChannelType.PrivateThread or ChannelType.PublicThread or ChannelType.NewsThread => SocketThreadChannel.Create(guild, state, model),
                 ChannelType.Stage => SocketStageChannel.Create(guild, state, model),
                 ChannelType.Forum => SocketForumChannel.Create(guild, state, model),
+                ChannelType.Media => SocketMediaChannel.Create(guild, state, model),
                 _ => new SocketGuildChannel(guild.Discord, model.Id, guild),
             };
         }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketMediaChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketMediaChannel.cs
@@ -1,0 +1,24 @@
+using Model = Discord.API.Channel;
+
+namespace Discord.WebSocket;
+
+public class SocketMediaChannel : SocketForumChannel, IMediaChannel
+{
+    internal SocketMediaChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
+        : base(discord, id, guild)
+    {
+
+    }
+
+    internal new static SocketMediaChannel Create(SocketGuild guild, ClientState state, Model model)
+    {
+        var entity = new SocketMediaChannel(guild?.Discord, model.Id, guild);
+        entity.Update(state, model);
+        return entity;
+    }
+
+    internal override void Update(ClientState state, Model model)
+    {
+        base.Update(state, model);
+    }
+}

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -338,6 +338,15 @@ namespace Discord.WebSocket
             => Channels.OfType<SocketForumChannel>().ToImmutableArray();
 
         /// <summary>
+        ///     Gets a collection of all media channels in this guild.
+        /// </summary>
+        /// <returns>
+        ///     A read-only collection of forum channels found within this guild.
+        /// </returns>
+        public IReadOnlyCollection<SocketMediaChannel> MediaChannels
+            => Channels.OfType<SocketMediaChannel>().ToImmutableArray();
+
+        /// <summary>
         ///     Gets the current logged-in user.
         /// </summary>
         public SocketGuildUser CurrentUser => _members.TryGetValue(Discord.CurrentUser.Id, out SocketGuildUser member) ? member : null;
@@ -781,6 +790,16 @@ namespace Discord.WebSocket
             => GetChannel(id) as SocketCategoryChannel;
 
         /// <summary>
+        ///     Gets a media channel in this guild.
+        /// </summary>
+        /// <param name="id">The snowflake identifier for the stage channel.</param>
+        /// <returns>
+        ///     A stage channel associated with the specified <paramref name="id" />; <see langword="null"/> if none is found.
+        /// </returns>
+        public SocketMediaChannel GetMediaChannel(ulong id)
+            => GetChannel(id) as SocketMediaChannel;
+
+        /// <summary>
         ///     Creates a new text channel in this guild.
         /// </summary>
         /// <example>
@@ -847,7 +866,7 @@ namespace Discord.WebSocket
             => GuildHelper.CreateCategoryChannelAsync(this, Discord, name, options, func);
 
         /// <summary>
-        ///     Creates a new channel forum in this guild.
+        ///     Creates a new forum channel in this guild.
         /// </summary>
         /// <param name="name">The new name for the forum.</param>
         /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
@@ -859,6 +878,20 @@ namespace Discord.WebSocket
         /// </returns>
         public Task<RestForumChannel> CreateForumChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null)
             => GuildHelper.CreateForumChannelAsync(this, Discord, name, options, func);
+
+        /// <summary>
+        ///     Creates a new media channel in this guild.
+        /// </summary>
+        /// <param name="name">The new name for the media channel.</param>
+        /// <param name="func">The delegate containing the properties to be applied to the channel upon its creation.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+        /// <returns>
+        ///     A task that represents the asynchronous creation operation. The task result contains the newly created
+        ///     media channel.
+        /// </returns>
+        public Task<RestMediaChannel> CreateMediaChannelAsync(string name, Action<ForumChannelProperties> func = null, RequestOptions options = null)
+            => GuildHelper.CreateMediaChannelAsync(this, Discord, name, options, func);
 
         internal SocketGuildChannel AddChannel(ClientState state, ChannelModel model)
         {
@@ -2055,6 +2088,21 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         Task<ITextChannel> IGuild.GetPublicUpdatesChannelAsync(CacheMode mode, RequestOptions options)
             => Task.FromResult<ITextChannel>(PublicUpdatesChannel);
+
+        /// <inheritdoc />
+        Task<IForumChannel> IGuild.GetForumChannelAsync(ulong id, CacheMode mode, RequestOptions options)
+            => Task.FromResult<IForumChannel>(GetForumChannel(id));
+        /// <inheritdoc />
+        Task<IReadOnlyCollection<IForumChannel>> IGuild.GetForumChannelsAsync(CacheMode mode, RequestOptions options)
+            => Task.FromResult<IReadOnlyCollection<IForumChannel>>(ForumChannels);
+
+        /// <inheritdoc />
+        Task<IMediaChannel> IGuild.GetMediaChannelAsync(ulong id, CacheMode mode, RequestOptions options)
+            => Task.FromResult<IMediaChannel>(GetMediaChannel(id));
+        /// <inheritdoc />
+        Task<IReadOnlyCollection<IMediaChannel>> IGuild.GetMediaChannelsAsync(CacheMode mode, RequestOptions options)
+            => Task.FromResult<IReadOnlyCollection<IMediaChannel>>(MediaChannels);
+
         /// <inheritdoc />
         async Task<ITextChannel> IGuild.CreateTextChannelAsync(string name, Action<TextChannelProperties> func, RequestOptions options)
             => await CreateTextChannelAsync(name, func, options).ConfigureAwait(false);
@@ -2070,6 +2118,10 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         async Task<IForumChannel> IGuild.CreateForumChannelAsync(string name, Action<ForumChannelProperties> func, RequestOptions options)
             => await CreateForumChannelAsync(name, func, options).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        async Task<IMediaChannel> IGuild.CreateMediaChannelAsync(string name, Action<ForumChannelProperties> func, RequestOptions options)
+            => await CreateMediaChannelAsync(name, func, options).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IVoiceRegion>> IGuild.GetVoiceRegionsAsync(RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
+++ b/src/Discord.Net.WebSocket/Entities/Invites/SocketInvite.cs
@@ -39,6 +39,8 @@ namespace Discord.WebSocket
                     IGroupChannel groupChannel => ChannelType.Group,
                     INewsChannel newsChannel => ChannelType.News,
                     ITextChannel textChannel => ChannelType.Text,
+                    IMediaChannel mediaChannel => ChannelType.Media,
+                    IForumChannel forumChannel => ChannelType.Forum,
                     _ => throw new InvalidOperationException("Invalid channel type."),
                 };
             }

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -45,6 +45,9 @@ namespace Discord.WebSocket
         public RoleTags Tags { get; private set; }
 
         /// <inheritdoc />
+        public RoleFlags Flags { get; private set; }
+
+        /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <summary>
         ///     Returns a value that determines if the role is an @everyone role.
@@ -82,6 +85,8 @@ namespace Discord.WebSocket
             Position = model.Position;
             Color = new Color(model.Color);
             Permissions = new GuildPermissions(model.Permissions);
+            Flags = model.Flags;
+
             if (model.Tags.IsSpecified)
                 Tags = model.Tags.Value.ToEntity();
 


### PR DESCRIPTION
[docs](https://github.com/discord/discord-api-docs/pull/6232)

This PR adds support for the new media channels. 

## Warning
This feature is not released & fully documented yet, so use this at your own risk as things might change at any moment.

### Changes
- add `IMediaChannel`, rest & socket entities.
- add new channel flag
- add `IsThumbnail` property to `FileAttachment` - one can be set for an image used as a thumbnail in a media channel post
- update everything to support new `ChannelType`
- **misc** Add some missing forum channel related methods to `IGuild`


#### This PR is based on PR #2720