### PR TITLE
[Fix] Missing null checks in `RoleConnectionProperties`

### DIFF
--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionProperties.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionProperties.cs
@@ -126,7 +126,10 @@ public class RoleConnectionProperties
     /// <summary>
     ///     Initializes a new instance of <see cref="RoleConnectionProperties"/>.
     /// </summary>
-    public RoleConnectionProperties() { }
+    public RoleConnectionProperties()
+    {
+        Metadata = new();
+    }
 
     /// <summary>
     ///     Initializes a new <see cref="RoleConnectionProperties"/> with the data from provided <see cref="RoleConnection"/>.
@@ -136,6 +139,6 @@ public class RoleConnectionProperties
         {
             PlatformName = roleConnection.PlatformName,
             PlatformUsername = roleConnection.PlatformUsername,
-            Metadata = roleConnection.Metadata.ToDictionary()
+            Metadata = roleConnection.Metadata?.ToDictionary()
         };
 }

--- a/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionProperties.cs
+++ b/src/Discord.Net.Core/Entities/ApplicationRoleConnection/RoleConnectionProperties.cs
@@ -120,7 +120,7 @@ public class RoleConnectionProperties
     {
         PlatformName = platformName;
         PlatformUsername = platformUsername;
-        Metadata = metadata.ToDictionary();
+        Metadata = metadata?.ToDictionary() ?? new ();
     }
 
     /// <summary>


### PR DESCRIPTION
This PR adds a null checks to `RoleConnectionProperties`