### PR TITLE
Make Cacheable constructors public

### DIFF
--- a/src/Discord.Net.Core/Utils/Cacheable.cs
+++ b/src/Discord.Net.Core/Utils/Cacheable.cs
@@ -29,8 +29,8 @@ namespace Discord
         /// </remarks>
         public TEntity Value { get; }
         private Func<Task<TEntity>> DownloadFunc { get; }
-
-        internal Cacheable(TEntity value, TId id, bool hasValue, Func<Task<TEntity>> downloadFunc)
+        
+        public Cacheable(TEntity value, TId id, bool hasValue, Func<Task<TEntity>> downloadFunc)
         {
             Value = value;
             Id = id;
@@ -84,7 +84,7 @@ namespace Discord
         public TCachedEntity Value { get; }
         private Func<Task<TDownloadableEntity>> DownloadFunc { get; }
 
-        internal Cacheable(TCachedEntity value, TId id, bool hasValue, Func<Task<TDownloadableEntity>> downloadFunc)
+        public Cacheable(TCachedEntity value, TId id, bool hasValue, Func<Task<TDownloadableEntity>> downloadFunc)
         {
             Value = value;
             Id = id;


### PR DESCRIPTION
### Description
This PR simply makes the constructors for the 2 different Cacheable structs public. 

I want to use this mechanism in my bot's code without duplicating the class in my own project but obviously I can if this functionality is not desired.

I did not add an XML doc, however I can add one if that is desired.

### Changes
`internal` constructor for `Cacheable<TCachedEntity, TDownloadableEntity, TRelationship, TId>` made `public`
`internal` constructor for `Cacheable<TEntity, TId>` made `public`

### Related Issues
N/A
