### PR TITLE
Ensure the required gateway intent is available when connecting to audio

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1748,6 +1748,8 @@ namespace Discord.WebSocket
         }
         internal async Task<IAudioClient> ConnectAudioAsync(ulong channelId, bool selfDeaf, bool selfMute, bool external, bool disconnect = true)
         {
+            Discord.EnsureGatewayIntent(GatewayIntents.GuildVoiceStates);
+
             TaskCompletionSource<AudioClient> promise;
 
             await _audioLock.WaitAsync().ConfigureAwait(false);


### PR DESCRIPTION
### Description
I've seen that [DiscordSocketClient.DownloadUsersAsync](https://github.com/discord-net/Discord.Net/blob/348928a06553c0a818b0fc19779f88175e10eabe/src/Discord.Net.WebSocket/DiscordSocketClient.cs#L692) ensures that the required intent is available so other methods that also require specific intent should do the same for more consistency.

### Changes
- Call `EnsureGatewayIntent(GatewayIntents.GuildVoiceStates)` before even trying to connect the audio client.

### Related Issues
N/A