### PR TITLE
[Code Quality] MaxBitrate and UploadLimit in GuildHelper

### DIFF
--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -136,17 +136,29 @@ namespace Discord.Rest
         public static Task DeleteAsync(IGuild guild, BaseDiscordClient client, RequestOptions options)
             => client.ApiClient.DeleteGuildAsync(guild.Id, options);
 
-        public static ulong GetUploadLimit(IGuild guild)
+        public static int GetMaxBitrate(PremiumTier premiumTier)
         {
-            var tierFactor = guild.PremiumTier switch
+            return premiumTier switch
+            {
+                PremiumTier.Tier1 => 128000,
+                PremiumTier.Tier2 => 256000,
+                PremiumTier.Tier3 => 384000,
+                _ => 96000,
+            };
+        }
+
+        public static ulong GetUploadLimit(PremiumTier premiumTier)
+        {
+            ulong tierFactor = premiumTier switch
             {
                 PremiumTier.Tier2 => 50,
                 PremiumTier.Tier3 => 100,
                 _ => 25
             };
 
-            var mebibyte = Math.Pow(2, 20);
-            return (ulong)(tierFactor * mebibyte);
+            // 1 << 20 = 2 pow 20
+            var mebibyte = 1UL << 20;
+            return tierFactor * mebibyte;
         }
 
         public static async Task<GuildIncidentsData> ModifyGuildIncidentActionsAsync(IGuild guild, BaseDiscordClient client, Action<GuildIncidentsDataProperties> func, RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -91,21 +91,10 @@ namespace Discord.Rest
         public int? ApproximatePresenceCount { get; private set; }
         /// <inheritdoc/>
         public int MaxBitrate
-        {
-            get
-            {
-                return PremiumTier switch
-                {
-                    PremiumTier.Tier1 => 128000,
-                    PremiumTier.Tier2 => 256000,
-                    PremiumTier.Tier3 => 384000,
-                    _ => 96000,
-                };
-            }
-        }
+            => GuildHelper.GetMaxBitrate(PremiumTier);
         /// <inheritdoc/>
         public ulong MaxUploadLimit
-            => GuildHelper.GetUploadLimit(this);
+            => GuildHelper.GetUploadLimit(PremiumTier);
         /// <inheritdoc />
         public NsfwLevel NsfwLevel { get; private set; }
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -203,21 +203,10 @@ namespace Discord.WebSocket
         }
         /// <inheritdoc/>
         public int MaxBitrate
-        {
-            get
-            {
-                return PremiumTier switch
-                {
-                    PremiumTier.Tier1 => 128000,
-                    PremiumTier.Tier2 => 256000,
-                    PremiumTier.Tier3 => 384000,
-                    _ => 96000,
-                };
-            }
-        }
+            => GuildHelper.GetMaxBitrate(PremiumTier);
         /// <inheritdoc/>
         public ulong MaxUploadLimit
-            => GuildHelper.GetUploadLimit(this);
+            => GuildHelper.GetUploadLimit(PremiumTier);
         /// <summary>
         ///     Gets the widget channel (i.e. the channel set in the guild's widget settings) in this guild.
         /// </summary>

--- a/test/Discord.Net.Tests.Integration/DiscordRestApiClientTests.cs
+++ b/test/Discord.Net.Tests.Integration/DiscordRestApiClientTests.cs
@@ -32,7 +32,7 @@ public class DiscordRestApiClientTests : IClassFixture<RestGuildFixture>, IAsync
     [Fact]
     public async Task UploadFile_WithMaximumSize_DontThrowsException()
     {
-        var fileSize = GuildHelper.GetUploadLimit(_guild);
+        var fileSize = GuildHelper.GetUploadLimit(_guild.PremiumTier);
         using var stream = new MemoryStream(new byte[fileSize]);
 
         await _apiClient.UploadFileAsync(_channel.Id, new UploadFileParams(new FileAttachment(stream, "filename")));
@@ -41,7 +41,7 @@ public class DiscordRestApiClientTests : IClassFixture<RestGuildFixture>, IAsync
     [Fact]
     public async Task UploadFile_WithOverSize_ThrowsException()
     {
-        var fileSize = GuildHelper.GetUploadLimit(_guild) + 1;
+        var fileSize = GuildHelper.GetUploadLimit(_guild.PremiumTier) + 1;
         using var stream = new MemoryStream(new byte[fileSize]);
 
         Func<Task> upload = async () =>

--- a/test/Discord.Net.Tests.Unit/GuildHelperTests.cs
+++ b/test/Discord.Net.Tests.Unit/GuildHelperTests.cs
@@ -14,12 +14,9 @@ public class GuildHelperTests
     [InlineData(PremiumTier.Tier3, 100)]
     public void GetUploadLimit(PremiumTier tier, ulong factor)
     {
-        var guild = Substitute.For<IGuild>();
-        guild.PremiumTier.Returns(tier);
-
         var expected = factor * (ulong)Math.Pow(2, 20);
 
-        var actual = GuildHelper.GetUploadLimit(guild);
+        var actual = GuildHelper.GetUploadLimit(tier);
 
         Assert.Equal(expected, actual);
     }


### PR DESCRIPTION
### Description
Changes `GuildHelper.GetUploadLimit` to take a `PremiumTier`, and `GetMaxBitrate` has been added to reduce code duplication.

### Changes
- GuildHelper.GetUploadLimit takes a `PremiumTier` instead of `IGuild`
- GuildHelper.GetMaxBitrate has been added which takes a `PremiumTier`
- RestGuild.MaxBitrate now calls `GuildHelper.GetMaxBitrate`
- RestGuild.UploadLimit now passes `PremiumTier` instead of `this` to `GetUploadLimit`
- SocketGuild.MaxBitrate now calls `GuildHelper.GetMaxBitrate`
- SocketGuild.UploadLimit now passes `PremiumTier` instead of `this` to `GetUploadLimit`
