### PR TITLE
[Fix] Prevent multiline values in short TextInputs

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -1406,6 +1406,9 @@ namespace Discord
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <see cref="Value"/>.Length is greater than <see cref="LargestMaxLength"/> or <see cref="MaxLength"/>.
         /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <see cref="Style"/> is <see cref="TextInputStyle.Short"/> and <see cref="Value"/> contains a new line character.
+        /// </exception>
         public string Value
         {
             get => _value;
@@ -1415,6 +1418,9 @@ namespace Discord
                     throw new ArgumentOutOfRangeException(nameof(value), $"Value must not be longer than {MaxLength ?? LargestMaxLength}.");
                 if (value?.Length < (MinLength ?? 0))
                     throw new ArgumentOutOfRangeException(nameof(value), $"Value must not be shorter than {MinLength}");
+                if (Style == TextInputStyle.Short && value?.Contains('\n') == true)
+                    throw new ArgumentOutOfRangeException(nameof(value), $"Value must not contain new line characters when style is {TextInputStyle.Short}.");
+
                 _value = value;
             }
         }

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -1418,8 +1418,6 @@ namespace Discord
                     throw new ArgumentOutOfRangeException(nameof(value), $"Value must not be longer than {MaxLength ?? LargestMaxLength}.");
                 if (value?.Length < (MinLength ?? 0))
                     throw new ArgumentOutOfRangeException(nameof(value), $"Value must not be shorter than {MinLength}");
-                if (Style == TextInputStyle.Short && value?.Contains('\n') == true)
-                    throw new ArgumentException(nameof(value), $"Value must not contain new line characters when style is {TextInputStyle.Short}.");
 
                 _value = value;
             }
@@ -1556,6 +1554,9 @@ namespace Discord
                 throw new ArgumentException("TextInputComponents must have a custom id.", nameof(CustomId));
             if (string.IsNullOrWhiteSpace(Label))
                 throw new ArgumentException("TextInputComponents must have a label.", nameof(Label));
+            if (Style == TextInputStyle.Short && Value?.Contains('\n') == true)
+                throw new ArgumentException(nameof(Value), $"Value must not contain new line characters when style is {TextInputStyle.Short}.");
+
             return new TextInputComponent(CustomId, Label, Placeholder, MinLength, MaxLength, Style, Required, Value);
         }
     }

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -1555,7 +1555,7 @@ namespace Discord
             if (string.IsNullOrWhiteSpace(Label))
                 throw new ArgumentException("TextInputComponents must have a label.", nameof(Label));
             if (Style == TextInputStyle.Short && Value?.Contains('\n') == true)
-                throw new ArgumentException(nameof(Value), $"Value must not contain new line characters when style is {TextInputStyle.Short}.");
+                throw new ArgumentException($"Value must not contain new line characters when style is {TextInputStyle.Short}.", nameof(Value));
 
             return new TextInputComponent(CustomId, Label, Placeholder, MinLength, MaxLength, Style, Required, Value);
         }

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -1406,7 +1406,7 @@ namespace Discord
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <see cref="Value"/>.Length is greater than <see cref="LargestMaxLength"/> or <see cref="MaxLength"/>.
         /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentException">
         ///     <see cref="Style"/> is <see cref="TextInputStyle.Short"/> and <see cref="Value"/> contains a new line character.
         /// </exception>
         public string Value
@@ -1419,7 +1419,7 @@ namespace Discord
                 if (value?.Length < (MinLength ?? 0))
                     throw new ArgumentOutOfRangeException(nameof(value), $"Value must not be shorter than {MinLength}");
                 if (Style == TextInputStyle.Short && value?.Contains('\n') == true)
-                    throw new ArgumentOutOfRangeException(nameof(value), $"Value must not contain new line characters when style is {TextInputStyle.Short}.");
+                    throw new ArgumentException(nameof(value), $"Value must not contain new line characters when style is {TextInputStyle.Short}.");
 
                 _value = value;
             }


### PR DESCRIPTION
### Description
When creating a Modal TextInput with the style Short and setting the value to a multi-line string, the error received will say just "Invalid Form Body", without exact feedback to the developer what the issue is. 

```csharp

// var description = <multi-line string>

var builder = new ModalBuilder()
{
    Title = "Custom modal",
    CustomId = "custom-id"
};

builder.AddTextInput("Description", "description", placeholder: "Description", value: description, required: true);

var modal = builder.Build();

// send modal

```

This will cause an error: 
```
The server responded with error 50035: Invalid Form Body
COMPONENT_VALIDATION_FAILED: Component validation failed
```

### Changes
In TextInputBuilder we check if the value set is a multi-line string by checking the presence of ``\n`` and if the Style is short we throw a ArgumentException.

Currently it would still be possible to cause this error by doing the following step:
1. Set Style to Paragraph
2. Set multi-line string
3. Change Style to Short

Additional checks could be set if requested to the setter of TextInputStyle property



