### PR TITLE
Add WithDisabled(bool) to SelectMenuOptionBuilder

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuOptionBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuOptionBuilder.cs
@@ -80,6 +80,11 @@ public class SelectMenuOptionBuilder
     /// </summary>
     public bool? IsDefault { get; set; }
 
+    /// <summary>
+    ///     Gets or sets whether this option is disabled.
+    /// </summary>
+    public bool? IsDisabled { get; set; }
+
     private string _label;
     private string _value;
     private string _description;
@@ -97,13 +102,15 @@ public class SelectMenuOptionBuilder
     /// <param name="description">The description of this option.</param>
     /// <param name="emote">The emote of this option.</param>
     /// <param name="isDefault">Render this option as selected by default or not.</param>
-    public SelectMenuOptionBuilder(string label, string value, string description = null, IEmote emote = null, bool? isDefault = null)
+    /// <param name="isDisabled">Set whether the option should be disabled.</param>
+    public SelectMenuOptionBuilder(string label, string value, string description = null, IEmote emote = null, bool? isDefault = null, bool? isDisabled = null)
     {
         Label = label;
         Value = value;
         Description = description;
         Emote = emote;
         IsDefault = isDefault;
+        IsDisabled = isDisabled;
     }
 
     /// <summary>
@@ -116,6 +123,7 @@ public class SelectMenuOptionBuilder
         Description = option.Description;
         Emote = option.Emote;
         IsDefault = option.IsDefault;
+        IsDisabled = option.Disabled;
     }
 
     /// <summary>
@@ -187,6 +195,19 @@ public class SelectMenuOptionBuilder
     }
 
     /// <summary>
+    ///     Sets whether this option is disabled.
+    /// </summary>
+    /// <param name="isDisabled">The value to set the disabled state to.</param>
+    /// <returns>
+    ///     The current builder.
+    /// </returns>
+    public SelectMenuOptionBuilder WithDisabled(bool isDisabled)
+    {
+        IsDisabled = isDisabled;
+        return this;
+    }
+
+    /// <summary>
     ///     Builds a <see cref="SelectMenuOption"/>.
     /// </summary>
     /// <returns>The newly built <see cref="SelectMenuOption"/>.</returns>
@@ -202,6 +223,6 @@ public class SelectMenuOptionBuilder
 
         Preconditions.AtMost(Value.Length, MaxSelectValueLength, nameof(Value), $"Value length must be less or equal to {MaxSelectValueLength}.");
 
-        return new SelectMenuOption(Label, Value, Description, Emote, IsDefault);
+        return new SelectMenuOption(Label, Value, Description, Emote, IsDefault, IsDisabled);
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/SelectMenuOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/SelectMenuOption.cs
@@ -30,13 +30,19 @@ namespace Discord
         /// </summary>
         public bool? IsDefault { get; }
 
-        internal SelectMenuOption(string label, string value, string description, IEmote emote, bool? defaultValue)
+        /// <summary>
+        ///     Gets whether or not this option is disabled.
+        /// </summary>
+        public bool? Disabled { get; }
+
+        internal SelectMenuOption(string label, string value, string description, IEmote emote, bool? defaultValue, bool? disabled = null)
         {
             Label = label;
             Value = value;
             Description = description;
             Emote = emote;
             IsDefault = defaultValue;
+            Disabled = disabled;
         }
     }
 }


### PR DESCRIPTION
### Description
This PR adds support for disabling individual `SelectMenuOption`s via the `SelectMenuOptionBuilder`.

Discord's native API supports a `disabled` field for select menu options, but Discord.NET previously had no way to represent this in the builder pattern. This PR introduces a `WithDisabled(bool)` method, as well as an `IsDisabled` property, to bring select menu options to feature parity with buttons and align the library with Discord’s capabilities.

This also updates `SelectMenuOption` to store the `Disabled` value and exposes a corresponding constructor parameter.

### Changes
- Added `IsDisabled` property and backing field to `SelectMenuOptionBuilder`
- Added `WithDisabled(bool)` method to `SelectMenuOptionBuilder`
- Extended the constructor and `Build()` method to support the `disabled` field
- Updated `SelectMenuOption` to accept and expose the `Disabled` flag
- Updated `SelectMenuOptionBuilder(SelectMenuOption option)` constructor to copy the disabled state
- Extended XML documentation to reflect the new parameter

### Related Issues
- Feature parity request with native Discord API behavior
- Useful for cases such as gated access (e.g. subscriber/booster-only UI options)