### PR TITLE
Fix: Empty VC & leave/rejoin causes no audio to be heard/played from libdave

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/AudioClient.cs
+++ b/src/Discord.Net.WebSocket/Audio/AudioClient.cs
@@ -384,7 +384,7 @@ namespace Discord.Audio
                 {
                     opusDecoder = new DaveDecryptStream(
                         this,
-                        _dave.GetDecryptor(userId),
+                        _dave.GetOrCreateDecryptor(userId),
                         opusDecoder,
                         Discord.LogManager.CreateLogger($"Dave decrypt stream {userId}"),
                         userId
@@ -534,7 +534,7 @@ namespace Discord.Audio
                     {
                         var data = ((JToken)payload).ToObject<SpeakingEvent>(_serializer);
                         _ssrcMap.AddClient(data.Ssrc, data.UserId, data.Speaking);
-                        _dave?.AddUser(data.UserId);
+                        _dave?.GetOrCreateDecryptor(data.UserId);
 
                         await _speakingUpdatedEvent.InvokeAsync(data.UserId, data.Speaking);
                         break;
@@ -549,7 +549,10 @@ namespace Discord.Audio
                         if (data?.UserIds is not null)
                         {
                             for (var i = 0; i < data.UserIds.Length; i++)
-                                _dave.AddUser(data.UserIds[i]);
+                            {
+                                await _audioLogger.DebugAsync($"New client connected: {data.UserIds[i]}");
+                                _dave.GetOrCreateDecryptor(data.UserIds[i]);
+                            }
                         }
 
                         break;

--- a/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
+++ b/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
@@ -36,6 +36,18 @@ internal sealed class DaveSessionManager : IDisposable
         _preparedTransitions = [];
         _session = Dave.CreateSession();
         Encryptor = Dave.CreateEncryptor();
+
+        /*
+         * TODO: ask staff about correct ways of handling empty VCs
+         *
+         * When the client connects to an empty voice channel, no protocol transition occurs, leaving the encryptor
+         * without a ratchet. This causes the encrypt method to fail.
+         *
+         * By setting passthrough mode to 'true' before doing any protocol operations ensures that we don't try to
+         * encrypt anything before we've set up all the cogs.
+         */
+        Encryptor.IsInPassthroughMode = true;
+
         _logger = client.Discord.LogManager.CreateLogger($"Dave #{clientId}");
 
         _session.OnMLSFailure += (source, reason) =>
@@ -51,25 +63,26 @@ internal sealed class DaveSessionManager : IDisposable
         };
     }
 
-    public DaveDecryptor GetDecryptor(ulong userId)
-        => _decryptors.GetOrAdd(
+    public DaveDecryptor GetOrCreateDecryptor(ulong userId)
+    {
+        var decryptor = _decryptors.GetOrAdd(
             userId,
             _ => Dave.CreateDecryptor()
         );
+
+        /*
+         * ensure the decryptor is configured correctly for the sessions state, this deals with updating the passthrough
+         * mode and the decryptors key ratchet.
+         */
+        decryptor.PrepareTransition(_session, userId, _session.ProtocolVersion);
+
+        return decryptor;
+    }
 
     public void AssignSsrc(uint ssrc)
     {
         // TODO: hardcode opus here?
         Encryptor.AssignSsrcToCodec(ssrc, Codec.Opus);
-    }
-
-    public void AddUser(ulong userId)
-    {
-        _decryptors.AddOrUpdate(
-            userId,
-            _ => Dave.CreateDecryptor(),
-            (_, existing) => existing
-        );
     }
 
     public bool RemoveUser(ulong id)
@@ -148,6 +161,13 @@ internal sealed class DaveSessionManager : IDisposable
 
     private async ValueTask OnDaveMLSProposalsAsync(ReadOnlyMemory<byte> payload)
     {
+        if (_logger.Level is LogSeverity.Debug)
+        {
+            await _logger.DebugAsync(
+                $"Processing MLS proposal; our users: [{string.Join(", ", _decryptors.Keys)}]"
+            );
+        }
+
         using var result = _session.ProcessProposals(
             payload,
             _decryptors.Keys
@@ -232,8 +252,6 @@ internal sealed class DaveSessionManager : IDisposable
         if (protocolVersion > Dave.DisabledProtocolVersion)
         {
             await HandlePrepareEpochAsync(Dave.MLSNewGroupExpectedEpoch, protocolVersion);
-            using var keyPackage = _session.GetMarshalledKeyPackage();
-            await SendMLSKeyPackageAsync(keyPackage.ToMemory());
         }
         else
         {
@@ -253,6 +271,9 @@ internal sealed class DaveSessionManager : IDisposable
             _client.ChannelId,
             SelfUserId
         );
+
+        using var keyPackage = _session.GetMarshalledKeyPackage();
+        await SendMLSKeyPackageAsync(keyPackage.ToMemory());
     }
 
     public async Task ExecuteProtocolTransitionAsync(ushort transitionId)


### PR DESCRIPTION
## Summary

There were a few issues with the new libdave implementation related to playing audio in an empty VC and when users leave/rejoin

### Empty VC causes audio to fail to be encrypted/sent
Fixed by setting the encryptors pass through mode to true when a session is first created, this causes any attempts at encryption before proper initialization to just not happen, fixing a case where the stream would fail with `MissingKeyRatchet`.

### Users joining/leaving leads to no audio heard
Fixed by sending MLS key packages on prepare epoch, like the spec says to, as well as syncing a new users decryptor to the latest sessions state.