### PR TITLE
[Fix] Embed `ToJsonString` & `(Try)Parse`

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -161,55 +161,6 @@ namespace Discord
         }
 
         /// <summary>
-        ///     Tries to parse a string into an <see cref="EmbedBuilder"/>.
-        /// </summary>
-        /// <param name="json">The json string to parse.</param>
-        /// <param name="builder">The <see cref="EmbedBuilder"/> with populated values. An empty instance if method returns <see langword="false"/>.</param>
-        /// <returns><see langword="true"/> if <paramref name="json"/> was successfully parsed. <see langword="false"/> if not.</returns>
-        public static bool TryParse(string json, out EmbedBuilder builder)
-        {
-            builder = new EmbedBuilder();
-            try
-            {
-                var model = JsonConvert.DeserializeObject<Embed>(json);
-
-                if (model is not null)
-                {
-                    builder = model.ToEmbedBuilder();
-                    return true;
-                }
-                return false;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        ///     Parses a string into an <see cref="EmbedBuilder"/>.
-        /// </summary>
-        /// <param name="json">The json string to parse.</param>
-        /// <returns>An <see cref="EmbedBuilder"/> with populated values from the passed <paramref name="json"/>.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if the string passed is not valid json.</exception>
-        public static EmbedBuilder Parse(string json)
-        {
-            try
-            {
-                var model = JsonConvert.DeserializeObject<Embed>(json);
-
-                if (model is not null)
-                    return model.ToEmbedBuilder();
-
-                return new EmbedBuilder();
-            }
-            catch
-            {
-                throw;
-            }
-        }
-
-        /// <summary>
         ///     Sets the title of an <see cref="Embed"/>.
         /// </summary>
         /// <param name="title">The title to be set.</param>

--- a/src/Discord.Net.Rest/Extensions/StringExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/StringExtensions.cs
@@ -16,7 +16,6 @@ namespace Discord.Rest
             {
                 ContractResolver = new DiscordContractResolver()
             };
-            serializer.Converters.Add(new EmbedTypeConverter());
             return serializer;
         });
 

--- a/src/Discord.Net.Rest/Extensions/StringExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/StringExtensions.cs
@@ -23,7 +23,7 @@ namespace Discord.Rest
         ///     Gets a Json formatted <see langword="string"/> from an <see cref="EmbedBuilder"/>.
         /// </summary>
         /// <remarks>
-        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
+        ///     See <see cref="EmbedBuilderUtils.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
         /// </remarks>
         /// <param name="builder">The builder to format as Json <see langword="string"/>.</param>
         /// <param name="formatting">The formatting in which the Json will be returned.</param>
@@ -35,7 +35,7 @@ namespace Discord.Rest
         ///     Gets a Json formatted <see langword="string"/> from an <see cref="Embed"/>.
         /// </summary>
         /// <remarks>
-        ///     See <see cref="EmbedBuilder.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
+        ///     See <see cref="EmbedBuilderUtils.TryParse(string, out EmbedBuilder)"/> to parse Json back into embed.
         /// </remarks>
         /// <param name="embed">The embed to format as Json <see langword="string"/>.</param>
         /// <param name="formatting">The formatting in which the Json will be returned.</param>

--- a/src/Discord.Net.Rest/Utils/EmbedBuilderUtils.cs
+++ b/src/Discord.Net.Rest/Utils/EmbedBuilderUtils.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Discord.Rest;
 
-public static class EmbedUtils
+public static class EmbedBuilderUtils
 {
     private static JsonSerializerSettings _settings = new () { ContractResolver = new DiscordContractResolver() };
 

--- a/src/Discord.Net.Rest/Utils/EmbedBuilderUtils.cs
+++ b/src/Discord.Net.Rest/Utils/EmbedBuilderUtils.cs
@@ -7,8 +7,15 @@ namespace Discord.Rest;
 
 public static class EmbedBuilderUtils
 {
-    private static JsonSerializerSettings _settings = new () { ContractResolver = new DiscordContractResolver() };
-
+    private static Lazy<JsonSerializerSettings> _settings = new(() =>
+    {
+        var serializer = new JsonSerializerSettings()
+        {
+            ContractResolver = new DiscordContractResolver()
+        };
+        return serializer;
+    });
+    
     /// <summary>
     ///     Parses a string into an <see cref="EmbedBuilder"/>.
     /// </summary>
@@ -19,7 +26,7 @@ public static class EmbedBuilderUtils
     {
         try
         {
-            var model = JsonConvert.DeserializeObject<API.Embed>(json, _settings);
+            var model = JsonConvert.DeserializeObject<API.Embed>(json, _settings.Value);
 
             var embed = model?.ToEntity();
 
@@ -45,7 +52,7 @@ public static class EmbedBuilderUtils
         builder = new EmbedBuilder();
         try
         {
-            var model = JsonConvert.DeserializeObject<API.Embed>(json, _settings);
+            var model = JsonConvert.DeserializeObject<API.Embed>(json, _settings.Value);
 
             var embed = model?.ToEntity();
 

--- a/src/Discord.Net.Rest/Utils/EmbedUtils.cs
+++ b/src/Discord.Net.Rest/Utils/EmbedUtils.cs
@@ -1,0 +1,64 @@
+using Discord.Net.Converters;
+using Newtonsoft.Json;
+
+using System;
+
+namespace Discord.Rest;
+
+public static class EmbedUtils
+{
+    private static JsonSerializerSettings _settings = new () { ContractResolver = new DiscordContractResolver() };
+
+    /// <summary>
+    ///     Parses a string into an <see cref="EmbedBuilder"/>.
+    /// </summary>
+    /// <param name="json">The json string to parse.</param>
+    /// <returns>An <see cref="EmbedBuilder"/> with populated values from the passed <paramref name="json"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the string passed is not valid json.</exception>
+    public static EmbedBuilder Parse(string json)
+    {
+        try
+        {
+            var model = JsonConvert.DeserializeObject<API.Embed>(json, _settings);
+
+            var embed = model?.ToEntity();
+
+            if (embed is not null)
+                return embed.ToEmbedBuilder();
+
+            return new EmbedBuilder();
+        }
+        catch
+        {
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///     Tries to parse a string into an <see cref="EmbedBuilder"/>.
+    /// </summary>
+    /// <param name="json">The json string to parse.</param>
+    /// <param name="builder">The <see cref="EmbedBuilder"/> with populated values. An empty instance if method returns <see langword="false"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="json"/> was successfully parsed. <see langword="false"/> if not.</returns>
+    public static bool TryParse(string json, out EmbedBuilder builder)
+    {
+        builder = new EmbedBuilder();
+        try
+        {
+            var model = JsonConvert.DeserializeObject<API.Embed>(json, _settings);
+
+            var embed = model?.ToEntity();
+
+            if (embed is not null)
+            {
+                builder = embed.ToEmbedBuilder();
+                return true;
+            }
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR fixes issues related to `IEmbed.ToJsonString` & `EmbedBuilder.(Try)Parse` methods.
While moving `(Try)Parse` to a new class is technically a breaking change - these ones were broken since they've been implemented.

### Changes
- move `(Try)Parse` methods to `EmbedBuilderUtils` class
- fix `ToJsonString` method

### Related Issues
- resolves #2669 
