### PR TITLE
StickFormat gif and animated guild icon

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -103,11 +103,17 @@ namespace Discord
         /// <param name="guildId">The guild snowflake identifier.</param>
         /// <param name="iconId">The icon identifier.</param>
         /// <param name="size">The size of the image to return in horizontal pixels. This can be any power of two between 16 and 2048.</param>
+        /// <param name="format">The format to return.</param>
         /// <returns>
         ///     A URL pointing to the guild's icon.
         /// </returns>
-        public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size = 2048)
-            => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg?size={size}" : null;
+        public static string GetGuildIconUrl(ulong guildId, string iconId, ushort size = 2048, ImageFormat format = ImageFormat.Auto)
+        {
+            if (iconId == null)
+                return null;
+            string extension = FormatToExtension(format, iconId);
+            return $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.{extension}?size={size}";
+        }
         /// <summary>
         ///     Returns a guild role's icon URL.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Messages/StickerFormatType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/StickerFormatType.cs
@@ -20,6 +20,10 @@ namespace Discord
         /// <summary>
         ///     The sticker format type is lottie.
         /// </summary>
-        Lottie = 3
+        Lottie = 3,
+        /// <summary>
+        ///     The sticker format type is gif.
+        /// </summary>
+        Gif = 4
     }
 }


### PR DESCRIPTION
### Changes
- Add `gif` in `StickFormatType`
- Updated `CDN.GetGuildIconUrl` with `ImageFormat` to support animated guild icon