### PR TITLE
fixed error on changing role icon/emoji to an image.

### DIFF
--- a/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
@@ -40,7 +40,7 @@ namespace Discord.Rest
 
             if ((args.Icon.IsSpecified && args.Icon.Value != null) && role.Emoji != null)
             {
-                apiArgs.Emoji = "";
+                apiArgs.Emoji = Optional.Create<string>();
             }
 
             if ((args.Emoji.IsSpecified && args.Emoji.Value != null) && !string.IsNullOrEmpty(role.Icon))

--- a/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
@@ -40,7 +40,7 @@ namespace Discord.Rest
 
             if ((args.Icon.IsSpecified && args.Icon.Value != null) && role.Emoji != null)
             {
-                apiArgs.Emoji = Optional.Create<string>();
+                apiArgs.Emoji = Optional<string>. Unspecified;
             }
 
             if ((args.Emoji.IsSpecified && args.Emoji.Value != null) && !string.IsNullOrEmpty(role.Icon))


### PR DESCRIPTION
### Description
Trying to change a role icon to an image throws an error:
The server responded with error 10014: Unknown Emoji

<img width="1043" height="286" alt="image" src="https://github.com/user-attachments/assets/c3223d6e-9c34-48d9-9ab9-8a720daaad5b" />


### Changes
setting up emoji to an Optional.Create<string>() solves the issue.
