### PR TITLE
fix: edge case missed

### DIFF
--- a/src/Discord.Net.Core/Extensions/ObjectExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/ObjectExtensions.cs
@@ -20,6 +20,7 @@ namespace Discord
                 TypeCode.UInt16 => (ushort.MinValue, ushort.MaxValue),
                 TypeCode.Int32 => (int.MinValue, int.MaxValue),
                 TypeCode.UInt32 => (uint.MinValue, uint.MaxValue),
+                TypeCode.UInt64 => (ulong.MinValue, Int53Max),
                 _ => (Int53Min, Int53Max)
             };
 


### PR DESCRIPTION
### Description
This PR fixes an edge case that was missed in https://github.com/discord-net/Discord.Net/pull/3142 (commit 0c1536d).

The edge case was `TypeCode.UInt64`:
- It fell into the default section of the switch expression which resulted in it returning `(Int53Min, Int53Max)` instead of `(ulong.MinValue, Int53Max)`.

### Changes
- fix: edge case missed

### Related Issues
N/A, no related issues. See description for related pull request.
