### PR TITLE
Fix: NRE with rest interactions & no api call (again)

### DIFF
--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBaseData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBaseData.cs
@@ -27,20 +27,20 @@ namespace Discord.Rest
         {
         }
 
-        internal static async Task<RestCommandBaseData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
+        internal static async Task<RestCommandBaseData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, ulong? guildId, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestCommandBaseData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, guildId, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
 
-        internal virtual Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
+        internal virtual Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, ulong? guildId, IRestMessageChannel channel, bool doApiCall)
         {
             Name = model.Name;
             if (model.Resolved.IsSpecified && ResolvableData == null)
             {
                 ResolvableData = new RestResolvableData<Model>();
-                return ResolvableData.PopulateAsync(client, guild, channel, model, doApiCall);
+                return ResolvableData.PopulateAsync(client, guild, guildId, channel, model, doApiCall);
             }
             return Task.CompletedTask;
         }

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestResolvableData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestResolvableData.cs
@@ -22,7 +22,7 @@ namespace Discord.Rest
         internal readonly Dictionary<ulong, Attachment> Attachments
             = new Dictionary<ulong, Attachment>();
 
-        internal async Task PopulateAsync(DiscordRestClient discord, RestGuild guild, IRestMessageChannel channel, T model, bool doApiCall)
+        internal async Task PopulateAsync(DiscordRestClient discord, RestGuild guild, ulong? guildId, IRestMessageChannel channel, T model, bool doApiCall)
         {
             var resolved = model.Resolved.Value;
 
@@ -67,7 +67,7 @@ namespace Discord.Rest
                 {
                     // pull the adjacent user model
                     member.Value.User = resolved.Users.Value.FirstOrDefault(x => x.Key == member.Key).Value;
-                    var restMember = RestGuildUser.Create(discord, guild, member.Value);
+                    var restMember = RestGuildUser.Create(discord, guild, member.Value, guildId);
 
                     GuildMembers.Add(ulong.Parse(member.Key), restMember);
                 }

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommand.cs
@@ -35,7 +35,7 @@ namespace Discord.Rest
                 ? (DataModel)model.Data.Value
                 : null;
 
-            Data = await RestMessageCommandData.CreateAsync(client, dataModel, Guild, Channel, doApiCall).ConfigureAwait(false);
+            Data = await RestMessageCommandData.CreateAsync(client, dataModel, Guild, model.GuildId.ToNullable(), Channel, doApiCall).ConfigureAwait(false);
         }
 
         //IMessageCommandInteraction

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/MessageCommands/RestMessageCommandData.cs
@@ -28,10 +28,10 @@ namespace Discord.Rest
         internal RestMessageCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal new static async Task<RestMessageCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
+        internal new static async Task<RestMessageCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, ulong? guildId, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestMessageCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, guildId, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommand.cs
@@ -38,7 +38,7 @@ namespace Discord.Rest
                 ? (DataModel)model.Data.Value
                 : null;
 
-            Data = await RestUserCommandData.CreateAsync(client, dataModel, Guild, Channel, doApiCall).ConfigureAwait(false);
+            Data = await RestUserCommandData.CreateAsync(client, dataModel, Guild, model.GuildId.ToNullable(), Channel, doApiCall).ConfigureAwait(false);
         }
 
         //IUserCommandInteractionData

--- a/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/ContextMenuCommands/UserCommands/RestUserCommandData.cs
@@ -26,10 +26,10 @@ namespace Discord.Rest
         internal RestUserCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal new static async Task<RestUserCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
+        internal new static async Task<RestUserCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, ulong? guildId, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestUserCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, guildId, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommand.cs
@@ -38,7 +38,7 @@ namespace Discord.Rest
                 ? (DataModel)model.Data.Value
                 : null;
 
-            Data = await RestSlashCommandData.CreateAsync(client, dataModel, Guild, Channel, doApiCall).ConfigureAwait(false);
+            Data = await RestSlashCommandData.CreateAsync(client, dataModel, Guild, model.GuildId.ToNullable(), Channel, doApiCall).ConfigureAwait(false);
         }
 
         //ISlashCommandInteraction

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommandData.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestSlashCommandData.cs
@@ -14,15 +14,15 @@ namespace Discord.Rest
         internal RestSlashCommandData(DiscordRestClient client, Model model)
             : base(client, model) { }
 
-        internal static new async Task<RestSlashCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
+        internal new static async Task<RestSlashCommandData> CreateAsync(DiscordRestClient client, Model model, RestGuild guild, ulong? guildId, IRestMessageChannel channel, bool doApiCall)
         {
             var entity = new RestSlashCommandData(client, model);
-            await entity.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
+            await entity.UpdateAsync(client, model, guild, guildId, channel, doApiCall).ConfigureAwait(false);
             return entity;
         }
-        internal override async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, IRestMessageChannel channel, bool doApiCall)
+        internal override async Task UpdateAsync(DiscordRestClient client, Model model, RestGuild guild, ulong? guildId, IRestMessageChannel channel, bool doApiCall)
         {
-            await base.UpdateAsync(client, model, guild, channel, doApiCall).ConfigureAwait(false);
+            await base.UpdateAsync(client, model, guild, guildId, channel, doApiCall).ConfigureAwait(false);
 
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(x => new RestSlashCommandDataOption(this, x)).ToImmutableArray()

--- a/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestGuildUser.cs
@@ -91,7 +91,9 @@ namespace Discord.Rest
         {
             if (guild is not null)
                 Guild = guild;
-            GuildId = guildId ?? Guild.Id;
+
+            // kind of dangerous if the callee fucks up the 'guildId' parameter.
+            GuildId = guildId ?? Guild?.Id ?? throw new ArgumentNullException(nameof(guild), $"Expected either {nameof(guild)} or {nameof(guildId)} to be non-null");
         }
         internal static RestGuildUser Create(BaseDiscordClient discord, IGuild guild, Model model, ulong? guildId = null)
         {


### PR DESCRIPTION
when trying to resolve a guild member from resolvable data, the client *assumes* the guild is not null.. which is not the case when api req are off.