### PR TITLE
Fix overflow exception

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/TimestampTagStyle.cs
+++ b/src/Discord.Net.Core/Entities/Messages/TimestampTagStyle.cs
@@ -8,36 +8,36 @@ namespace Discord
         /// <summary>
         ///     A short time string: 16:20
         /// </summary>
-        ShortTime = 116,
+        ShortTime = 't',
 
         /// <summary>
         ///     A long time string: 16:20:30
         /// </summary>
-        LongTime = 84,
+        LongTime = 'T',
 
         /// <summary>
         ///     A short date string: 20/04/2021
         /// </summary>
-        ShortDate = 100,
+        ShortDate = 'd',
 
         /// <summary>
         ///     A long date string: 20 April 2021
         /// </summary>
-        LongDate = 68,
+        LongDate = 'D',
 
         /// <summary>
         ///     A short datetime string: 20 April 2021 16:20
         /// </summary>
-        ShortDateTime = 102,
+        ShortDateTime = 'f',
 
         /// <summary>
         ///     A long datetime string: Tuesday, 20 April 2021 16:20
         /// </summary>
-        LongDateTime = 70,
+        LongDateTime = 'F',
 
         /// <summary>
         ///     The relative time to the user: 2 months ago
         /// </summary>
-        Relative = 82
+        Relative = 'R'
     }
 }

--- a/src/Discord.Net.Core/Extensions/ObjectExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/ObjectExtensions.cs
@@ -8,6 +8,21 @@ namespace Discord
 {
     internal static class ObjectExtensions
     {
+        private const long Int53Max = (1L << 53) - 1;
+        private const long Int53Min = -Int53Max;
+
+        public static (double Min, double Max) GetSupportedNumericalRange(this object o)
+            => Type.GetTypeCode(o.GetType()) switch
+            {
+                TypeCode.Byte => (byte.MinValue, byte.MaxValue),
+                TypeCode.SByte => (sbyte.MinValue, sbyte.MaxValue),
+                TypeCode.Int16 => (short.MinValue, short.MaxValue),
+                TypeCode.UInt16 => (ushort.MinValue, ushort.MaxValue),
+                TypeCode.Int32 => (int.MinValue, int.MaxValue),
+                TypeCode.UInt32 => (uint.MinValue, uint.MaxValue),
+                _ => (Int53Min, Int53Max)
+            };
+
         public static bool IsNumericType(this object o)
         {
             switch (Type.GetTypeCode(o.GetType()))

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -466,6 +466,10 @@ namespace Discord.Interactions.Builders
             builder.IsRequired = !paramInfo.IsOptional;
             builder.DefaultValue = paramInfo.DefaultValue;
 
+            var supportedNumericalRange = paramInfo.GetSupportedNumericalRange();
+            builder.MinValue = supportedNumericalRange.Min;
+            builder.MaxValue = supportedNumericalRange.Max;
+
             foreach (var attribute in attributes)
             {
                 switch (attribute)
@@ -497,9 +501,15 @@ namespace Discord.Interactions.Builders
                             builder.WithAutocompleteHandler(autocomplete.AutocompleteHandlerType, services);
                         break;
                     case MaxValueAttribute maxValue:
+                        if (maxValue.Value > supportedNumericalRange.Max)
+                            throw new ArgumentOutOfRangeException($"{nameof(maxValue)} cannot be greater than {supportedNumericalRange.Max}.");
+
                         builder.MaxValue = maxValue.Value;
                         break;
                     case MinValueAttribute minValue:
+                        if (minValue.Value < supportedNumericalRange.Min)
+                            throw new ArgumentOutOfRangeException($"{nameof(minValue)} cannot be less than {supportedNumericalRange.Min}.");
+
                         builder.MinValue = minValue.Value;
                         break;
                     case MinLengthAttribute minLength:


### PR DESCRIPTION
### Description
This PR validates the arguments parsed into MinValueAttribute and MaxValueAttribute when building a SlashCommandParameter.
It ensures that it is within the supported range of the type itself and within the supported range set by Discord.

### Changes
- fix: validate min/max value against OverflowException

### Related Issues
N/A
