### PR TITLE
[Fix] `GetEventCoverImageUrl` throwing NRE in case event cover image is null

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -223,7 +223,7 @@ namespace Discord
             => $"{DiscordConfig.CDNUrl}stickers/{stickerId}.{FormatToExtension(format)}";
 
         /// <summary>
-        ///     Returns an events cover image url.
+        ///     Returns an events cover image url. <see langword="null"/> if the <see cref="assetId"/> is <see langword="null"/>.
         /// </summary>
         /// <param name="guildId">The guild id that the event is in.</param>
         /// <param name="eventId">The id of the event.</param>
@@ -232,7 +232,9 @@ namespace Discord
         /// <param name="size">The size of the image.</param>
         /// <returns></returns>
         public static string GetEventCoverImageUrl(ulong guildId, ulong eventId, string assetId, ImageFormat format = ImageFormat.Auto, ushort size = 1024)
-            => $"{DiscordConfig.CDNUrl}guild-events/{eventId}/{assetId}.{FormatToExtension(format, assetId)}?size={size}";
+            => string.IsNullOrEmpty(assetId)
+                ? null
+                : $"{DiscordConfig.CDNUrl}guild-events/{eventId}/{assetId}.{FormatToExtension(format, assetId)}?size={size}";
 
         private static string FormatToExtension(StickerFormatType format)
         {

--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -223,7 +223,7 @@ namespace Discord
             => $"{DiscordConfig.CDNUrl}stickers/{stickerId}.{FormatToExtension(format)}";
 
         /// <summary>
-        ///     Returns an events cover image url. <see langword="null"/> if the <see cref="assetId"/> is <see langword="null"/>.
+        ///     Returns an events cover image url. <see langword="null"/> if the assetId <see langword="null"/>.
         /// </summary>
         /// <param name="guildId">The guild id that the event is in.</param>
         /// <param name="eventId">The id of the event.</param>

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuildEvent.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuildEvent.cs
@@ -110,7 +110,7 @@ namespace Discord.Rest
 
         /// <inheritdoc/>
         public string GetCoverImageUrl(ImageFormat format = ImageFormat.Auto, ushort size = 1024)
-            => CDN.GetEventCoverImageUrl(Guild.Id, Id, CoverImageId, format, size);
+            => CDN.GetEventCoverImageUrl(GuildId, Id, CoverImageId, format, size);
 
         /// <inheritdoc/>
         public Task StartAsync(RequestOptions options = null)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuildEvent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuildEvent.cs
@@ -121,7 +121,7 @@ namespace Discord.WebSocket
 
         /// <inheritdoc/>
         public string GetCoverImageUrl(ImageFormat format = ImageFormat.Auto, ushort size = 1024)
-            => CDN.GetEventCoverImageUrl(Guild.Id, Id, CoverImageId, format, size);
+            => CDN.GetEventCoverImageUrl(GuildId, Id, CoverImageId, format, size);
 
         /// <inheritdoc/>
         public Task DeleteAsync(RequestOptions options = null)


### PR DESCRIPTION
### Changes
- add a null check & return `null` if a banner has no cover image
