### PR TITLE
Fix #2917 Correct incomplete required tags validation

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -213,7 +213,9 @@ namespace Discord.Rest
                 throw new ArgumentException("The only valid MessageFlags are SuppressEmbeds and none.", nameof(flags));
 
             if (channel.Flags.HasFlag(ChannelFlags.RequireTag))
-                throw new ArgumentException($"The channel {channel.Name} requires posts to have at least one tag.");
+            {
+                Preconditions.AtLeast(tagIds?.Length ?? 0, 1, nameof(tagIds), $"The channel {channel.Name} requires posts to have at least one tag.");
+            }
 
             var args = new CreateMultipartPostAsync(attachments.ToArray())
             {


### PR DESCRIPTION
### Description
When a channel has required tags there is a missing validation to check if atleast one tag is actually passed in.

### Changes
- Added missing validation to check for atleast one flag in the CreatePostAsync function in ThreadHelper.cs


### Related Issues
- resolves #2917
