### PR TITLE
Add OpenCollective links to readme + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Discord.Net is an unofficial .NET API Wrapper for the Discord client (https://di
 
 - https://discordnet.dev
 
+## 🩷 Supporting Discord.Net
+
+Discord.Net is an MIT-licensed open source project with its development made possible entirely by volunteers. 
+If you'd like to support our efforts financially, please consider:
+
+- [Contributing on Open Collective](https://opencollective.com/discordnet).
+
 ## 📥 Installation
 
 ### Stable (NuGet)

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,13 @@ FAQ. Read it thoroughly because most common questions are already answered there
 If you still have unanswered questions after reading the [FAQ](xref:FAQ.Basics.GetStarted), further support is available on
 [Discord](https://discord.gg/dnet).
 
+## Supporting Discord.Net
+
+Discord.Net is an MIT-licensed open source project with its development made possible entirely by volunteers. 
+If you'd like to support our efforts financially, please consider:
+
+- [Contributing on Open Collective](https://opencollective.com/discordnet).
+
 ## New in V3
 
 #### Interaction Framework


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
I feel like the OpenCollective could be linked a bit more so funding can be increased, so I added it to two places.

Took some inspiration from how [Svelte](https://github.com/sveltejs/svelte) does it.

### Changes
- Adds OpenCollective link to Git readme
- Adds OpenCollective link to docs homepage

