### PR TITLE
[Fix] Silent NRE in integration tests

### DIFF
--- a/test/Discord.Net.Tests.Integration/ChannelsTests.cs
+++ b/test/Discord.Net.Tests.Integration/ChannelsTests.cs
@@ -19,7 +19,7 @@ namespace Discord
         public ChannelsTests(RestGuildFixture guildFixture, ITestOutputHelper output)
         {
             guild = guildFixture.Guild;
-            output = output;
+            this.output = output;
             output.WriteLine($"RestGuildFixture using guild: {guild.Id}");
             // capture all console output
             guildFixture.Client.Log += LogAsync;

--- a/test/Discord.Net.Tests.Integration/GuildTests.cs
+++ b/test/Discord.Net.Tests.Integration/GuildTests.cs
@@ -18,7 +18,7 @@ namespace Discord
         {
             client = guildFixture.Client;
             guild = guildFixture.Guild;
-            output = output;
+            this.output = output;
             output.WriteLine($"RestGuildFixture using guild: {guild.Id}");
             guildFixture.Client.Log += LogAsync;
         }


### PR DESCRIPTION
### Description

The private field `ITestOutputHelper` is not assigned properly.

### Changes

- Fix improper assignment in constructors of `ChannelsTests.cs` and `GuildTests.cs`.

### Related Issues

This pull request tries to fix #2767.
