### PR TITLE
Longer MaxCustomBlockMessageLength

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/AutoModeration/AutoModRuleProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/AutoModeration/AutoModRuleProperties.cs
@@ -69,7 +69,7 @@ namespace Discord
         /// <summary>
         ///     Returns the max custom message length AutoMod rule action allowed by Discord.
         /// </summary>
-        public const int MaxCustomBlockMessageLength = 50;
+        public const int MaxCustomBlockMessageLength = 150;
 
 
         /// <summary>


### PR DESCRIPTION
Adjusted the number of characters in `MaxCustomBlockMessageLength` to `150` according to the documentation.

<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->
