### PR TITLE
Fix guild tag badge URL helper

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -293,6 +293,6 @@ namespace Discord
         ///     A URL to the guild tag badge.
         /// </returns>
         public static string GetGuildTagBadgeUrl(ulong guildId, string badgeHash)
-            => $"{DiscordConfig.CDNUrl} guild-tag-badges/{guildId}/{badgeHash}.png";
+            => $"{DiscordConfig.CDNUrl}guild-tag-badges/{guildId}/{badgeHash}.png";
     }
 }


### PR DESCRIPTION
### Description
Fixes the extra space returned by the guild tag badge URL helper in [CDN.cs](https://github.com/discord-net/Discord.Net/blob/dev/src/Discord.Net.Core/CDN.cs#L295).

### Changes
Removed an extra space in a URL helper in CDN.cs.

### Related Issues
N/A
