### PR TITLE
[Fix] GetMessagesAsync with Direction.After not working as expected #2744

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
@@ -55,6 +55,7 @@ namespace Discord.WebSocket
                         return result;
                 }
 
+                //Download remaining messages
                 var downloadedMessages = ChannelHelper.GetMessagesAsync(channel, discord, fromMessageId, dir, limit, options);
                 if (!ignoreCache && cachedMessages.Count != 0)
                     return result.Concat(downloadedMessages);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketChannelHelper.cs
@@ -33,14 +33,30 @@ namespace Discord.WebSocket
             }
             else if (dir == Direction.After)
             {
-                limit -= cachedMessages.Count;
-                if (mode == CacheMode.CacheOnly || limit <= 0)
+                if (mode == CacheMode.CacheOnly)
                     return result;
 
-                //Download remaining messages
-                ulong maxId = cachedMessages.Count > 0 ? cachedMessages.Max(x => x.Id) : fromMessageId.Value;
-                var downloadedMessages = ChannelHelper.GetMessagesAsync(channel, discord, maxId, dir, limit, options);
-                if (cachedMessages.Count != 0)
+                bool ignoreCache = false;
+
+                // We can find two cases:
+                // 1. fromMessageId is not null and corresponds to a message that is not in the cache,
+                // so we have to make a request and ignore the cache
+                if (fromMessageId.HasValue && messages?.Get(fromMessageId.Value) == null)
+                {
+                    ignoreCache = true;
+                }
+                // 2. fromMessageId is null or already in the cache, so we start from the cache
+                else if (cachedMessages.Count > 0)
+                {
+                    fromMessageId = cachedMessages.Max(x => x.Id);
+                    limit -= cachedMessages.Count;
+
+                    if (limit <= 0)
+                        return result;
+                }
+
+                var downloadedMessages = ChannelHelper.GetMessagesAsync(channel, discord, fromMessageId, dir, limit, options);
+                if (!ignoreCache && cachedMessages.Count != 0)
                     return result.Concat(downloadedMessages);
                 else
                     return downloadedMessages;


### PR DESCRIPTION
Calling the GetMessagesAsync method with Direction.After worked correctly in case the messages cache is empty. However, when used inside a method called by command, it stops working correctly due to cache misuse. The code has been modified to contemplate the different cases that we can find in this situation and that it works correctly.