### PR TITLE
[Featured] Consider `AutoServiceScopes` in autocomplete handler executions

### DIFF
--- a/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
+++ b/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
@@ -29,12 +29,8 @@ namespace Discord.Interactions
         public Task<IResult> ExecuteAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter,
             IServiceProvider services)
         {
-            IServiceScope scope = null;
-            if(InteractionService._autoServiceScopes)
-            {
-                scope = services?.CreateScope();
-                services = scope?.ServiceProvider ?? EmptyServiceProvider.Instance;
-            }
+            using IServiceScope scope = InteractionService._autoServiceScopes ? services?.CreateScope() : null;
+            services = InteractionService._autoServiceScopes ? scope?.ServiceProvider ?? EmptyServiceProvider.Instance : services;
 
             switch (InteractionService._runMode)
             {
@@ -52,8 +48,6 @@ namespace Discord.Interactions
                     throw new InvalidOperationException($"RunMode {InteractionService._runMode} is not supported.");
             }
             
-            scope?.Dispose();
-
             return Task.FromResult((IResult)ExecuteResult.FromSuccess());
         }
 

--- a/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
+++ b/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
@@ -29,6 +29,13 @@ namespace Discord.Interactions
         public Task<IResult> ExecuteAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter,
             IServiceProvider services)
         {
+            IServiceScope scope = null;
+            if(InteractionService._autoServiceScopes)
+            {
+                scope = services?.CreateScope();
+                services = scope?.ServiceProvider ?? EmptyServiceProvider.Instance;
+            }
+
             switch (InteractionService._runMode)
             {
                 case RunMode.Sync:
@@ -44,6 +51,8 @@ namespace Discord.Interactions
                 default:
                     throw new InvalidOperationException($"RunMode {InteractionService._runMode} is not supported.");
             }
+            
+            scope?.Dispose();
 
             return Task.FromResult((IResult)ExecuteResult.FromSuccess());
         }

--- a/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
+++ b/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Discord.Interactions
 {


### PR DESCRIPTION
### Description

This adds support for considering `InteractionService._autoServiceScope` in autocomplete handlers, creating a new scope for the `IServiceProvider` passed to `GenerateSuggestionsAsync()`. The code follows the same concept already applied for command executions [here](https://github.com/discord-net/Discord.Net/blob/6e7b3c2577c40d22464658ad3ade52407e2d4b1e/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs#L470-L475).

### Changes

- Update `AutocompleteHandler.ExecuteAsync` method
