### PR TITLE
Fix AutocompleteResult.Value having no length limit

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/Autocomplete/AutocompleteResult.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Autocomplete/AutocompleteResult.cs
@@ -46,6 +46,9 @@ namespace Discord
                 if (value is not string && !value.IsNumericType())
                     throw new ArgumentException($"{nameof(value)} must be a numeric type or a string! Value: \"{value}\"");
 
+                if (value is string stringValue)
+                    Preconditions.AtMost(stringValue.Length, 100, nameof(Value));
+
                 _value = value;
             }
         }


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
This PR fixes an issue where `AutocompleteResult.Value` had no precondition for its length. The [Discord API Docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-choice-structure) specify a maximum length of 100 for the `value`. This would cause issues where if the program tried to send an `AutocompleteResult` with a `Value` that's longer than 100 characters, [it would throw a `Discord.Net.HttpException` after sending a request to the server](https://github.com/discord-net/Discord.Net/issues/3182#issuecomment-3651089706), which is not ideal.

### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->
- Add AtMost Precondition for the `AutocompleteResult.Value`

### Related Issues
<!--
List issues that are related to this PR.
Example:
- resolves #6969
-->
- resolves #3182 