### PR TITLE
Fix forum CreatePostWithFileAsync with V2 components

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -211,8 +211,10 @@ namespace Discord.Rest
                 Preconditions.AtMost(stickers.Length, 3, nameof(stickers), "A max of 3 stickers are allowed.");
             }
 
-            if (flags is not MessageFlags.None and not MessageFlags.SuppressEmbeds)
-                throw new ArgumentException("The only valid MessageFlags are SuppressEmbeds and none.", nameof(flags));
+            if (components?.Components?.Any(x => x.Type != ComponentType.ActionRow) ?? false)
+                flags |= MessageFlags.ComponentsV2;
+
+            Preconditions.ValidateMessageFlags(flags);
 
             if (channel.Flags.HasFlag(ChannelFlags.RequireTag))
             {


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
Fixes forum post creation with attachments when using Components V2

### Changes
- Set MessageFlags.ComponentsV2 when a non-actionrow comp is used.
- Replaced flag validation with Preconditions.ValidateMessageFlags
