### PR TITLE
Fixed a bug when creating a `SelectMenuBuilder` from a `SelectMenuComponent` incorrectly set the `CustomId`

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -925,7 +925,7 @@ namespace Discord
         public SelectMenuBuilder(SelectMenuComponent selectMenu)
         {
             Placeholder = selectMenu.Placeholder;
-            CustomId = selectMenu.Placeholder;
+            CustomId = selectMenu.CustomId;
             MaxValues = selectMenu.MaxValues;
             MinValues = selectMenu.MinValues;
             IsDisabled = selectMenu.IsDisabled;


### PR DESCRIPTION
### Description
When creating a `SelectMenuBuilder` from a `SelectMenuComponent`, it would set the `CustomId` to the component's `Placeholder` instead.

### Changes
- Made the `SelectMenuBuilder` set its `CustomId` to the `SelectMenuComponent`'s `CustomId`

### Related Issues
- N/A