### PR TITLE
Switch lock backport package to #if defs instead

### DIFF
--- a/src/Discord.Net.Commands/Map/CommandMapNode.cs
+++ b/src/Discord.Net.Commands/Map/CommandMapNode.cs
@@ -12,7 +12,11 @@ namespace Discord.Commands
 
         private readonly ConcurrentDictionary<string, CommandMapNode> _nodes;
         private readonly string _name;
+#if NET9_0_OR_GREATER
         private readonly Lock _lockObj = new();
+#else
+        private readonly object _lockObj = new();
+#endif
         private ImmutableArray<CommandInfo> _commands;
 
         public bool IsEmpty => _commands.Length == 0 && _nodes.Count == 0;

--- a/src/Discord.Net.Core/Discord.Net.Core.csproj
+++ b/src/Discord.Net.Core/Discord.Net.Core.csproj
@@ -19,9 +19,5 @@
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Include="Backport.System.Threading.Lock" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>analyzers</IncludeAssets>
-    </PackageReference>  
   </ItemGroup>
 </Project>

--- a/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBase.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/CommandBase/RestCommandBase.cs
@@ -33,7 +33,11 @@ namespace Discord.Rest
         /// </summary>
         internal new RestCommandBaseData Data { get; private set; }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
 
         internal RestCommandBase(DiscordRestClient client, Model model)
             : base(client, model.Id)

--- a/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
@@ -25,7 +25,11 @@ namespace Discord.Rest
         /// <inheritdoc cref="IComponentInteraction.Message"/>
         public RestUserMessage Message { get; private set; }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
 
         internal RestMessageComponent(BaseDiscordClient client, Model model)
             : base(client, model.Id)
@@ -457,7 +461,7 @@ namespace Discord.Rest
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="ephemeral"></param>
         /// <param name="options"></param>

--- a/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/Modals/RestModal.cs
@@ -42,7 +42,11 @@ namespace Discord.Rest
             return entity;
         }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
 
         /// <summary>
         ///     Acknowledges this interaction with the <see cref="InteractionResponseType.DeferredUpdateMessage"/> if the modal was created
@@ -139,7 +143,7 @@ namespace Discord.Rest
             MessageComponent component = null,
             Embed embed = null,
             RequestOptions options = null,
-            PollProperties poll = null, 
+            PollProperties poll = null,
             MessageFlags flags = MessageFlags.None)
         {
             if (!IsValidToken)

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
@@ -20,7 +20,11 @@ namespace Discord.Rest
         /// </summary>
         public new RestAutocompleteInteractionData Data { get; }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
 
         internal RestAutocompleteInteraction(DiscordRestClient client, Model model)
             : base(client, model.Id)

--- a/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
+++ b/src/Discord.Net.Rest/Net/Queue/RequestQueueBucket.cs
@@ -17,7 +17,11 @@ namespace Discord.Net.Queue
     {
         private const int MinimumSleepTimeMs = 750;
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock;
+#else
+        private readonly object _lock;
+#endif
         private readonly RequestQueue _queue;
         private int _semaphore;
         private DateTimeOffset? _resetTick;

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -21,7 +21,11 @@ namespace Discord.WebSocket
         private ImmutableArray<StickerPack<SocketSticker>> _defaultStickers;
         private int _totalShards;
         private SemaphoreSlim[] _identifySemaphores;
+#if NET9_0_OR_GREATER
         private readonly Lock _semaphoreResetLock;
+#else
+        private readonly object _semaphoreResetLock;
+#endif
         private Task _semaphoreResetTask;
 
         private bool _isDisposed;
@@ -524,7 +528,7 @@ namespace Discord.WebSocket
             client.AuditLogCreated += (arg1, arg2) => _auditLogCreated.InvokeAsync(arg1, arg2);
 
             client.VoiceChannelStatusUpdated += (arg1, arg2, arg3) => _voiceChannelStatusUpdated.InvokeAsync(arg1, arg2, arg3);
-            
+
             client.EntitlementCreated += (arg1) => _entitlementCreated.InvokeAsync(arg1);
             client.EntitlementUpdated += (arg1, arg2) => _entitlementUpdated.InvokeAsync(arg1, arg2);
             client.EntitlementDeleted += (arg1) => _entitlementDeleted.InvokeAsync(arg1);

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -111,8 +111,13 @@ namespace Discord.WebSocket
 
         private bool _usersDownloaded;
 
+#if NET9_0_OR_GREATER
         private readonly Lock _downloadLock = new();
         private readonly Lock _ownerLock = new();
+#else
+        private readonly object _downloadLock = new();
+        private readonly object _ownerLock = new();
+#endif
 
         private ulong _ownerId;
 

--- a/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
@@ -21,11 +21,15 @@ namespace Discord.WebSocket
         ///     Gets the data received with this interaction, contains the button that was clicked.
         /// </summary>
         public new SocketMessageComponentData Data { get; }
-        
+
         /// <inheritdoc cref="IComponentInteraction.Message"/>
         public SocketUserMessage Message { get; private set; }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
         public override bool HasResponded { get; internal set; } = false;
 
         internal SocketMessageComponent(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
@@ -359,7 +363,7 @@ namespace Discord.WebSocket
                 flags |= MessageFlags.Ephemeral;
 
             Preconditions.ValidateMessageFlags(flags);
-                
+
 
             var args = new API.Rest.CreateWebhookMessageParams
             {

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Modals/SocketModal.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Modals/SocketModal.cs
@@ -67,7 +67,11 @@ namespace Discord.WebSocket
 
         /// <inheritdoc/>
         public override bool HasResponded { get; internal set; }
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
 
         /// <inheritdoc/>
         public override async Task RespondWithFilesAsync(
@@ -440,7 +444,7 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc/>
-        /// <remarks>     
+        /// <remarks>
         ///     Acknowledges this interaction with the <see cref="InteractionResponseType.DeferredUpdateMessage"/> if the modal was created
         ///     in a response to a message component interaction, <see cref="InteractionResponseType.DeferredChannelMessageWithSource"/> otherwise.
         /// </remarks>

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
@@ -22,7 +22,11 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public override bool HasResponded { get; internal set; }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
 
         internal SocketAutocompleteInteraction(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
             : base(client, model.Id, channel, user)

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
@@ -36,7 +36,11 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public override bool HasResponded { get; internal set; }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
 
         internal SocketCommandBase(DiscordSocketClient client, Model model, ISocketMessageChannel channel, SocketUser user)
             : base(client, model.Id, channel, user)

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
@@ -32,7 +32,11 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         internal override SocketGlobalUser GlobalUser { get => this; set => throw new NotImplementedException(); }
 
+#if NET9_0_OR_GREATER
         private readonly Lock _lockObj = new();
+#else
+        private readonly object _lockObj = new();
+#endif
         private ushort _references;
 
         private SocketGlobalUser(DiscordSocketClient discord, ulong id)


### PR DESCRIPTION
The addition of a new package and the details surrounding that new package somewhat irks me, so this PR removes said new package and replaces it with some simple `#if NET9_0_OR_GREATER`s. Should accomplish the same thing but without adding new stuff to the csproj.