### PR TITLE
Add select menu `IsRequired` property and fix usage of `DefaultValues`

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuBuilder.cs
@@ -122,6 +122,11 @@ public class SelectMenuBuilder : IInteractableComponentBuilder
     }
 
     /// <summary>
+    ///     Gets or sets whether the current menu is required to answer in a modal (defaults to <see langword="true"/>).
+    /// </summary>
+    public bool IsRequired { get ; set; } = true;
+
+    /// <summary>
     ///     Gets or sets whether the current menu is disabled.
     /// </summary>
     public bool IsDisabled { get; set; }
@@ -168,11 +173,13 @@ public class SelectMenuBuilder : IInteractableComponentBuilder
         CustomId = selectMenu.CustomId;
         MaxValues = selectMenu.MaxValues;
         MinValues = selectMenu.MinValues;
+        IsRequired = selectMenu.IsRequired;
         IsDisabled = selectMenu.IsDisabled;
         Type = selectMenu.Type;
         Options = selectMenu.Options?
            .Select(x => new SelectMenuOptionBuilder(x.Label, x.Value, x.Description, x.Emote, x.IsDefault))
            .ToList();
+        ChannelTypes = selectMenu.ChannelTypes?.ToList();
         DefaultValues = selectMenu.DefaultValues?.ToList();
         Id = selectMenu.Id;
     }
@@ -188,12 +195,16 @@ public class SelectMenuBuilder : IInteractableComponentBuilder
     /// <param name="isDisabled">Disabled this select menu or not.</param>
     /// <param name="type">The <see cref="ComponentType"/> of this select menu.</param>
     /// <param name="channelTypes">The types of channels this menu can select (only valid on <see cref="ComponentType.ChannelSelect"/>s)</param>
-    public SelectMenuBuilder(string customId, List<SelectMenuOptionBuilder> options = null, string placeholder = null, int maxValues = 1, int minValues = 1,
-        bool isDisabled = false, ComponentType type = ComponentType.SelectMenu, List<ChannelType> channelTypes = null, List<SelectMenuDefaultValue> defaultValues = null, int? id = null)
+    /// <param name="defaultValues">The list of default values.</param>
+    /// <param name="id">An optional id for the component.</param>
+    /// <param name="isRequired">Whether the current menu is required to answer in a modal.</param>
+    public SelectMenuBuilder(string customId, List<SelectMenuOptionBuilder> options = null, string placeholder = null, int maxValues = 1, int minValues = 1, bool isDisabled = false,
+        ComponentType type = ComponentType.SelectMenu, List<ChannelType> channelTypes = null, List<SelectMenuDefaultValue> defaultValues = null, int? id = null, bool isRequired = true)
     {
         CustomId = customId;
         Options = options;
         Placeholder = placeholder;
+        IsRequired = isRequired;
         IsDisabled = isDisabled;
         MaxValues = maxValues;
         MinValues = minValues;
@@ -353,6 +364,19 @@ public class SelectMenuBuilder : IInteractableComponentBuilder
     }
 
     /// <summary>
+    ///     Sets whether the current menu is required to answer in a modal.
+    /// </summary>
+    /// <param name="isRequired">Whether the current menu is required to answer in a modal.</param>
+    /// <returns>
+    ///     The current builder.
+    /// </returns>
+    public SelectMenuBuilder WithRequired(bool isRequired)
+    {
+        IsRequired = isRequired;
+        return this;
+    }
+
+    /// <summary>
     ///     Sets whether the current menu is disabled.
     /// </summary>
     /// <param name="isDisabled">Whether the current menu is disabled or not.</param>
@@ -414,7 +438,7 @@ public class SelectMenuBuilder : IInteractableComponentBuilder
     {
         var options = Options?.Select(x => x.Build()).ToList();
 
-        return new SelectMenuComponent(CustomId, options, Placeholder, MinValues, MaxValues, IsDisabled, Type, Id, ChannelTypes, DefaultValues);
+        return new SelectMenuComponent(CustomId, options, Placeholder, MinValues, MaxValues, IsRequired, IsDisabled, Type, Id, ChannelTypes, DefaultValues);
     }
 
     /// <inheritdoc/>

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/SelectMenuComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/SelectMenuComponent.cs
@@ -38,6 +38,11 @@ public class SelectMenuComponent : IInteractableComponent
     public int MaxValues { get; }
 
     /// <summary>
+    ///     Gets whether this menu is required to answer in a modal.
+    /// </summary>
+    public bool IsRequired { get;}
+
+    /// <summary>
     ///     Gets whether this menu is disabled or not.
     /// </summary>
     public bool IsDisabled { get; }
@@ -58,7 +63,7 @@ public class SelectMenuComponent : IInteractableComponent
     public SelectMenuBuilder ToBuilder()
         => new(this);
 
