### PR TITLE
added a missing step in the AutocompleteHandlers doc page

### DIFF
--- a/docs/guides/int_framework/autocompletion.md
+++ b/docs/guides/int_framework/autocompletion.md
@@ -20,6 +20,10 @@ A valid AutocompleteHandlers must inherit [AutocompleteHandler] base type and im
 
 [!code-csharp[Autocomplete Command Example](samples/autocompletion/autocomplete-example.cs)]
 
+In order for Autocompletehandlers to work you must register a AutocompleteExecuted method with your DiscordSocketClient
+
+[!code-csharp[RegisterAutocompleteExecuted](docs/guides/int_framework/samples/autocompletion/exampleRegisterAutocompletion.cs)]
+
 ### GenerateSuggestionsAsync()
 
 The Interactions Service uses this method to generate a response of an Autocomplete Interaction.

--- a/docs/guides/int_framework/samples/autocompletion/exampleRegisterAutocompletion.cs
+++ b/docs/guides/int_framework/samples/autocompletion/exampleRegisterAutocompletion.cs
@@ -1,0 +1,6 @@
+_client.AutocompleteExecuted += HandleAutocompleteExecution;
+
+private static async Task HandleAutocompleteExecution(SocketAutocompleteInteraction arg){
+    var context = new InteractionContext(_client, arg, arg.Channel);
+    await _interactionService.ExecuteCommandAsync(context, null);
+}


### PR DESCRIPTION


### Description
added a missing step in the AutocompleteHandlers doc page

### Changes
- added an example code snippet: docs/guides/int_framework/samples/autocompletion/exampleRegisterAutocompletion.cs
- added modified the AutocompleteHandlers doc page explaining that you have to register a AutocompleteExecuted  with your DiscordSocketClient


### Related Issues
N/A 
