### PR TITLE
Remove unnecessary checks for content in `ModifyAsync`

### DIFF
--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -38,17 +38,6 @@ namespace Discord.Rest
             var embed = args.Embed;
             var embeds = args.Embeds;
 
-            bool hasText = args.Content.IsSpecified && !string.IsNullOrEmpty(args.Content.Value);
-            bool hasEmbeds = embed is { IsSpecified: true, Value: not null }
-                             || embeds is { IsSpecified: true, Value.Length: > 0 };
-            bool hasComponents = args.Components is { IsSpecified: true, Value: not null };
-            bool hasAttachments = args.Attachments.IsSpecified;
-            bool hasFlags = args.Flags.IsSpecified;
-
-            // No content needed if modifying flags
-            if ((!hasComponents && !hasText && !hasEmbeds && !hasAttachments) && !hasFlags)
-                Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
-
             if (args.AllowedMentions.IsSpecified)
             {
                 var allowedMentions = args.AllowedMentions.Value;


### PR DESCRIPTION
these checks make no sense in the current lib design, since the `ModifyAsync` has no information about the current state of the message. and just setting a property to `null` is a valid action