### PR TITLE
Fix duplicated flag value in ActivityProperties enum

### DIFF
--- a/src/Discord.Net.Core/Entities/Activities/ActivityProperties.cs
+++ b/src/Discord.Net.Core/Entities/Activities/ActivityProperties.cs
@@ -45,6 +45,6 @@ namespace Discord
         /// <summary>
         ///     Indicates that a user is playing an activity in a voice channel.
         /// </summary>
-        Embedded = 0b10000000
+        Embedded = 0b100000000
     }
 }


### PR DESCRIPTION
### Description
Corrected a duplicated flag value in the `ActivityProperties` enum. The `Embedded` flag previously shared the same bitwise value (`0b10000000`) with `PartyPrivacyVoiceChannel`, which caused ambiguity when combining flags. The `Embedded` flag has been updated to `0b100000000` (256) to ensure each flag has a unique value.
[developers#activity-object-activity-flags](https://discord.com/developers/docs/events/gateway-events#activity-object-activity-flags)

### Changes
- Updated `Embedded` flag value from `0b10000000` to `0b100000000`
