### PR TITLE
Update voice encryption to support Discord's new AEAD modes

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -63,6 +63,7 @@ namespace Discord.Audio
         public int UdpLatency { get; private set; }
         public ulong ChannelId { get; internal set; }
         internal byte[] SecretKey { get; private set; }
+        internal VoiceEncryptionMode EncryptionMode => ApiClient.EncryptionMode;
         internal bool IsFinished { get; private set; }
 
         private DiscordSocketClient Discord => Guild.Discord;
@@ -321,8 +322,9 @@ namespace Discord.Audio
 
                             _ssrc = data.SSRC;
 
-                            if (!data.Modes.Contains(DiscordVoiceAPIClient.Mode))
-                                throw new InvalidOperationException($"Discord does not support {DiscordVoiceAPIClient.Mode}. Available modes: {string.Join(", ", data.Modes)}");
+                            // Select the best encryption mode from available modes
+                            ApiClient.SelectEncryptionMode(data.Modes);
+                            await _audioLogger.DebugAsync($"Selected encryption mode: {ApiClient.Mode}").ConfigureAwait(false);
 
                             ApiClient.SetUdpEndpoint(data.Ip, data.Port);
                             await ApiClient.SendDiscoveryAsync(_ssrc).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/Audio/Sodium/SecretBox.cs
