### PR TITLE
[Feature] `SentRequest` event

### DIFF
--- a/src/Discord.Net.Rest/BaseDiscordClient.cs
+++ b/src/Discord.Net.Rest/BaseDiscordClient.cs
@@ -20,6 +20,13 @@ namespace Discord.Rest
         public event Func<Task> LoggedOut { add { _loggedOutEvent.Add(value); } remove { _loggedOutEvent.Remove(value); } }
         private readonly AsyncEvent<Func<Task>> _loggedOutEvent = new AsyncEvent<Func<Task>>();
 
+        internal readonly AsyncEvent<Func<string, string, double, Task>> _sentRequest = new();
+        /// <summary>
+        ///     Fired when a REST request is sent to the API. First parameter is the HTTP method,
+        ///     second is the endpoint, and third is the time taken to complete the request.
+        /// </summary>
+        public event Func<string, string, double, Task> SentRequest { add { _sentRequest.Add(value); } remove { _sentRequest.Remove(value); } }
+
         internal readonly Logger _restLogger;
         private readonly SemaphoreSlim _stateLock;
         private bool _isFirstLogin, _isDisposed;
@@ -61,6 +68,7 @@ namespace Discord.Rest
                     await _restLogger.WarningAsync($"Rate limit triggered: {endpoint} Remaining: {info.Value.RetryAfter}s {(id.IsHashBucket ? $"(Bucket: {id.BucketHash})" : "")}").ConfigureAwait(false);
             };
             ApiClient.SentRequest += async (method, endpoint, millis) => await _restLogger.VerboseAsync($"{method} {endpoint}: {millis} ms").ConfigureAwait(false);
+            ApiClient.SentRequest += (method, endpoint, millis) => _sentRequest.InvokeAsync(method, endpoint, millis);
         }
 
         public async Task LoginAsync(TokenType tokenType, string token, bool validateToken = true)

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -431,6 +431,8 @@ namespace Discord.WebSocket
                 return Task.Delay(0);
             };
 
+            client.SentRequest += (method, endpoint, millis) => _sentRequest.InvokeAsync(method, endpoint, millis);
+
             client.Connected += () => _shardConnectedEvent.InvokeAsync(client);
             client.Disconnected += (exception) => _shardDisconnectedEvent.InvokeAsync(exception, client);
             client.Ready += () => _shardReadyEvent.InvokeAsync(client);


### PR DESCRIPTION
### Description
This PR adds a `SentRequest` event to `BaseDiscordClient` which forwards the data from the similar event on a `DiscordRestApiClient` to simplify collection of bot statistics

Previously the only way to access this data was parsing logs from the `Log` event