### PR TITLE
[Fix]: Slash Command Localizations lost after AddCommandsToGuildAsync and deleteMissing = false

### DIFF
--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -392,7 +392,7 @@ namespace Discord.Interactions
             if (!deleteMissing)
             {
 
-                var existing = await RestClient.GetGuildApplicationCommands(guildId).ConfigureAwait(false);
+                var existing = await RestClient.GetGuildApplicationCommands(guildId, true).ConfigureAwait(false);
                 var missing = existing.Where(x => !props.Any(y => y.Name.IsSpecified && y.Name.Value == x.Name));
                 props.AddRange(missing.Select(x => x.ToApplicationCommandProps()));
             }
@@ -416,7 +416,7 @@ namespace Discord.Interactions
 
             if (!deleteMissing)
             {
-                var existing = await RestClient.GetGlobalApplicationCommands().ConfigureAwait(false);
+                var existing = await RestClient.GetGlobalApplicationCommands(true).ConfigureAwait(false);
                 var missing = existing.Where(x => !props.Any(y => y.Name.IsSpecified && y.Name.Value == x.Name));
                 props.AddRange(missing.Select(x => x.ToApplicationCommandProps()));
             }
@@ -481,7 +481,7 @@ namespace Discord.Interactions
 
             if (!deleteMissing)
             {
-                var existing = await RestClient.GetGuildApplicationCommands(guildId).ConfigureAwait(false);
+                var existing = await RestClient.GetGuildApplicationCommands(guildId, true).ConfigureAwait(false);
                 var missing = existing.Where(x => !props.Any(y => y.Name.IsSpecified && y.Name.Value == x.Name));
                 props.AddRange(missing.Select(x => x.ToApplicationCommandProps()));
             }
@@ -523,7 +523,7 @@ namespace Discord.Interactions
 
             if (!deleteMissing)
             {
-                var existing = await RestClient.GetGuildApplicationCommands(guildId).ConfigureAwait(false);
+                var existing = await RestClient.GetGuildApplicationCommands(guildId, true).ConfigureAwait(false);
                 var missing = existing.Where(x => !props.Any(y => y.Name.IsSpecified && y.Name.Value == x.Name));
                 props.AddRange(missing.Select(x => x.ToApplicationCommandProps()));
             }
@@ -547,7 +547,7 @@ namespace Discord.Interactions
 
             if (!deleteMissing)
             {
-                var existing = await RestClient.GetGlobalApplicationCommands().ConfigureAwait(false);
+                var existing = await RestClient.GetGlobalApplicationCommands(true).ConfigureAwait(false);
                 var missing = existing.Where(x => !props.Any(y => y.Name.IsSpecified && y.Name.Value == x.Name));
                 props.AddRange(missing.Select(x => x.ToApplicationCommandProps()));
             }
@@ -590,7 +590,7 @@ namespace Discord.Interactions
 
             if (!deleteMissing)
             {
-                var existing = await RestClient.GetGlobalApplicationCommands().ConfigureAwait(false);
+                var existing = await RestClient.GetGlobalApplicationCommands(true).ConfigureAwait(false);
                 var missing = existing.Where(x => !props.Any(y => y.Name.IsSpecified && y.Name.Value == x.Name));
                 props.AddRange(missing.Select(x => x.ToApplicationCommandProps()));
             }


### PR DESCRIPTION
### Description
<!-- A brief explanation of changes made in this PR. -->
Fetch localizations when adding commands with `deleteMissing` = `false` to prevent them getting lost.

### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->
- add missing `withLocalizations` parameter with value `true` to the calls to `RestClient.GetGlobal`/`GuildApplicationCommands` calls.

### Related Issues
<!--
List issues that are related to this PR.
Example:
- resolves #6969
-->

- resolves #2757
