### PR TITLE
[Docs] Update docfx and remove tocFilter hack.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         dotnet-version: 8.0.x
 
     - name: Setup DocFX
-      run: dotnet tool install -g docfx --version 2.76.0
+      run: dotnet tool install -g docfx --version 2.77.0
 
     - name: Build DNet docs
       run: docfx docs/docfx.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The documentation for the Discord.Net library uses [DocFX][docfx-main].
 Instructions for installing this tool can be found [here][docfx-installing].
 
 > [!IMPORTANT]
-> You must use DocFX version **2.76.0** for everything to work correctly.
+> You must use DocFX version **2.77.0** for everything to work correctly.
 
 1. Navigate to the root of the repository.
 2. Build the docs using `docfx docs/docfx.json`. Add the `--serve`

--- a/docs/_template/material/public/main.js
+++ b/docs/_template/material/public/main.js
@@ -22,28 +22,17 @@
     {
         // Ugly hack to improve toc filter.
         let target = document.getElementById("toc");
-        
-        if(!target) return;
-        
+
+        if (!target) return;
+
         let config = { attributes: false, childList: true, subtree: true };
         let observer = new MutationObserver((list) =>
         {
-            for(const mutation of list)
+            for (const mutation of list)
             {
-                if(mutation.type === "childList" && mutation.target == target)
+                if (mutation.type === "childList" && mutation.target == target)
                 {
-                    let filter = target.getElementsByClassName("form-control")[0];
-
-                    let filterValue = localStorage.getItem("tocFilter");
                     let scrollValue = localStorage.getItem("tocScroll");
-
-                    if(filterValue && filterValue !== "")
-                    {
-                        filter.value = filterValue;
-
-                        let inputEvent = new Event("input");
-                        filter.dispatchEvent(inputEvent);
-                    }
 
                     // Add event to store scroll pos.
                     let tocDiv = target.getElementsByClassName("flex-fill")[0];
@@ -56,7 +45,7 @@
                         }
                     });
 
-                    if(scrollValue && scrollValue >= 0)
+                    if (scrollValue && scrollValue >= 0)
                     {
                         tocDiv.scroll(0, scrollValue);
                     }


### PR DESCRIPTION
### Description
https://github.com/dotnet/docfx/pull/9912 fixed the TOC filter value not being kept between page loads. This removes the hack I used to get around it but keeps the scroll code.

### Changes
- Update to docfx 2.77.0 successfully.
- Remove tocFilter local storage hack.

### Related Issues
None.