### PR TITLE
[Fix] Incorrect `ConnectionState` of a `DiscordSocketClient` casted to `IDiscordClient`/`BaseSocketClient`

### DIFF
--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -178,11 +178,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public Task<BotGateway> GetBotGatewayAsync(RequestOptions options = null)
             => ClientHelper.GetBotGatewayAsync(this, options);
+
+        /// <inheritdoc />
+        public virtual ConnectionState ConnectionState => ConnectionState.Disconnected;
         #endregion
 
         #region IDiscordClient
-        /// <inheritdoc />
-        ConnectionState IDiscordClient.ConnectionState => ConnectionState.Disconnected;
         /// <inheritdoc />
         ISelfUser IDiscordClient.CurrentUser => CurrentUser;
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -58,8 +58,8 @@ namespace Discord.WebSocket
         public override DiscordSocketRestClient Rest { get; }
         /// <summary> Gets the shard of this client. </summary>
         public int ShardId { get; }
-        /// <summary> Gets the current connection state of this client. </summary>
-        public ConnectionState ConnectionState => _connection.State;
+        /// <inheritdoc />
+        public override ConnectionState ConnectionState => _connection.State;
         /// <inheritdoc />
         public override int Latency { get; protected set; }
         /// <inheritdoc />


### PR DESCRIPTION
### Changes
- override `BaseSocketClient.ConnectionState` in `DiscordSocketClient`
