### PR TITLE
[Feature] Support for setting custom status

### DIFF
--- a/src/Discord.Net.Core/Entities/Activities/CustomStatusGame.cs
+++ b/src/Discord.Net.Core/Entities/Activities/CustomStatusGame.cs
@@ -12,6 +12,20 @@ namespace Discord
         internal CustomStatusGame() { }
 
         /// <summary>
+        ///     Creates a new custom status activity.
+        /// </summary>
+        /// <remarks>
+        ///     Bots can't set custom status emoji.
+        /// </remarks>
+        /// <param name="state">The string displayed as bot's custom status.</param>
+        public CustomStatusGame(string state)
+        {
+            Name = "Custom Status";
+            State = state;
+            Type = ActivityType.CustomStatus;
+        }
+
+        /// <summary>
         ///     Gets the emote, if it is set.
         /// </summary>
         /// <returns>

--- a/src/Discord.Net.WebSocket/BaseSocketClient.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.cs
@@ -227,6 +227,16 @@ namespace Discord.WebSocket
         ///     A task that represents the asynchronous set operation.
         /// </returns>
         public abstract Task SetActivityAsync(IActivity activity);
+
+        /// <summary>
+        ///     Sets the custom status of the logged-in user.
+        /// </summary>
+        /// <param name="status">The string that will be displayed as status.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous set operation.
+        /// </returns>
+        public abstract Task SetCustomStatusAsync(string status);
+
         /// <summary>
         ///     Attempts to download users into the user cache for the selected guilds.
         /// </summary>

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -412,6 +412,14 @@ namespace Discord.WebSocket
                 await _shards[i].SetActivityAsync(activity).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
+        public override async Task SetCustomStatusAsync(string status)
+        {
+            var statusGame = new CustomStatusGame(status);
+            for (int i = 0; i < _shards.Length; i++)
+                await _shards[i].SetActivityAsync(statusGame).ConfigureAwait(false);
+        }
+
         private void RegisterEvents(DiscordSocketClient client, bool isPrimary)
         {
             client.Log += (msg) => _logEvent.InvokeAsync(msg);

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -694,6 +694,7 @@ namespace Discord.WebSocket
                 Activity = null;
             await SendStatusAsync().ConfigureAwait(false);
         }
+
         /// <inheritdoc />
         public override async Task SetActivityAsync(IActivity activity)
         {
@@ -701,11 +702,20 @@ namespace Discord.WebSocket
             await SendStatusAsync().ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
+        public override async Task SetCustomStatusAsync(string status)
+        {
+            var statusGame = new CustomStatusGame(status);
+            await SetActivityAsync(statusGame);
+        }
+
         private async Task SendStatusAsync()
         {
             if (CurrentUser == null)
                 return;
-            var activities = _activity.IsSpecified ? ImmutableList.Create(_activity.Value) : null;
+            var activities = _activity.IsSpecified
+                ? ImmutableList.Create(_activity.Value)
+                : null;
             CurrentUser.Presence = new SocketPresence(Status, null, activities);
 
             var presence = BuildCurrentStatus() ?? (UserStatus.Online, false, null, null);
@@ -738,6 +748,8 @@ namespace Discord.WebSocket
                 gameModel.Type = Activity.Type;
                 if (Activity is StreamingGame streamGame)
                     gameModel.StreamUrl = streamGame.Url;
+                if (Activity is CustomStatusGame customStatus)
+                    gameModel.State = customStatus.State;
                 game = gameModel;
             }
             else if (activity.IsSpecified)


### PR DESCRIPTION
[Docs PR](https://github.com/discord/discord-api-docs/pull/6345)\

This PR allows bot to set custom statuses. With current impl discord only allows setting the `State` string with no status emoji.

#### Changes
- add public constructor to `CustomStatusGame`
- add new method to `BaseSocketClient`
