### PR TITLE
Fixed incorrect ComponentType in TextDisplayBuilder.

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/TextDisplayBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/TextDisplayBuilder.cs
@@ -10,7 +10,7 @@ public class TextDisplayBuilder : IMessageComponentBuilder
     public const int MaxContentLength = 4000;
 
     /// <inheritdoc/>
-    public ComponentType Type => ComponentType.ActionRow;
+    public ComponentType Type => ComponentType.TextDisplay;
 
     /// <inheritdoc/>
     public int? Id { get; set; }


### PR DESCRIPTION

### Description
It seems the component type is incorrect in TextDisplayBuilder, although not sure how much of an effect this has on the functionality of it.

### Changes
* Changed the Type of TextDisplayBuilder from ActionRow to TextDisplay