### PR TITLE
Bump guild batch limit to 200

### DIFF
--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -116,7 +116,7 @@ namespace Discord
         /// <returns>
         ///     The maximum number of guilds that can be gotten per-batch.
         /// </returns>
-        public const int MaxGuildsPerBatch = 100;
+        public const int MaxGuildsPerBatch = 200;
         /// <summary>
         ///     Returns the max user reactions allowed to be in a request.
         /// </summary>


### PR DESCRIPTION
https://discord.com/developers/docs/resources/user#get-current-user-guilds
apparently it's 200