### PR TITLE
[Fix] Add missing parameters to `RespondWithModalAsync` methods and implement missing overloads

### DIFF
--- a/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
+++ b/src/Discord.Net.Interactions/Extensions/IDiscordInteractionExtensions.cs
@@ -84,23 +84,8 @@ namespace Discord.Interactions
 
         private static async Task SendModalResponseAsync(IDiscordInteraction interaction, string customId, ModalInfo modalInfo, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
         {
-            var builder = new ModalBuilder(modalInfo.Title, customId);
-
-            foreach (var input in modalInfo.Components)
-                switch (input)
-                {
-                    case TextInputComponentInfo textComponent:
-                        builder.AddTextInput(textComponent.Label, textComponent.CustomId, textComponent.Style, textComponent.Placeholder, textComponent.IsRequired ? textComponent.MinLength : null,
-                            textComponent.MaxLength, textComponent.IsRequired, textComponent.InitialValue);
-                        break;
-                    default:
-                        throw new InvalidOperationException($"{input.GetType().FullName} isn't a valid component info class");
-                }
-
-            if (modifyModal is not null)
-                modifyModal(builder);
-
-            await interaction.RespondWithModalAsync(builder.Build(), options).ConfigureAwait(false);
+            var modal = modalInfo.ToModal(customId, modifyModal);
+            await interaction.RespondWithModalAsync(modal, options).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Interactions/Extensions/RestExtensions.cs
+++ b/src/Discord.Net.Interactions/Extensions/RestExtensions.cs
@@ -21,5 +21,41 @@ namespace Discord.Rest
             var modal = modalInfo.ToModal(customId, modifyModal);
             return interaction.RespondWithModal(modal, options);
         }
+
+        /// <summary>
+        ///     Respond to an interaction with an <see cref="IModal"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of the <see cref="IModal"/> implementation.</typeparam>
+        /// <param name="interaction">The interaction to respond to.</param>
+        /// <param name="modal">The <see cref="IModal"/> instance to get field values from.</param>
+        /// <param name="options">The request options for this <see langword="async"/> request.</param>
+        /// <param name="modifyModal">Delegate that can be used to modify the modal.</param>
+        /// <returns>Serialized payload to be used to create a HTTP response.</returns>
+        public static string RespondWithModal<T>(this RestInteraction interaction, string customId, T modal, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
+            where T : class, IModal
+        {
+            if (!ModalUtils.TryGet<T>(out var modalInfo))
+                throw new ArgumentException($"{typeof(T).FullName} isn't referenced by any registered Modal Interaction Command and doesn't have a cached {typeof(ModalInfo)}");
+
+            var builder = new ModalBuilder(modal.Title, customId);
+
+            foreach (var input in modalInfo.Components)
+                switch (input)
+                {
+                    case TextInputComponentInfo textComponent:
+                        {
+                            builder.AddTextInput(textComponent.Label, textComponent.CustomId, textComponent.Style, textComponent.Placeholder, textComponent.IsRequired ? textComponent.MinLength : null,
+                            textComponent.MaxLength, textComponent.IsRequired, textComponent.Getter(modal) as string);
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException($"{input.GetType().FullName} isn't a valid component info class");
+                }
+
+            if (modifyModal is not null)
+                modifyModal(builder);
+
+            return interaction.RespondWithModal(builder.Build(), options);
+        }
     }
 }

--- a/src/Discord.Net.Interactions/InteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/InteractionModuleBase.cs
@@ -116,7 +116,9 @@ namespace Discord.Interactions
         }
 
         /// <inheritdoc cref="IDiscordInteraction.RespondWithModalAsync(Modal, RequestOptions)"/>
-        protected virtual async Task RespondWithModalAsync(Modal modal, RequestOptions options = null) => await Context.Interaction.RespondWithModalAsync(modal);
+        protected virtual async Task RespondWithModalAsync(Modal modal, RequestOptions options = null) 
+            => await Context.Interaction.RespondWithModalAsync(modal, options);
+
 
         /// <inheritdoc cref="IDiscordInteractionExtentions.RespondWithModalAsync{T}(IDiscordInteraction, string, RequestOptions, Action{ModalBuilder})"/>
         protected virtual async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null) where TModal : class, IModal

--- a/src/Discord.Net.Interactions/InteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/InteractionModuleBase.cs
@@ -1,4 +1,3 @@
-using Discord.Rest;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -122,8 +121,6 @@ namespace Discord.Interactions
         /// <inheritdoc cref="IDiscordInteractionExtentions.RespondWithModalAsync{T}(IDiscordInteraction, string, RequestOptions, Action{ModalBuilder})"/>
         protected virtual async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null) where TModal : class, IModal
             => await Context.Interaction.RespondWithModalAsync<TModal>(customId, options, modifyModal);
