### PR TITLE
An AddSlashCommand overload should be AddAutocompleteCommand in ModuleBuilder

### DIFF
--- a/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
@@ -370,6 +370,11 @@ namespace Discord.Interactions.Builders
             return this;
         }
 
+        /// <inheritdoc cref="Discord.Interactions.Builders.ModuleBuilder.AddAutocompleteCommand(System.String,Discord.Interactions.ExecuteCallback,System.Action{Discord.Interactions.Builders.AutocompleteCommandBuilder})" />
+        [Obsolete("This method will be deprecated soon. Use AddAutocompleteCommand instead.")]
+        public ModuleBuilder AddSlashCommand(string name, ExecuteCallback callback, Action<AutocompleteCommandBuilder> configure)
+            => AddAutocompleteCommand(name, callback, configure);
+
         /// <summary>
         ///     Adds autocomplete command builder to <see cref="AutocompleteCommands"/>.
         /// </summary>
@@ -379,7 +384,7 @@ namespace Discord.Interactions.Builders
         /// <returns>
         ///     The builder instance.
         /// </returns>
-        public ModuleBuilder AddSlashCommand(string name, ExecuteCallback callback, Action<AutocompleteCommandBuilder> configure)
+        public ModuleBuilder AddAutocompleteCommand(string name, ExecuteCallback callback, Action<AutocompleteCommandBuilder> configure)
         {
             var command = new AutocompleteCommandBuilder(this, name, callback);
             configure(command);
@@ -402,7 +407,7 @@ namespace Discord.Interactions.Builders
             _modalCommands.Add(command);
             return this;
         }
-        
+
         /// <summary>
         ///     Adds a modal command builder to <see cref="ModalCommands"/>.
         /// </summary>


### PR DESCRIPTION
### Description

In `ModuleBuidler`, an overload for adding autocomplete command was named `AddSlashCommand` instead of `AddAutocompleteCommand`. This pull request would like to correct the method name while maintaining backward compatibility. 

https://github.com/discord-net/Discord.Net/blob/de8da0d3b998d32e248e5e438039d266139e4776/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs#L373-L389

### Changes

- Renamed the method called `AddSlashCommand` to `AddAutocompleteCommand` to better reflect its functionality.
- Introduced a new `AddAutocompleteCommand` method to supersede the original functionality.
- Added an Obsolete attribute to the `AddSlashCommand` method.

