### PR TITLE
Fix: RestDMChannel relies on recipient 

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -29,7 +29,9 @@ namespace Discord.Rest
         /// <summary>
         ///     Gets a collection that is the current logged-in user and the recipient.
         /// </summary>
-        public IReadOnlyCollection<RestUser> Users => ImmutableArray.Create(CurrentUser, Recipient);
+        public IReadOnlyCollection<RestUser> Users => Recipient is null
+            ? Array.Empty<RestUser>()
+            : ImmutableArray.Create(CurrentUser, Recipient);
 
         internal RestDMChannel(BaseDiscordClient discord, ulong id, ulong? recipientId)
             : base(discord, id)
@@ -45,7 +47,8 @@ namespace Discord.Rest
         }
         internal override void Update(Model model)
         {
-            Recipient.Update(model.Recipients.Value[0]);
+            if(model.Recipients.IsSpecified)
+                Recipient?.Update(model.Recipients.Value[0]);
         }
 
         /// <inheritdoc />
@@ -68,7 +71,7 @@ namespace Discord.Rest
         /// </returns>
         public RestUser GetUser(ulong id)
         {
-            if (id == Recipient.Id)
+            if (id == Recipient?.Id)
                 return Recipient;
             else if (id == Discord.CurrentUser.Id)
                 return CurrentUser;

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -31,15 +31,15 @@ namespace Discord.Rest
         /// </summary>
         public IReadOnlyCollection<RestUser> Users => ImmutableArray.Create(CurrentUser, Recipient);
 
-        internal RestDMChannel(BaseDiscordClient discord, ulong id, ulong recipientId)
+        internal RestDMChannel(BaseDiscordClient discord, ulong id, ulong? recipientId)
             : base(discord, id)
         {
-            Recipient = new RestUser(Discord, recipientId);
+            Recipient = recipientId.HasValue ? new RestUser(Discord, recipientId.Value) : null;
             CurrentUser = new RestUser(Discord, discord.CurrentUser.Id);
         }
         internal new static RestDMChannel Create(BaseDiscordClient discord, Model model)
         {
-            var entity = new RestDMChannel(discord, model.Id, model.Recipients.Value[0].Id);
+            var entity = new RestDMChannel(discord, model.Id, model.Recipients.GetValueOrDefault(null)?[0].Id);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestDMChannel.cs
@@ -30,7 +30,7 @@ namespace Discord.Rest
         ///     Gets a collection that is the current logged-in user and the recipient.
         /// </summary>
         public IReadOnlyCollection<RestUser> Users => Recipient is null
-            ? Array.Empty<RestUser>()
+            ? ImmutableArray<RestUser>.Empty
             : ImmutableArray.Create(CurrentUser, Recipient);
 
         internal RestDMChannel(BaseDiscordClient discord, ulong id, ulong? recipientId)


### PR DESCRIPTION
### Summary
The `RestDMChannel` relies on `Recipient` when in actuality it can be unspecified in the case of a user app dm interaction.