### PR TITLE
fix(IsLoadableModule): return false for abstract classes

### DIFF
--- a/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Commands/Builders/ModuleClassBuilder.cs
@@ -13,9 +13,9 @@ namespace Discord.Commands
 
         public static async Task<IReadOnlyList<TypeInfo>> SearchAsync(Assembly assembly, CommandService service)
         {
-            bool IsLoadableModule(TypeInfo info)
+            static bool IsLoadableModule(TypeInfo info)
             {
-                return info.DeclaredMethods.Any(x => x.GetCustomAttribute<CommandAttribute>() != null) &&
+                return !info.IsAbstract && info.DeclaredMethods.Any(x => x.GetCustomAttribute<CommandAttribute>() != null) &&
                     info.GetCustomAttribute<DontAutoLoadAttribute>() == null;
             }
 

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -63,7 +63,7 @@ namespace Discord.Interactions.Builders
                 result.Add(type.AsType(), moduleInfo);
             }
 
-            await commandService._cmdLogger.DebugAsync($"Successfully built {built.Count} Slash Command modules.").ConfigureAwait(false);
+            await commandService._cmdLogger.DebugAsync($"Successfully built {built.Count} interaction modules.").ConfigureAwait(false);
 
             return result;
         }

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -18,7 +18,7 @@ namespace Discord.Interactions.Builders
         {
             static bool IsLoadableModule(TypeInfo info)
             {
-                return info.DeclaredMethods.Any(x => x.GetCustomAttribute<SlashCommandAttribute>() != null);
+                return !info.IsAbstract && info.DeclaredMethods.Any(x => x.GetCustomAttribute<SlashCommandAttribute>() != null);
             }
 
             var result = new List<TypeInfo>();

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -18,7 +18,11 @@ namespace Discord.Interactions.Builders
         {
             static bool IsLoadableModule(TypeInfo info)
             {
-                return !info.IsAbstract && info.DeclaredMethods.Any(x => x.GetCustomAttribute<SlashCommandAttribute>() != null);
+               return !info.IsAbstract && info.DeclaredMethods.SelectMany(x => x.GetCustomAttributes()).Any(x => x switch
+    {
+        SlashCommandAttribute or ComponentInteractionAttribute or ContextCommandAttribute or AutocompleteCommandAttribute or ModalInteractionAttribute => true,
+        _ => false
+    });
             }
 
             var result = new List<TypeInfo>();

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -16,14 +16,15 @@ namespace Discord.Interactions.Builders
 
         public static async Task<IEnumerable<TypeInfo>> SearchAsync(Assembly assembly, InteractionService commandService)
         {
-            static bool IsLoadableModule(TypeInfo info)
-            {
-               return !info.IsAbstract && info.DeclaredMethods.SelectMany(x => x.GetCustomAttributes()).Any(x => x switch
-    {
-        SlashCommandAttribute or ComponentInteractionAttribute or ContextCommandAttribute or AutocompleteCommandAttribute or ModalInteractionAttribute => true,
-        _ => false
-    });
-            }
+            static bool IsLoadableModule(TypeInfo info) =>
+                !info.IsAbstract &&
+                info.DeclaredMethods
+                    .SelectMany(x => x.GetCustomAttributes())
+                    .Any(x => x is SlashCommandAttribute
+                                or ComponentInteractionAttribute
+                                or ContextCommandAttribute
+                                or AutocompleteCommandAttribute
+                                or ModalInteractionAttribute);
 
             var result = new List<TypeInfo>();
 


### PR DESCRIPTION
### Description
`IsLoadableModule` did not check the property `TypeInfo.IsAbstract`. Therefore, an unnecessary warning log stated that it could not be loaded.

Now, if a class is abstract, it will be ignored safely and all the inheritors will continue to load any commands.

### Changes
- fix(IsLoadableModule): return false for abstract classes
- fix: handle other attributes
- refactor: simplify attribute logic
- fix: correct terminology in debug message

### Related Issues
N/A
