### PR TITLE
Fixed type reader/converter parsing exception

### DIFF
--- a/src/Discord.Net.Interactions/TypeConverters/ComponentInteractions/DefaultValueComponentConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/ComponentInteractions/DefaultValueComponentConverter.cs
@@ -17,9 +17,9 @@ namespace Discord.Interactions
                     _ => Task.FromResult(TypeConverterResult.FromError(InteractionCommandError.ConvertFailed, $"{option.Type} doesn't have a convertible value."))
                 };
             }
-            catch (InvalidCastException castEx)
+            catch (Exception ex) when (ex is FormatException or InvalidCastException)
             {
-                return Task.FromResult(TypeConverterResult.FromError(castEx));
+                return Task.FromResult(TypeConverterResult.FromError(ex));
             }
         }
     }

--- a/src/Discord.Net.Interactions/TypeConverters/SlashCommands/DefaultValueConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/SlashCommands/DefaultValueConverter.cs
@@ -41,7 +41,6 @@ namespace Discord.Interactions
         public override Task<TypeConverterResult> ReadAsync(IInteractionContext context, IApplicationCommandInteractionDataOption option, IServiceProvider services)
         {
             object value;
-
             if (option.Value is Optional<object> optional)
                 value = optional.IsSpecified ? optional.Value : default(T);
             else
@@ -52,9 +51,9 @@ namespace Discord.Interactions
                 var converted = Convert.ChangeType(value, typeof(T));
                 return Task.FromResult(TypeConverterResult.FromSuccess(converted));
             }
-            catch (InvalidCastException castEx)
+            catch (Exception ex) when (ex is FormatException or InvalidCastException)
             {
-                return Task.FromResult(TypeConverterResult.FromError(castEx));
+                return Task.FromResult(TypeConverterResult.FromError(ex));
             }
         }
     }

--- a/src/Discord.Net.Interactions/TypeReaders/DefaultValueReader.cs
+++ b/src/Discord.Net.Interactions/TypeReaders/DefaultValueReader.cs
@@ -13,9 +13,9 @@ namespace Discord.Interactions
                 var converted = Convert.ChangeType(option, typeof(T));
                 return Task.FromResult(TypeConverterResult.FromSuccess(converted));
             }
-            catch (InvalidCastException castEx)
+            catch (Exception ex) when (ex is FormatException or InvalidCastException)
             {
-                return Task.FromResult(TypeConverterResult.FromError(castEx));
+                return Task.FromResult(TypeConverterResult.FromError(ex));
             }
         }
     }


### PR DESCRIPTION
### Description
The default value reader/converter only catch for `InvalidCastException`s but not for FormatExceptions which will be thrown if Convert.ChangeType can't parse the provided value.
This causes `InteractionService.ExecuteAsync` to return an `ExecuteResult` instead of a `TypeConverterResult` when invalid values were provided.

### Changes
Catches also `FormatException`s on every use of `Convert.ChangeType`.

### Related Issues
N/A