### PR TITLE
fix: properly handle ComponentV2 when modifying messages with MessageFlags.None

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/MessageType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageType.cs
@@ -166,6 +166,11 @@ namespace Discord
         /// <summary>
         ///     The message is a purchase notification.
         /// </summary>
-        PurchaseNotification = 44
+        PurchaseNotification = 44,
+
+        /// <summary>
+        ///     The message for a poll result.
+        /// </summary>
+        PollResult = 46
     }
 }

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -127,7 +127,7 @@ namespace Discord.Interactions.Builders
             var validContextCommands = methods.Where(IsValidContextCommandDefinition);
             var validInteractions = methods.Where(IsValidComponentCommandDefinition);
             var validAutocompleteCommands = methods.Where(IsValidAutocompleteCommandDefinition);
-            var validModalCommands = methods.Where(IsValidModalCommanDefinition);
+            var validModalCommands = methods.Where(IsValidModalCommandDefinition);
 
             Func<IServiceProvider, IInteractionModuleBase> createInstance = commandService._useCompiledLambda ?
                 ReflectionUtils<IInteractionModuleBase>.CreateLambdaBuilder(typeInfo, commandService) : ReflectionUtils<IInteractionModuleBase>.CreateBuilder(typeInfo, commandService);
@@ -693,7 +693,7 @@ namespace Discord.Interactions.Builders
                 methodInfo.GetParameters().Length == 0;
         }
 
-        private static bool IsValidModalCommanDefinition(MethodInfo methodInfo)
+        private static bool IsValidModalCommandDefinition(MethodInfo methodInfo)
         {
             return methodInfo.IsDefined(typeof(ModalInteractionAttribute)) &&
                 (methodInfo.ReturnType == typeof(Task) || methodInfo.ReturnType == typeof(Task<RuntimeResult>)) &&

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -478,7 +478,13 @@ namespace Discord.Rest
                     Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,
                     AllowedMentions = args.AllowedMentions.IsSpecified ? args.AllowedMentions.Value?.ToModel() : Optional<API.AllowedMentions>.Unspecified,
                     Components = args.Components.IsSpecified
-                        ? args.Components.Value?.Components.Select(x => x.ToModel()).ToArray() ?? [] : Optional<IMessageComponent[]>.Unspecified,
+                     ? args.Components.Value?.Components
+                         .Select(b => b.ToModel())
+                         .SelectMany(c => c is API.ContainerComponent container
+                             ? new IMessageComponent[] { new API.ActionRowComponent { Components = container.Components, Id = container.Id } }
+                             : new IMessageComponent[] { c })
+                         .ToArray()
+                     : Optional<IMessageComponent[]>.Unspecified,
                     Flags = args.Flags
                 };
 

--- a/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestMessage.cs
@@ -119,7 +119,8 @@ namespace Discord.Rest
                 model.Type == MessageType.Reply ||
                 model.Type == MessageType.ApplicationCommand ||
                 model.Type == MessageType.ContextMenuCommand ||
-                model.Type == MessageType.ThreadStarterMessage)
+                model.Type == MessageType.ThreadStarterMessage ||
+                model.Type == MessageType.PollResult)
                 return RestUserMessage.Create(discord, channel, author, model);
             else
                 return RestSystemMessage.Create(discord, channel, author, model);

--- a/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
+++ b/src/Discord.Net.WebSocket/Entities/Messages/SocketMessage.cs
@@ -161,7 +161,8 @@ namespace Discord.WebSocket
                 model.Type == MessageType.Reply ||
                 model.Type == MessageType.ApplicationCommand ||
                 model.Type == MessageType.ThreadStarterMessage ||
-                model.Type == MessageType.ContextMenuCommand)
+                model.Type == MessageType.ContextMenuCommand ||
+                model.Type == MessageType.PollResult)
                 return SocketUserMessage.Create(discord, state, author, channel, model);
             else
                 return SocketSystemMessage.Create(discord, state, author, channel, model);


### PR DESCRIPTION
### Description
This PR fixes an issue where modifying messages containing ComponentV2 with `MessageFlags.None` would throw an API exception. The fix properly converts container components to ActionRow components when modifying messages.

### Changes
- Modified component handling in message modification methods to properly convert ContainerComponent to ActionRowComponent
- Added proper type validation when processing components

### Related Issues
- resolves #3132 
