### PR TITLE
[Fix] Receiving voice packets (use system-assigned port)

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -321,11 +321,9 @@ namespace Discord.Audio
                         return;
                     }
                     string ip;
-                    int port;
                     try
                     {
                         ip = Encoding.UTF8.GetString(packet, 8, 74 - 10).TrimEnd('\0');
-                        port = (packet[73] << 8) | packet[72];
                     }
                     catch (Exception ex)
                     {
@@ -334,7 +332,7 @@ namespace Discord.Audio
                     }
 
                     await _audioLogger.DebugAsync("Received Discovery").ConfigureAwait(false);
-                    await ApiClient.SendSelectProtocol(ip, port).ConfigureAwait(false);
+                    await ApiClient.SendSelectProtocol(ip).ConfigureAwait(false);
                 }
                 else if (_connection.State == ConnectionState.Connected)
                 {

--- a/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
@@ -143,7 +143,7 @@ namespace Discord.Audio
             });
         }
 
-        public Task SendSelectProtocol(string externalIp, int externalPort)
+        public Task SendSelectProtocol(string externalIp)
         {
             return SendAsync(VoiceOpCode.SelectProtocol, new SelectProtocolParams
             {
@@ -151,7 +151,7 @@ namespace Discord.Audio
                 Data = new UdpProtocolInfo
                 {
                     Address = externalIp,
-                    Port = externalPort,
+                    Port = UdpPort,
                     Mode = Mode
                 }
             });

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1744,11 +1744,9 @@ namespace Discord.WebSocket
 
                 if (external)
                 {
-#pragma warning disable IDISP001
-                    var _ = promise.TrySetResultAsync(null);
+                    _ = promise.TrySetResultAsync(null);
                     await Discord.ApiClient.SendVoiceStateUpdateAsync(_voiceStateUpdateParams).ConfigureAwait(false);
                     return null;
-#pragma warning restore IDISP001
                 }
 
                 if (_audioClient == null)
@@ -1766,19 +1764,15 @@ namespace Discord.WebSocket
                                 await promise.TrySetExceptionAsync(ex);
                             else
                                 await promise.TrySetCanceledAsync();
-                            return;
                         }
                     };
                     audioClient.Connected += () =>
                     {
-#pragma warning disable IDISP001
-                        var _ = promise.TrySetResultAsync(_audioClient);
-#pragma warning restore IDISP001
+                        _ = promise.TrySetResultAsync(_audioClient);
                         return Task.Delay(0);
                     };
-#pragma warning disable IDISP003
+
                     _audioClient = audioClient;
-#pragma warning restore IDISP003
                 }
 
                 await Discord.ApiClient.SendVoiceStateUpdateAsync(_voiceStateUpdateParams).ConfigureAwait(false);


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
This pull request modifies [DiscordVoiceAPIClient](src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs) and [AudioClient](src/Discord.Net.WebSocket/Audio/AudioClient.cs) implementations in order to allow receiving packets from Discord's voice UDP server.
The reason for inability to receive voice packets from Discord was that the library used to send [Select Protocol Request](https://discord.com/developers/docs/topics/voice-connections#establishing-a-voice-udp-connection-example-select-protocol-payload) with invalid UDP port, which caused Discord to send packets that then could not be captured. Now it sends the port which has been assigned and bound automatically.

### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->
**DiscordVoiceAPIClient:**
- **SendSelectProtocol()** now sends IP from discovery with port that was assigned to the UDP client by the system.
- Removed redundant parameter from previously mentioned method.

**AudioClient:**
- In **ProcessPacketAsync()** removed redundant code that used to receive port from IP discovery. Now we only need IP so everything regarding port is redundant.
- Changed **DiscordVoiceAPIClient.SendSelectProtocol()** call in order to match new parameters.

### Related Issues
<!--
List issues that are related to this PR.
Example:
- resolves #6969
-->

- This PR resolves #2674 and an issue related to this [discussion](https://discord.com/channels/848176216011046962/918349926113611806/1079395210758459432).