### PR TITLE
[Fix] Add null check in `SelectMenuBuilder`

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -1103,7 +1103,7 @@ namespace Discord
         /// </returns>
         public SelectMenuBuilder WithDefaultValues(params SelectMenuDefaultValue[] defaultValues)
         {
-            DefaultValues = defaultValues.ToList();
+            DefaultValues = defaultValues?.ToList();
             return this;
         }
 


### PR DESCRIPTION
This PR fixes a [bug](https://discord.com/channels/848176216011046962/1176997744834007167) caused by missing `null` check in `SelectMenuBuilder` method.

### Changes
- add a `null` check