### PR TITLE
Enable Nuget debug symbols (snupkg).

### DIFF
--- a/experiment/Discord.Net.BuildOverrides/Discord.Net.BuildOverrides.csproj
+++ b/experiment/Discord.Net.BuildOverrides/Discord.Net.BuildOverrides.csproj
@@ -9,6 +9,8 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0;net5.0;</TargetFrameworks>
     <IsTrimmable>false</IsTrimmable>
     <IsAotCompatible>false</IsAotCompatible>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Discord.Net.Commands/Discord.Net.Commands.csproj
+++ b/src/Discord.Net.Commands/Discord.Net.Commands.csproj
@@ -10,6 +10,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <IsTrimmable>false</IsTrimmable>
     <IsAotCompatible>false</IsAotCompatible>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -10,6 +10,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <IsTrimmable>false</IsTrimmable>
     <IsAotCompatible>false</IsAotCompatible>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
+++ b/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
@@ -10,6 +10,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <IsTrimmable>false</IsTrimmable>
     <IsAotCompatible>false</IsAotCompatible>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Discord.Net.Rest/Discord.Net.Rest.csproj
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.csproj
@@ -10,6 +10,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <IsTrimmable>false</IsTrimmable>
     <IsAotCompatible>false</IsAotCompatible>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.csproj
@@ -11,6 +11,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <IsTrimmable>false</IsTrimmable>
     <IsAotCompatible>false</IsAotCompatible>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />

--- a/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
+++ b/src/Discord.Net.Webhook/Discord.Net.Webhook.csproj
@@ -10,6 +10,8 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <IsTrimmable>false</IsTrimmable>
     <IsAotCompatible>false</IsAotCompatible>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Core\Discord.Net.Core.csproj" />


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
<!-- A brief explanation of changes made in this PR. -->
Enabled pushing debug symbols to Nuget. Made this as this will give much better support for looking at Discord.Net's code compared to Visual Studio's decompiler (or Resharpers). Previously would have to pull up the Github, which wasn't ideal. (Had to do this more than a couple times to see how some methods work and the like). Will also obviously mean we get all the other benefits of debug symbols.

On your end with Nuget pushes, the Nuget CLI should auto-push it automatically whenever pushing a new version, meaning you shouldn't need to do anything differently. [See MSDocs about this here](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg)

### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->
Enabled building .snupkg files for all packages that are pushed to Nuget (to my knowledge), being BuildOverrides, Commands, Core, Interactions, Rest, WebSocket, and Webhook. 
