### PR TITLE
[Fix] Some `async` related issues

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -648,7 +648,6 @@ namespace Discord.WebSocket
             if (ConnectionState == ConnectionState.Connected)
             {
                 EnsureGatewayIntent(GatewayIntents.GuildMembers);
-
                 //Race condition leads to guilds being requested twice, probably okay
                 return ProcessUserDownloadsAsync(guilds.Select(x => GetGuild(x.Id)).Where(x => x != null));
             }
@@ -997,7 +996,14 @@ namespace Discord.WebSocket
                                                 return;
 
                                             if (BaseConfig.AlwaysDownloadUsers)
-                                                _ = DownloadUsersAsync(Guilds.Where(x => x.IsAvailable && !x.HasAllMembers));
+                                                try
+                                                {
+                                                    _ = DownloadUsersAsync(Guilds.Where(x => x.IsAvailable && !x.HasAllMembers));
+                                                }
+                                                catch (Exception ex)
+                                                {
+                                                    await _gatewayLogger.WarningAsync(ex);
+                                                }
 
                                             await TimedInvokeAsync(_readyEvent, nameof(Ready)).ConfigureAwait(false);
                                             await _gatewayLogger.InfoAsync("Ready").ConfigureAwait(false);


### PR DESCRIPTION
### Description
The merge of #2739 has uncovered some issues with the library that have been ignored/unnoticed for a long time. This PR aims to fix those issues.

### Changes
- fix the exception thrown by [`DownloadUsersAsync`](https://github.com/discord-net/Discord.Net/blob/dev/src/Discord.Net.WebSocket/DiscordSocketClient.cs#L1000) in `DiscordSocketClient` hanging the connection. Previously in case the client had `AlwaysDownloadUsers` set to `true` while missing `GatewayIntents.GuildMembers` the exception would just go unnoticed, when after the update it would hang the WS. Now it will be caught & logged.
