### PR TITLE
fix: crash when poll is null in RestMessageComponent

### DIFF
--- a/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
@@ -278,7 +278,7 @@ namespace Discord.Rest
                 Embeds = embeds.Select(x => x.ToModel()).ToArray(),
                 Components = components?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 Flags = ephemeral ? MessageFlags.Ephemeral : MessageFlags.None,
-                Poll = poll.ToModel() ?? Optional<CreatePollParams>.Unspecified
+                Poll = poll?.ToModel() ?? Optional<CreatePollParams>.Unspecified
             };
 
             if (ephemeral)
@@ -409,7 +409,7 @@ namespace Discord.Rest
                 Embeds = embeds.Any() ? embeds.Select(x => x.ToModel()).ToArray() : Optional<API.Embed[]>.Unspecified,
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 MessageComponents = components?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
-                Poll = poll.ToModel() ?? Optional<CreatePollParams>.Unspecified
+                Poll = poll?.ToModel() ?? Optional<CreatePollParams>.Unspecified
             };
             return InteractionHelper.SendFollowupAsync(Discord, args, Token, Channel, options);
         }


### PR DESCRIPTION
### Description
The poll isn't check for null values everywhere which causes crashes when using the Rest API

### Changes
- Fixed missing null checks for poll in RestMessageComponent