### PR TITLE
[Fix] Some IDiscordClient methods are not properly implemented in clients

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -371,6 +371,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         async Task<IApplicationCommand> IDiscordClient.GetGlobalApplicationCommandAsync(ulong id, RequestOptions options)
             => await ClientHelper.GetGlobalApplicationCommandAsync(this, id, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IApplicationCommand> IDiscordClient.CreateGlobalApplicationCommand(ApplicationCommandProperties properties, RequestOptions options)
+            => await CreateGlobalCommand(properties, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IApplicationCommand>> IDiscordClient.BulkOverwriteGlobalApplicationCommand(ApplicationCommandProperties[] properties, RequestOptions options)
+            => await BulkOverwriteGlobalCommands(properties, options).ConfigureAwait(false);
         #endregion
     }
 }

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -519,6 +519,49 @@ namespace Discord.WebSocket
             client.WebhooksUpdated += (arg1, arg2) => _webhooksUpdated.InvokeAsync(arg1, arg2);
             client.AuditLogCreated += (arg1, arg2) => _auditLogCreated.InvokeAsync(arg1, arg2);
         }
+
+        public async Task<SocketApplicationCommand> CreateGlobalApplicationCommandAsync(ApplicationCommandProperties properties, RequestOptions options = null)
+        {
+            var model = await InteractionHelper.CreateGlobalCommandAsync(this, properties, options).ConfigureAwait(false);
+
+            SocketApplicationCommand entity = null;
+
+            foreach (var shard in _shards)
+            {
+                entity = shard.State.GetOrAddCommand(model.Id, (id) => SocketApplicationCommand.Create(shard, model));
+            }
+
+            System.Diagnostics.Debug.Assert(entity != null, "There should be at least one shard to get the entity");
+
+            //Update it in case it was cached
+            entity.Update(model);
+
+            return entity;
+        }
+
+        public async Task<IReadOnlyCollection<SocketApplicationCommand>> BulkOverwriteGlobalApplicationCommandsAsync(
+            ApplicationCommandProperties[] properties, RequestOptions options = null)
+        {
+            var models = await InteractionHelper.BulkOverwriteGlobalCommandsAsync(this, properties, options);
+
+            IEnumerable<SocketApplicationCommand> entities = null;
+
+            foreach (var shard in _shards)
+            {
+                entities = models.Select(x => SocketApplicationCommand.Create(shard, x));
+                //Purge our previous commands
+                shard.State.PurgeCommands(x => x.IsGlobalCommand);
+
+                foreach (var entity in entities)
+                {
+                    shard.State.AddCommand(entity);
+                }
+            }
+
+            System.Diagnostics.Debug.Assert(entities != null, "There should be at least one shard to get the entities");
+            return entities.ToImmutableArray();
+        }
+
         #endregion
 
         #region IDiscordClient
@@ -578,6 +621,12 @@ namespace Discord.WebSocket
         {
             return await GetVoiceRegionAsync(id).ConfigureAwait(false);
         }
+        /// <inheritdoc />
+        async Task<IApplicationCommand> IDiscordClient.CreateGlobalApplicationCommand(ApplicationCommandProperties properties, RequestOptions options)
+            => await CreateGlobalApplicationCommandAsync(properties, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IApplicationCommand>> IDiscordClient.BulkOverwriteGlobalApplicationCommand(ApplicationCommandProperties[] properties, RequestOptions options)
+            => await BulkOverwriteGlobalApplicationCommandsAsync(properties, options);
         #endregion
 
         #region Dispose

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -529,12 +529,12 @@ namespace Discord.WebSocket
             foreach (var shard in _shards)
             {
                 entity = shard.State.GetOrAddCommand(model.Id, (id) => SocketApplicationCommand.Create(shard, model));
+
+                //Update it in case it was cached
+                entity.Update(model);
             }
 
             System.Diagnostics.Debug.Assert(entity != null, "There should be at least one shard to get the entity");
-
-            //Update it in case it was cached
-            entity.Update(model);
 
             return entity;
         }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -3442,6 +3442,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IApplicationCommand>> IDiscordClient.GetGlobalApplicationCommandsAsync(bool withLocalizations, string locale, RequestOptions options)
             => await GetGlobalApplicationCommandsAsync(withLocalizations, locale, options);
+        /// <inheritdoc />
+        async Task<IApplicationCommand> IDiscordClient.CreateGlobalApplicationCommand(ApplicationCommandProperties properties, RequestOptions options)
+            => await CreateGlobalApplicationCommandAsync(properties, options).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IReadOnlyCollection<IApplicationCommand>> IDiscordClient.BulkOverwriteGlobalApplicationCommand(ApplicationCommandProperties[] properties, RequestOptions options)
+            => await BulkOverwriteGlobalApplicationCommandsAsync(properties, options);
 
         /// <inheritdoc />
         async Task IDiscordClient.StartAsync()


### PR DESCRIPTION
### Description
Fixes some bugs related to `IDiscordClient` methods not being properly implemented in `RestClient`, `SocketClient`, and `ShardedSocketClient` due to `BaseDiscordClient` *"blankly"* implementing them.

### Changes
- Added `CreateGlobalApplicationCommandAsync` and `BulkOverwriteGlobalApplicationCommandsAsync` to `ShardedSocketClient`
- `ShardedSocketClient` properly implements `IDiscordClient.BulkOverwriteGlobalApplicationCommand` and `CreateGlobalApplicationCommand`
- `SocketClient` properly implements `IDiscordClient.BulkOverwriteGlobalApplicationCommand` and `CreateGlobalApplicationCommand`
- `RestClient` properly implements `IDiscordClient.BulkOverwriteGlobalApplicationCommand` and `CreateGlobalApplicationCommand`

### Related Issues
- Bulk Overriding Global Commands does not work with `IDiscordClient`