-
-        //IInteractionModuleBase
 
         /// <inheritdoc/>
         void IInteractionModuleBase.SetContext(IInteractionContext context) => SetContext(context);

--- a/src/Discord.Net.Interactions/InteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/InteractionModuleBase.cs
@@ -120,8 +120,8 @@ namespace Discord.Interactions
         protected virtual async Task RespondWithModalAsync(Modal modal, RequestOptions options = null) => await Context.Interaction.RespondWithModalAsync(modal);
 
         /// <inheritdoc cref="IDiscordInteractionExtentions.RespondWithModalAsync{T}(IDiscordInteraction, string, RequestOptions, Action{ModalBuilder})"/>
-        protected virtual async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null) where TModal : class, IModal
-            => await Context.Interaction.RespondWithModalAsync<TModal>(customId, options);
+        protected virtual async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null) where TModal : class, IModal
+            => await Context.Interaction.RespondWithModalAsync<TModal>(customId, options, modifyModal);
 
         //IInteractionModuleBase
 

--- a/src/Discord.Net.Interactions/InteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/InteractionModuleBase.cs
@@ -119,6 +119,9 @@ namespace Discord.Interactions
         protected virtual async Task RespondWithModalAsync(Modal modal, RequestOptions options = null) 
             => await Context.Interaction.RespondWithModalAsync(modal, options);
 
+        /// <inheritdoc cref="IDiscordInteractionExtentions.RespondWithModalAsync{T}(IDiscordInteraction, string, T, RequestOptions, Action{ModalBuilder})"/>
+        protected virtual async Task RespondWithModalAsync<TModal>(string customId, TModal modal, RequestOptions options = null, Action<ModalBuilder> modifyModal = null) where TModal : class, IModal
+            => await Context.Interaction.RespondWithModalAsync(customId, modal, options, modifyModal);
 
         /// <inheritdoc cref="IDiscordInteractionExtentions.RespondWithModalAsync{T}(IDiscordInteraction, string, RequestOptions, Action{ModalBuilder})"/>
         protected virtual async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null) where TModal : class, IModal

--- a/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
@@ -58,7 +58,20 @@ namespace Discord.Interactions
         protected override async Task RespondWithModalAsync(Modal modal, RequestOptions options = null)
             => await HandleInteractionAsync(x => x.RespondWithModal(modal, options));
 
-            var payload = restInteraction.RespondWithModal(modal, options);
+        /// <summary>
+        ///     Responds to the interaction with a modal.
+        /// </summary>
+        /// <typeparam name="TModal">The type of the modal.</typeparam>
+        /// <param name="customId">The custom ID of the modal.</param>
+        /// <param name="modal">The modal to respond with.</param>
+        /// <param name="options">The request options for this <see langword="async"/> request.</param>
+        /// <param name="modifyModal">Delegate that can be used to modify the modal.</param>
+        /// <returns>
+        ///     A Task representing the operation of creating the interaction response.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown if the interaction isn't a type of <see cref="RestInteraction"/>.</exception>
+        protected override async Task RespondWithModalAsync<TModal>(string customId, TModal modal, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
+            => await HandleInteractionAsync(x => x.RespondWithModal(customId, modal, options, modifyModal));
 
         /// <summary>
         ///     Responds to the interaction with a modal.
@@ -71,7 +84,7 @@ namespace Discord.Interactions
         ///     A Task representing the operation of creating the interaction response.
         /// </returns>
         /// <exception cref="InvalidOperationException">Thrown if the interaction isn't a type of <see cref="RestInteraction"/>.</exception>
-        protected override async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
+        protected override async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null) 
             => await HandleInteractionAsync(x => x.RespondWithModal<TModal>(customId, options, modifyModal));
 
         private async Task HandleInteractionAsync(Func<RestInteraction, string> action)

--- a/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
@@ -26,17 +26,7 @@ namespace Discord.Interactions
         /// </returns>
         /// <exception cref="InvalidOperationException">Thrown if the interaction isn't a type of <see cref="RestInteraction"/>.</exception>
         protected override async Task DeferAsync(bool ephemeral = false, RequestOptions options = null)
-        {
-            if (Context.Interaction is not RestInteraction restInteraction)
-                throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
-
-            var payload = restInteraction.Defer(ephemeral, options);
-
-            if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
-                await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);
-            else
-                await InteractionService._restResponseCallback(Context, payload).ConfigureAwait(false);
-        }
+            => await HandleInteractionAsync(x => x.Defer(ephemeral, options));
 
         /// <summary>
         ///     Respond to a Rest based Discord Interaction using the <see cref="InteractionServiceConfig.RestResponseCallback"/> delegate.
