### PR TITLE
Make `MessageComponent.Empty` public

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/MessageComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/MessageComponent.cs
@@ -18,8 +18,8 @@ public class MessageComponent : INestedComponent
     }
 
     /// <summary>
-    ///     Returns a empty <see cref="MessageComponent"/>.
+    ///     Returns an empty <see cref="MessageComponent"/>.
     /// </summary>
-    internal static MessageComponent Empty
+    public static MessageComponent Empty
         => new([]);
 }


### PR DESCRIPTION
### Description
This PR changes the access modifier of `MessageComponent.Empty` so it becomes public (no idea why it wasn't in the first place)

### Changes
- Changed access modifier of `MessageComponent.Empty` to `public`