### PR TITLE
[Feature] Add `AppliedTags` to `DiscordWebhookClient.SendXAsync`

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateWebhookMessageParams.cs
@@ -45,6 +45,9 @@ namespace Discord.API.Rest
         [JsonProperty("thread_name")]
         public Optional<string> ThreadName { get; set; }
 
+        [JsonProperty("applied_tags")]
+        public Optional<ulong[]> AppliedTags { get; set; }
+
         public IReadOnlyDictionary<string, object> ToDictionary()
         {
             var d = new Dictionary<string, object>();
@@ -75,6 +78,8 @@ namespace Discord.API.Rest
                 payload["components"] = Components.Value;
             if (ThreadName.IsSpecified)
                 payload["thread_name"] = ThreadName.Value;
+            if (AppliedTags.IsSpecified)
+                payload["applied_tags"] = AppliedTags.Value;
 
             var json = new StringBuilder();
             using (var text = new StringWriter(json))

--- a/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/UploadWebhookFileParams.cs
@@ -23,6 +23,7 @@ namespace Discord.API.Rest
         public Optional<ActionRowComponent[]> MessageComponents { get; set; }
         public Optional<MessageFlags> Flags { get; set; }
         public Optional<string> ThreadName { get; set; }
+        public Optional<ulong[]> AppliedTags { get; set; }
 
         public UploadWebhookFileParams(params FileAttachment[] files)
         {
@@ -54,6 +55,8 @@ namespace Discord.API.Rest
                 payload["flags"] = Flags.Value;
             if (ThreadName.IsSpecified)
                 payload["thread_name"] = ThreadName.Value;
+            if (AppliedTags.IsSpecified)
+                payload["applied_tags"] = AppliedTags.Value;
 
             List<object> attachments = new();
 

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -114,8 +114,9 @@ public class DiscordWebhookClient : IDisposable
     /// </returns>
     public Task<ulong> SendMessageAsync(string text = null, bool isTTS = false, IEnumerable<Embed> embeds = null,
         string username = null, string avatarUrl = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
-        MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
-        => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId, threadName);
+        MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null,
+        ulong[] appliedTags = null)
+        => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId, threadName, appliedTags);
 
     /// <summary>
     ///     Modifies a message posted using this webhook.
@@ -155,9 +156,10 @@ public class DiscordWebhookClient : IDisposable
     public Task<ulong> SendFileAsync(string filePath, string text, bool isTTS = false,
         IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
         RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-        MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
+        MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null,
+        string threadName = null, ulong[] appliedTags = null)
         => WebhookClientHelper.SendFileAsync(this, filePath, text, isTTS, embeds, username, avatarUrl,
-            allowedMentions, options, isSpoiler, components, flags, threadId, threadName);
+            allowedMentions, options, isSpoiler, components, flags, threadId, threadName, appliedTags);
             
     /// <summary> 
     ///     Sends a message to the channel for this webhook with an attachment. 
@@ -168,18 +170,19 @@ public class DiscordWebhookClient : IDisposable
     public Task<ulong> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false,
         IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
         RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null,
-        MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
+        MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null,
+        string threadName = null, ulong[] appliedTags = null)
         => WebhookClientHelper.SendFileAsync(this, stream, filename, text, isTTS, embeds, username,
-            avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId, threadName);
+            avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId, threadName, appliedTags);
 
     /// <summary> Sends a message to the channel for this webhook with an attachment. </summary>
     /// <returns> Returns the ID of the created message. </returns>
     public Task<ulong> SendFileAsync(FileAttachment attachment, string text, bool isTTS = false,
         IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
         RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null,
-        MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
+        MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null, ulong[] appliedTags = null)
         => WebhookClientHelper.SendFileAsync(this, attachment, text, isTTS, embeds, username,
-            avatarUrl, allowedMentions, components, options, flags, threadId, threadName);
+            avatarUrl, allowedMentions, components, options, flags, threadId, threadName, appliedTags);
 
     /// <summary> 
     ///     Sends a message to the channel for this webhook with an attachment.
@@ -190,9 +193,9 @@ public class DiscordWebhookClient : IDisposable
     public Task<ulong> SendFilesAsync(IEnumerable<FileAttachment> attachments, string text, bool isTTS = false,
         IEnumerable<Embed> embeds = null, string username = null, string avatarUrl = null,
         RequestOptions options = null, AllowedMentions allowedMentions = null, MessageComponent components = null,
-        MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
+        MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null, ulong[] appliedTags = null)
         => WebhookClientHelper.SendFilesAsync(this, attachments, text, isTTS, embeds, username, avatarUrl,
-            allowedMentions, components, options, flags, threadId, threadName);
+            allowedMentions, components, options, flags, threadId, threadName, appliedTags);
 
     /// <summary> 
     ///     Modifies the properties of this webhook.

