### PR TITLE
Add embed parameter for webhooks in SendMessageAsync

### DIFF
--- a/samples/WebhookClient/Program.cs
+++ b/samples/WebhookClient/Program.cs
@@ -24,6 +24,6 @@ class Program
 
         // Webhooks are able to send multiple embeds per message
         // As such, your embeds must be passed as a collection.
-        await client.SendMessageAsync(text: "Send a message to this webhook!", embeds: new[] { embed.Build() });
+        await client.SendMessageAsync(text: "Send a message to this webhook!", embed: embed.Build() );
     }
 }

--- a/src/Discord.Net.Webhook/DiscordWebhookClient.cs
+++ b/src/Discord.Net.Webhook/DiscordWebhookClient.cs
@@ -115,8 +115,8 @@ public class DiscordWebhookClient : IDisposable
     public Task<ulong> SendMessageAsync(string text = null, bool isTTS = false, IEnumerable<Embed> embeds = null,
         string username = null, string avatarUrl = null, RequestOptions options = null, AllowedMentions allowedMentions = null,
         MessageComponent components = null, MessageFlags flags = MessageFlags.None, ulong? threadId = null, string threadName = null,
-        ulong[] appliedTags = null)
-        => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId, threadName, appliedTags);
+        ulong[] appliedTags = null, Embed embed = null)
+        => WebhookClientHelper.SendMessageAsync(this, text, isTTS, embeds, username, avatarUrl, allowedMentions, options, components, flags, threadId, threadName, appliedTags, embed);
 
     /// <summary>
     ///     Modifies a message posted using this webhook.

--- a/src/Discord.Net.Webhook/WebhookClientHelper.cs
+++ b/src/Discord.Net.Webhook/WebhookClientHelper.cs
@@ -26,8 +26,13 @@ namespace Discord.Webhook
         public static async Task<ulong> SendMessageAsync(DiscordWebhookClient client,
             string text, bool isTTS, IEnumerable<Embed> embeds, string username, string avatarUrl,
             AllowedMentions allowedMentions, RequestOptions options, MessageComponent components,
-            MessageFlags flags, ulong? threadId = null, string threadName = null, ulong[] appliedTags = null)
+            MessageFlags flags, ulong? threadId = null, string threadName = null, ulong[] appliedTags = null,
+            Embed embed = null)
         {
+            embeds ??= Array.Empty<Embed>();
+            if (embed != null)
+                embeds = new[] { embed }.Concat(embeds).ToArray();
+
             var args = new CreateWebhookMessageParams
             {
                 Content = text,


### PR DESCRIPTION
### Description
This PR adds a `embed` parameter to the `SendMessageAsync` method for Webhooks, like it is already in the `SendMessageAsync` method for Channels.

### Changes
- Add `embed` parameter
- Update Webhook sample