### PR TITLE
[Fix] URL encode timestamps sent as query parameters

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -618,11 +618,13 @@ namespace Discord.API
 
             if (limit.HasValue)
             {
-                query = $"?before={before.GetValueOrDefault(DateTimeOffset.UtcNow).ToString("O")}&limit={limit.Value}";
+                string beforeEncoded = WebUtility.UrlEncode(before.GetValueOrDefault(DateTimeOffset.UtcNow).ToString("O"));
+                query = $"?before={beforeEncoded}&limit={limit.Value}";
             }
             else if (before.HasValue)
             {
-                query = $"?before={before.Value.ToString("O")}";
+                string beforeEncoded = WebUtility.UrlEncode(before.Value.ToString("O"));
+                query = $"?before={beforeEncoded}";
             }
 
             return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/archived/public{query}", bucket, options: options);
@@ -641,11 +643,13 @@ namespace Discord.API
 
             if (limit.HasValue)
             {
-                query = $"?before={before.GetValueOrDefault(DateTimeOffset.UtcNow).ToString("O")}&limit={limit.Value}";
+                string beforeEncoded = WebUtility.UrlEncode(before.GetValueOrDefault(DateTimeOffset.UtcNow).ToString("O"));
+                query = $"?before={beforeEncoded}&limit={limit.Value}";
             }
             else if (before.HasValue)
             {
-                query = $"?before={before.Value.ToString("O")}";
+                string beforeEncoded = WebUtility.UrlEncode(before.Value.ToString("O"));
+                query = $"?before={beforeEncoded}";
             }
 
             return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/archived/private{query}", bucket, options: options);
@@ -664,11 +668,13 @@ namespace Discord.API
 
             if (limit.HasValue)
             {
-                query = $"?before={SnowflakeUtils.ToSnowflake(before.GetValueOrDefault(DateTimeOffset.UtcNow))}&limit={limit.Value}";
+                string beforeEncoded = WebUtility.UrlEncode(before.GetValueOrDefault(DateTimeOffset.UtcNow).ToString("O"));
+                query = $"?before={beforeEncoded}&limit={limit.Value}";
             }
             else if (before.HasValue)
             {
-                query = $"?before={before.Value.ToString("O")}";
+                string beforeEncoded = WebUtility.UrlEncode(before.Value.ToString("O"));
+                query = $"?before={beforeEncoded}";
             }
 
             return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/users/@me/threads/archived/private{query}", bucket, options: options);

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -668,13 +668,11 @@ namespace Discord.API
 
             if (limit.HasValue)
             {
-                string beforeEncoded = WebUtility.UrlEncode(before.GetValueOrDefault(DateTimeOffset.UtcNow).ToString("O"));
-                query = $"?before={beforeEncoded}&limit={limit.Value}";
+                query = $"?before={SnowflakeUtils.ToSnowflake(before.GetValueOrDefault(DateTimeOffset.UtcNow))}&limit={limit.Value}";
             }
             else if (before.HasValue)
             {
-                string beforeEncoded = WebUtility.UrlEncode(before.Value.ToString("O"));
-                query = $"?before={beforeEncoded}";
+                query = $"?before={before.Value.ToString("O")}";
             }
 
             return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/users/@me/threads/archived/private{query}", bucket, options: options);


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
<!-- A brief explanation of changes made in this PR. -->
Methods calling to the `threads/archived/*` endpoints don't escape the '+' character in the `before` query parameter, resulting in a DATE_TIME_TYPE_PARSE error. URL escaping the timestamp solves this.

### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->
- Update ~all three~ two of the archived thread enumeration methods

### Related Issues
<!--
List issues that are related to this PR.
Example:
- resolves #6969
-->
none

EDIT: Sorry, I just realized one of these endpoints expects a different date format. Should have RTFM.
The other 2 methods are still in scope, reverted changes for the third one.
(The third method still seems to be incorrect in one of the branches, but that isn't related to this PR.)