### PR TITLE
[Fix] `SocketKickAuditLogData` `User` never having value

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketKickAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketKickAuditLogData.cs
@@ -1,4 +1,5 @@
 using Discord.Rest;
+
 using EntryModel = Discord.API.AuditLogEntry;
 
 namespace Discord.WebSocket;
@@ -15,17 +16,16 @@ public class SocketKickAuditLogData : ISocketAuditLogData
 
     internal static SocketKickAuditLogData Create(DiscordSocketClient discord, EntryModel entry)
     {
-        var cachedUser = discord.GetUser(entry.Id);
+        var cachedUser = discord.GetUser(entry.TargetId!.Value);
         var cacheableUser = new Cacheable<SocketUser, RestUser, IUser, ulong>(
             cachedUser,
-            entry.Id,
+            entry.TargetId.Value,
             cachedUser is not null,
             async () =>
             {
                 var user = await discord.ApiClient.GetUserAsync(entry.TargetId!.Value);
                 return user is not null ? RestUser.Create(discord, user) : null;
             });
-
         return new SocketKickAuditLogData(cacheableUser);
     }
 


### PR DESCRIPTION
### Description
This PR fixes `SocketKickAuditLogData` `Target` cacheable user never having a value assigned