-    internal SelectMenuComponent(string customId, List<SelectMenuOption> options, string placeholder, int minValues, int maxValues,
+    internal SelectMenuComponent(string customId, List<SelectMenuOption> options, string placeholder, int minValues, int maxValues, bool required,
         bool disabled, ComponentType type, int? id, IEnumerable<ChannelType> channelTypes = null, IEnumerable<SelectMenuDefaultValue> defaultValues = null)
     {
         CustomId = customId;
@@ -66,6 +71,7 @@ public class SelectMenuComponent : IInteractableComponent
         Placeholder = placeholder;
         MinValues = minValues;
         MaxValues = maxValues;
+        IsRequired = required;
         IsDisabled = disabled;
         Type = type;
         Id = id;

--- a/src/Discord.Net.Core/Entities/Interactions/Modals/ModalBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Modals/ModalBuilder.cs
@@ -165,7 +165,7 @@ namespace Discord
             return this;
         }
 
-        /// <inheritdoc cref="ModalComponentBuilder.WithSelectMenu(string, string, List{SelectMenuOptionBuilder}, string, int, int, bool, ComponentType, ChannelType[], int?, string, int?)"/>
+        /// <inheritdoc cref="ModalComponentBuilder.WithSelectMenu(string, string, List{SelectMenuOptionBuilder}, string, int, int, bool, bool, ComponentType, ChannelType[], SelectMenuDefaultValue[], int?, string, int?)"/>
         /// <returns>The current <see cref="ModalBuilder"/>.</returns>
         public ModalBuilder AddSelectMenu(
             string label,
@@ -174,9 +174,11 @@ namespace Discord
             string placeholder = null,
             int minValues = 1,
             int maxValues = 1,
+            bool required = true,
             bool disabled = false,
             ComponentType type = ComponentType.SelectMenu,
             ChannelType[] channelTypes = null,
+            SelectMenuDefaultValue[] defaultValues = null,
             int? id = null,
             string description = null,
             int? labelId = null
@@ -189,9 +191,11 @@ namespace Discord
                 placeholder,
                 minValues,
                 maxValues,
+                required,
                 disabled,
                 type,
                 channelTypes,
+                defaultValues,
                 id,
                 description,
                 labelId
@@ -624,9 +628,11 @@ namespace Discord
         /// <param name="placeholder">The placeholder of the <see cref="SelectMenuBuilder"/>.</param>
         /// <param name="minValues">The min values of the <see cref="SelectMenuBuilder"/>.</param>
         /// <param name="maxValues">The max values of the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="required">Whether the <see cref="SelectMenuBuilder"/> is required to be answered.</param>
         /// <param name="disabled">Whether the <see cref="SelectMenuBuilder"/> is disabled.</param>
         /// <param name="type">The type of the <see cref="SelectMenuBuilder"/>.</param>
         /// <param name="channelTypes">The channel types of the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="defaultValues">The default values of the <see cref="SelectMenuBuilder"/>.</param>
         /// <param name="id">The id of the <see cref="SelectMenuBuilder"/>.</param>
         /// <param name="description">The description around the <see cref="SelectMenuBuilder"/>.</param>
         /// <param name="labelId">
@@ -640,9 +646,11 @@ namespace Discord
             string placeholder = null,
             int minValues = 1,
             int maxValues = 1,
+            bool required = true,
             bool disabled = false,
             ComponentType type = ComponentType.SelectMenu,
             ChannelType[] channelTypes = null,
+            SelectMenuDefaultValue[] defaultValues = null,
             int? id = null,
             string description = null,
             int? labelId = null
@@ -655,9 +663,11 @@ namespace Discord
                 .WithPlaceholder(placeholder)
                 .WithMaxValues(maxValues)
                 .WithMinValues(minValues)
+                .WithRequired(required)
                 .WithDisabled(disabled)
                 .WithType(type)
-                .WithChannelTypes(channelTypes),
+                .WithChannelTypes(channelTypes)
+                .WithDefaultValues(defaultValues),
             description,
             labelId
         );
@@ -695,11 +705,11 @@ namespace Discord
         ///     Constructs and adds a <see cref="LabelBuilder"/> with the provided
         ///     <see cref="FileUploadComponentBuilder"/> to the current <see cref="ModalComponentBuilder"/>.
         /// </summary>
-        /// <param name="label">The label around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="label">The label around the <see cref="FileUploadComponentBuilder"/>.</param>
         /// <param name="fileUpload">The file upload to add.</param>
-        /// <param name="description">The description around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="description">The description around the <see cref="FileUploadComponentBuilder"/>.</param>
         /// <param name="labelId">
-        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="SelectMenuBuilder"/>.
+        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="FileUploadComponentBuilder"/>.
         /// </param>
         /// <returns>The current <see cref="ModalComponentBuilder"/>.</returns>
         public ModalComponentBuilder WithFileUpload(
@@ -713,15 +723,15 @@ namespace Discord
         ///     Constructs and adds a <see cref="LabelBuilder"/> with a <see cref="FileUploadComponentBuilder"/>
         ///     to the current <see cref="ModalComponentBuilder"/>.
         /// </summary>
-        /// <param name="label">The label around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="label">The label around the <see cref="FileUploadComponentBuilder"/>.</param>
         /// <param name="customId">The custom id of the <see cref="FileUploadComponentBuilder"/>.</param>
         /// <param name="minValues">The min values of the <see cref="FileUploadComponentBuilder"/>.</param>
         /// <param name="maxValues">The max values of the <see cref="FileUploadComponentBuilder"/>.</param>
         /// <param name="isRequired">Whether the <see cref="FileUploadComponentBuilder"/> is required.</param>
         /// <param name="id">The id of the <see cref="FileUploadComponentBuilder"/>.</param>
-        /// <param name="description">The description around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="description">The description around the <see cref="FileUploadComponentBuilder"/>.</param>
         /// <param name="labelId">
-        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="SelectMenuBuilder"/>.
+        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="FileUploadComponentBuilder"/>.
         /// </param>
         /// <returns>The current <see cref="ModalComponentBuilder"/>.</returns>
         public ModalComponentBuilder WithFileUpload(
@@ -767,11 +777,11 @@ namespace Discord
         ///     Constructs and adds a <see cref="LabelBuilder"/> with the provided <see cref="TextInputBuilder"/> to
         ///     the current <see cref="ModalComponentBuilder"/>.
         /// </summary>
-        /// <param name="label">The label around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="label">The label around the <see cref="TextInputBuilder"/>.</param>
         /// <param name="textInput">The text input to add.</param>
-        /// <param name="description">The description around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="description">The description around the <see cref="TextInputBuilder"/>.</param>
         /// <param name="labelId">
-        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="SelectMenuBuilder"/>.
+        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="TextInputBuilder"/>.
         /// </param>
         /// <returns>The current <see cref="ModalComponentBuilder"/>.</returns>
         public ModalComponentBuilder WithTextInput(
@@ -823,7 +833,7 @@ namespace Discord
         ///     Constructs and adds a <see cref="LabelBuilder"/> with a <see cref="TextInputBuilder"/>
         ///     to the current <see cref="ModalComponentBuilder"/>.
         /// </summary>
-        /// <param name="label">The label around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="label">The label around the <see cref="TextInputBuilder"/>.</param>
         /// <param name="customId">The custom id of the <see cref="TextInputBuilder"/>.</param>
         /// <param name="style">The style of the <see cref="TextInputBuilder"/>.</param>
         /// <param name="placeholder">The placeholder of the <see cref="TextInputBuilder"/>.</param>
@@ -833,9 +843,9 @@ namespace Discord
         /// <param name="required">Whether the <see cref="TextInputBuilder"/> is required.</param>
         /// <param name="value">The value of the <see cref="TextInputBuilder"/>.</param>
         /// <param name="id">The id of the <see cref="TextInputBuilder"/>.</param>
-        /// <param name="description">The description around the <see cref="SelectMenuBuilder"/>.</param>
+        /// <param name="description">The description around the <see cref="TextInputBuilder"/>.</param>
         /// <param name="labelId">
-        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="SelectMenuBuilder"/>.
+        ///     The id of the <see cref="LabelBuilder"/> wrapping the <see cref="TextInputBuilder"/>.
         /// </param>
         /// <returns>The current <see cref="ModalComponentBuilder"/>.</returns>
         public ModalComponentBuilder WithTextInput(

--- a/src/Discord.Net.Rest/API/Common/SelectMenuComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/SelectMenuComponent.cs
@@ -26,6 +26,9 @@ namespace Discord.API
         [JsonProperty("max_values")]
         public int MaxValues { get; set; }
 
+        [JsonProperty("required")]
+        public bool Required { get; set; }
+
         [JsonProperty("disabled")]
         public bool Disabled { get; set; }
 
@@ -51,6 +54,7 @@ namespace Discord.API
             Placeholder = component.Placeholder;
             MinValues = component.MinValues;
             MaxValues = component.MaxValues;
+            Required = component.IsRequired;
             Disabled = component.IsDisabled;
             ChannelTypes = component.ChannelTypes.ToArray();
             DefaultValues = component.DefaultValues.Select(x => new SelectMenuDefaultValue {Id = x.Id, Type = x.Type}).ToArray();

--- a/src/Discord.Net.Rest/Extensions/MessageComponentExtension.cs
+++ b/src/Discord.Net.Rest/Extensions/MessageComponentExtension.cs
@@ -102,6 +102,7 @@ internal static class MessageComponentExtension
                     parsed.Placeholder.GetValueOrDefault(),
                     parsed.MinValues,
                     parsed.MaxValues,
+                    parsed.Required,
                     parsed.Disabled,
                     parsed.Type,
                     parsed.Id.ToNullable(),


### PR DESCRIPTION
### Description
This PR adds the `IsRequired` property to `SelectMenuBuilder` and `SelectMenuComponent`, fixes `DefaultValues` not being passed when creating select menus in some methods and fixes some xml doc in `ModalBuilder`.

### Changes
- Add `IsRequired` ´property to select menu
- Update documentation in `ModalBuilder`
- Fix usage of `DefaultValues` in some methods