### PR TITLE
Fix voice receive: wrong port in SelectProtocol + missing DAVE decrypt layer on early streams

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -599,9 +599,11 @@ namespace Discord.Audio
                     }
 
                     string ip;
+                    ushort externalPort;
                     try
                     {
                         ip = Encoding.UTF8.GetString(packet, 8, 74 - 10).TrimEnd('\0');
+                        externalPort = (ushort)((packet[72] << 8) | packet[73]);
                     }
                     catch (Exception ex)
                     {
@@ -609,8 +611,8 @@ namespace Discord.Audio
                         return;
                     }
 
-                    await _audioLogger.DebugAsync("Received Discovery").ConfigureAwait(false);
-                    await ApiClient.SendSelectProtocol(ip).ConfigureAwait(false);
+                    await _audioLogger.DebugAsync($"Received Discovery (ip={ip}, externalPort={externalPort}, localPort={ApiClient.UdpPort})").ConfigureAwait(false);
+                    await ApiClient.SendSelectProtocol(ip, externalPort).ConfigureAwait(false);
                 }
                 else if (_connection.State == ConnectionState.Connected)
                 {

--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -379,7 +379,8 @@ namespace Discord.Audio
 
                 AudioOutStream opusDecoder = new OpusDecodeStream(readerStream); //Passes header
 
-                if (_dave is not null)
+                var hasDave = _dave is not null;
+                if (hasDave)
                 {
                     opusDecoder = new DaveDecryptStream(
                         this,
@@ -396,6 +397,7 @@ namespace Discord.Audio
 
                 _streams.TryAdd(userId, new StreamPair(readerStream, decryptStream));
 
+                await _audioLogger.DebugAsync($"Created input stream for user {userId} (dave={hasDave})");
                 await _streamCreatedEvent.InvokeAsync(userId, readerStream);
             }
         }
@@ -427,6 +429,35 @@ namespace Discord.Audio
 
             _ssrcMap.Clear();
             _streams.Clear();
+        }
+
+        /// <summary>
+        ///     Rebuilds all existing input streams to include the DAVE decrypt layer.
+        ///     Called after the initial DAVE transition completes since streams may have
+        ///     been created before the DaveSessionManager was initialized.
+        /// </summary>
+        internal async Task RebuildInputStreamsForDaveAsync()
+        {
+            if (_dave is null) return;
+
+            var existingUsers = _streams.Keys.ToArray();
+            if (existingUsers.Length == 0) return;
+
+            await _audioLogger.DebugAsync($"Rebuilding {existingUsers.Length} input stream(s) with DAVE decrypt layer");
+
+            foreach (var userId in existingUsers)
+            {
+                if (_streams.TryRemove(userId, out var pair))
+                {
+                    await _streamDestroyedEvent.InvokeAsync(userId).ConfigureAwait(false);
+                    await pair.Reader.DisposeAsync();
+                }
+            }
+
+            foreach (var userId in existingUsers)
+            {
+                await CreateInputStreamAsync(userId);
+            }
         }
 
         #endregion

--- a/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
+++ b/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
@@ -213,6 +213,10 @@ internal sealed class DaveSessionManager : IDisposable
 
             if (protocolVersion is not Dave.DisabledProtocolVersion && !ratchet.IsNull)
                 Encryptor.Ratchet = ratchet;
+
+            // Streams created before DAVE was initialized lack the DaveDecryptStream layer.
+            // Rebuild them now that keys are ready.
+            await _client.RebuildInputStreamsForDaveAsync();
         }
         else
         {

--- a/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordVoiceApiClient.cs
@@ -164,7 +164,7 @@ namespace Discord.Audio
             });
         }
 
-        public Task SendSelectProtocol(string externalIp)
+        public Task SendSelectProtocol(string externalIp, ushort externalPort)
         {
             return SendAsync(VoiceOpCode.SelectProtocol, new SelectProtocolParams
             {
@@ -172,7 +172,7 @@ namespace Discord.Audio
                 Data = new UdpProtocolInfo
                 {
                     Address = externalIp,
-                    Port = UdpPort,
+                    Port = externalPort,
                     Mode = Mode
                 }
             });


### PR DESCRIPTION
Ran into two issues getting audio receive to work on this branch:

**1. SelectProtocol sends local port instead of external port**

UDP discovery gives back the external IP and port as seen by the voice server, but `SendSelectProtocol` was passing `UdpPort` (local socket port) instead of the external port from the discovery bytes. Works fine without NAT since they're the same, but behind NAT the voice server ends up sending audio to the wrong port.

Fix: extract external port from bytes 72-73 of the discovery response and pass it through.

**2. Input streams created before DAVE is ready**

`RepopulateAudioStreamsAsync` fires `StreamCreated` before `OnConnectingAsync` sets up the `DaveSessionManager`, so the initial input streams get built without `DaveDecryptStream` in the pipeline. Once MLS finishes and audio starts flowing, the still-encrypted frames hit `OpusDecodeStream` directly → `InvalidPacket`.

Fix: added `RebuildInputStreamsForDaveAsync` on `AudioClient` — tears down existing streams and recreates them with the DAVE layer once the initial key exchange completes (`PrepareProtocolTransitionAsync` with `InitTransitionId`).

**Tested with:**
- Voice connection behind NAT
- Full receive pipeline working: sodium → RTP → DAVE decrypt → opus → PCM (322 frames decrypted, 1 failed on the very first unencrypted frame)
- Streams correctly go from `dave=False` → rebuild → `dave=True`