### PR TITLE
Add Application Approximate User Install Count

### DIFF
--- a/src/Discord.Net.Core/Entities/Applications/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/Applications/IApplication.cs
@@ -96,6 +96,11 @@ namespace Discord
         int? ApproximateGuildCount { get; }
 
         /// <summary>
+        ///     Gets the approximate count of the users the application was added to. <see langword="null" /> if not returned.
+        /// </summary>
+        int? ApproximateUserInstallCount { get; }
+
+        /// <summary>
         ///     Gets the application's discoverability state.
         /// </summary>
         ApplicationDiscoverabilityState DiscoverabilityState { get; }

--- a/src/Discord.Net.Rest/API/Common/Application.cs
+++ b/src/Discord.Net.Rest/API/Common/Application.cs
@@ -38,6 +38,9 @@ internal class Application
     [JsonProperty("approximate_guild_count")]
     public Optional<int> ApproximateGuildCount { get; set; }
 
+    [JsonProperty("approximate_user_install_count")]
+    public Optional<int> ApproximateUserInstallCount { get; set; }
+
     [JsonProperty("guild")]
     public Optional<PartialGuild> PartialGuild { get; set; }
 

--- a/src/Discord.Net.Rest/Entities/RestApplication.cs
+++ b/src/Discord.Net.Rest/Entities/RestApplication.cs
@@ -56,6 +56,9 @@ public class RestApplication : RestEntity<ulong>, IApplication
     public int? ApproximateGuildCount { get; private set; }
 
     /// <inheritdoc />
+    public int? ApproximateUserInstallCount { get; private set; }
+
+    /// <inheritdoc />
     public IReadOnlyCollection<string> RedirectUris { get; private set; }
 
     /// <inheritdoc />
@@ -151,7 +154,8 @@ public class RestApplication : RestEntity<ulong>, IApplication
         if (model.RedirectUris.IsSpecified)
             RedirectUris = model.RedirectUris.Value.ToImmutableArray();
 
-        ApproximateGuildCount = model.ApproximateGuildCount.IsSpecified ? model.ApproximateGuildCount.Value : null;
+        ApproximateGuildCount       = model.ApproximateGuildCount.IsSpecified ? model.ApproximateGuildCount.Value : null;
+        ApproximateUserInstallCount = model.ApproximateUserInstallCount.IsSpecified ? model.ApproximateUserInstallCount.Value : null;
 
         DiscoverabilityState = model.DiscoverabilityState.GetValueOrDefault(ApplicationDiscoverabilityState.None);
         DiscoveryEligibilityFlags = model.DiscoveryEligibilityFlags.GetValueOrDefault(DiscoveryEligibilityFlags.None);
@@ -168,7 +172,7 @@ public class RestApplication : RestEntity<ulong>, IApplication
         RpcState = model.RpcState.GetValueOrDefault(ApplicationRpcState.Disabled);
         StoreState = model.StoreState.GetValueOrDefault(ApplicationStoreState.None);
         VerificationState = model.VerificationState.GetValueOrDefault(ApplicationVerificationState.Ineligible);
-            
+
         var dict = new Dictionary<ApplicationIntegrationType, ApplicationInstallParams>();
         if (model.IntegrationTypesConfig.IsSpecified)
         {

--- a/src/Discord.Net.Rest/Entities/RestApplication.cs
+++ b/src/Discord.Net.Rest/Entities/RestApplication.cs
@@ -154,7 +154,7 @@ public class RestApplication : RestEntity<ulong>, IApplication
         if (model.RedirectUris.IsSpecified)
             RedirectUris = model.RedirectUris.Value.ToImmutableArray();
 
-        ApproximateGuildCount       = model.ApproximateGuildCount.IsSpecified ? model.ApproximateGuildCount.Value : null;
+        ApproximateGuildCount = model.ApproximateGuildCount.IsSpecified ? model.ApproximateGuildCount.Value : null;
         ApproximateUserInstallCount = model.ApproximateUserInstallCount.IsSpecified ? model.ApproximateUserInstallCount.Value : null;
 
         DiscoverabilityState = model.DiscoverabilityState.GetValueOrDefault(ApplicationDiscoverabilityState.None);


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
<!-- A brief explanation of changes made in this PR. -->
Add Approximate User Install Count after Discord added `approximate_guild_count` to application API.

### Changes
Add `ApproximateUserInstallCount` to `Application` model and `RestApplication`.

### Related Issues
None