+++ b/src/Discord.Net.WebSocket/Audio/Sodium/SecretBox.cs
@@ -1,28 +1,123 @@
+using System;
 using System.Runtime.InteropServices;
 using System.Security;
 
 namespace Discord.Audio
 {
+    /// <summary>
+    ///     Specifies the encryption mode used for voice data.
+    /// </summary>
+    public enum VoiceEncryptionMode
+    {
+        /// <summary>
+        ///     AES256-GCM encryption with RTP size header.
+        ///     Preferred when hardware acceleration is available.
+        /// </summary>
+        Aes256Gcm,
+
+        /// <summary>
+        ///     XChaCha20-Poly1305 encryption with RTP size header.
+        ///     Always available, used as fallback.
+        /// </summary>
+        XChaCha20Poly1305
+    }
+
+    /// <summary>
+    ///     Provides AEAD encryption functions using libsodium.
+    /// </summary>
     public unsafe static class SecretBox
     {
+        // XChaCha20-Poly1305 constants
+        public const int XChaCha20NonceSize = 24;
+        public const int XChaCha20TagSize = 16;
+
+        // AES256-GCM constants
+        public const int Aes256GcmNonceSize = 12;
+        public const int Aes256GcmTagSize = 16;
+
+        // Nonce counter size (appended to packet)
+        public const int NonceCounterSize = 4;
+
+        #region XChaCha20-Poly1305
         [DllImport("libsodium", EntryPoint = "crypto_aead_xchacha20poly1305_ietf_encrypt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int Encrypt(byte* ciphertext, out ulong ciphertextLength, byte* message, ulong messageLength, byte* ad, ulong adLength, byte* nsec, byte[] nonce, byte[] key);
+        private static extern int XChaCha20Encrypt(byte* ciphertext, out ulong ciphertextLength, byte* message, ulong messageLength, byte* ad, ulong adLength, byte* nsec, byte[] nonce, byte[] key);
 
         [DllImport("libsodium", EntryPoint = "crypto_aead_xchacha20poly1305_ietf_decrypt", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int Decrypt(byte* plaintext, out ulong plaintextLength, byte* nsec, byte* ciphertext, ulong ciphertextLength, byte* ad, ulong adLength, byte[] nonce, byte[] key);
+        private static extern int XChaCha20Decrypt(byte* plaintext, out ulong plaintextLength, byte* nsec, byte* ciphertext, ulong ciphertextLength, byte* ad, ulong adLength, byte[] nonce, byte[] key);
+        #endregion
 
-        public static int Encrypt(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, byte[] header, byte[] nonce, byte[] key)
+        #region AES256-GCM
+        [DllImport("libsodium", EntryPoint = "crypto_aead_aes256gcm_is_available", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int Aes256GcmIsAvailable();
+
+        [DllImport("libsodium", EntryPoint = "crypto_aead_aes256gcm_encrypt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int Aes256GcmEncrypt(byte* ciphertext, out ulong ciphertextLength, byte* message, ulong messageLength, byte* ad, ulong adLength, byte* nsec, byte[] nonce, byte[] key);
+
+        [DllImport("libsodium", EntryPoint = "crypto_aead_aes256gcm_decrypt", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int Aes256GcmDecrypt(byte* plaintext, out ulong plaintextLength, byte* nsec, byte* ciphertext, ulong ciphertextLength, byte* ad, ulong adLength, byte[] nonce, byte[] key);
+        #endregion
+
+        #region Sodium init
+        [DllImport("libsodium", EntryPoint = "sodium_init", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int SodiumInit();
+
+        private static bool _initialized;
+        private static bool? _aes256GcmAvailable;
+
+        private static void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                SodiumInit();
+                _initialized = true;
+            }
+        }
+
+        /// <summary>
+        ///     Checks if AES256-GCM hardware acceleration is available.
+        /// </summary>
+        /// <returns><c>true</c> if AES256-GCM is available; otherwise, <c>false</c>.</returns>
+        public static bool IsAes256GcmAvailable()
+        {
+            if (_aes256GcmAvailable.HasValue)
+                return _aes256GcmAvailable.Value;
+
+            EnsureInitialized();
+            _aes256GcmAvailable = Aes256GcmIsAvailable() == 1;
+            return _aes256GcmAvailable.Value;
+        }
+        #endregion
+
+        /// <summary>
+        ///     Encrypts data using the specified encryption mode.
+        /// </summary>
+        public static int Encrypt(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, byte[] header, byte[] nonce, byte[] key, VoiceEncryptionMode mode)
         {
             fixed (byte* inPtr = input)
             fixed (byte* outPtr = output)
             fixed (byte* adPtr = header)
             {
-                int error = Encrypt(
-                    outPtr + outputOffset, out ulong cipherLen,
-                    inPtr + inputOffset, (ulong)inputLength,
-                    adPtr, (ulong)header.Length,
-                    null, nonce, key
-                );
+                int error;
+                ulong cipherLen;
+
+                if (mode == VoiceEncryptionMode.Aes256Gcm)
+                {
+                    error = Aes256GcmEncrypt(
+                        outPtr + outputOffset, out cipherLen,
+                        inPtr + inputOffset, (ulong)inputLength,
+                        adPtr, (ulong)header.Length,
+                        null, nonce, key
+                    );
+                }
+                else
+                {
+                    error = XChaCha20Encrypt(
+                        outPtr + outputOffset, out cipherLen,
+                        inPtr + inputOffset, (ulong)inputLength,
+                        adPtr, (ulong)header.Length,
+                        null, nonce, key
+                    );
+                }
 
                 if (error != 0)
                     throw new SecurityException($"Sodium AEAD Error: {error}");
@@ -31,25 +126,85 @@ namespace Discord.Audio
             }
         }
 
-        public static int Decrypt(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, byte[] header, int headerSize, byte[] nonce, byte[] key)
+        /// <summary>
+        ///     Decrypts data using the specified encryption mode.
+        /// </summary>
+        public static int Decrypt(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, byte[] header, int headerSize, byte[] nonce, byte[] key, VoiceEncryptionMode mode)
         {
             fixed (byte* inPtr = input)
             fixed (byte* outPtr = output)
             fixed (byte* adPtr = header)
             {
-                int error = Decrypt(
-                    outPtr + outputOffset, out ulong plainLen,
-                    null,
-                    inPtr + inputOffset, (ulong)inputLength,
-                    adPtr, (ulong)headerSize,
-                    nonce, key
-                );
+                int error;
+                ulong plainLen;
+
+                if (mode == VoiceEncryptionMode.Aes256Gcm)
+                {
+                    error = Aes256GcmDecrypt(
+                        outPtr + outputOffset, out plainLen,
+                        null,
+                        inPtr + inputOffset, (ulong)inputLength,
+                        adPtr, (ulong)headerSize,
+                        nonce, key
+                    );
+                }
+                else
+                {
+                    error = XChaCha20Decrypt(
+                        outPtr + outputOffset, out plainLen,
+                        null,
+                        inPtr + inputOffset, (ulong)inputLength,
+                        adPtr, (ulong)headerSize,
+                        nonce, key
+                    );
+                }
 
                 if (error != 0)
                     throw new SecurityException($"Sodium AEAD Decrypt Error: {error}");
 
                 return (int)plainLen;
             }
+        }
+
+        #region Legacy overloads for backwards compatibility
+        /// <summary>
+        ///     Encrypts data using XChaCha20-Poly1305 (legacy overload).
+        /// </summary>
+        public static int Encrypt(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, byte[] header, byte[] nonce, byte[] key)
+            => Encrypt(input, inputOffset, inputLength, output, outputOffset, header, nonce, key, VoiceEncryptionMode.XChaCha20Poly1305);
+
+        /// <summary>
+        ///     Decrypts data using XChaCha20-Poly1305 (legacy overload).
+        /// </summary>
+        public static int Decrypt(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, byte[] header, int headerSize, byte[] nonce, byte[] key)
+            => Decrypt(input, inputOffset, inputLength, output, outputOffset, header, headerSize, nonce, key, VoiceEncryptionMode.XChaCha20Poly1305);
+        #endregion
+
+        /// <summary>
+        ///     Gets the nonce size for the specified encryption mode.
+        /// </summary>
+        public static int GetNonceSize(VoiceEncryptionMode mode)
+            => mode == VoiceEncryptionMode.Aes256Gcm ? Aes256GcmNonceSize : XChaCha20NonceSize;
+
+        /// <summary>
+        ///     Gets the mode string for the specified encryption mode.
+        /// </summary>
+        public static string GetModeString(VoiceEncryptionMode mode)
+            => mode == VoiceEncryptionMode.Aes256Gcm
+                ? "aead_aes256_gcm_rtpsize"
+                : "aead_xchacha20_poly1305_rtpsize";
+
+        /// <summary>
+        ///     Parses a mode string to an encryption mode.
+        /// </summary>
+        public static VoiceEncryptionMode? ParseMode(string mode)
+        {
+            return mode switch
+            {
+                "aead_aes256_gcm_rtpsize" => VoiceEncryptionMode.Aes256Gcm,
+                "aead_xchacha20_poly1305_rtpsize" => VoiceEncryptionMode.XChaCha20Poly1305,
+                _ => null
+            };
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Audio/Streams/SodiumDecryptStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/SodiumDecryptStream.cs
@@ -11,13 +11,11 @@ namespace Discord.Audio.Streams
     {
         private const int RtpHeaderSize = 12;
         private const int ExtendedRtpHeaderSize = RtpHeaderSize + 4;
-        private const int NonceSize = 24;
-        private const int NonceCounterSize = 4;
 
         private readonly AudioClient _client;
         private readonly AudioStream _next;
         private readonly byte[] _rtpHeader;
-        private readonly byte[] _nonce;
+        private byte[] _nonce;
 
         public override bool CanRead => true;
         public override bool CanSeek => false;
@@ -28,7 +26,8 @@ namespace Discord.Audio.Streams
             _next = next;
             _client = (AudioClient)client;
             _rtpHeader = new byte[ExtendedRtpHeaderSize];
-            _nonce = new byte[NonceSize];
+            // Nonce will be initialized on first write based on encryption mode
+            _nonce = null;
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancelToken)
@@ -38,9 +37,22 @@ namespace Discord.Audio.Streams
             if (_client.SecretKey == null)
                 return Task.CompletedTask;
 
+            var encryptionMode = _client.EncryptionMode;
+
+            // Initialize nonce buffer based on encryption mode (lazy initialization)
+            if (_nonce == null || _nonce.Length != SecretBox.GetNonceSize(encryptionMode))
+            {
+                _nonce = new byte[SecretBox.GetNonceSize(encryptionMode)];
+            }
+            else
+            {
+                // Clear the nonce buffer
+                Array.Clear(_nonce, 0, _nonce.Length);
+            }
+
             // Extract nonce counter from the end of the payload.
-            for (int i = 0; i < NonceCounterSize; i++)
-                _nonce[i] = buffer[offset + count - NonceCounterSize + i];
+            for (int i = 0; i < SecretBox.NonceCounterSize; i++)
+                _nonce[i] = buffer[offset + count - SecretBox.NonceCounterSize + i];
 
             // Extract RTP header
             bool hasExtendedHeader = (buffer[0] & 0x10) != 0;
@@ -49,7 +61,7 @@ namespace Discord.Audio.Streams
 
             // Decrypt payload
             int payloadOffset = offset + rtpHeaderSize;
-            int payloadLength = count - offset - rtpHeaderSize - NonceCounterSize;
+            int payloadLength = count - offset - rtpHeaderSize - SecretBox.NonceCounterSize;
             int decryptedLength = SecretBox.Decrypt(
                 buffer,
                 payloadOffset,
@@ -59,7 +71,8 @@ namespace Discord.Audio.Streams
                 _rtpHeader,
                 rtpHeaderSize,
                 _nonce,
-                _client.SecretKey);
+                _client.SecretKey,
+                encryptionMode);
 
             int packageLength = rtpHeaderSize + decryptedLength;
             return _next.WriteAsync(buffer, offset, packageLength, cancelToken);

--- a/src/Discord.Net.WebSocket/Audio/Streams/SodiumEncryptStream.cs
+++ b/src/Discord.Net.WebSocket/Audio/Streams/SodiumEncryptStream.cs
@@ -10,12 +10,11 @@ namespace Discord.Audio.Streams
     public class SodiumEncryptStream : AudioOutStream
     {
         private const int RtpHeaderSize = 12;
-        private const int NonceSize = 24;
 
         private readonly AudioClient _client;
         private readonly AudioStream _next;
         private readonly byte[] _rtpHeader;
-        private readonly byte[] _nonce;
+        private byte[] _nonce;
         private bool _hasHeader;
         private ushort _nextSeq;
         private uint _nextTimestamp;
@@ -26,7 +25,8 @@ namespace Discord.Audio.Streams
             _next = next;
             _client = (AudioClient)client;
             _rtpHeader = new byte[RtpHeaderSize];
-            _nonce = new byte[NonceSize];
+            // Nonce will be initialized on first write based on encryption mode
+            _nonce = null;
             _nonceCounter = 0;
         }
 
@@ -53,11 +53,19 @@ namespace Discord.Audio.Streams
             if (_client.SecretKey == null)
                 return;
 
+            var encryptionMode = _client.EncryptionMode;
+
+            // Initialize nonce buffer based on encryption mode (lazy initialization)
+            if (_nonce == null || _nonce.Length != SecretBox.GetNonceSize(encryptionMode))
+            {
+                _nonce = new byte[SecretBox.GetNonceSize(encryptionMode)];
+            }
+
             // The first bytes of the nonce are the counter in big-endian.
             byte[] counterBytes = BitConverter.GetBytes(_nonceCounter);
             if (BitConverter.IsLittleEndian)
                 Array.Reverse(counterBytes); // big-endian
-            Buffer.BlockCopy(counterBytes, offset, _nonce, 0, counterBytes.Length);
+            Buffer.BlockCopy(counterBytes, 0, _nonce, 0, counterBytes.Length);
             if (++_nonceCounter >= uint.MaxValue)
                 _nonceCounter = 0;
 
@@ -73,9 +81,10 @@ namespace Discord.Audio.Streams
                 payloadOffset,
                 _rtpHeader,
                 _nonce,
-                _client.SecretKey);
+                _client.SecretKey,
+                encryptionMode);
 
-            // Append nonce to encripted payload
+            // Append nonce counter to encrypted payload
             Buffer.BlockCopy(counterBytes, 0, buffer, payloadOffset + encryptedLength, counterBytes.Length);
             int packageLength = _rtpHeader.Length + encryptedLength + counterBytes.Length;
 

--- a/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
@@ -19,7 +19,41 @@ namespace Discord.Audio
     {
         #region DiscordVoiceAPIClient
         public const int MaxBitrate = 128 * 1024;
-        public const string Mode = "aead_xchacha20_poly1305_rtpsize";
+
+        /// <summary>
+        ///     The currently selected encryption mode.
+        /// </summary>
+        public VoiceEncryptionMode EncryptionMode { get; private set; } = VoiceEncryptionMode.XChaCha20Poly1305;
+
+        /// <summary>
+        ///     Gets the mode string for the current encryption mode.
+        /// </summary>
+        public string Mode => SecretBox.GetModeString(EncryptionMode);
+
+        /// <summary>
+        ///     Selects the best encryption mode from the available modes.
+        ///     Prefers AES256-GCM when hardware acceleration is available.
+        /// </summary>
+        public void SelectEncryptionMode(string[] availableModes)
+        {
+            // Prefer AES256-GCM if hardware acceleration is available
+            if (SecretBox.IsAes256GcmAvailable() &&
+                Array.Exists(availableModes, m => m == "aead_aes256_gcm_rtpsize"))
+            {
+                EncryptionMode = VoiceEncryptionMode.Aes256Gcm;
+                return;
+            }
+
+            // Fall back to XChaCha20-Poly1305 (always available)
+            if (Array.Exists(availableModes, m => m == "aead_xchacha20_poly1305_rtpsize"))
+            {
+                EncryptionMode = VoiceEncryptionMode.XChaCha20Poly1305;
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"Discord does not support any compatible encryption modes. Available modes: {string.Join(", ", availableModes)}");
+        }
 
         public event Func<string, string, double, Task> SentRequest { add { _sentRequestEvent.Add(value); } remove { _sentRequestEvent.Remove(value); } }
         private readonly AsyncEvent<Func<string, string, double, Task>> _sentRequestEvent = new AsyncEvent<Func<string, string, double, Task>>();


### PR DESCRIPTION
- Add support for aead_aes256_gcm_rtpsize encryption mode
- Automatically prefer AES256-GCM when hardware acceleration is available
- Fall back to aead_xchacha20_poly1305_rtpsize (always supported)
- Fix nonce construction bug in SodiumEncryptStream
- Add VoiceEncryptionMode enum and dynamic mode selection
- Update SecretBox with hardware availability detection

Discord deprecated all xsalsa20_poly1305 modes in November 2024. The new rtpsize modes use the RTP header as additional authenticated data (AAD) and append a 4-byte nonce counter to the encrypted payload.

https://claude.ai/code/session_01STu3iSjn9J3FNLSMq5F18a

<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
<!-- A brief explanation of changes made in this PR. -->

### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->

### Related Issues
<!--
List issues that are related to this PR.
Example:
- resolves #6969
-->
