### PR TITLE
Fix docs DI picture appearance

### DIFF
--- a/docs/guides/dependency_injection/basics.md
+++ b/docs/guides/dependency_injection/basics.md
@@ -23,7 +23,7 @@ DI is not native to .NET. You need to install the extension packages to your pro
 
 ### Visual Package Manager:
 
-[Installing](images/manager.png)
+![Installing](images/manager.png)
 
 ### Command Line:
 


### PR DESCRIPTION
### Description
[Dependency injection guide](https://docs.discordnet.dev/guides/dependency_injection/basics.html#visual-package-manager) displays VS package manager as link instead of picture.

### Changes
Makes it emdedded in page.