### PR TITLE
Fix buttons-in-depth Table / Typo.

### DIFF
--- a/docs/guides/int_basics/message-components/buttons-in-depth.md
+++ b/docs/guides/int_basics/message-components/buttons-in-depth.md
@@ -5,7 +5,7 @@ title: Buttons in Depth
 
 # Buttons in depth
 
-There are many changes you can make to buttons, lets take a look at the parameters in the `WithButton` "function."
+There are many changes you can make to buttons, lets take a look at the parameters in the `WithButton` function.
 
 | Name | Type | Description |
 |----------|---------------|----------------------------------------------------------------|

--- a/docs/guides/int_basics/message-components/buttons-in-depth.md
+++ b/docs/guides/int_basics/message-components/buttons-in-depth.md
@@ -5,7 +5,8 @@ title: Buttons in Depth
 
 # Buttons in depth
 
-There are many changes you can make to buttons, lets take a look at the parameters in the `WithButton` function"
+There are many changes you can make to buttons, lets take a look at the parameters in the `WithButton` "function."
+
 | Name | Type | Description |
 |----------|---------------|----------------------------------------------------------------|
 | label | `string` | The label text for the button. |


### PR DESCRIPTION
### Description
Corrected display of table and fixed a typo [here](https://docs.discordnet.dev/guides/int_basics/message-components/buttons-in-depth.html ).

### Changes
- Added a new line after the starting sentence.
- Made " -> . in the starting sentence (after the word function).
