### PR TITLE
Fixes incorrect cast of parameters in CommandBuilder

### DIFF
--- a/src/Discord.Net.Interactions/Builders/Commands/CommandBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Commands/CommandBuilder.cs
@@ -185,7 +185,7 @@ namespace Discord.Interactions.Builders
 
         /// <inheritdoc/>
         ICommandBuilder ICommandBuilder.AddParameters(params IParameterBuilder[] parameters) =>
-            AddParameters(parameters as TParamBuilder);
+            AddParameters(parameters as TParamBuilder[]);
 
         /// <inheritdoc/>
         ICommandBuilder ICommandBuilder.WithPreconditions(params PreconditionAttribute[] preconditions) =>


### PR DESCRIPTION
### Description

In `CommandBuidler`, the `AddParameters` expects an array of `TParamBuidler`.

https://github.com/discord-net/Discord.Net/blob/de8da0d3b998d32e248e5e438039d266139e4776/src/Discord.Net.Interactions/Builders/Commands/CommandBuilder.cs#L136-L147

In the explicit implementation of `ICommandBuilder.AddParameters`, the `parameters` of type `IParameterBuilder[]` should be cast to `TParamBuilder[]` array instead of a single `TParamBuilder`.

https://github.com/discord-net/Discord.Net/blob/de8da0d3b998d32e248e5e438039d266139e4776/src/Discord.Net.Interactions/Builders/Commands/CommandBuilder.cs#L186-L188
