### PR TITLE
Make ParameterChoice constructor public

### DIFF
--- a/src/Discord.Net.Interactions/Entities/ParameterChoice.cs
+++ b/src/Discord.Net.Interactions/Entities/ParameterChoice.cs
@@ -15,7 +15,12 @@ namespace Discord.Interactions
         /// </summary>
         public object Value { get; }
 
-        internal ParameterChoice(string name, object value)
+        /// <summary>
+        ///     Initializes a new <see cref="ParameterChoice"/>.
+        /// </summary>
+        /// <param name="name">Name of this choice.</param>
+        /// <param name="value">Value of this choice.</param>
+        public ParameterChoice(string name, object value)
         {
             Name = name;
             Value = value;


### PR DESCRIPTION
### Description
This PR changes the [ParameterChoice](https://github.com/discord-net/Discord.Net/blob/958d28636b752b15f04a78dad3476ace90a05895/src/Discord.Net.Interactions/Entities/ParameterChoice.cs#L18) constructor from `internal` to `public`, this is necessary so that a `ParameterChoice` can be manually constructed for [SlashCommandParameterBuilder.WithChoices](https://github.com/discord-net/Discord.Net/blob/958d28636b752b15f04a78dad3476ace90a05895/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs#L171).

### Changes
- Changed constructor visibility from `internal` to `public`.
- Documented the constructor.

### Related Issues