### PR TITLE
[Fix] `SocketInteraction` is messed up

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
@@ -26,6 +26,14 @@ namespace Discord.WebSocket
         /// </remarks>
         public ISocketMessageChannel Channel { get; private set; }
 
+        /// <summary>
+        ///     Gets the channel this interaction was used in.
+        /// </summary>
+        /// <remarks>
+        ///     This property can contain a partial channel object. <see langword="null"/> if no channel was passed with the interaction.
+        /// </remarks>
+        public IMessageChannel InteractionChannel { get; private set; }
+
         /// <inheritdoc/>
         public ulong? ChannelId { get; private set; }
 
@@ -165,6 +173,27 @@ namespace Discord.WebSocket
                 : null;
 
             Permissions = new GuildPermissions((ulong)model.ApplicationPermissions);
+
+            InteractionChannel = Channel;
+            if (model.Channel.IsSpecified && InteractionChannel is null)
+            {
+                InteractionChannel = model.Channel.Value.Type switch
+                {
+                    ChannelType.News or
+                        ChannelType.Text or
+                        ChannelType.Voice or
+                        ChannelType.Stage or
+                        ChannelType.NewsThread or
+                        ChannelType.PrivateThread or
+                        ChannelType.PublicThread or
+                        ChannelType.Media or
+                        ChannelType.Forum
+                        => RestChannel.Create(Discord, model.Channel.Value) as IMessageChannel,
+                    ChannelType.DM => RestDMChannel.Create(Discord, model.Channel.Value),
+                    ChannelType.Group => RestGroupChannel.Create(Discord, model.Channel.Value),
+                    _ => null
+                };
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
this PR adds a `SocketInteraction.InteractionChannel` property so you can get the (partial) channel even if the interaction was created from uncached channel (it also allows you to get the channel when a user uses a user-app command)