### PR TITLE
Fix: Don't rely on Guild for id

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestCategoryChannel.cs
@@ -13,13 +13,13 @@ namespace Discord.Rest
     public class RestCategoryChannel : RestGuildChannel, ICategoryChannel
     {
         #region RestCategoryChannel
-        internal RestCategoryChannel(BaseDiscordClient discord, IGuild guild, ulong id)
-            : base(discord, guild, id)
+        internal RestCategoryChannel(BaseDiscordClient discord, IGuild guild, ulong id, ulong guildId)
+            : base(discord, guild, id, guildId)
         {
         }
         internal new static RestCategoryChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestCategoryChannel(discord, guild, model.Id);
+            var entity = new RestCategoryChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestForumChannel.cs
@@ -47,15 +47,15 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public string Mention => MentionUtils.MentionChannel(Id);
 
-        internal RestForumChannel(BaseDiscordClient client, IGuild guild, ulong id)
-            : base(client, guild, id)
+        internal RestForumChannel(BaseDiscordClient client, IGuild guild, ulong id, ulong guildId)
+            : base(client, guild, id, guildId)
         {
 
         }
 
         internal new static RestForumChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestForumChannel(discord, guild, model.Id);
+            var entity = new RestForumChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestGuildChannel.cs
@@ -23,16 +23,18 @@ namespace Discord.Rest
         public string Name { get; private set; }
         /// <inheritdoc />
         public int Position { get; private set; }
+
         /// <inheritdoc />
-        public ulong GuildId => Guild.Id;
+        public ulong GuildId { get; }
 
         /// <inheritdoc />
         public ChannelFlags Flags { get; private set; }
 
-        internal RestGuildChannel(BaseDiscordClient discord, IGuild guild, ulong id)
+        internal RestGuildChannel(BaseDiscordClient discord, IGuild guild, ulong id, ulong guildId)
             : base(discord, id)
         {
             Guild = guild;
+            GuildId = guildId;
         }
         internal static RestGuildChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
@@ -46,7 +48,7 @@ namespace Discord.Rest
                 ChannelType.Forum => RestForumChannel.Create(discord, guild, model),
                 ChannelType.Category => RestCategoryChannel.Create(discord, guild, model),
                 ChannelType.PublicThread or ChannelType.PrivateThread or ChannelType.NewsThread => RestThreadChannel.Create(discord, guild, model),
-                _ => new RestGuildChannel(discord, guild, model.Id),
+                _ => new RestGuildChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value),
             };
         }
         internal override void Update(Model model)

--- a/src/Discord.Net.Rest/Entities/Channels/RestMediaChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestMediaChannel.cs
@@ -4,15 +4,15 @@ namespace Discord.Rest;
 
 public class RestMediaChannel : RestForumChannel, IMediaChannel
 {
-    internal RestMediaChannel(BaseDiscordClient client, IGuild guild, ulong id)
-        : base(client, guild, id)
+    internal RestMediaChannel(BaseDiscordClient client, IGuild guild, ulong id, ulong guildId)
+        : base(client, guild, id, guildId)
     {
 
     }
 
     internal new static RestMediaChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
     {
-        var entity = new RestMediaChannel(discord, guild, model.Id);
+        var entity = new RestMediaChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value);
         entity.Update(model);
         return entity;
     }

--- a/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestNewsChannel.cs
@@ -15,13 +15,13 @@ namespace Discord.Rest
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     public class RestNewsChannel : RestTextChannel, INewsChannel
     {
-        internal RestNewsChannel(BaseDiscordClient discord, IGuild guild, ulong id)
-            : base(discord, guild, id)
+        internal RestNewsChannel(BaseDiscordClient discord, IGuild guild, ulong id, ulong guildId)
+            : base(discord, guild, id, guildId)
         {
         }
         internal new static RestNewsChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestNewsChannel(discord, guild, model.Id);
+            var entity = new RestNewsChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestStageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestStageChannel.cs
@@ -15,7 +15,7 @@ namespace Discord.Rest
         /// <remarks>
         ///     This field is always true for stage channels.
         /// </remarks>
-        /// 
+        ///
         [Obsolete("This property is no longer used because Discord enabled text-in-voice and text-in-stage for all channels.")]
         public override bool IsTextInVoice
             => true;
@@ -28,12 +28,12 @@ namespace Discord.Rest
 
         /// <inheritdoc/>
         public bool IsLive { get; private set; }
-        internal RestStageChannel(BaseDiscordClient discord, IGuild guild, ulong id)
-            : base(discord, guild, id) { }
+        internal RestStageChannel(BaseDiscordClient discord, IGuild guild, ulong id, ulong guildId)
+            : base(discord, guild, id, guildId) { }
 
         internal new static RestStageChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestStageChannel(discord, guild, model.Id);
+            var entity = new RestStageChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -30,13 +30,13 @@ namespace Discord.Rest
         /// <inheritdoc />
         public int DefaultSlowModeInterval { get; private set; }
 
-        internal RestTextChannel(BaseDiscordClient discord, IGuild guild, ulong id)
-            : base(discord, guild, id)
+        internal RestTextChannel(BaseDiscordClient discord, IGuild guild, ulong id, ulong guildId)
+            : base(discord, guild, id, guildId)
         {
         }
         internal new static RestTextChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestTextChannel(discord, guild, model.Id);
+            var entity = new RestTextChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value);
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
@@ -51,15 +51,15 @@ namespace Discord.Rest
         /// </summary>
         public ulong ParentChannelId { get; private set; }
 
-        internal RestThreadChannel(BaseDiscordClient discord, IGuild guild, ulong id, DateTimeOffset? createdAt)
-            : base(discord, guild, id)
+        internal RestThreadChannel(BaseDiscordClient discord, IGuild guild, ulong id, ulong guildId, DateTimeOffset? createdAt)
+            : base(discord, guild, id, guildId)
         {
             CreatedAt = createdAt ?? new DateTimeOffset(2022, 1, 9, 0, 0, 0, TimeSpan.Zero);
         }
 
         internal new static RestThreadChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestThreadChannel(discord, guild, model.Id, model.ThreadMetadata.GetValueOrDefault()?.CreatedAt.GetValueOrDefault());
+            var entity = new RestThreadChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value, model.ThreadMetadata.GetValueOrDefault()?.CreatedAt.GetValueOrDefault());
             entity.Update(model);
             return entity;
         }

--- a/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestVoiceChannel.cs
@@ -31,13 +31,13 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public VideoQualityMode VideoQualityMode { get; private set; }
 
-        internal RestVoiceChannel(BaseDiscordClient discord, IGuild guild, ulong id)
-            : base(discord, guild, id)
+        internal RestVoiceChannel(BaseDiscordClient discord, IGuild guild, ulong id, ulong guildId)
+            : base(discord, guild, id, guildId)
         {
         }
         internal new static RestVoiceChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
-            var entity = new RestVoiceChannel(discord, guild, model.Id);
+            var entity = new RestVoiceChannel(discord, guild, model.Id, guild?.Id ?? model.GuildId.Value);
             entity.Update(model);
             return entity;
         }


### PR DESCRIPTION
### Summary
If API calls are off for rest interactions, guild channels will attempt to pull the guild id from the entity, not the model. This fixes that