@@ -54,45 +44,42 @@ namespace Discord.Interactions
         /// </returns>
         /// <exception cref="InvalidOperationException">Thrown if the interaction isn't a type of <see cref="RestInteraction"/>.</exception>
         protected override async Task RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent components = null, Embed embed = null)
-        {
-            if (Context.Interaction is not RestInteraction restInteraction)
-                throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
-
-            var payload = restInteraction.Respond(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options);
-
-            if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
-                await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);
-            else
-                await InteractionService._restResponseCallback(Context, payload).ConfigureAwait(false);
-        }
+            => await HandleInteractionAsync(x => x.Respond(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options));
 
         /// <summary>
         ///     Responds to the interaction with a modal.
         /// </summary>
         /// <param name="modal">The modal to respond with.</param>
         /// <param name="options">The request options for this <see langword="async"/> request.</param>
-        /// <returns>A string that contains json to write back to the incoming http request.</returns>
-        /// <exception cref="TimeoutException"></exception>
-        /// <exception cref="InvalidOperationException"></exception>
+        /// <returns>
+        ///     A Task representing the operation of creating the interaction response.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown if the interaction isn't a type of <see cref="RestInteraction"/>.</exception>
         protected override async Task RespondWithModalAsync(Modal modal, RequestOptions options = null)
-        {
-            if (Context.Interaction is not RestInteraction restInteraction)
-                throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
+            => await HandleInteractionAsync(x => x.RespondWithModal(modal, options));
 
             var payload = restInteraction.RespondWithModal(modal, options);
 
-            if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
-                await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);
-            else
-                await InteractionService._restResponseCallback(Context, payload).ConfigureAwait(false);
-        }
-
+        /// <summary>
+        ///     Responds to the interaction with a modal.
+        /// </summary>
+        /// <typeparam name="TModal"></typeparam>
+        /// <param name="customId">The custom ID of the modal.</param>
+        /// <param name="options">The request options for this <see langword="async"/> request.</param>
+        /// <param name="modifyModal">Delegate that can be used to modify the modal.</param>
+        /// <returns>
+        ///     A Task representing the operation of creating the interaction response.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown if the interaction isn't a type of <see cref="RestInteraction"/>.</exception>
         protected override async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
+            => await HandleInteractionAsync(x => x.RespondWithModal<TModal>(customId, options, modifyModal));
+
+        private async Task HandleInteractionAsync(Func<RestInteraction, string> action)
         {
             if (Context.Interaction is not RestInteraction restInteraction)
-                throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
+                throw new InvalidOperationException($"Interaction must be a type of {nameof(RestInteraction)} in order to execute this method.");
 
-            var payload = restInteraction.RespondWithModal<TModal>(customId, options, modifyModal);
+            var payload = action(restInteraction);
 
             if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
                 await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);

--- a/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
@@ -87,12 +87,12 @@ namespace Discord.Interactions
                 await InteractionService._restResponseCallback(Context, payload).ConfigureAwait(false);
         }
 
-        protected override async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null)
+        protected override async Task RespondWithModalAsync<TModal>(string customId, RequestOptions options = null, Action<ModalBuilder> modifyModal = null)
         {
             if (Context.Interaction is not RestInteraction restInteraction)
                 throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
 
-            var payload = restInteraction.RespondWithModal<TModal>(customId, options);
+            var payload = restInteraction.RespondWithModal<TModal>(customId, options, modifyModal);
 
             if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
                 await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);

--- a/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
+++ b/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
@@ -296,8 +296,7 @@ namespace Discord.Interactions
                         throw new InvalidOperationException($"{input.GetType().FullName} isn't a valid component info class");
                 }
 
-            if (modifyModal is not null)
-                modifyModal(builder);
+            modifyModal?.Invoke(builder);
 
             return builder.Build();
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
@@ -104,7 +104,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc/>
         public override Task RespondWithModalAsync(Modal modal, RequestOptions requestOptions = null)
-            => throw new NotSupportedException("Autocomplete interactions cannot have normal responces!");
+            => throw new NotSupportedException("Autocomplete interactions cannot have normal responses!");
 
         //IAutocompleteInteraction
         /// <inheritdoc/>


### PR DESCRIPTION
### Description
This PR adds missing implementation of modal modification in module bases.

### Changes
- Add missing `modifyModal` parameters to the `RespondWithModalAsync<T>` methods. (b7ee974)
- Add missing `RespondWithModalAsync<T>` overload to module bases. (e63665d)
- Fix inactive `options` parameter in the `RespondWithModalAsync` method. (46bcd72)
- Remove code duplication in `IDiscordInteractionExtensions` by using the `modalInfo.FromModal` method. (42f448b)
- Remove code duplication in `RestInteractionModuleBase` by extracting a `HandleInteractionAsync` method. (1a788d4)