### PR TITLE
Fix IndexOf bug in CreateBucketId method

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -2705,14 +2705,14 @@ namespace Discord.API
                 int lastIndex = 0;
                 while (true)
                 {
-                    int leftIndex = format.IndexOf("{", lastIndex);
+                    int leftIndex = format.IndexOf('{', lastIndex);
                     if (leftIndex == -1 || leftIndex > endIndex)
                     {
                         builder.Append(format, lastIndex, endIndex - lastIndex);
                         break;
                     }
                     builder.Append(format, lastIndex, leftIndex - lastIndex);
-                    int rightIndex = format.IndexOf("}", leftIndex);
+                    int rightIndex = format.IndexOf('}', leftIndex);
 
                     int argId = int.Parse(format.Substring(leftIndex + 1, rightIndex - leftIndex - 1), NumberStyles.None, CultureInfo.InvariantCulture);
                     string fieldName = GetFieldName(methodArgs[argId + 1]);


### PR DESCRIPTION
I get error about Substring in CreateBucketId method. I try to debug it and i see IndexOf("{") it return 0 every time.
it return 0 if use `"`. but it return index if use `'`.
I change "{" and "}" in IndexOf() to '{' and '}' for fix this bug.

![image](https://github.com/discord-net/Discord.Net/assets/92650477/3098139c-fd34-45e2-b369-07908674eb46)
