### PR TITLE
ModifyAsync Attachments Bug Fix #2236

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
@@ -18,8 +18,5 @@ namespace Discord.API.Rest
 
         [JsonProperty("flags")]
         public Optional<MessageFlags?> Flags { get; set; }
-
-        [JsonProperty("attachments")]
-        public Optional<IAttachment[]> Attatchments { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
@@ -18,5 +18,8 @@ namespace Discord.API.Rest
 
         [JsonProperty("flags")]
         public Optional<MessageFlags?> Flags { get; set; }
+
+        [JsonProperty("attachments")]
+        public Optional<IAttachment[]> Attatchments { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -473,7 +473,8 @@ namespace Discord.Rest
                     Components = args.Components.IsSpecified
                         ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Array.Empty<API.ActionRowComponent>()
                         : Optional<API.ActionRowComponent[]>.Unspecified,
-                    Flags = args.Flags
+                    Flags = args.Flags,
+                    Attatchments = args.Attachments.GetValueOrDefault() == new FileAttachment[] { } ? new IAttachment[] { } : Optional<IAttachment[]>.Unspecified
                 };
 
                 return await client.ApiClient.ModifyInteractionResponseAsync(apiArgs, token, options).ConfigureAwait(false);

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -473,15 +473,16 @@ namespace Discord.Rest
                     Components = args.Components.IsSpecified
                         ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Array.Empty<API.ActionRowComponent>()
                         : Optional<API.ActionRowComponent[]>.Unspecified,
-                    Flags = args.Flags,
-                    Attatchments = args.Attachments.GetValueOrDefault() == new FileAttachment[] { } ? new IAttachment[] { } : Optional<IAttachment[]>.Unspecified
+                    Flags = args.Flags
                 };
 
                 return await client.ApiClient.ModifyInteractionResponseAsync(apiArgs, token, options).ConfigureAwait(false);
             }
             else
             {
-                var apiArgs = new UploadWebhookFileParams(args.Attachments.Value.ToArray())
+                var attatchments = args.Attachments.Value?.ToArray() ?? new FileAttachment[] { };
+
+                var apiArgs = new UploadWebhookFileParams(attatchments)
                 {
                     Content = args.Content,
                     Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -480,9 +480,9 @@ namespace Discord.Rest
             }
             else
             {
-                var attatchments = args.Attachments.Value?.ToArray() ?? new FileAttachment[] { };
+                var attachments = args.Attachments.Value?.ToArray() ?? new FileAttachment[] { };
 
-                var apiArgs = new UploadWebhookFileParams(attatchments)
+                var apiArgs = new UploadWebhookFileParams(attachments)
                 {
                     Content = args.Content,
                     Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -480,7 +480,7 @@ namespace Discord.Rest
             }
             else
             {
-                var attachments = args.Attachments.Value?.ToArray() ?? new FileAttachment[] { };
+                var attachments = args.Attachments.Value?.ToArray() ?? Array.Empty<FileAttachment>();
 
                 var apiArgs = new UploadWebhookFileParams(attachments)
                 {


### PR DESCRIPTION
PR in relation to #2236 

**Edits Permitted**

Simple fix, could be improved if necessary. ModifyAsync can now has access to an Attachment object if an empty array is passed the image(s) will be removed from the target interaction being modified. 