--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -25,7 +25,8 @@ namespace Discord.Webhook
 
         public static async Task<ulong> SendMessageAsync(DiscordWebhookClient client,
             string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl,
-            AllowedMentions allowedMentions, RequestOptions options, MessageComponent components, MessageFlags flags, ulong? threadId = null, string threadName = null)
+            AllowedMentions allowedMentions, RequestOptions options, MessageComponent components,
+            MessageFlags flags, ulong? threadId = null, string threadName = null, ulong[] appliedTags = null)
         {
             var args = new CreateWebhookMessageParams
             {
@@ -48,6 +49,8 @@ namespace Discord.Webhook
                 args.Components = components?.Components.Select(x => new API.ActionRowComponent(x)).ToArray();
             if (threadName is not null)
                 args.ThreadName = threadName;
+            if (appliedTags != null)
+                args.AppliedTags = appliedTags;
 
             if (flags is not MessageFlags.None and not MessageFlags.SuppressEmbeds)
                 throw new ArgumentException("The only valid MessageFlags are SuppressEmbeds and none.", nameof(flags));
@@ -132,27 +135,29 @@ namespace Discord.Webhook
 
         public static async Task<ulong> SendFileAsync(DiscordWebhookClient client, string filePath, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options,
-            bool isSpoiler, MessageComponent components, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null)
+            bool isSpoiler, MessageComponent components, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null,
+            ulong[] appliedTags = null)
         {
             string filename = Path.GetFileName(filePath);
             using (var file = File.OpenRead(filePath))
-                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId, threadName).ConfigureAwait(false);
+                return await SendFileAsync(client, file, filename, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, isSpoiler, components, flags, threadId, threadName, appliedTags).ConfigureAwait(false);
         }
 
         public static Task<ulong> SendFileAsync(DiscordWebhookClient client, Stream stream, string filename, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions, RequestOptions options, bool isSpoiler,
-            MessageComponent components, MessageFlags flags, ulong? threadId, string threadName = null)
-            => SendFileAsync(client, new FileAttachment(stream, filename, isSpoiler: isSpoiler), text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId, threadName);
+            MessageComponent components, MessageFlags flags, ulong? threadId, string threadName = null, ulong[] appliedTags = null)
+            => SendFileAsync(client, new FileAttachment(stream, filename, isSpoiler: isSpoiler), text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId, threadName, appliedTags);
 
         public static Task<ulong> SendFileAsync(DiscordWebhookClient client, FileAttachment attachment, string text, bool isTTS,
             IEnumerable<Embed> embeds, string username, string avatarUrl, AllowedMentions allowedMentions,
-            MessageComponent components, RequestOptions options, MessageFlags flags, ulong? threadId, string threadName = null)
-            => SendFilesAsync(client, new FileAttachment[] { attachment }, text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId, threadName);
+            MessageComponent components, RequestOptions options, MessageFlags flags, ulong? threadId, string threadName = null,
+            ulong[] appliedTags = null)
+            => SendFilesAsync(client, new FileAttachment[] { attachment }, text, isTTS, embeds, username, avatarUrl, allowedMentions, components, options, flags, threadId, threadName, appliedTags);
 
         public static async Task<ulong> SendFilesAsync(DiscordWebhookClient client,
             IEnumerable<FileAttachment> attachments, string text, bool isTTS, IEnumerable<Embed> embeds, string username,
             string avatarUrl, AllowedMentions allowedMentions, MessageComponent components, RequestOptions options,
-            MessageFlags flags, ulong? threadId, string threadName = null)
+            MessageFlags flags, ulong? threadId, string threadName = null, ulong[] appliedTags = null)
         {
             embeds ??= Array.Empty<Embed>();
 
@@ -196,7 +201,8 @@ namespace Discord.Webhook
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 MessageComponents = components?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 Flags = flags,
-                ThreadName = threadName
+                ThreadName = threadName,
+                AppliedTags = appliedTags
             };
             var msg = await client.ApiClient.UploadWebhookFileAsync(client.Webhook.Id, args, options, threadId).ConfigureAwait(false);
             return msg.Id;


### PR DESCRIPTION
This PR adds support for setting applied tags in `DiscordWebhookClient.SendXAsync` methods 
[docs PR] (https://github.com/discord/discord-api-docs/pull/6560)

### Changes
- Add `AppliedTags` to `DiscordWebhookClient.SendXAsync`
