### PR TITLE
Added StickerId to REST and WebSocket Sticker audit log data classes

### DIFF
--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StickerCreatedAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StickerCreatedAuditLogData.cs
@@ -9,8 +9,9 @@ namespace Discord.Rest;
 /// </summary>
 public class StickerCreatedAuditLogData : IAuditLogData
 {
-    internal StickerCreatedAuditLogData(StickerInfo data)
+    internal StickerCreatedAuditLogData(ulong id, StickerInfo data)
     {
+        StickerId = id;
         Data = data;
     }
 
@@ -19,8 +20,16 @@ public class StickerCreatedAuditLogData : IAuditLogData
         var changes = entry.Changes;
         var (_, data) = AuditLogHelper.CreateAuditLogEntityInfo<StickerInfoAuditLogModel>(changes, discord);
 
-        return new StickerCreatedAuditLogData(new(data));
+        return new StickerCreatedAuditLogData(entry.TargetId.Value, new(data));
     }
+
+    /// <summary>
+    ///     Gets the snowflake ID of the created sticker.
+    /// </summary>
+    /// <returns>
+    ///     A <see cref="ulong"/> representing the snowflake identifier of the created sticker.
+    /// </returns>
+    public ulong StickerId { get; }
 
     /// <summary>
     ///     Gets the sticker information after the changes.

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StickerDeletedAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StickerDeletedAuditLogData.cs
@@ -9,8 +9,9 @@ namespace Discord.Rest;
 /// </summary>
 public class StickerDeletedAuditLogData : IAuditLogData
 {
-    internal StickerDeletedAuditLogData(StickerInfo data)
+    internal StickerDeletedAuditLogData(ulong id, StickerInfo data)
     {
+        StickerId = id;
         Data = data;
     }
 
@@ -19,8 +20,16 @@ public class StickerDeletedAuditLogData : IAuditLogData
         var changes = entry.Changes;
         var (data, _) = AuditLogHelper.CreateAuditLogEntityInfo<StickerInfoAuditLogModel>(changes, discord);
 
-        return new StickerDeletedAuditLogData(new(data));
+        return new StickerDeletedAuditLogData(entry.TargetId.Value, new(data));
     }
+
+    /// <summary>
+    ///     Gets the snowflake ID of the deleted sticker.
+    /// </summary>
+    /// <returns>
+    ///     A <see cref="ulong"/> representing the snowflake identifier of the deleted sticker.
+    /// </returns>
+    public ulong StickerId { get; }
 
     /// <summary>
     ///     Gets the sticker information before the changes.

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StickerUpdatedAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StickerUpdatedAuditLogData.cs
@@ -9,8 +9,9 @@ namespace Discord.Rest;
 /// </summary>
 public class StickerUpdatedAuditLogData : IAuditLogData
 {
-    internal StickerUpdatedAuditLogData(StickerInfo before, StickerInfo after)
+    internal StickerUpdatedAuditLogData(ulong id, StickerInfo before, StickerInfo after)
     {
+        StickerId = id;
         Before = before;
         After = after;
     }
@@ -20,8 +21,16 @@ public class StickerUpdatedAuditLogData : IAuditLogData
         var changes = entry.Changes;
         var (before, after) = AuditLogHelper.CreateAuditLogEntityInfo<StickerInfoAuditLogModel>(changes, discord);
 
-        return new StickerUpdatedAuditLogData(new(before), new (after));
+        return new StickerUpdatedAuditLogData(entry.TargetId.Value, new(before), new (after));
     }
+
+    /// <summary>
+    ///     Gets the snowflake ID of the updated sticker.
+    /// </summary>
+    /// <returns>
+    ///     A <see cref="ulong"/> representing the snowflake identifier of the updated sticker.
+    /// </returns>
+    public ulong StickerId { get; }
 
     /// <summary>
     ///     Gets the sticker information before the changes.

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketStickerCreatedAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketStickerCreatedAuditLogData.cs
@@ -9,8 +9,9 @@ namespace Discord.WebSocket;
 /// </summary>
 public class SocketStickerCreatedAuditLogData : ISocketAuditLogData
 {
-    internal SocketStickerCreatedAuditLogData(SocketStickerInfo data)
+    internal SocketStickerCreatedAuditLogData(ulong id, SocketStickerInfo data)
     {
+        StickerId = id;
         Data = data;
     }
 
@@ -19,8 +20,16 @@ public class SocketStickerCreatedAuditLogData : ISocketAuditLogData
         var changes = entry.Changes;
         var (_, data) = AuditLogHelper.CreateAuditLogEntityInfo<StickerInfoAuditLogModel>(changes, discord);
 
-        return new SocketStickerCreatedAuditLogData(new(data));
+        return new SocketStickerCreatedAuditLogData(entry.TargetId.Value, new(data));
     }
