### PR TITLE
Add handler for unknown Discord dispatch events

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -1,5 +1,5 @@
 using Discord.Rest;
-
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -1067,6 +1067,21 @@ namespace Discord.WebSocket
         }
 
         internal readonly AsyncEvent<Func<Cacheable<SocketSubscription, ulong>, Task>> _subscriptionDeleted = new();
+
+        #endregion
+
+        #region Others
+
+        /// <summary>
+        ///     Fired when a dispatch event is received from Discord that does not match any known event type.
+        /// </summary>
+        public event Func<string, JToken, Task> UnknownDispatchReceived
+        {
+            add => _unknownDispatchReceived.Add(value);
+            remove => _unknownDispatchReceived.Remove(value);
+        }
+
+        internal readonly AsyncEvent<Func<string, JToken, Task>> _unknownDispatchReceived = new();
 
         #endregion
     }

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.EventHandling.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.EventHandling.cs
@@ -2506,6 +2506,8 @@ public partial class DiscordSocketClient
                         default:
                             if (!SuppressUnknownDispatchWarnings)
                                 await _gatewayLogger.WarningAsync($"Unknown Dispatch ({type})").ConfigureAwait(false);
+
+                            await TimedInvokeAsync(_unknownDispatchReceived, nameof(UnknownDispatchReceived), type, (payload as JToken));
                             break;
                             #endregion
                     }


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
- Does your changeset adhere to the Contributing Guidelines?
- Does your changeset address a specific issue or idea?
- Have your changes been previously discussed with the community?
-->

### Description
<!-- A brief explanation of changes made in this PR. -->
Adds a new event (`UnknownDispatchReceived`) which fires whenever the library encounters an unknown or unhandled dispatch type.

### Changes
<!--
List things changed in this pull request. Example:
- Add X entity
- Update Y method
-->
- Added a new `UnknownDispatchReceived` event and an internal `AsyncEvent<Func<string, JToken, Task>>` field named `_unknownDispatchReceived`.
- Modified `ProcessMessageAsync` to invoke `UnknownDispatchReceived` when a dispatch event is received with an unknown `type`.

### Related Issues
<!--
List issues that are related to this PR. Example:
- resolves #6969
-->
Resolves #2899