### PR TITLE
Fix missing SelectMenu Type, ChannelTypes, DefaultValues in ComponentBuilder

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/ComponentBuilder.cs
@@ -75,7 +75,7 @@ public class ComponentBuilder
                     AddComponent(cmp, row);
                 break;
             case SelectMenuComponent menu:
-                WithSelectMenu(menu.CustomId, menu.Options?.Select(x => new SelectMenuOptionBuilder(x.Label, x.Value, x.Description, x.Emote, x.IsDefault)).ToList(), menu.Placeholder, menu.MinValues, menu.MaxValues, menu.IsDisabled, row);
+                WithSelectMenu(menu.CustomId, menu.Options?.Select(x => new SelectMenuOptionBuilder(x.Label, x.Value, x.Description, x.Emote, x.IsDefault)).ToList(), menu.Placeholder, menu.MinValues, menu.MaxValues, menu.IsDisabled, row, menu.Type, menu.ChannelTypes.ToArray(), menu.DefaultValues.ToArray());
                 break;
         }
     }

--- a/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
@@ -36,7 +36,7 @@ namespace Discord.Net.Converters
                 case ComponentType.MentionableSelect:
                 case ComponentType.RoleSelect:
                 case ComponentType.UserSelect:
-                    messageComponent = new API.SelectMenuComponent();
+                    messageComponent = new API.SelectMenuComponent(){Type = (ComponentType)typeProperty};
                     break;
                 case ComponentType.TextInput:
                     messageComponent = new API.TextInputComponent();


### PR DESCRIPTION
### Description
Fixes a bug where doing ComponentBuilder:AddComponent (called by ComponentBuilder:FromComponents which is in turn used when doing interaction.ModifyOriginalResponseAsync) will void some of the properties of a SelectMenu.

### Changes
- Added some missing SelectMenu properties in the ComponentBuilder:AddComponent that would result in the new component missing some key values, like for instance the selection of whether it is a UserSelect, MentionSelect or other.
- Added the Type to an empty constructor in MessageComponentConverter.ReadJson since it would be expected that a UserSelect isn't the same thing as a ChannelSelect.

### Related Issues
None, I did make a post to the #help channel in the discord, but I got no response back within the first 24 hrs.
