### PR TITLE
Added UnknownComponent classes and support

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/UnknownComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/UnknownComponent.cs
@@ -1,0 +1,34 @@
+namespace Discord;
+
+/// <summary>
+///     Represents an unknown message component type that Discord has sent but is not yet supported by the library.
+/// </summary>
+public class UnknownComponent : IMessageComponent
+{
+    /// <summary>
+    ///     Gets the raw component type value from Discord.
+    /// </summary>
+    public int RawType { get; }
+
+    /// <inheritdoc/>
+    public ComponentType Type => (ComponentType)RawType;
+
+    /// <inheritdoc/>
+    public int? Id { get; }
+
+    /// <summary>
+    ///     Gets the raw JSON data of this component.
+    /// </summary>
+    public string RawJson { get; }
+
+    internal UnknownComponent(int rawType, string rawJson, int? id = null)
+    {
+        RawType = rawType;
+        RawJson = rawJson;
+        Id = id;
+    }
+
+    /// <inheritdoc />
+    IMessageComponentBuilder IMessageComponent.ToBuilder()
+        => throw new System.NotSupportedException("Unknown components cannot be converted to builders.");
+}

--- a/src/Discord.Net.Rest/API/Common/UnknownComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/UnknownComponent.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class UnknownComponent : IMessageComponent
+    {
+        [JsonProperty("type")]
+        public int RawType { get; set; }
+
+        public ComponentType Type => (ComponentType)RawType;
+
+        [JsonProperty("id")]
+        public Optional<int> Id { get; set; }
+
+        int? IMessageComponent.Id => Id.ToNullable();
+
+        public string RawJson { get; set; }
+
+        public UnknownComponent() { }
+
+        /// <inheritdoc />
+        IMessageComponentBuilder IMessageComponent.ToBuilder()
+            => throw new System.NotSupportedException("Unknown components cannot be converted to builders.");
+    }
+}

--- a/src/Discord.Net.Rest/Extensions/MessageComponentExtension.cs
+++ b/src/Discord.Net.Rest/Extensions/MessageComponentExtension.cs
@@ -47,6 +47,9 @@ internal static class MessageComponentExtension
 
             case FileUploadComponent fileUpload:
                 return new API.FileUploadComponent(fileUpload);
+
+            case UnknownComponent unknown:
+                return new API.UnknownComponent { RawType = unknown.RawType, RawJson = unknown.RawJson, Id = unknown.Id ?? Optional<int>.Unspecified };
         }
 
         return null;
@@ -197,7 +200,11 @@ internal static class MessageComponentExtension
             }
 
             default:
+            {
+                if (component is API.UnknownComponent unknown)
+                    return new UnknownComponent(unknown.RawType, unknown.RawJson, unknown.Id.ToNullable());
                 return null;
+            }
         }
     }
 

--- a/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
@@ -69,7 +69,8 @@ namespace Discord.Net.Converters
                     messageComponent = new API.FileUploadComponent();
                     break;
                 default:
-                    throw new JsonSerializationException($"Unknown component type value '{typeProperty}' while deserializing message component");
+                    messageComponent = new API.UnknownComponent { RawType = typeProperty, RawJson = jsonObject.ToString() };
+                    break;
             }
             serializer.Populate(jsonObject.CreateReader(), messageComponent);
             return messageComponent;


### PR DESCRIPTION
### Description
Added UnknownComponent classes, and support to MessageComponentConverter and MessageComponentExtensions

### Changes
Added UnknownComponent classes, and support to MessageComponentConverter and MessageComponentExtensions. UnknownComponent classes retain their original types as `RawType`, and retain the JSON as `RawJson`.

### Related Issues
Resolves #3205. Minimally tested (it works in my local environment which broke prior to this change).
