### PR TITLE
Add Opus.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ docs/api/\.manifest
 
 # Codealike UID
 codealike.json
+
+# This is so coderush data isn't included...
+.cr/

--- a/Discord.Net.sln
+++ b/Discord.Net.sln
@@ -16,15 +16,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Discord.Net.V4.Rest", "src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Discord.Net.V4.Core", "src\Discord.Net.V4.Core\Discord.Net.V4.Core.csproj", "{3277421C-AD38-43A7-89EB-D4E1F866004E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Discord.Net.V4.Audio", "src\Discord.Net.V4.Audio\Discord.Net.V4.Audio.csproj", "{EE97E2F3-8A85-46D4-A5D6-EE985047F9F6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Discord.Net.V4.Audio", "src\Discord.Net.V4.Audio\Discord.Net.V4.Audio.csproj", "{EE97E2F3-8A85-46D4-A5D6-EE985047F9F6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Discord.Net.Models", "src\Discord.Net.Models\Discord.Net.Models.csproj", "{2EC5A01A-91CB-4E3F-AFBD-7DDAEC61FF15}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Discord.Net.Models", "src\Discord.Net.Models\Discord.Net.Models.csproj", "{2EC5A01A-91CB-4E3F-AFBD-7DDAEC61FF15}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SourceGenerators", "SourceGenerators", "{C1C763AF-3DC5-4F7D-8551-0A65B6011305}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Discord.Net.Hanz", "sourcegen\Discord.Net.Hanz\Discord.Net.Hanz.csproj", "{595DFC73-902A-4A2B-BE33-16B627134451}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Discord.Net.Hanz", "sourcegen\Discord.Net.Hanz\Discord.Net.Hanz.csproj", "{595DFC73-902A-4A2B-BE33-16B627134451}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeatureSamples", "samples\FeatureSamples\FeatureSamples.csproj", "{2A082FC0-B17A-4109-9B73-2B2F721F49E8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureSamples", "samples\FeatureSamples\FeatureSamples.csproj", "{2A082FC0-B17A-4109-9B73-2B2F721F49E8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Discord.Net.V4.Audio/Discord.Net.V4.Audio.csproj
+++ b/src/Discord.Net.V4.Audio/Discord.Net.V4.Audio.csproj
@@ -8,6 +8,7 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <IsAotCompatible>false</IsAotCompatible>
     <RootNamespace>Discord.Audio</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Discord.Net.V4.Audio/Discord.Net.V4.Audio.csproj
+++ b/src/Discord.Net.V4.Audio/Discord.Net.V4.Audio.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Discord.Net.V4.Audio/Discord.Net.V4.Audio.csproj
+++ b/src/Discord.Net.V4.Audio/Discord.Net.V4.Audio.csproj
@@ -12,11 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Discord.Net.V4.Core\Discord.Net.V4.Core.csproj" />
-    <ProjectReference Include="..\Discord.Net.V4.Gateway\Discord.Net.V4.Gateway.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/Discord.Net.V4.Audio/Opus/Enums.cs
+++ b/src/Discord.Net.V4.Audio/Opus/Enums.cs
@@ -1,0 +1,418 @@
+﻿namespace Discord.Audio.Opus
+{
+    /// <summary>
+    /// Error codes for opus.
+    /// </summary>
+    public enum OpusErrorCodes
+    {
+        /// <summary>
+        /// No error.
+        /// </summary>
+        OPUS_OK = 0,
+
+        /// <summary>
+        /// One or more invalid/out of range arguments.
+        /// </summary>
+        OPUS_BAD_ARG = -1,
+
+        /// <summary>
+        /// Not enough bytes allocated in the buffer.
+        /// </summary>
+        OPUS_BUFFER_TOO_SMALL = -2,
+
+        /// <summary>
+        /// An internal error was detected.
+        /// </summary>
+        OPUS_INTERNAL_ERROR = -3,
+
+        /// <summary>
+        /// The compressed data passed is corrupted.
+        /// </summary>
+        OPUS_INVALID_PACKET = -4,
+
+        /// <summary>
+        /// Invalid/unsupported request number.
+        /// </summary>
+        OPUS_UNIMPLEMENTED = -5,
+
+        /// <summary>
+        /// An encoder or decoder structure is invalid or already freed.
+        /// </summary>
+        OPUS_INVALID_STATE = -6,
+
+        /// <summary>
+        /// Memory allocation has failed.
+        /// </summary>
+        OPUS_ALLOC_FAIL = -7
+    }
+
+    /// <summary>
+    /// Pre-defined values for CTL interface.
+    /// </summary>
+    public enum OpusPredefinedValues
+    {
+        /// <summary>
+        /// Auto/default setting.
+        /// </summary>
+        OPUS_AUTO = -1000,
+
+        /// <summary>
+        /// Maximum bitrate.
+        /// </summary>
+        OPUS_BITRATE_MAX = -1,
+
+        /// <summary>
+        /// Best for most VoIP/Video Conference applications where listening quality and intelligibility matter most.
+        /// </summary>
+        OPUS_APPLICATION_VOIP = 2048,
+
+        /// <summary>
+        /// Best for broadcast/high-fidelity application where the decoded audio should be as close as possible to the input.
+        /// </summary>
+        OPUS_APPLICATION_AUDIO = 2049,
+
+        /// <summary>
+        /// Only use when lowest-achievable latency is what matters most. Voice-optimized modes cannot be used.
+        /// </summary>
+        OPUS_APPLICATION_RESTRICTED_LOWDELAY = 2051,
+
+        /// <summary>
+        /// Signal being encoded is voice.
+        /// </summary>
+        OPUS_SIGNAL_VOICE = 3001,
+
+        /// <summary>
+        /// Signal being encoded is music.
+        /// </summary>
+        OPUS_SIGNAL_MUSIC = 3002,
+
+        /// <summary>
+        /// 4 kHz bandpass.
+        /// </summary>
+        OPUS_BANDWIDTH_NARROWBAND = 1101,
+
+        /// <summary>
+        /// 6 kHz bandpass.
+        /// </summary>
+        OPUS_BANDWIDTH_MEDIUMBAND = 1102,
+
+        /// <summary>
+        /// 8 kHz bandpass.
+        /// </summary>
+        OPUS_BANDWIDTH_WIDEBAND = 1103,
+
+        /// <summary>
+        /// 12 kHz bandpass.
+        /// </summary>
+        OPUS_BANDWIDTH_SUPERWIDEBAND = 1104,
+
+        /// <summary>
+        /// 20 kHz bandpass.
+        /// </summary>
+        OPUS_BANDWIDTH_FULLBAND = 1105,
+
+        /// <summary>
+        /// Select frame size from the argument (default).
+        /// </summary>
+        OPUS_FRAMESIZE_ARG = 5000,
+
+        /// <summary>
+        /// Use 2.5 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_2_5_MS = 5001,
+
+        /// <summary>
+        /// Use 5 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_5_MS = 5002,
+
+        /// <summary>
+        /// Use 10 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_10_MS = 5003,
+
+        /// <summary>
+        /// Use 20 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_20_MS = 5004,
+
+        /// <summary>
+        /// Use 40 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_40_MS = 5005,
+
+        /// <summary>
+        /// Use 60 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_60_MS = 5006,
+
+        /// <summary>
+        /// Use 80 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_80_MS = 5007,
+
+        /// <summary>
+        /// Use 100 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_100_MS = 5008,
+
+        /// <summary>
+        /// Use 120 ms frames.
+        /// </summary>
+        OPUS_FRAMESIZE_120_MS = 5009
+    }
+
+    /// <summary>
+    /// These macros are used with the opus_decoder_ctl and opus_encoder_ctl calls to generate a particular request.
+    /// </summary>
+    public enum GenericCTL
+    {
+        /// <summary>
+        /// Resets the codec state to be equivalent to a freshly initialized state.
+        /// </summary>
+        OPUS_RESET_STATE = 4028,
+
+        /// <summary>
+        /// Gets the final state of the codec's entropy coder.
+        /// </summary>
+        OPUS_GET_FINAL_RANGE = 4031,
+
+        /// <summary>
+        /// Gets the encoder's configured bandpass or the decoder's last bandpass.
+        /// </summary>
+        OPUS_GET_BANDWIDTH = 4009,
+
+        /// <summary>
+        /// Gets the sampling rate the encoder or decoder was initialized with.
+        /// </summary>
+        OPUS_GET_SAMPLE_RATE = 4029,
+
+        /// <summary>
+        /// If set to 1, disables the use of phase inversion for intensity stereo, improving the quality of mono down-mixes, but slightly reducing normal stereo quality.
+        /// </summary>
+        OPUS_SET_PHASE_INVERSION_DISABLED = 4046,
+
+        /// <summary>
+        /// Gets the encoder's configured phase inversion status.
+        /// </summary>
+        OPUS_GET_PHASE_INVERSION_DISABLED = 4047,
+    }
+
+    /// <summary>
+    /// These are convenience macros for use with the opus_encoder_ctl interface.
+    /// </summary>
+    public enum EncoderCTL
+    {
+        /// <summary>
+        /// Configures the encoder's intended application.
+        /// </summary>
+        OPUS_SET_APPLICATION = 4000,
+
+        /// <summary>
+        /// Gets the encoder's configured application.
+        /// </summary>
+        OPUS_GET_APPLICATION = 4001,
+
+        /// <summary>
+        /// Configures the bitrate in the encoder.
+        /// </summary>
+        OPUS_SET_BITRATE = 4002,
+
+        /// <summary>
+        /// Gets the encoder's bitrate configuration.
+        /// </summary>
+        OPUS_GET_BITRATE = 4003,
+
+        /// <summary>
+        /// Configures the maximum bandpass that the encoder will select automatically.
+        /// </summary>
+        OPUS_SET_MAX_BANDWIDTH = 4004,
+
+        /// <summary>
+        /// Gets the encoder's configured maximum allowed bandpass.
+        /// </summary>
+        OPUS_GET_MAX_BANDWIDTH = 4005,
+
+        /// <summary>
+        /// Enables or disables variable bitrate (VBR) in the encoder.
+        /// </summary>
+        OPUS_SET_VBR = 4006,
+
+        /// <summary>
+        /// Determine if variable bitrate (VBR) is enabled in the encoder.
+        /// </summary>
+        OPUS_GET_VBR = 4007,
+
+        /// <summary>
+        /// Sets the encoder's bandpass to a specific value.
+        /// </summary>
+        OPUS_SET_BANDWIDTH = 4008,
+
+        /// <summary>
+        /// Configures the encoder's computational complexity.
+        /// </summary>
+        OPUS_SET_COMPLEXITY = 4010,
+
+        /// <summary>
+        /// Gets the encoder's complexity configuration.
+        /// </summary>
+        OPUS_GET_COMPLEXITY = 4011,
+
+        /// <summary>
+        /// Configures the encoder's use of in-band forward error correction (FEC).
+        /// </summary>
+        OPUS_SET_INBAND_FEC = 4012,
+
+        /// <summary>
+        /// Gets encoder's configured use of in-band forward error correction.
+        /// </summary>
+        OPUS_GET_INBAND_FEC = 4013,
+
+        /// <summary>
+        /// Configures the encoder's expected packet loss percentage.
+        /// </summary>
+        OPUS_SET_PACKET_LOSS_PERC = 4014,
+
+        /// <summary>
+        /// Gets the encoder's configured packet loss percentage.
+        /// </summary>
+        OPUS_GET_PACKET_LOSS_PERC = 4015,
+
+        /// <summary>
+        /// Configures the encoder's use of discontinuous transmission (DTX).
+        /// </summary>
+        OPUS_SET_DTX = 4016,
+
+        /// <summary>
+        /// Gets encoder's configured use of discontinuous transmission.
+        /// </summary>
+        OPUS_GET_DTX = 4017,
+
+        /// <summary>
+        /// Enables or disables constrained VBR in the encoder.
+        /// </summary>
+        OPUS_SET_VBR_CONSTRAINT = 4020,
+
+        /// <summary>
+        /// Determine if constrained VBR is enabled in the encoder.
+        /// </summary>
+        OPUS_GET_VBR_CONSTRAINT = 4021,
+
+        /// <summary>
+        /// Configures mono/stereo forcing in the encoder.
+        /// </summary>
+        OPUS_SET_FORCE_CHANNELS = 4022,
+
+        /// <summary>
+        /// Gets the encoder's forced channel configuration.
+        /// </summary>
+        OPUS_GET_FORCE_CHANNELS = 4023,
+
+        /// <summary>
+        /// Configures the type of signal being encoded.
+        /// </summary>
+        OPUS_SET_SIGNAL = 4024,
+
+        /// <summary>
+        /// Gets the encoder's configured signal type.
+        /// </summary>
+        OPUS_GET_SIGNAL = 4025,
+
+        /// <summary>
+        /// Gets the total samples of delay added by the entire codec.
+        /// </summary>
+        OPUS_GET_LOOKAHEAD = 4027,
+
+        /// <summary>
+        /// Configures the depth of signal being encoded.
+        /// </summary>
+        OPUS_SET_LSB_DEPTH = 4036,
+
+        /// <summary>
+        /// Gets the encoder's configured signal depth.
+        /// </summary>
+        OPUS_GET_LSB_DEPTH = 4037,
+
+        /// <summary>
+        /// Configures the encoder's use of variable duration frames.
+        /// </summary>
+        OPUS_SET_EXPERT_FRAME_DURATION = 4040,
+
+        /// <summary>
+        /// Gets the encoder's configured use of variable duration frames.
+        /// </summary>
+        OPUS_GET_EXPERT_FRAME_DURATION = 4041,
+
+        /// <summary>
+        /// If set to 1, disables almost all use of prediction, making frames almost completely independent. This reduces quality.
+        /// </summary>
+        OPUS_SET_PREDICTION_DISABLED = 4042,
+
+        /// <summary>
+        /// Gets the encoder's configured prediction status.
+        /// </summary>
+        OPUS_GET_PREDICTION_DISABLED = 4043,
+
+        /// <summary>
+        /// Gets the DTX state of the encoder.
+        /// </summary>
+        OPUS_GET_IN_DTX = 4049, //Encoder only, seems to be listed as generic in docs though.
+
+        /// <summary>
+        /// If non-zero, enables Deep Redundancy (DRED) and use the specified maximum number of 10-ms redundant frames.
+        /// </summary>
+        OPUS_SET_DRED_DURATION = 4050,
+
+        /// <summary>
+        /// Gets the encoder's configured Deep Redundancy (DRED) maximum number of frames.
+        /// </summary>
+        OPUS_GET_DRED_DURATION = 4051,
+
+        /// <summary>
+        /// Provide external DNN weights from binary object (only when explicitly built without the weights).
+        /// </summary>
+        OPUS_SET_DNN_BLOB = 4052,
+    }
+
+    /// <summary>
+    /// These are convenience macros for use with the opus_decoder_ctl interface
+    /// </summary>
+    public enum DecoderCTL
+    {
+        /// <summary>
+        /// Configures decoder gain adjustment.
+        /// </summary>
+        OPUS_SET_GAIN = 4034,
+
+        /// <summary>
+        /// Gets the decoder's configured gain adjustment.
+        /// </summary>
+        OPUS_GET_GAIN = 4045,/* Should have been 4035 */
+
+        /// <summary>
+        /// Gets the duration (in samples) of the last packet successfully decoded or concealed.
+        /// </summary>
+        OPUS_GET_LAST_PACKET_DURATION = 4039,
+
+        /// <summary>
+        /// Gets the pitch of the last decoded frame, if available.
+        /// </summary>
+        OPUS_GET_PITCH = 4033,
+    }
+
+    /// <summary>
+    /// These are convenience macros that are specific to the opus_multistream_encoder_ctl() and opus_multistream_decoder_ctl() interface.
+    /// </summary>
+    public enum MultistreamCTL
+    {
+        /// <summary>
+        /// Gets the encoder state for an individual stream of a multi-stream encoder.
+        /// </summary>
+        OPUS_MULTISTREAM_GET_ENCODER_STATE = 5120,
+
+        /// <summary>
+        /// Gets the decoder state for an individual stream of a multi-stream decoder.
+        /// </summary>
+        OPUS_MULTISTREAM_GET_DECODER_STATE = 5122
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
+++ b/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
@@ -5,7 +5,7 @@ namespace Discord.Audio.Opus
     /// <summary>
     /// Native opus handler that directly calls the exported opus functions.
     /// </summary>
-    internal static class NativeOpus
+    internal static partial class NativeOpus
     {
 #if ANDROID
         private const string DllName = "libopus.so";
@@ -20,210 +20,210 @@ namespace Discord.Audio.Opus
 #endif
 
         //Encoder
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_encoder_get_size(int channels);
+        [LibraryImport(DllName)]
+        public static partial int opus_encoder_get_size(int channels);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern OpusEncoderSafeHandle opus_encoder_create(int Fs, int application, int* error);
+        [LibraryImport(DllName)]
+        public static unsafe partial OpusEncoderSafeHandle opus_encoder_create(int Fs, int application, int* error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_encoder_init(OpusEncoderSafeHandle st, int Fs, int channels, int application);
+        [LibraryImport(DllName)]
+        public static partial int opus_encoder_init(OpusEncoderSafeHandle st, int Fs, int channels, int application);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_encode(OpusEncoderSafeHandle st, short* pcm, int frame_size, byte* data, int max_data_bytes);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_encode(OpusEncoderSafeHandle st, short* pcm, int frame_size, byte* data, int max_data_bytes);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_encode_float(OpusEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_encode_float(OpusEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void opus_encoder_destroy(IntPtr st);
+        [LibraryImport(DllName)]
+        public static partial void opus_encoder_destroy(IntPtr st);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_encoder_ctl(OpusEncoderSafeHandle st, int request, void* data);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_encoder_ctl(OpusEncoderSafeHandle st, int request, void* data);
 
         //Decoder
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_decoder_get_size(int channels);
+        [LibraryImport(DllName)]
+        public static partial int opus_decoder_get_size(int channels);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern OpusDecoderSafeHandle opus_decoder_create(int Fs, int channels, int* error);
+        [LibraryImport(DllName)]
+        public static unsafe partial OpusDecoderSafeHandle opus_decoder_create(int Fs, int channels, int* error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_decoder_init(OpusDecoderSafeHandle st, int Fs, int channels);
+        [LibraryImport(DllName)]
+        public static partial int opus_decoder_init(OpusDecoderSafeHandle st, int Fs, int channels);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_decode(OpusDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_decode(OpusDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_decode_float(OpusDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_decode_float(OpusDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_decoder_ctl(OpusDecoderSafeHandle st, int request, void* data);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_decoder_ctl(OpusDecoderSafeHandle st, int request, void* data);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void opus_decoder_destroy(IntPtr st);
+        [LibraryImport(DllName)]
+        public static partial void opus_decoder_destroy(IntPtr st);
 
         //Dred Decoder
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_dred_decoder_get_size();
+        [LibraryImport(DllName)]
+        public static partial int opus_dred_decoder_get_size();
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern OpusDREDDecoderSafeHandle opus_dred_decoder_create(int* error);
+        [LibraryImport(DllName)]
+        public static unsafe partial OpusDREDDecoderSafeHandle opus_dred_decoder_create(int* error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_dred_decoder_init(OpusDREDDecoderSafeHandle dec);
+        [LibraryImport(DllName)]
+        public static partial int opus_dred_decoder_init(OpusDREDDecoderSafeHandle dec);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void opus_dred_decoder_destroy(IntPtr dec);
+        [LibraryImport(DllName)]
+        public static partial void opus_dred_decoder_destroy(IntPtr dec);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_dred_decoder_ctl(OpusDREDDecoderSafeHandle dred_dec, int request, void* data);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_dred_decoder_ctl(OpusDREDDecoderSafeHandle dred_dec, int request, void* data);
 
         //Dred Packet?
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_dred_get_size();
+        [LibraryImport(DllName)]
+        public static partial int opus_dred_get_size();
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern OpusDREDSafeHandle opus_dred_alloc(int* error);
+        [LibraryImport(DllName)]
+        public static unsafe partial OpusDREDSafeHandle opus_dred_alloc(int* error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void opus_dred_free(IntPtr dec); //I'M JUST FOLLOWING THE DOCS!
+        [LibraryImport(DllName)]
+        public static partial void opus_dred_free(IntPtr dec); //I'M JUST FOLLOWING THE DOCS!
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_dred_parse(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle dred, byte* data, int len, int max_dred_samples, int sampling_rate, int* dred_end, int defer_processing);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_dred_parse(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle dred, byte* data, int len, int max_dred_samples, int sampling_rate, int* dred_end, int defer_processing);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_dred_process(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle src, OpusDREDSafeHandle dst);
+        [LibraryImport(DllName)]
+        public static partial int opus_dred_process(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle src, OpusDREDSafeHandle dst);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_decoder_dred_decode(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, int* pcm, int frame_size);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_decoder_dred_decode(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, int* pcm, int frame_size);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_decoder_dred_decode_float(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, float* pcm, int frame_size);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_decoder_dred_decode_float(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, float* pcm, int frame_size);
 
         //Opus Packet Parsers
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_parse(byte* data, int len, byte* out_toc, byte* frames, short* size, int* payload_offset);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_parse(byte* data, int len, byte* out_toc, byte* frames, short* size, int* payload_offset);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_get_bandwidth(byte* data);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_get_bandwidth(byte* data);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_get_samples_per_frame(byte* data, int Fs);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_get_samples_per_frame(byte* data, int Fs);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_get_nb_channels(byte* data);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_get_nb_channels(byte* data);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_get_nb_frames(byte* packet, int len);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_get_nb_frames(byte* packet, int len);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_get_nb_samples(byte* packet, int len, int Fs);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_get_nb_samples(byte* packet, int len, int Fs);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_has_lbrr(byte* packet, int len);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_has_lbrr(byte* packet, int len);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_get_nb_samples(OpusDecoderSafeHandle dec, byte* packet, int len);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_get_nb_samples(OpusDecoderSafeHandle dec, byte* packet, int len);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern void opus_pcm_soft_clip(float* pcm, int frame_size, int channels, float* softclip_mem);
+        [LibraryImport(DllName)]
+        public static unsafe partial void opus_pcm_soft_clip(float* pcm, int frame_size, int channels, float* softclip_mem);
 
         //Repacketizer
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_repacketizer_get_size();
+        [LibraryImport(DllName)]
+        public static partial int opus_repacketizer_get_size();
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern OpusRepacketizerSafeHandle opus_repacketizer_init(OpusRepacketizerSafeHandle rp);
+        [LibraryImport(DllName)]
+        public static partial OpusRepacketizerSafeHandle opus_repacketizer_init(OpusRepacketizerSafeHandle rp);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern OpusRepacketizerSafeHandle opus_repacketizer_create();
+        [LibraryImport(DllName)]
+        public static partial OpusRepacketizerSafeHandle opus_repacketizer_create();
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void opus_repacketizer_destroy(IntPtr rp);
+        [LibraryImport(DllName)]
+        public static partial void opus_repacketizer_destroy(IntPtr rp);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_repacketizer_cat(OpusRepacketizerSafeHandle rp, byte* data, int len);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_repacketizer_cat(OpusRepacketizerSafeHandle rp, byte* data, int len);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_repacketizer_out_range(OpusRepacketizerSafeHandle rp, int begin, int end, byte* data, int maxlen);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_repacketizer_out_range(OpusRepacketizerSafeHandle rp, int begin, int end, byte* data, int maxlen);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_repacketizer_get_nb_frames(OpusRepacketizerSafeHandle rp);
+        [LibraryImport(DllName)]
+        public static partial int opus_repacketizer_get_nb_frames(OpusRepacketizerSafeHandle rp);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_repacketizer_out(OpusRepacketizerSafeHandle rp, byte* data, int maxlen);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_repacketizer_out(OpusRepacketizerSafeHandle rp, byte* data, int maxlen);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_pad(byte* data, int len, int new_len);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_pad(byte* data, int len, int new_len);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_packet_unpad(byte* data, int len);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_packet_unpad(byte* data, int len);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_packet_pad(byte* data, int len, int new_len, int nb_streams);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_packet_pad(byte* data, int len, int new_len, int nb_streams);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_packet_unpad(byte* data, int len, int nb_streams);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_packet_unpad(byte* data, int len, int nb_streams);
 
         //Multistream Encoder
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_multistream_encoder_get_size(int streams, int coupled_streams);
+        [LibraryImport(DllName)]
+        public static partial int opus_multistream_encoder_get_size(int streams, int coupled_streams);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_multistream_surround_encoder_get_size(int channels, int mapping_family);
+        [LibraryImport(DllName)]
+        public static partial int opus_multistream_surround_encoder_get_size(int channels, int mapping_family);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern OpusMSEncoderSafeHandle opus_multistream_encoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application, int* error);
+        [LibraryImport(DllName)]
+        public static unsafe partial OpusMSEncoderSafeHandle opus_multistream_encoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application, int* error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern OpusMSEncoderSafeHandle opus_multistream_surround_encoder_create(int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application, int* error);
+        [LibraryImport(DllName)]
+        public static unsafe partial OpusMSEncoderSafeHandle opus_multistream_surround_encoder_create(int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application, int* error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_surround_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_surround_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_encode(OpusMSEncoderSafeHandle st, byte* pcm, int frame_size, byte* data, int max_data_bytes);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_encode(OpusMSEncoderSafeHandle st, byte* pcm, int frame_size, byte* data, int max_data_bytes);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_encode_float(OpusMSEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_encode_float(OpusMSEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void opus_multistream_encoder_destroy(IntPtr st);
+        [LibraryImport(DllName)]
+        public static partial void opus_multistream_encoder_destroy(IntPtr st);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_encoder_ctl(OpusMSEncoderSafeHandle st, int request, void* data);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_encoder_ctl(OpusMSEncoderSafeHandle st, int request, void* data);
 
         //Multistream Decoder
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int opus_multistream_decoder_get_size(int streams, int coupled_streams);
+        [LibraryImport(DllName)]
+        public static partial int opus_multistream_decoder_get_size(int streams, int coupled_streams);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern OpusMSDecoderSafeHandle opus_multistream_decoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int* error);
+        [LibraryImport(DllName)]
+        public static unsafe partial OpusMSDecoderSafeHandle opus_multistream_decoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int* error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_decoder_init(OpusMSDecoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_decoder_init(OpusMSDecoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_decode(OpusMSDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_decode(OpusMSDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_decode_float(OpusMSDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_decode_float(OpusMSDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern int opus_multistream_decoder_ctl(OpusMSDecoderSafeHandle st, int request, void* data);
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_decoder_ctl(OpusMSDecoderSafeHandle st, int request, void* data);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void opus_multistream_decoder_destroy(IntPtr st);
+        [LibraryImport(DllName)]
+        public static partial void opus_multistream_decoder_destroy(IntPtr st);
 
         //Library Information
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern byte* opus_strerror(int error);
+        [LibraryImport(DllName)]
+        public static unsafe partial byte* opus_strerror(int error);
 
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static unsafe extern byte* opus_get_version_string();
+        [LibraryImport(DllName)]
+        public static unsafe partial byte* opus_get_version_string();
     }
 }

--- a/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
+++ b/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
@@ -1,0 +1,229 @@
+﻿using Discord.Audio.Opus.SafeHandlers;
+using System.Runtime.InteropServices;
+namespace Discord.Audio.Opus
+{
+    /// <summary>
+    /// Native opus handler that directly calls the exported opus functions.
+    /// </summary>
+    internal static class NativeOpus
+    {
+#if ANDROID
+        private const string DllName = "libopus.so";
+#elif LINUX
+        private const string DllName = "libopus.so.0.10.1";
+#elif WINDOWS
+        private const string DllName = "opus.dll";
+#elif MACOS || IOS || MACCATALYST
+        private const string DllName = "__Internal__";
+#else
+        private const string DllName = "opus";
+#endif
+
+        //Encoder
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_encoder_get_size(int channels);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern OpusEncoderSafeHandle opus_encoder_create(int Fs, int application, int* error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_encoder_init(OpusEncoderSafeHandle st, int Fs, int channels, int application);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_encode(OpusEncoderSafeHandle st, short* pcm, int frame_size, byte* data, int max_data_bytes);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_encode_float(OpusEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void opus_encoder_destroy(IntPtr st);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_encoder_ctl(OpusEncoderSafeHandle st, int request, void* data);
+
+        //Decoder
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_decoder_get_size(int channels);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern OpusDecoderSafeHandle opus_decoder_create(int Fs, int channels, int* error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_decoder_init(OpusDecoderSafeHandle st, int Fs, int channels);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_decode(OpusDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_decode_float(OpusDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_decoder_ctl(OpusDecoderSafeHandle st, int request, void* data);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void opus_decoder_destroy(IntPtr st);
+
+        //Dred Decoder
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_dred_decoder_get_size();
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern OpusDREDDecoderSafeHandle opus_dred_decoder_create(int* error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_dred_decoder_init(OpusDREDDecoderSafeHandle dec);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void opus_dred_decoder_destroy(IntPtr dec);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_dred_decoder_ctl(OpusDREDDecoderSafeHandle dred_dec, int request, void* data);
+
+        //Dred Packet?
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_dred_get_size();
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern OpusDREDSafeHandle opus_dred_alloc(int* error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void opus_dred_free(IntPtr dec); //I'M JUST FOLLOWING THE DOCS!
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_dred_parse(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle dred, byte* data, int len, int max_dred_samples, int sampling_rate, int* dred_end, int defer_processing);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_dred_process(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle src, OpusDREDSafeHandle dst);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_decoder_dred_decode(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, int* pcm, int frame_size);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_decoder_dred_decode_float(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, float* pcm, int frame_size);
+
+        //Opus Packet Parsers
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_parse(byte* data, int len, byte* out_toc, byte* frames, short* size, int* payload_offset);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_get_bandwidth(byte* data);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_get_samples_per_frame(byte* data, int Fs);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_get_nb_channels(byte* data);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_get_nb_frames(byte* packet, int len);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_get_nb_samples(byte* packet, int len, int Fs);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_has_lbrr(byte* packet, int len);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_get_nb_samples(OpusDecoderSafeHandle dec, byte* packet, int len);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern void opus_pcm_soft_clip(float* pcm, int frame_size, int channels, float* softclip_mem);
+
+        //Repacketizer
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_repacketizer_get_size();
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern OpusRepacketizerSafeHandle opus_repacketizer_init(OpusRepacketizerSafeHandle rp);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern OpusRepacketizerSafeHandle opus_repacketizer_create();
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void opus_repacketizer_destroy(IntPtr rp);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_repacketizer_cat(OpusRepacketizerSafeHandle rp, byte* data, int len);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_repacketizer_out_range(OpusRepacketizerSafeHandle rp, int begin, int end, byte* data, int maxlen);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_repacketizer_get_nb_frames(OpusRepacketizerSafeHandle rp);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_repacketizer_out(OpusRepacketizerSafeHandle rp, byte* data, int maxlen);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_pad(byte* data, int len, int new_len);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_packet_unpad(byte* data, int len);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_packet_pad(byte* data, int len, int new_len, int nb_streams);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_packet_unpad(byte* data, int len, int nb_streams);
+
+        //Multistream Encoder
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_multistream_encoder_get_size(int streams, int coupled_streams);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_multistream_surround_encoder_get_size(int channels, int mapping_family);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern OpusMSEncoderSafeHandle opus_multistream_encoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application, int* error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern OpusMSEncoderSafeHandle opus_multistream_surround_encoder_create(int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application, int* error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_surround_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_encode(OpusMSEncoderSafeHandle st, byte* pcm, int frame_size, byte* data, int max_data_bytes);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_encode_float(OpusMSEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void opus_multistream_encoder_destroy(IntPtr st);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_encoder_ctl(OpusMSEncoderSafeHandle st, int request, void* data);
+
+        //Multistream Decoder
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int opus_multistream_decoder_get_size(int streams, int coupled_streams);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern OpusMSDecoderSafeHandle opus_multistream_decoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int* error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_decoder_init(OpusMSDecoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_decode(OpusMSDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_decode_float(OpusMSDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern int opus_multistream_decoder_ctl(OpusMSDecoderSafeHandle st, int request, void* data);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void opus_multistream_decoder_destroy(IntPtr st);
+
+        //Library Information
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern byte* opus_strerror(int error);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static unsafe extern byte* opus_get_version_string();
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
+++ b/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
@@ -7,223 +7,710 @@ namespace Discord.Audio.Opus
     /// </summary>
     internal static partial class NativeOpus
     {
-#if ANDROID
-        private const string DllName = "libopus.so";
-#elif LINUX
-        private const string DllName = "libopus.so.0.10.1";
-#elif WINDOWS
-        private const string DllName = "opus.dll";
-#elif MACOS || IOS || MACCATALYST
+#if MACOS || IOS || MACCATALYST
         private const string DllName = "__Internal__";
 #else
         private const string DllName = "opus";
 #endif
 
         //Encoder
+        /// <summary>
+        /// Gets the size of an <see cref="OpusEncoderSafeHandle"/> structure.
+        /// </summary>
+        /// <param name="channels">Number of channels. This must be 1 or 2.</param>
+        /// <returns>The size in bytes.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_encoder_get_size(int channels);
 
+        /// <summary>
+        /// Allocates and initializes an encoder state.
+        /// </summary>
+        /// <param name="Fs">Sampling rate of input signal (Hz) This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels (1 or 2) in input signal.</param>
+        /// <param name="application">Coding mode (one of <see cref="OpusPredefinedValues.OPUS_APPLICATION_VOIP"/>, <see cref="OpusPredefinedValues.OPUS_APPLICATION_AUDIO"/> or <see cref="OpusPredefinedValues.OPUS_APPLICATION_RESTRICTED_LOWDELAY"/>)</param>
+        /// <param name="error"><see cref="OpusErrorCodes.OPUS_OK"/> Success or <see cref="OpusErrorCodes"/>.</param>
+        /// <returns><see cref="OpusEncoderSafeHandle"/></returns>
         [LibraryImport(DllName)]
-        public static unsafe partial OpusEncoderSafeHandle opus_encoder_create(int Fs, int application, int* error);
+        public static unsafe partial OpusEncoderSafeHandle opus_encoder_create(int Fs, int channels, int application, int* error);
 
+        /// <summary>
+        /// Initializes a previously allocated <see cref="OpusEncoderSafeHandle"/> state. The memory pointed to by st must be at least the size returned by <see cref="opus_encoder_get_size(int)"/>.
+        /// </summary>
+        /// <param name="st">Encoder state.</param>
+        /// <param name="Fs">Sampling rate of input signal (Hz) This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels (1 or 2) in input signal.</param>
+        /// <param name="application">>Coding mode (one of <see cref="OpusPredefinedValues.OPUS_APPLICATION_VOIP"/>, <see cref="OpusPredefinedValues.OPUS_APPLICATION_AUDIO"/> or <see cref="OpusPredefinedValues.OPUS_APPLICATION_RESTRICTED_LOWDELAY"/>)</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static partial int opus_encoder_init(OpusEncoderSafeHandle st, int Fs, int channels, int application);
 
+        /// <summary>
+        /// Encodes an Opus frame.
+        /// </summary>
+        /// <param name="st">Encoder state.</param>
+        /// <param name="pcm">Input signal (interleaved if 2 channels). length is frame_size*channels*sizeof(short)</param>
+        /// <param name="frame_size">Number of samples per channel in the input signal. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="data">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes) on success or a negative error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_encode(OpusEncoderSafeHandle st, short* pcm, int frame_size, byte* data, int max_data_bytes);
 
+        /// <summary>
+        /// Encodes an Opus frame from floating point input.
+        /// </summary>
+        /// <param name="st">Encoder state.</param>
+        /// <param name="pcm">Input in float format (interleaved if 2 channels), with a normal range of +/-1.0. Samples with a range beyond +/-1.0 are supported but will be clipped by decoders using the integer API and should only be used if it is known that the far end supports extended dynamic range. length is frame_size*channels*sizeof(float)</param>
+        /// <param name="frame_size">Number of samples per channel in the input signal. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="data">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes) on success or a negative error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_encode_float(OpusEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
 
+        /// <summary>
+        /// Frees an <see cref="OpusEncoderSafeHandle"/> allocated by <see cref="opus_encoder_create(int, int, int, int*)"/>.
+        /// </summary>
+        /// <param name="st">State to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_encoder_destroy(IntPtr st);
 
+        /// <summary>
+        /// Perform a CTL function on an <see cref="OpusEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Encoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="EncoderCTL"/>.</param>
+        /// <param name="data">The data to input/output.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_encoder_ctl(OpusEncoderSafeHandle st, int request, void* data);
 
+        /// <summary>
+        /// Perform a CTL function on an Opus encoder.
+        /// </summary>
+        /// <param name="st">Encoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="EncoderCTL"/>.</param>
+        /// <param name="data">The data to input/output.</param>
+        /// <param name="data2">The second data to input/output.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_encoder_ctl(OpusEncoderSafeHandle st, int request, void* data, void* data2);
+
         //Decoder
+        /// <summary>
+        /// Gets the size of an <see cref="OpusDecoderSafeHandle"/> structure.
+        /// </summary>
+        /// <param name="channels">Number of channels. This must be 1 or 2.</param>
+        /// <returns>The size in bytes.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_decoder_get_size(int channels);
 
+        /// <summary>
+        /// Allocates and initializes a <see cref="OpusDecoderSafeHandle"/> state.
+        /// </summary>
+        /// <param name="Fs">Sample rate to decode at (Hz). This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels (1 or 2) to decode.</param>
+        /// <param name="error"><see cref="OpusErrorCodes.OPUS_OK"/> Success or <see cref="OpusErrorCodes"/>.</param>
+        /// <returns><see cref="OpusDecoderSafeHandle"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial OpusDecoderSafeHandle opus_decoder_create(int Fs, int channels, int* error);
 
+        /// <summary>
+        /// Initializes a previously allocated <see cref="OpusDecoderSafeHandle"/> state.
+        /// </summary>
+        /// <param name="st">Decoder state.</param>
+        /// <param name="Fs">Sampling rate to decode to (Hz). This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels (1 or 2) to decode.</param>
+        /// <returns><see cref="OpusErrorCodes.OPUS_OK"/> Success or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_decoder_init(OpusDecoderSafeHandle st, int Fs, int channels);
 
+        /// <summary>
+        /// Decode an Opus packet.
+        /// </summary>
+        /// <param name="st">Decoder state.</param>
+        /// <param name="data">Input payload. Use a NULL pointer to indicate packet loss.</param>
+        /// <param name="len">Number of bytes in payload.</param>
+        /// <param name="pcm">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(short).</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Flag (0 or 1) to request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_decode(OpusDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
 
+        /// <summary>
+        /// Decode an Opus packet with floating point output.
+        /// </summary>
+        /// <param name="st">Decoder state.</param>
+        /// <param name="data">Input payload. Use a NULL pointer to indicate packet loss.</param>
+        /// <param name="len">Number of bytes in payload.</param>
+        /// <param name="pcm">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(float).</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Flag (0 or 1) to request that any in-band forward error correction data be decoded. If no such data is available the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_decode_float(OpusDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
 
+        /// <summary>
+        /// Perform a CTL function on an <see cref="OpusDecoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Decoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="DecoderCTL"/>.</param>
+        /// <param name="data">The data to input or output.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_decoder_ctl(OpusDecoderSafeHandle st, int request, void* data);
 
+        /// <summary>
+        /// Frees an <see cref="OpusDecoderSafeHandle"/> allocated by <see cref="opus_decoder_create(int, int, int*)"/>.
+        /// </summary>
+        /// <param name="st">State to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_decoder_destroy(IntPtr st);
 
         //Dred Decoder
+        /// <summary>
+        /// Gets the size of an <see cref="OpusDREDDecoderSafeHandle"/> structure.
+        /// </summary>
+        /// <returns>The size in bytes.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_dred_decoder_get_size();
 
+        /// <summary>
+        /// Allocates and initializes an <see cref="OpusDREDDecoderSafeHandle"/> state.
+        /// </summary>
+        /// <param name="error"><see cref="OpusErrorCodes.OPUS_OK"/> Success or <see cref="OpusErrorCodes"/>.</param>
+        /// <returns><see cref="OpusDREDDecoderSafeHandle"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial OpusDREDDecoderSafeHandle opus_dred_decoder_create(int* error);
 
+        /// <summary>
+        /// Initializes an <see cref="OpusDREDDecoderSafeHandle"/> state.
+        /// </summary>
+        /// <param name="dec">State to be initialized.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static partial int opus_dred_decoder_init(OpusDREDDecoderSafeHandle dec);
 
+        /// <summary>
+        /// Frees an <see cref="OpusDREDDecoderSafeHandle"/> allocated by <see cref="opus_dred_decoder_create(int*)"/>.
+        /// </summary>
+        /// <param name="dec">State to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_dred_decoder_destroy(IntPtr dec);
 
+        /// <summary>
+        /// Perform a CTL function on an <see cref="OpusDREDDecoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="dred_dec">DRED Decoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="DecoderCTL"/>.</param>
+        /// <param name="data">The data to input or output.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_dred_decoder_ctl(OpusDREDDecoderSafeHandle dred_dec, int request, void* data);
 
         //Dred Packet?
+        /// <summary>
+        /// Gets the size of an <see cref="OpusDREDSafeHandle"/> structure.
+        /// </summary>
+        /// <returns>The size in bytes.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_dred_get_size();
 
+        /// <summary>
+        /// Allocates and initializes a <see cref="OpusDREDSafeHandle"/> state.
+        /// </summary>
+        /// <param name="error"><see cref="OpusErrorCodes.OPUS_OK"/> Success or <see cref="OpusErrorCodes"/>.</param>
+        /// <returns><see cref="OpusDREDSafeHandle"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial OpusDREDSafeHandle opus_dred_alloc(int* error);
 
+        /// <summary>
+        /// Frees an <see cref="OpusDREDSafeHandle"/> allocated by <see cref="opus_dred_alloc(int*)"/>.
+        /// </summary>
+        /// <param name="dec">State to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_dred_free(IntPtr dec); //I'M JUST FOLLOWING THE DOCS!
 
+        /// <summary>
+        /// Decode an Opus DRED packet.
+        /// </summary>
+        /// <param name="dred_dec">DRED Decoder state.</param>
+        /// <param name="dred">DRED state.</param>
+        /// <param name="data">Input payload.</param>
+        /// <param name="len">Number of bytes in payload.</param>
+        /// <param name="max_dred_samples">Maximum number of DRED samples that may be needed (if available in the packet).</param>
+        /// <param name="sampling_rate">Sampling rate used for max_dred_samples argument. Needs not match the actual sampling rate of the decoder.</param>
+        /// <param name="dred_end">Number of non-encoded (silence) samples between the DRED timestamp and the last DRED sample.</param>
+        /// <param name="defer_processing">Flag (0 or 1). If set to one, the CPU-intensive part of the DRED decoding is deferred until <see cref="opus_dred_process(OpusDREDDecoderSafeHandle, OpusDREDSafeHandle, OpusDREDSafeHandle)"/> is called.</param>
+        /// <returns>Offset (positive) of the first decoded DRED samples, zero if no DRED is present, or <see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_dred_parse(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle dred, byte* data, int len, int max_dred_samples, int sampling_rate, int* dred_end, int defer_processing);
 
+        /// <summary>
+        /// Finish decoding an <see cref="OpusDREDSafeHandle"/> packet.
+        /// </summary>
+        /// <param name="dred_dec">DRED Decoder state.</param>
+        /// <param name="src">Source DRED state to start the processing from.</param>
+        /// <param name="dst">Destination DRED state to store the updated state after processing.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static partial int opus_dred_process(OpusDREDDecoderSafeHandle dred_dec, OpusDREDSafeHandle src, OpusDREDSafeHandle dst);
 
+        /// <summary>
+        /// Decode audio from an <see cref="OpusDREDSafeHandle"/> packet with floating point output.
+        /// </summary>
+        /// <param name="st">Decoder state.</param>
+        /// <param name="dred">DRED state.</param>
+        /// <param name="dred_offset">position of the redundancy to decode (in samples before the beginning of the real audio data in the packet).</param>
+        /// <param name="pcm">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(short)</param>
+        /// <param name="frame_size">Number of samples per channel to decode in pcm. frame_size must be a multiple of 2.5 ms.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
-        public static unsafe partial int opus_decoder_dred_decode(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, int* pcm, int frame_size);
+        public static unsafe partial int opus_decoder_dred_decode(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, short* pcm, int frame_size);
 
+        /// <summary>
+        /// Decode audio from an <see cref="OpusDREDSafeHandle"/> packet with floating point output.
+        /// </summary>
+        /// <param name="st">Decoder state.</param>
+        /// <param name="dred">DRED state.</param>
+        /// <param name="dred_offset">position of the redundancy to decode (in samples before the beginning of the real audio data in the packet).</param>
+        /// <param name="pcm">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(float).</param>
+        /// <param name="frame_size">Number of samples per channel to decode in pcm. frame_size must be a multiple of 2.5 ms.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_decoder_dred_decode_float(OpusDecoderSafeHandle st, OpusDREDSafeHandle dred, int dred_offset, float* pcm, int frame_size);
 
         //Opus Packet Parsers
+        /// <summary>
+        /// Parse an opus packet into one or more frames.
+        /// </summary>
+        /// <param name="data">Opus packet to be parsed.</param>
+        /// <param name="len">size of data.</param>
+        /// <param name="out_toc">TOC pointer.</param>
+        /// <param name="frames">encapsulated frames.</param>
+        /// <param name="size">sizes of the encapsulated frames.</param>
+        /// <param name="payload_offset">returns the position of the payload within the packet (in bytes).</param>
+        /// <returns>number of frames.</returns>
         [LibraryImport(DllName)]
-        public static unsafe partial int opus_packet_parse(byte* data, int len, byte* out_toc, byte* frames, short* size, int* payload_offset);
+        public static unsafe partial int opus_packet_parse(byte* data, int len, byte* out_toc, byte*[] frames, short[] size, int* payload_offset);
 
+        /// <summary>
+        /// Gets the bandwidth of an Opus packet.
+        /// </summary>
+        /// <param name="data">Opus packet.</param>
+        /// <returns><see cref="OpusPredefinedValues"/> or <see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_get_bandwidth(byte* data);
 
+        /// <summary>
+        /// Gets the number of samples per frame from an Opus packet.
+        /// </summary>
+        /// <param name="data">Opus packet. This must contain at least one byte of data.</param>
+        /// <param name="Fs">Sampling rate in Hz. This must be a multiple of 400, or inaccurate results will be returned.</param>
+        /// <returns>Number of samples per frame.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_get_samples_per_frame(byte* data, int Fs);
 
+        /// <summary>
+        /// Gets the number of channels from an Opus packet.
+        /// </summary>
+        /// <param name="data">Opus packet.</param>
+        /// <returns>Number of channels or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_get_nb_channels(byte* data);
 
+        /// <summary>
+        /// Gets the number of frames in an Opus packet.
+        /// </summary>
+        /// <param name="packet">Opus packet.</param>
+        /// <param name="len">Length of packet.</param>
+        /// <returns>Number of frames or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_get_nb_frames(byte* packet, int len);
 
+        /// <summary>
+        /// Gets the number of samples of an Opus packet.
+        /// </summary>
+        /// <param name="packet">Opus packet.</param>
+        /// <param name="len">Length of packet.</param>
+        /// <param name="Fs">Sampling rate in Hz. This must be a multiple of 400, or inaccurate results will be returned.</param>
+        /// <returns>Number of samples or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_get_nb_samples(byte* packet, int len, int Fs);
 
+        /// <summary>
+        /// Checks whether an Opus packet has LBRR.
+        /// </summary>
+        /// <param name="packet">Opus packet.</param>
+        /// <param name="len">Length of packet.</param>
+        /// <returns>1 is LBRR is present, 0 otherwise or <see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_has_lbrr(byte* packet, int len);
 
+        /// <summary>
+        /// Gets the number of samples of an Opus packet.
+        /// </summary>
+        /// <param name="dec">Decoder state.</param>
+        /// <param name="packet">Opus packet.</param>
+        /// <param name="len">Length of packet.</param>
+        /// <returns>Number of samples or <see cref="OpusErrorCodes"/>.</returns>
         [LibraryImport(DllName)]
-        public static unsafe partial int opus_packet_get_nb_samples(OpusDecoderSafeHandle dec, byte* packet, int len);
+        public static unsafe partial int opus_decoder_get_nb_samples(OpusDecoderSafeHandle dec, byte* packet, int len);
 
+        /// <summary>
+        /// Applies soft-clipping to bring a float signal within the [-1,1] range.
+        /// </summary>
+        /// <param name="pcm">Input PCM and modified PCM.</param>
+        /// <param name="frame_size">Number of samples per channel to process.</param>
+        /// <param name="channels">Number of channels.</param>
+        /// <param name="softclip_mem">State memory for the soft clipping process (one float per channel, initialized to zero).</param>
         [LibraryImport(DllName)]
         public static unsafe partial void opus_pcm_soft_clip(float* pcm, int frame_size, int channels, float* softclip_mem);
 
         //Repacketizer
+        /// <summary>
+        /// Gets the size of an <see cref="OpusRepacketizerSafeHandle"/> structure.
+        /// </summary>
+        /// <returns>The size in bytes.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_repacketizer_get_size();
 
+        /// <summary>
+        /// (Re)initializes a previously allocated <see cref="OpusRepacketizerSafeHandle"/> state.
+        /// </summary>
+        /// <param name="rp">The <see cref="OpusRepacketizerSafeHandle"/> state to (re)initialize.</param>
+        /// <returns><see cref="OpusRepacketizerSafeHandle"/></returns>
         [LibraryImport(DllName)]
         public static partial OpusRepacketizerSafeHandle opus_repacketizer_init(OpusRepacketizerSafeHandle rp);
 
+        /// <summary>
+        /// Allocates memory and initializes the new <see cref="OpusRepacketizerSafeHandle"/> with <see cref="opus_repacketizer_init(OpusRepacketizerSafeHandle)"/>.
+        /// </summary>
+        /// <returns><see cref="OpusRepacketizerSafeHandle"/></returns>
         [LibraryImport(DllName)]
         public static partial OpusRepacketizerSafeHandle opus_repacketizer_create();
 
+        /// <summary>
+        /// Frees an <see cref="OpusRepacketizerSafeHandle"/> allocated by <see cref="opus_repacketizer_create"/>.
+        /// </summary>
+        /// <param name="rp">State to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_repacketizer_destroy(IntPtr rp);
 
+        /// <summary>
+        /// Add a packet to the current <see cref="OpusRepacketizerSafeHandle"/> state.
+        /// </summary>
+        /// <param name="rp">The repacketizer state to which to add the packet.</param>
+        /// <param name="data">The packet data. The application must ensure this pointer remains valid until the next call to <see cref="opus_repacketizer_init(OpusRepacketizerSafeHandle)"/> or <see cref="opus_repacketizer_destroy(IntPtr)"/>.</param>
+        /// <param name="len">The number of bytes in the packet data.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_repacketizer_cat(OpusRepacketizerSafeHandle rp, byte* data, int len);
 
+        /// <summary>
+        /// Construct a new packet from data previously submitted to the <see cref="OpusRepacketizerSafeHandle"/> state via <see cref="opus_repacketizer_cat(OpusRepacketizerSafeHandle, byte*, int)"/>.
+        /// </summary>
+        /// <param name="rp">The repacketizer state from which to construct the new packet.</param>
+        /// <param name="begin">The index of the first frame in the current repacketizer state to include in the output.</param>
+        /// <param name="end">One past the index of the last frame in the current repacketizer state to include in the output.</param>
+        /// <param name="data">The buffer in which to store the output packet.</param>
+        /// <param name="maxlen">The maximum number of bytes to store in the output buffer. In order to guarantee success, this should be at least 1276 for a single frame, or for multiple frames, 1277*(end-begin). However, 1*(end-begin) plus the size of all packet data submitted to the repacketizer since the last call to <see cref="opus_repacketizer_init(OpusRepacketizerSafeHandle)"/> or <see cref="opus_repacketizer_create"/> is also sufficient, and possibly much smaller.</param>
+        /// <returns>The total size of the output packet on success, or an <see cref="OpusErrorCodes"/> on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_repacketizer_out_range(OpusRepacketizerSafeHandle rp, int begin, int end, byte* data, int maxlen);
 
+        /// <summary>
+        /// Return the total number of frames contained in packet data submitted to the <see cref="OpusRepacketizerSafeHandle"/> state so far via <see cref="opus_repacketizer_cat(OpusRepacketizerSafeHandle, byte*, int)"/> since the last call to <see cref="opus_repacketizer_init(OpusRepacketizerSafeHandle)"/> or <see cref="opus_repacketizer_create"/>.
+        /// </summary>
+        /// <param name="rp">The repacketizer state containing the frames.</param>
+        /// <returns>The total number of frames contained in the packet data submitted to the repacketizer state.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_repacketizer_get_nb_frames(OpusRepacketizerSafeHandle rp);
 
+        /// <summary>
+        /// Construct a new packet from data previously submitted to the <see cref="OpusRepacketizerSafeHandle"/> state via <see cref="opus_repacketizer_cat(OpusRepacketizerSafeHandle, byte*, int)"/>.
+        /// </summary>
+        /// <param name="rp">The repacketizer state from which to construct the new packet.</param>
+        /// <param name="data">The buffer in which to store the output packet.</param>
+        /// <param name="maxlen">The maximum number of bytes to store in the output buffer. In order to guarantee success, this should be at least 1277*opus_repacketizer_get_nb_frames(rp). However, 1*opus_repacketizer_get_nb_frames(rp) plus the size of all packet data submitted to the repacketizer since the last call to opus_repacketizer_init() or opus_repacketizer_create() is also sufficient, and possibly much smaller.</param>
+        /// <returns>The total size of the output packet on success, or an <see cref="OpusErrorCodes"/> on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_repacketizer_out(OpusRepacketizerSafeHandle rp, byte* data, int maxlen);
 
+        /// <summary>
+        /// Pads a given Opus packet to a larger size (possibly changing the TOC sequence).
+        /// </summary>
+        /// <param name="data">The buffer containing the packet to pad.</param>
+        /// <param name="len">The size of the packet. This must be at least 1.</param>
+        /// <param name="new_len">The desired size of the packet after padding. This must be at least as large as len.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_pad(byte* data, int len, int new_len);
 
+        /// <summary>
+        /// Remove all padding from a given Opus packet and rewrite the TOC sequence to minimize space usage.
+        /// </summary>
+        /// <param name="data">The buffer containing the packet to strip.</param>
+        /// <param name="len">The size of the packet. This must be at least 1.</param>
+        /// <returns>The new size of the output packet on success, or an <see cref="OpusErrorCodes"/> on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_packet_unpad(byte* data, int len);
 
+        /// <summary>
+        /// Pads a given Opus multi-stream packet to a larger size (possibly changing the TOC sequence).
+        /// </summary>
+        /// <param name="data">The buffer containing the packet to pad.</param>
+        /// <param name="len">The size of the packet. This must be at least 1.</param>
+        /// <param name="new_len">The desired size of the packet after padding. This must be at least 1.</param>
+        /// <param name="nb_streams">The number of streams (not channels) in the packet. This must be at least as large as len.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_packet_pad(byte* data, int len, int new_len, int nb_streams);
 
+        /// <summary>
+        /// Remove all padding from a given Opus multi-stream packet and rewrite the TOC sequence to minimize space usage.
+        /// </summary>
+        /// <param name="data">The buffer containing the packet to strip.</param>
+        /// <param name="len">The size of the packet. This must be at least 1.</param>
+        /// <param name="nb_streams">The number of streams (not channels) in the packet. This must be at least 1.</param>
+        /// <returns>The new size of the output packet on success, or an <see cref="OpusErrorCodes"/> on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_packet_unpad(byte* data, int len, int nb_streams);
 
         //Multistream Encoder
+        /// <summary>
+        /// Gets the size of an <see cref="OpusMSEncoderSafeHandle"/> structure.
+        /// </summary>
+        /// <param name="streams">The total number of streams to encode from the input. This must be no more than 255.</param>
+        /// <param name="coupled_streams">Number of coupled (2 channel) streams to encode. This must be no larger than the total number of streams. Additionally, The total number of encoded channels (streams + coupled_streams) must be no more than 255.</param>
+        /// <returns>The size in bytes on success, or a negative error code (see <see cref="OpusErrorCodes"/>) on error.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_multistream_encoder_get_size(int streams, int coupled_streams);
 
+        /// <summary>
+        /// N.A.
+        /// </summary>
+        /// <param name="channels"></param>
+        /// <param name="mapping_family"></param>
+        /// <returns></returns>
         [LibraryImport(DllName)]
         public static partial int opus_multistream_surround_encoder_get_size(int channels, int mapping_family);
 
+        /// <summary>
+        /// Allocates and initializes a <see cref="OpusMSEncoderSafeHandle"/> state.
+        /// </summary>
+        /// <param name="Fs">Sampling rate of the input signal (in Hz). This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels in the input signal. This must be at most 255. It may be greater than the number of coded channels (streams + coupled_streams).</param>
+        /// <param name="streams">The total number of streams to encode from the input. This must be no more than the number of channels.</param>
+        /// <param name="coupled_streams">Number of coupled (2 channel) streams to encode. This must be no larger than the total number of streams. Additionally, The total number of encoded channels (streams + coupled_streams) must be no more than the number of input channels.</param>
+        /// <param name="mapping">Mapping from encoded channels to input channels, as described in Opus Multistream API. As an extra constraint, the multistream encoder does not allow encoding coupled streams for which one channel is unused since this is never a good idea.</param>
+        /// <param name="application">The target encoder application. This must be one of the following: <see cref="OpusPredefinedValues.OPUS_APPLICATION_VOIP"/>, <see cref="OpusPredefinedValues.OPUS_APPLICATION_AUDIO"/> or <see cref="OpusPredefinedValues.OPUS_APPLICATION_RESTRICTED_LOWDELAY"/>.</param>
+        /// <param name="error">Returns <see cref="OpusErrorCodes.OPUS_OK"/> on success, or an error code (see <see cref="OpusErrorCodes"/>) on failure.</param>
+        /// <returns><see cref="OpusMSEncoderSafeHandle"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial OpusMSEncoderSafeHandle opus_multistream_encoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application, int* error);
 
+        /// <summary>
+        /// N.A.
+        /// </summary>
+        /// <param name="Fs"></param>
+        /// <param name="channels"></param>
+        /// <param name="mapping_family"></param>
+        /// <param name="streams"></param>
+        /// <param name="coupled_streams"></param>
+        /// <param name="mapping"></param>
+        /// <param name="application"></param>
+        /// <param name="error"></param>
+        /// <returns></returns>
         [LibraryImport(DllName)]
         public static unsafe partial OpusMSEncoderSafeHandle opus_multistream_surround_encoder_create(int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application, int* error);
 
+        /// <summary>
+        /// Initialize a previously allocated <see cref="OpusMSEncoderSafeHandle"/> state.
+        /// </summary>
+        /// <param name="st">Multistream encoder state to initialize.</param>
+        /// <param name="Fs">Sampling rate of the input signal (in Hz). This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels in the input signal. This must be at most 255. It may be greater than the number of coded channels (streams + coupled_streams).</param>
+        /// <param name="streams">The total number of streams to encode from the input. This must be no more than the number of channels.</param>
+        /// <param name="coupled_streams">Number of coupled (2 channel) streams to encode. This must be no larger than the total number of streams. Additionally, The total number of encoded channels (streams + coupled_streams) must be no more than the number of input channels.</param>
+        /// <param name="mapping">Mapping from encoded channels to input channels, as described in Opus Multistream API. As an extra constraint, the multistream encoder does not allow encoding coupled streams for which one channel is unused since this is never a good idea.</param>
+        /// <param name="application">The target encoder application. This must be one of the following: <see cref="OpusPredefinedValues.OPUS_APPLICATION_VOIP"/>, <see cref="OpusPredefinedValues.OPUS_APPLICATION_AUDIO"/> or <see cref="OpusPredefinedValues.OPUS_APPLICATION_RESTRICTED_LOWDELAY"/>.</param>
+        /// <returns><see cref="OpusErrorCodes.OPUS_OK"/> on success, or an error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping, int application);
 
+        /// <summary>
+        /// N.A.
+        /// </summary>
+        /// <param name="st"></param>
+        /// <param name="Fs"></param>
+        /// <param name="channels"></param>
+        /// <param name="mapping_family"></param>
+        /// <param name="streams"></param>
+        /// <param name="coupled_streams"></param>
+        /// <param name="mapping"></param>
+        /// <param name="application"></param>
+        /// <returns></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_surround_encoder_init(OpusMSEncoderSafeHandle st, int Fs, int channels, int mapping_family, int* streams, int* coupled_streams, byte* mapping, int application);
 
+        /// <summary>
+        /// Encodes a multistream Opus frame.
+        /// </summary>
+        /// <param name="st">Multistream encoder state.</param>
+        /// <param name="pcm">The input signal as interleaved samples. This must contain frame_size*channels samples.</param>
+        /// <param name="frame_size">Number of samples per channel in the input signal. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="data">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes) on success or a negative error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
-        public static unsafe partial int opus_multistream_encode(OpusMSEncoderSafeHandle st, byte* pcm, int frame_size, byte* data, int max_data_bytes);
+        public static unsafe partial int opus_multistream_encode(OpusMSEncoderSafeHandle st, short* pcm, int frame_size, byte* data, int max_data_bytes);
 
+        /// <summary>
+        /// Encodes a multistream Opus frame from floating point input.
+        /// </summary>
+        /// <param name="st">Multistream encoder state.</param>
+        /// <param name="pcm">The input signal as interleaved samples with a normal range of +/-1.0. Samples with a range beyond +/-1.0 are supported but will be clipped by decoders using the integer API and should only be used if it is known that the far end supports extended dynamic range. This must contain frame_size*channels samples.</param>
+        /// <param name="frame_size">Number of samples per channel in the input signal. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="data">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes) on success or a negative error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_encode_float(OpusMSEncoderSafeHandle st, float* pcm, int frame_size, byte* data, int max_data_bytes);
 
+        /// <summary>
+        /// Frees an <see cref="OpusMSEncoderSafeHandle"/> allocated by <see cref="opus_multistream_encoder_create(int, int, int, int, byte*, int, int*)"/>.
+        /// </summary>
+        /// <param name="st">Multistream encoder state to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_multistream_encoder_destroy(IntPtr st);
 
+        /// <summary>
+        /// Perform a CTL function on a <see cref="OpusMSEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Multistream encoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/>, <see cref="EncoderCTL"/>, or <see cref="MultistreamCTL"/> specific encoder and decoder CTLs.</param>
+        /// <param name="data">The input/output data.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_encoder_ctl(OpusMSEncoderSafeHandle st, int request, void* data);
 
+        /// <summary>
+        /// Perform a CTL function on a <see cref="OpusMSEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Multistream encoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/>, <see cref="EncoderCTL"/>, or <see cref="MultistreamCTL"/> specific encoder and decoder CTLs.</param>
+        /// <param name="data">The input/output data.</param>
+        /// <param name="data2">The input/output data.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_encoder_ctl(OpusMSEncoderSafeHandle st, int request, void* data, void* data2);
+
         //Multistream Decoder
+        /// <summary>
+        /// Gets the size of an <see cref="OpusMSDecoderSafeHandle"/> structure.
+        /// </summary>
+        /// <param name="streams">The total number of streams coded in the input. This must be no more than 255.</param>
+        /// <param name="coupled_streams">Number streams to decode as coupled (2 channel) streams. This must be no larger than the total number of streams. Additionally, The total number of coded channels (streams + coupled_streams) must be no more than 255.</param>
+        /// <returns>The size in bytes on success, or a negative error code (see <see cref="OpusErrorCodes"/>) on error.</returns>
         [LibraryImport(DllName)]
         public static partial int opus_multistream_decoder_get_size(int streams, int coupled_streams);
 
+        /// <summary>
+        /// Allocates and initializes a <see cref="OpusMSDecoderSafeHandle"/> state.
+        /// </summary>
+        /// <param name="Fs">Sampling rate to decode at (in Hz). This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels to output. This must be at most 255. It may be different from the number of coded channels (streams + coupled_streams).</param>
+        /// <param name="streams">The total number of streams coded in the input. This must be no more than 255.</param>
+        /// <param name="coupled_streams">Number of streams to decode as coupled (2 channel) streams. This must be no larger than the total number of streams. Additionally, The total number of coded channels (streams + coupled_streams) must be no more than 255.</param>
+        /// <param name="mapping">Mapping from coded channels to output channels, as described in Opus Multistream API.</param>
+        /// <param name="error">Returns <see cref="OpusErrorCodes.OPUS_OK"/> on success, or an error code (see <see cref="OpusErrorCodes"/>) on failure.</param>
+        /// <returns><see cref="OpusMSDecoderSafeHandle"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial OpusMSDecoderSafeHandle opus_multistream_decoder_create(int Fs, int channels, int streams, int coupled_streams, byte* mapping, int* error);
 
+        /// <summary>
+        /// Intialize a previously allocated <see cref="OpusMSDecoderSafeHandle"/> state object.
+        /// </summary>
+        /// <param name="st">Multistream encoder state to initialize.</param>
+        /// <param name="Fs">Sampling rate to decode at (in Hz). This must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels to output. This must be at most 255. It may be different from the number of coded channels (streams + coupled_streams).</param>
+        /// <param name="streams">The total number of streams coded in the input. This must be no more than 255.</param>
+        /// <param name="coupled_streams">Number of streams to decode as coupled (2 channel) streams. This must be no larger than the total number of streams. Additionally, The total number of coded channels (streams + coupled_streams) must be no more than 255.</param>
+        /// <param name="mapping">Mapping from coded channels to output channels, as described in Opus Multistream API.</param>
+        /// <returns><see cref="OpusErrorCodes.OPUS_OK"/> on success, or an error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_decoder_init(OpusMSDecoderSafeHandle st, int Fs, int channels, int streams, int coupled_streams, byte* mapping);
 
+        /// <summary>
+        /// Decode a multistream Opus packet.
+        /// </summary>
+        /// <param name="st">Multistream decoder state.</param>
+        /// <param name="data">Input payload. Use a NULL pointer to indicate packet loss.</param>
+        /// <param name="len">Number of bytes in payload.</param>
+        /// <param name="pcm">Output signal, with interleaved samples. This must contain room for frame_size*channels samples.</param>
+        /// <param name="frame_size">The number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120 ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Flag (0 or 1) to request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of samples decoded on success or a negative error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_decode(OpusMSDecoderSafeHandle st, byte* data, int len, short* pcm, int frame_size, int decode_fec);
 
+        /// <summary>
+        /// Decode a multistream Opus packet with floating point output.
+        /// </summary>
+        /// <param name="st">Multistream decoder state.</param>
+        /// <param name="data">Input payload. Use a NULL pointer to indicate packet loss.</param>
+        /// <param name="len">Number of bytes in payload.</param>
+        /// <param name="pcm">Output signal, with interleaved samples. This must contain room for frame_size*channels samples.</param>
+        /// <param name="frame_size">The number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120 ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Flag (0 or 1) to request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of samples decoded on success or a negative error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_decode_float(OpusMSDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
 
+        /// <summary>
+        /// Perform a CTL function on a <see cref="OpusMSEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Multistream decoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/>, <see cref="DecoderCTL"/>, or <see cref="MultistreamCTL"/> specific encoder and decoder CTLs.</param>
+        /// <param name="data">The input/output data.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_decoder_ctl(OpusMSDecoderSafeHandle st, int request, void* data);
 
+        /// <summary>
+        /// Perform a CTL function on a <see cref="OpusMSEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Multistream decoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/>, <see cref="DecoderCTL"/>, or <see cref="MultistreamCTL"/> specific encoder and decoder CTLs.</param>
+        /// <param name="data">The input/output data.</param>
+        /// <param name="data2">The input/output data.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_decoder_ctl(OpusMSDecoderSafeHandle st, int request, void* data, void* data2);
+
+        /// <summary>
+        /// Frees an <see cref="OpusMSDecoderSafeHandle"/> allocated by <see cref="opus_multistream_decoder_create(int, int, int, int, byte*, int*)"/>.
+        /// </summary>
+        /// <param name="st">Multistream decoder state to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_multistream_decoder_destroy(IntPtr st);
 
         //Library Information
-        [LibraryImport(DllName)]
-        public static unsafe partial byte* opus_strerror(int error);
-
+        /// <summary>
+        /// Gets the libopus version string.
+        /// </summary>
+        /// <returns>Version string</returns>
         [LibraryImport(DllName)]
         public static unsafe partial byte* opus_get_version_string();
+
+        /// <summary>
+        /// Converts an opus error code into a human readable string.
+        /// </summary>
+        /// <param name="error">Error number.</param>
+        /// <returns>Error string.</returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial byte* opus_strerror(int error);
     }
 }

--- a/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
+++ b/src/Discord.Net.V4.Audio/Opus/NativeOpus.cs
@@ -80,6 +80,15 @@ namespace Discord.Audio.Opus
         /// </summary>
         /// <param name="st">Encoder state.</param>
         /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="EncoderCTL"/>.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_encoder_ctl(OpusEncoderSafeHandle st, int request); //Apparently GenericCTL.OPUS_RESET_STATE exists.
+
+        /// <summary>
+        /// Perform a CTL function on an <see cref="OpusEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Encoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="EncoderCTL"/>.</param>
         /// <param name="data">The data to input/output.</param>
         /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
@@ -156,6 +165,15 @@ namespace Discord.Audio.Opus
         /// </summary>
         /// <param name="st">Decoder state.</param>
         /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="DecoderCTL"/>.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_decoder_ctl(OpusDecoderSafeHandle st, int request); //Apparently GenericCTL.OPUS_RESET_STATE exists.
+
+        /// <summary>
+        /// Perform a CTL function on an <see cref="OpusDecoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Decoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="DecoderCTL"/>.</param>
         /// <param name="data">The data to input or output.</param>
         /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
@@ -198,6 +216,15 @@ namespace Discord.Audio.Opus
         /// <param name="dec">State to be freed.</param>
         [LibraryImport(DllName)]
         public static partial void opus_dred_decoder_destroy(IntPtr dec);
+
+        /// <summary>
+        /// Perform a CTL function on an <see cref="OpusDREDDecoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="dred_dec">DRED Decoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/> or <see cref="DecoderCTL"/>.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_dred_decoder_ctl(OpusDREDDecoderSafeHandle dred_dec, int request); //Apparently GenericCTL.OPUS_RESET_STATE exists.
 
         /// <summary>
         /// Perform a CTL function on an <see cref="OpusDREDDecoderSafeHandle"/>.
@@ -591,6 +618,15 @@ namespace Discord.Audio.Opus
         /// </summary>
         /// <param name="st">Multistream encoder state.</param>
         /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/>, <see cref="EncoderCTL"/>, or <see cref="MultistreamCTL"/> specific encoder and decoder CTLs.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_encoder_ctl(OpusMSEncoderSafeHandle st, int request); //Apparently GenericCTL.OPUS_RESET_STATE exists.
+
+        /// <summary>
+        /// Perform a CTL function on a <see cref="OpusMSEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Multistream encoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/>, <see cref="EncoderCTL"/>, or <see cref="MultistreamCTL"/> specific encoder and decoder CTLs.</param>
         /// <param name="data">The input/output data.</param>
         /// <returns><see cref="OpusErrorCodes"/></returns>
         [LibraryImport(DllName)]
@@ -668,6 +704,15 @@ namespace Discord.Audio.Opus
         /// <returns>Number of samples decoded on success or a negative error code (see <see cref="OpusErrorCodes"/>) on failure.</returns>
         [LibraryImport(DllName)]
         public static unsafe partial int opus_multistream_decode_float(OpusMSDecoderSafeHandle st, byte* data, int len, float* pcm, int frame_size, int decode_fec);
+
+        /// <summary>
+        /// Perform a CTL function on a <see cref="OpusMSEncoderSafeHandle"/>.
+        /// </summary>
+        /// <param name="st">Multistream decoder state.</param>
+        /// <param name="request">This and all remaining parameters should be replaced by one of the convenience macros in <see cref="GenericCTL"/>, <see cref="DecoderCTL"/>, or <see cref="MultistreamCTL"/> specific encoder and decoder CTLs.</param>
+        /// <returns><see cref="OpusErrorCodes"/></returns>
+        [LibraryImport(DllName)]
+        public static unsafe partial int opus_multistream_decoder_ctl(OpusMSDecoderSafeHandle st, int request); //Apparently GenericCTL.OPUS_RESET_STATE exists.
 
         /// <summary>
         /// Perform a CTL function on a <see cref="OpusMSEncoderSafeHandle"/>.

--- a/src/Discord.Net.V4.Audio/Opus/OpusDecoder.cs
+++ b/src/Discord.Net.V4.Audio/Opus/OpusDecoder.cs
@@ -1,0 +1,225 @@
+﻿using Discord.Audio.Opus.SafeHandlers;
+
+namespace Discord.Audio.Opus
+{
+    /// <summary>
+    /// An opus decoder.
+    /// </summary>
+    public class OpusDecoder : IDisposable
+    {
+        private OpusDecoderSafeHandle _handler;
+        private bool _disposed;
+
+        /// <summary>
+        /// Creates a new opus decoder.
+        /// </summary>
+        /// <param name="sample_rate">The sample rate, this must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels, this must be 1 or 2.</param>
+        /// <exception cref="OpusException" />
+        public unsafe OpusDecoder(int sample_rate, int channels)
+        {
+            int error = 0;
+            _handler = NativeOpus.opus_decoder_create(sample_rate, channels, &error);
+            CheckError(error);
+        }
+
+        /// <summary>
+        /// Decodes an opus encoded frame.
+        /// </summary>
+        /// <param name="input">Input payload. Use null to indicate packet loss</param>
+        /// <param name="length">Number of bytes in payload.</param>
+        /// <param name="output">Output signal (interleaved if 2 channels). length is frame_size*channels.</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=true), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
+        public unsafe int Decode(Span<byte> input, int length, Span<byte> output, int frame_size, bool decode_fec)
+        {
+            ThrowIfDisposed();
+
+            fixed (byte* inputPtr = input)
+            fixed (byte* outputPtr = output)
+            {
+                var result = NativeOpus.opus_decode(_handler, inputPtr, length, (short*)outputPtr, frame_size, decode_fec ? 1 : 0);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Decodes an opus encoded frame.
+        /// </summary>
+        /// <param name="input">Input payload. Use null to indicate packet loss</param>
+        /// <param name="length">Number of bytes in payload.</param>
+        /// <param name="output">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(short)</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=true), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
+        public unsafe int Decode(Span<byte> input, int length, Span<short> output, int frame_size, bool decode_fec)
+        {
+            ThrowIfDisposed();
+
+            fixed (byte* inputPtr = input)
+            fixed (short* outputPtr = output)
+            {
+                var result = NativeOpus.opus_decode(_handler, inputPtr, length, outputPtr, frame_size, decode_fec ? 1 : 0);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Decodes an opus encoded frame.
+        /// </summary>
+        /// <param name="input">Input payload. Use null to indicate packet loss</param>
+        /// <param name="length">Number of bytes in payload.</param>
+        /// <param name="output">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(float)</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=true), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
+        public unsafe int Decode(Span<byte> input, int length, Span<float> output, int frame_size, bool decode_fec)
+        {
+            ThrowIfDisposed();
+
+            fixed (byte* inputPtr = input)
+            fixed (float* outputPtr = output)
+            {
+                var result = NativeOpus.opus_decode_float(_handler, inputPtr, length, outputPtr, frame_size, decode_fec ? 1 : 0);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Decodes an opus encoded frame.
+        /// </summary>
+        /// <param name="input">Input payload. Use null to indicate packet loss</param>
+        /// <param name="length">Number of bytes in payload.</param>
+        /// <param name="output">Output signal (interleaved if 2 channels). length is frame_size*channels</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=true), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
+        public unsafe int Decode(byte[]? input, int length, byte[] output, int frame_size, bool decode_fec) => Decode(input.AsSpan(), length, output.AsSpan(), frame_size, decode_fec);
+
+        /// <summary>
+        /// Decodes an opus encoded frame.
+        /// </summary>
+        /// <param name="input">Input payload. Use null to indicate packet loss</param>
+        /// <param name="length">Number of bytes in payload.</param>
+        /// <param name="output">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(short)</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=true), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
+        public unsafe int Decode(byte[]? input, int length, short[] output, int frame_size, bool decode_fec) => Decode(input.AsSpan(), length, output.AsSpan(), frame_size, decode_fec);
+
+        /// <summary>
+        /// Decodes an opus encoded frame.
+        /// </summary>
+        /// <param name="input">Input payload. Use null to indicate packet loss</param>
+        /// <param name="length">Number of bytes in payload.</param>
+        /// <param name="output">Output signal (interleaved if 2 channels). length is frame_size*channels*sizeof(float)</param>
+        /// <param name="frame_size">Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=true), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms.</param>
+        /// <param name="decode_fec">Request that any in-band forward error correction data be decoded. If no such data is available, the frame is decoded as if it were lost.</param>
+        /// <returns>Number of decoded samples or <see cref="OpusErrorCodes"/>.</returns>
+        public unsafe int Decode(byte[]? input, int length, float[] output, int frame_size, bool decode_fec) => Decode(input.AsSpan(), length, output.AsSpan(), frame_size, decode_fec);
+
+        /// <summary>
+        /// Performs a ctl request.
+        /// </summary>
+        /// <typeparam name="T">The type you want to input/output.</typeparam>
+        /// <param name="request">The request you want to specify.</param>
+        /// <param name="value">The input/output value.</param>
+        /// <returns>The result code of the request. See <see cref="OpusErrorCodes"/>.</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Ctl<T>(DecoderCTL request, ref T value) where T : unmanaged
+        {
+            ThrowIfDisposed();
+            fixed (void* valuePtr = &value)
+            {
+                var result = NativeOpus.opus_decoder_ctl(_handler, (int)request, valuePtr);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Performs a ctl request.
+        /// </summary>
+        /// <param name="request">The request you want to specify.</param>
+        /// <returns>The result code of the request. See <see cref="OpusErrorCodes"/>.</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Ctl(GenericCTL request)
+        {
+            ThrowIfDisposed();
+            var result = NativeOpus.opus_decoder_ctl(_handler, (int)request);
+            CheckError(result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a ctl request.
+        /// </summary>
+        /// <typeparam name="T">The type you want to input/output.</typeparam>
+        /// <param name="request">The request you want to specify.</param>
+        /// <param name="value">The input/output value.</param>
+        /// <returns>The result code of the request. See <see cref="OpusErrorCodes"/>.</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Ctl<T>(GenericCTL request, ref T value) where T : unmanaged
+        {
+            ThrowIfDisposed();
+            fixed (void* valuePtr = &value)
+            {
+                var result = NativeOpus.opus_decoder_ctl(_handler, (int)request, valuePtr);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Dispose logic.
+        /// </summary>
+        /// <param name="disposing">Set to true if fully disposing.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                if (!_handler.IsClosed)
+                    _handler.Close();
+            }
+
+            _disposed = true;
+        }
+
+        /// <summary>
+        /// Throws an exception if this object is disposed or the handler is closed.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException" />
+        protected virtual void ThrowIfDisposed()
+        {
+            if (_disposed || _handler.IsClosed)
+                throw new ObjectDisposedException(GetType().FullName);
+        }
+
+        /// <summary>
+        /// Checks if there is an opus error and throws if the error is a negative value.
+        /// </summary>
+        /// <param name="error">The error code to input.</param>
+        /// <exception cref="OpusException"></exception>
+        protected void CheckError(int error)
+        {
+            if (error < 0)
+                throw new OpusException(((OpusErrorCodes)error).ToString());
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/OpusEncoder.cs
+++ b/src/Discord.Net.V4.Audio/Opus/OpusEncoder.cs
@@ -1,0 +1,254 @@
+﻿using Discord.Audio.Opus.SafeHandlers;
+
+namespace Discord.Audio.Opus
+{
+    /// <summary>
+    /// An opus encoder.
+    /// </summary>
+    public class OpusEncoder : IDisposable
+    {
+        private OpusEncoderSafeHandle _handler;
+        private bool _disposed;
+
+        /// <summary>
+        /// Creates a new opus encoder.
+        /// </summary>
+        /// <param name="sample_rate">The sample rate, this must be one of 8000, 12000, 16000, 24000, or 48000.</param>
+        /// <param name="channels">Number of channels, this must be 1 or 2.</param>
+        /// <param name="application">Coding mode (one of <see cref="OpusPredefinedValues.OPUS_APPLICATION_VOIP"/>, <see cref="OpusPredefinedValues.OPUS_APPLICATION_AUDIO"/> or <see cref="OpusPredefinedValues.OPUS_APPLICATION_RESTRICTED_LOWDELAY"/></param>
+        /// <exception cref="OpusException" />
+        public unsafe OpusEncoder(int sample_rate, int channels, OpusPredefinedValues application)
+        {
+            int error = 0;
+            _handler = NativeOpus.opus_encoder_create(sample_rate, channels, (int)application, &error);
+            CheckError(error);
+        }
+
+        /// <summary>
+        /// Encodes a pcm frame.
+        /// </summary>
+        /// <param name="input">Input signal (interleaved if 2 channels). length is frame_size*channels.</param>
+        /// <param name="frame_size">The frame size of the pcm data. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="output">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes).</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Encode(Span<byte> input, int frame_size, Span<byte> output, int max_data_bytes)
+        {
+            ThrowIfDisposed();
+            fixed (byte* inputPtr = input)
+            fixed (byte* outputPtr = output)
+            {
+                var result = NativeOpus.opus_encode(_handler, (short*)inputPtr, frame_size, outputPtr, max_data_bytes);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Encodes a pcm frame.
+        /// </summary>
+        /// <param name="input">Input signal (interleaved if 2 channels). length is frame_size*channels*sizeof(short).</param>
+        /// <param name="frame_size">The frame size of the pcm data. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="output">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes).</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Encode(Span<short> input, int frame_size, Span<byte> output, int max_data_bytes)
+        {
+            ThrowIfDisposed();
+            fixed (short* inputPtr = input)
+            fixed (byte* outputPtr = output)
+            {
+                var result = NativeOpus.opus_encode(_handler, inputPtr, frame_size, outputPtr, max_data_bytes);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Encodes a floating point pcm frame.
+        /// </summary>
+        /// <param name="input">Input signal (interleaved if 2 channels). length is frame_size*channels*sizeof(float).</param>
+        /// <param name="frame_size">The frame size of the pcm data. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="output">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes).</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Encode(Span<float> input, int frame_size, Span<byte> output, int max_data_bytes)
+        {
+            ThrowIfDisposed();
+            fixed (float* inputPtr = input)
+            fixed (byte* outputPtr = output)
+            {
+                var result = NativeOpus.opus_encode_float(_handler, inputPtr, frame_size, outputPtr, max_data_bytes);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Encodes a pcm frame.
+        /// </summary>
+        /// <param name="input">Input signal (interleaved if 2 channels). length is frame_size*channels.</param>
+        /// <param name="frame_size">The frame size of the pcm data. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="output">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes).</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public int Encode(byte[] input, int frame_size, byte[] output, int max_data_bytes) => Encode(input.AsSpan(), frame_size, output.AsSpan(), max_data_bytes);
+
+        /// <summary>
+        /// Encodes a pcm frame.
+        /// </summary>
+        /// <param name="input">Input signal (interleaved if 2 channels). length is frame_size*channels*sizeof(short).</param>
+        /// <param name="frame_size">The frame size of the pcm data. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="output">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes).</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public int Encode(short[] input, int frame_size, byte[] output, int max_data_bytes) => Encode(input.AsSpan(), frame_size, output.AsSpan(), max_data_bytes);
+
+        /// <summary>
+        /// Encodes a floating point pcm frame.
+        /// </summary>
+        /// <param name="input">Input signal (interleaved if 2 channels). length is frame_size*channels*sizeof(float).</param>
+        /// <param name="frame_size">The frame size of the pcm data. This must be an Opus frame size for the encoder's sampling rate. For example, at 48 kHz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10 ms (480 samples at 48 kHz) will prevent the encoder from using the LPC or hybrid modes.</param>
+        /// <param name="output">Output payload. This must contain storage for at least max_data_bytes.</param>
+        /// <param name="max_data_bytes">Size of the allocated memory for the output payload. This may be used to impose an upper limit on the instant bitrate, but should not be used as the only bitrate control. Use <see cref="EncoderCTL.OPUS_SET_BITRATE"/> to control the bitrate.</param>
+        /// <returns>The length of the encoded packet (in bytes).</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public int Encode(float[] input, int frame_size, byte[] output, int max_data_bytes) => Encode(input.AsSpan(), frame_size, output.AsSpan(), max_data_bytes);
+
+        /// <summary>
+        /// Performs a ctl request.
+        /// </summary>
+        /// <typeparam name="T">The type you want to input/output.</typeparam>
+        /// <param name="request">The request you want to specify.</param>
+        /// <param name="value">The input/output value.</param>
+        /// <returns>The result code of the request. See <see cref="OpusErrorCodes"/>.</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Ctl<T>(EncoderCTL request, ref T value) where T : unmanaged
+        {
+            ThrowIfDisposed();
+            fixed (void* valuePtr = &value)
+            {
+                var result = NativeOpus.opus_encoder_ctl(_handler, (int)request, valuePtr);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Performs a ctl request.
+        /// </summary>
+        /// <typeparam name="T">The type you want to input/output.</typeparam>        
+        /// <typeparam name="T2">The second type you want to input/output.</typeparam>
+        /// <param name="request">The request you want to specify.</param>
+        /// <param name="value">The input/output value.</param>
+        /// <param name="value2">The second input/output value.</param>
+        /// <returns>The result code of the request. See <see cref="OpusErrorCodes"/>.</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Ctl<T, T2>(EncoderCTL request, ref T value, ref T2 value2) 
+            where T : unmanaged
+            where T2 : unmanaged
+        {
+            ThrowIfDisposed();
+            fixed (void* valuePtr = &value)
+            fixed (void* value2Ptr = &value2)
+            {
+                var result = NativeOpus.opus_encoder_ctl(_handler, (int)request, valuePtr, value2Ptr);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Performs a ctl request.
+        /// </summary>
+        /// <param name="request">The request you want to specify.</param>
+        /// <returns>The result code of the request. See <see cref="OpusErrorCodes"/>.</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Ctl(GenericCTL request)
+        {
+            ThrowIfDisposed();
+            var result = NativeOpus.opus_encoder_ctl(_handler, (int)request);
+            CheckError(result);
+            return result;
+        }
+
+        /// <summary>
+        /// Performs a ctl request.
+        /// </summary>
+        /// <typeparam name="T">The type you want to input/output.</typeparam>
+        /// <param name="request">The request you want to specify.</param>
+        /// <param name="value">The input/output value.</param>
+        /// <returns>The result code of the request. See <see cref="OpusErrorCodes"/>.</returns>
+        /// <exception cref="OpusException" />
+        /// <exception cref="ObjectDisposedException" />
+        public unsafe int Ctl<T>(GenericCTL request, ref T value) where T : unmanaged
+        {
+            ThrowIfDisposed();
+            fixed (void* valuePtr = &value)
+            {
+                var result = NativeOpus.opus_encoder_ctl(_handler, (int)request, valuePtr);
+                CheckError(result);
+                return result;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Dispose logic.
+        /// </summary>
+        /// <param name="disposing">Set to true if fully disposing.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                if (!_handler.IsClosed)
+                    _handler.Close();
+            }
+
+            _disposed = true;
+        }
+
+        /// <summary>
+        /// Throws an exception if this object is disposed or the handler is closed.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException" />
+        protected virtual void ThrowIfDisposed()
+        {
+            if (_disposed || _handler.IsClosed)
+                throw new ObjectDisposedException(GetType().FullName);
+        }
+
+        /// <summary>
+        /// Checks if there is an opus error and throws if the error is a negative value.
+        /// </summary>
+        /// <param name="error">The error code to input.</param>
+        /// <exception cref="OpusException"></exception>
+        protected void CheckError(int error)
+        {
+            if (error < 0)
+                throw new OpusException(((OpusErrorCodes)error).ToString());
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/OpusException.cs
+++ b/src/Discord.Net.V4.Audio/Opus/OpusException.cs
@@ -1,0 +1,26 @@
+﻿namespace Discord.Audio.Opus
+{
+    /// <summary>
+    /// An opus exception.
+    /// </summary>
+    public class OpusException : Exception
+    {
+        /// <summary>
+        /// Constructs an opus exception.
+        /// </summary>
+        public OpusException() { }
+
+        /// <summary>
+        /// Constructs an opus exception.
+        /// </summary>
+        /// <param name="message">The message of the exception.</param>
+        public OpusException(string message) : base(message) { }
+
+        /// <summary>
+        /// Constructs an opus exception.
+        /// </summary>
+        /// <param name="message">The message of the exception.</param>
+        /// <param name="innerException">The root exception.</param>
+        public OpusException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/OpusInfo.cs
+++ b/src/Discord.Net.V4.Audio/Opus/OpusInfo.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus
+{
+    /// <summary>
+    /// Provides information about the opus DLL.
+    /// </summary>
+    public class OpusInfo
+    {
+        /// <summary>
+        /// Gets the libopus version string.
+        /// </summary>
+        /// <returns>Version string.</returns>
+        public static unsafe string Version()
+        {
+            byte* version = NativeOpus.opus_get_version_string();
+            return Marshal.PtrToStringAnsi((IntPtr)version) ?? "";
+        }
+
+        /// <summary>
+        /// Converts an opus error code into a human readable string.
+        /// </summary>
+        /// <param name="error">Error number.</param>
+        /// <returns>Error string.</returns>
+        public static unsafe string StringError(int error)
+        {
+            byte* stringError = NativeOpus.opus_strerror(error);
+            return Marshal.PtrToStringAnsi((IntPtr)stringError) ?? "";
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDDecoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDDecoderSafeHandle.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus.SafeHandlers
+{
+    public class OpusDREDDecoderSafeHandle : SafeHandle
+    {
+        public OpusDREDDecoderSafeHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            NativeOpus.opus_dred_decoder_destroy(handle);
+            return true;
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDDecoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDDecoderSafeHandle.cs
@@ -2,14 +2,22 @@
 
 namespace Discord.Audio.Opus.SafeHandlers
 {
-    public class OpusDREDDecoderSafeHandle : SafeHandle
+    /// <summary>
+    /// Managed wrapper over the OpusDREDDecoder state.
+    /// </summary>
+    internal class OpusDREDDecoderSafeHandle : SafeHandle
     {
+        /// <summary>
+        /// Creates a new <see cref="OpusDecoderSafeHandle"/>.
+        /// </summary>
         public OpusDREDDecoderSafeHandle() : base(IntPtr.Zero, true)
         {
         }
 
+        /// <inheritdoc/>
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             NativeOpus.opus_dred_decoder_destroy(handle);

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDSafeHandle.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus.SafeHandlers
+{
+    public class OpusDREDSafeHandle : SafeHandle
+    {
+        public OpusDREDSafeHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            NativeOpus.opus_dred_free(handle);
+            return true;
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDREDSafeHandle.cs
@@ -2,14 +2,22 @@
 
 namespace Discord.Audio.Opus.SafeHandlers
 {
-    public class OpusDREDSafeHandle : SafeHandle
+    /// <summary>
+    /// Managed wrapper over the OpusDRED state.
+    /// </summary>
+    internal class OpusDREDSafeHandle : SafeHandle
     {
+        /// <summary>
+        /// Creates a new <see cref="OpusDREDDecoderSafeHandle"/>.
+        /// </summary>
         public OpusDREDSafeHandle() : base(IntPtr.Zero, true)
         {
         }
 
+        /// <inheritdoc/>
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             NativeOpus.opus_dred_free(handle);

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDecoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDecoderSafeHandle.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus.SafeHandlers
+{
+    public class OpusDecoderSafeHandle : SafeHandle
+    {
+        public OpusDecoderSafeHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            NativeOpus.opus_decoder_destroy(handle);
+            return true;
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDecoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusDecoderSafeHandle.cs
@@ -2,14 +2,22 @@
 
 namespace Discord.Audio.Opus.SafeHandlers
 {
-    public class OpusDecoderSafeHandle : SafeHandle
+    /// <summary>
+    /// Managed wrapper over the OpusDecoder state.
+    /// </summary>
+    internal class OpusDecoderSafeHandle : SafeHandle
     {
+        /// <summary>
+        /// Create a new <see cref="OpusDecoderSafeHandle"/>.
+        /// </summary>
         public OpusDecoderSafeHandle() : base(IntPtr.Zero, true)
         {
         }
-
+        
+        /// <inheritdoc/>
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             NativeOpus.opus_decoder_destroy(handle);

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusEncoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusEncoderSafeHandle.cs
@@ -2,14 +2,22 @@
 
 namespace Discord.Audio.Opus.SafeHandlers
 {
-    public class OpusEncoderSafeHandle : SafeHandle
+    /// <summary>
+    /// Managed wrapper over the OpusEncoder state.
+    /// </summary>
+    internal class OpusEncoderSafeHandle : SafeHandle
     {
+        /// <summary>
+        /// Creates a new <see cref="OpusEncoderSafeHandle"/>.
+        /// </summary>
         public OpusEncoderSafeHandle(): base(IntPtr.Zero, true)
         {
         }
 
+        /// <inheritdoc/>
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             NativeOpus.opus_encoder_destroy(handle);

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusEncoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusEncoderSafeHandle.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus.SafeHandlers
+{
+    public class OpusEncoderSafeHandle : SafeHandle
+    {
+        public OpusEncoderSafeHandle(): base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            NativeOpus.opus_encoder_destroy(handle);
+            return true;
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSDecoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSDecoderSafeHandle.cs
@@ -2,14 +2,22 @@
 
 namespace Discord.Audio.Opus.SafeHandlers
 {
-    public class OpusMSDecoderSafeHandle : SafeHandle
+    /// <summary>
+    /// Managed wrapper over the OpusMultistreamDecoder state.
+    /// </summary>
+    internal class OpusMSDecoderSafeHandle : SafeHandle
     {
+        /// <summary>
+        /// Creates a new <see cref="OpusMSDecoderSafeHandle"/>.
+        /// </summary>
         public OpusMSDecoderSafeHandle() : base(IntPtr.Zero, true)
         {
         }
 
+        /// <inheritdoc/>
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             NativeOpus.opus_multistream_decoder_destroy(handle);

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSDecoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSDecoderSafeHandle.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus.SafeHandlers
+{
+    public class OpusMSDecoderSafeHandle : SafeHandle
+    {
+        public OpusMSDecoderSafeHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            NativeOpus.opus_multistream_decoder_destroy(handle);
+            return true;
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSEncoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSEncoderSafeHandle.cs
@@ -2,14 +2,22 @@
 
 namespace Discord.Audio.Opus.SafeHandlers
 {
-    public class OpusMSEncoderSafeHandle : SafeHandle
+    /// <summary>
+    /// Managed wrapper over the OpusMultistreamEncoder state.
+    /// </summary>
+    internal class OpusMSEncoderSafeHandle : SafeHandle
     {
+        /// <summary>
+        /// Creates a new <see cref="OpusMSEncoderSafeHandle"/>.
+        /// </summary>
         public OpusMSEncoderSafeHandle() : base(IntPtr.Zero, true)
         {
         }
 
+        /// <inheritdoc/>
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             NativeOpus.opus_multistream_encoder_destroy(handle);

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSEncoderSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusMSEncoderSafeHandle.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus.SafeHandlers
+{
+    public class OpusMSEncoderSafeHandle : SafeHandle
+    {
+        public OpusMSEncoderSafeHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            NativeOpus.opus_multistream_encoder_destroy(handle);
+            return true;
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusRepacketizerSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusRepacketizerSafeHandle.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Discord.Audio.Opus.SafeHandlers
+{
+    public class OpusRepacketizerSafeHandle : SafeHandle
+    {
+        public OpusRepacketizerSafeHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle()
+        {
+            NativeOpus.opus_repacketizer_destroy(handle);
+            return true;
+        }
+    }
+}

--- a/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusRepacketizerSafeHandle.cs
+++ b/src/Discord.Net.V4.Audio/Opus/SafeHandlers/OpusRepacketizerSafeHandle.cs
@@ -2,14 +2,22 @@
 
 namespace Discord.Audio.Opus.SafeHandlers
 {
-    public class OpusRepacketizerSafeHandle : SafeHandle
+    /// <summary>
+    /// Managed wrapper over the OpusRepacketizer state.
+    /// </summary>
+    internal class OpusRepacketizerSafeHandle : SafeHandle
     {
+        /// <summary>
+        /// Creates a new <see cref="OpusRepacketizerSafeHandle"/>.
+        /// </summary>
         public OpusRepacketizerSafeHandle() : base(IntPtr.Zero, true)
         {
         }
 
+        /// <inheritdoc/>
         public override bool IsInvalid => handle == IntPtr.Zero;
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             NativeOpus.opus_repacketizer_destroy(handle);


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
I've added nearly all of the opus's functions and implemented safe handlers for thread safety and reference safety. So it is easier to dispose of opus native objects using an IDisposable wrapper implementation.

Things that are missing are CTL definitions and Error Codes however these can optionally be implemented. Also this code only works with libopus v1.5 and above.

If you want, I can add all the opus cross platform binaries or workflow to this project.

### Changes
- Added NativeOpus.cs
- Added OpusDecoderSafeHandle.cs
- Added OpusDREDDecoderSafeHandle.cs
- Added OpusDREDSafeHandle.cs
- Added OpusEncoderSafeHandle.cs
- Added OpusMSDecoderSafeHandle.cs
- Added OpusMSEncoderSafeHandle.cs
- Added OpusRepacketizerSafeHandle.cs
- Created directory /Opus and /Opus/SafeHandlers in Discord.NET.V4.Audio
- Allowed unsafe blocks in Discord.NET.V4.Audio (You could probably make the NativeOpus code be able to be compiled without having to use unsafe but it requires a bit more thinking.)
- 
### Related Issues
N.A.