### PR TITLE
Fix value of `TextDisplayBuilder.MaxContentLength`

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/TextDisplayBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/TextDisplayBuilder.cs
@@ -7,7 +7,7 @@ public class TextDisplayBuilder : IMessageComponentBuilder
     /// <summary>
     ///     The maximum length of the content.
     /// </summary>
-    public const int MaxContentLength = 4096;
+    public const int MaxContentLength = 4000;
 
     /// <inheritdoc/>
     public ComponentType Type => ComponentType.ActionRow;


### PR DESCRIPTION
### Description
This PR fixes the value of `TextDisplayBuilder.MaxContentLength` to match the current API limits

### Changes
- Updated `TextDisplayBuilder.MaxContentLength` to 4000