+
+    /// <summary>
+    ///     Gets the snowflake ID of the created sticker.
+    /// </summary>
+    /// <returns>
+    ///     A <see cref="ulong"/> representing the snowflake identifier of the created sticker.
+    /// </returns>
+    public ulong StickerId { get; }
 
     /// <summary>
     ///     Gets the sticker information after the changes.

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketStickerDeletedAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketStickerDeletedAuditLogData.cs
@@ -9,8 +9,9 @@ namespace Discord.WebSocket;
 /// </summary>
 public class SocketStickerDeletedAuditLogData : ISocketAuditLogData
 {
-    internal SocketStickerDeletedAuditLogData(SocketStickerInfo data)
+    internal SocketStickerDeletedAuditLogData(ulong id, SocketStickerInfo data)
     {
+        StickerId = id;
         Data = data;
     }
 
@@ -19,8 +20,16 @@ public class SocketStickerDeletedAuditLogData : ISocketAuditLogData
         var changes = entry.Changes;
         var (data, _) = AuditLogHelper.CreateAuditLogEntityInfo<StickerInfoAuditLogModel>(changes, discord);
 
-        return new SocketStickerDeletedAuditLogData(new(data));
+        return new SocketStickerDeletedAuditLogData(entry.TargetId.Value, new(data));
     }
+
+    /// <summary>
+    ///     Gets the snowflake ID of the deleted sticker.
+    /// </summary>
+    /// <returns>
+    ///     A <see cref="ulong"/> representing the snowflake identifier of the deleted sticker.
+    /// </returns>
+    public ulong StickerId { get; }
 
     /// <summary>
     ///     Gets the sticker information before the changes.

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketStickerUpdatedAuditLogData.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketStickerUpdatedAuditLogData.cs
@@ -9,8 +9,9 @@ namespace Discord.WebSocket;
 /// </summary>
 public class SocketStickerUpdatedAuditLogData : ISocketAuditLogData
 {
-    internal SocketStickerUpdatedAuditLogData(SocketStickerInfo before, SocketStickerInfo after)
+    internal SocketStickerUpdatedAuditLogData(ulong id, SocketStickerInfo before, SocketStickerInfo after)
     {
+        StickerId = id;
         Before = before;
         After = after;
     }
@@ -20,8 +21,16 @@ public class SocketStickerUpdatedAuditLogData : ISocketAuditLogData
         var changes = entry.Changes;
         var (before, after) = AuditLogHelper.CreateAuditLogEntityInfo<StickerInfoAuditLogModel>(changes, discord);
 
-        return new SocketStickerUpdatedAuditLogData(new(before), new (after));
+        return new SocketStickerUpdatedAuditLogData(entry.TargetId.Value, new(before), new (after));
     }
+
+    /// <summary>
+    ///     Gets the snowflake ID of the updated sticker.
+    /// </summary>
+    /// <returns>
+    ///     A <see cref="ulong"/> representing the snowflake identifier of the updated sticker.
+    /// </returns>
+    public ulong StickerId { get; }
 
     /// <summary>
     ///     Gets the sticker information before the changes.


### PR DESCRIPTION
### Description
This PR adds `StickerId` to both REST and WebSocket sticker audit log data classes.

### Changes
- Added `StickerId` property to `StickerCreatedAuditLogData`, `StickerUpdatedAuditLogData`, `StickerDeletedAuditLogData`, `SocketStickerCreatedAuditLogData`, `SocketStickerUpdatedAuditLogData`, and `SocketStickerDeletedAuditLogData` classes.
- Updated constructors in the classes to accept and assign `StickerId`.
- Passed in `TargetId` for `StickerId`.

### Related Issues
None
