### PR TITLE
Make Make GetShardFor(ulong guildId) & DiscordShardedClient.GetUserAsync() public

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -611,7 +611,7 @@ namespace Discord.WebSocket
             => await CreateGuildAsync(name, region, jpegIcon).ConfigureAwait(false);
 
         /// <inheritdoc />
-        async Task<IUser> IDiscordClient.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
+        public async Task<IUser> GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
         {
             var user = GetUser(id);
             if (user is not null || mode == CacheMode.CacheOnly)

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -215,7 +215,7 @@ namespace Discord.WebSocket
             => (int)((guildId >> 22) % (uint)_totalShards);
         public int GetShardIdFor(IGuild guild)
             => GetShardIdFor(guild?.Id ?? 0);
-        private DiscordSocketClient GetShardFor(ulong guildId)
+        public DiscordSocketClient GetShardFor(ulong guildId)
             => GetShard(GetShardIdFor(guildId));
         public DiscordSocketClient GetShardFor(IGuild guild)
             => GetShardFor(guild?.Id ?? 0);


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
<!-- A brief explanation of changes made in this PR. -->
This PR makes `GetUserAsync()` and `GetShardFor(guildId)` public.
### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->
Changes accessibility level of `GetUserAsync()` and `GetShardFor(guildId)`  to public.
### Related Issues
<!--
List issues that are related to this PR.
Example:
- resolves #6969
-->
N/A