### PR TITLE
[Fix] Incorrect xmldoc

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -279,7 +279,7 @@ namespace Discord
         ///     This is the number of users who have boosted this guild.
         /// </remarks>
         /// <returns>
-        ///     The number of premium subscribers of this guild; <see langword="null" /> if not available.
+        ///     The number of premium subscribers of this guild;
         /// </returns>
         int PremiumSubscriptionCount { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -279,7 +279,7 @@ namespace Discord
         ///     This is the number of users who have boosted this guild.
         /// </remarks>
         /// <returns>
-        ///     The number of premium subscribers of this guild;
+        ///     The number of premium subscribers of this guild.
         /// </returns>
         int PremiumSubscriptionCount { get; }
         /// <summary>


### PR DESCRIPTION
### Description
The property is not nullable, as stated in [docs](https://discord.com/developers/docs/resources/guild#guild-object) and [OpenAPI spec](https://github.com/discord/discord-api-spec/blob/main/specs/openapi.json#L17592-L17595)

### Changes
- remove incorrect xmldoc

### Related Issues
- resolves #2280 