### PR TITLE
add support for enhanced role colors ( gradient and holograpic )

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/GuildFeature.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildFeature.cs
@@ -30,6 +30,11 @@ namespace Discord
         Banner = 1L << 2,
 
         /// <summary>
+        ///     The guild is able to set gradient role colors.
+        /// </summary>
+        EnhancedRoleColors = 1L << 48,
+
+        /// <summary>
         ///     The guild has access to channel banners.
         /// </summary>
         ChannelBanner = 1L << 3,

--- a/src/Discord.Net.Core/Entities/Guilds/GuildFeatures.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildFeatures.cs
@@ -83,6 +83,12 @@ namespace Discord
             => HasFeature(GuildFeature.RoleIcons);
 
         /// <summary>
+        ///     Gets whether or not this server has enhanced role colors enabled.
+        /// </summary>
+        public bool HasEnhancedRoleColors
+            => HasFeature(GuildFeature.EnhancedRoleColors);
+
+        /// <summary>
         ///     Gets whether or not this server has private threads enabled.
         /// </summary>
         public bool HasPrivateThreads

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -977,11 +977,8 @@ namespace Discord
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
-        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, RequestOptions options = null);
-        /// <summary>
-        ///     Creates a new role with the provided role colors.
-        /// </summary>
-        Task<IRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = null, bool isHoisted = false, RequestOptions options = null);
+        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, RoleColors? color = null, bool isHoisted = false, RequestOptions options = null);
+
         // TODO remove CreateRoleAsync overload that does not have isMentionable when breaking change is acceptable
         /// <summary>
         ///     Creates a new role with the provided name.
@@ -998,11 +995,7 @@ namespace Discord
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
-        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null);
-        /// <summary>
-        ///     Creates a new role with the provided role colors.
-        /// </summary>
-        Task<IRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = null, bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null);
+        Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, RoleColors? color = null, bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null);
 
         /// <summary>
         ///     Adds a user to this guild.

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -978,6 +978,10 @@ namespace Discord
         ///     role.
         /// </returns>
         Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, RequestOptions options = null);
+        /// <summary>
+        ///     Creates a new role with the provided role colors.
+        /// </summary>
+        Task<IRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = null, bool isHoisted = false, RequestOptions options = null);
         // TODO remove CreateRoleAsync overload that does not have isMentionable when breaking change is acceptable
         /// <summary>
         ///     Creates a new role with the provided name.
@@ -995,6 +999,10 @@ namespace Discord
         ///     role.
         /// </returns>
         Task<IRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, Color? color = null, bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null);
+        /// <summary>
+        ///     Creates a new role with the provided role colors.
+        /// </summary>
+        Task<IRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = null, bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null);
 
         /// <summary>
         ///     Adds a user to this guild.

--- a/src/Discord.Net.Core/Entities/Roles/Color.cs
+++ b/src/Discord.Net.Core/Entities/Roles/Color.cs
@@ -200,6 +200,11 @@ namespace Discord
         public static implicit operator uint(Color color)
             => color.RawValue;
 
+        public static implicit operator uint?(Color? color)
+            => color?.RawValue;
+
+        public static implicit operator Color?(uint? raw) => raw.HasValue ? raw.Value : null;
+
         /// <summary>
         ///     Converts the string representation of a color to a Color object.
         /// </summary>
@@ -228,7 +233,7 @@ namespace Discord
 
             if (string.IsNullOrWhiteSpace(rawValue))
                 return false;
-            
+
             rawValue = rawValue.TrimStart('#');
 
             if (rawValue.StartsWith("0x"))
@@ -256,7 +261,7 @@ namespace Discord
                     fullHex = (r << 16) | (g << 8) | b;
 
                     break;
-                
+
                 case (4, ColorType.CssHexColor):
                     r = (parsedValue & 0xF00) >> 8;
                     g = (parsedValue & 0xF0) >> 4;
@@ -284,7 +289,7 @@ namespace Discord
             }
 
             color = new Color(fullHex);
-            
+
             return true;
         }
 

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -24,6 +24,10 @@ namespace Discord
         /// </returns>
         Color Color { get; }
         /// <summary>
+        ///     Gets the full role color configuration of this role.
+        /// </summary>
+        RoleColors? Colors { get; }
+        /// <summary>
         ///     Gets a value that indicates whether the role can be separated in the user list.
         /// </summary>
         /// <returns>

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -22,11 +22,20 @@ namespace Discord
         /// <returns>
         ///     A <see cref="Color"/> struct representing the color of this role.
         /// </returns>
+        /// <remarks>
+        ///     This property is deprecated in the API, and its value will always be <see cref="Colors"/>.PrimaryColor
+        /// </remarks>
+        [Obsolete(
+            $"This property is deprecated in the API, and its value will always be {nameof(Colors)}.{nameof(RoleColors.PrimaryColor)}",
+            error: false
+        )]
         Color Color { get; }
+
         /// <summary>
         ///     Gets the full role color configuration of this role.
         /// </summary>
-        RoleColors? Colors { get; }
+        RoleColors Colors { get; }
+
         /// <summary>
         ///     Gets a value that indicates whether the role can be separated in the user list.
         /// </summary>
@@ -34,6 +43,7 @@ namespace Discord
         ///     <see langword="true" /> if users of this role are separated in the user list; otherwise <see langword="false" />.
         /// </returns>
         bool IsHoisted { get; }
+
         /// <summary>
         ///     Gets a value that indicates whether the role is managed by Discord.
         /// </summary>
@@ -41,6 +51,7 @@ namespace Discord
         ///     <see langword="true" /> if this role is automatically managed by Discord; otherwise <see langword="false" />.
         /// </returns>
         bool IsManaged { get; }
+
         /// <summary>
         ///     Gets a value that indicates whether the role is mentionable.
         /// </summary>
@@ -48,6 +59,7 @@ namespace Discord
         ///     <see langword="true" /> if this role may be mentioned in messages; otherwise <see langword="false" />.
         /// </returns>
         bool IsMentionable { get; }
+
         /// <summary>
         ///     Gets the name of this role.
         /// </summary>
@@ -55,6 +67,7 @@ namespace Discord
         ///     A string containing the name of this role.
         /// </returns>
         string Name { get; }
+
         /// <summary>
         ///     Gets the icon of this role.
         /// </summary>
@@ -62,6 +75,7 @@ namespace Discord
         ///     A string containing the hash of this role's icon.
         /// </returns>
         string Icon { get; }
+
         /// <summary>
         ///     Gets the unicode emoji of this role.
         /// </summary>
@@ -69,6 +83,7 @@ namespace Discord
         ///     This field is mutually exclusive with <see cref="Icon"/>, either icon is set or emoji is set.
         /// </remarks>
         Emoji Emoji { get; }
+
         /// <summary>
         ///     Gets the permissions granted to members of this role.
         /// </summary>
@@ -76,6 +91,7 @@ namespace Discord
         ///     A <see cref="GuildPermissions"/> struct that this role possesses.
         /// </returns>
         GuildPermissions Permissions { get; }
+
         /// <summary>
         ///     Gets this role's position relative to other roles in the same guild.
         /// </summary>
@@ -83,6 +99,7 @@ namespace Discord
         ///     An <see cref="int"/> representing the position of the role in the role list of the guild.
         /// </returns>
         int Position { get; }
+
         /// <summary>
         ///     Gets the tags related to this role.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Roles/RoleColors.cs
+++ b/src/Discord.Net.Core/Entities/Roles/RoleColors.cs
@@ -1,84 +1,81 @@
 using System;
 
-namespace Discord
+namespace Discord;
+
+/// <summary>
+///      Represents the full color configuration of a role.
+/// </summary>
+/// <param name="PrimaryColor">The primary (or main) color of the role.</param>
+/// <param name="SecondaryColor">
+///     The secondary color of the role, this will make the role a gradient between the other provided colors.
+/// </param>
+/// <param name="TertiaryColor">
+///     The tertiary color of the role, this will turn the gradient into a holographic style.
+/// </param>
+public readonly record struct RoleColors(
+    Color PrimaryColor,
+    Color? SecondaryColor = null,
+    Color? TertiaryColor = null
+)
 {
+    private const uint HolographicPrimaryColor = 11127295;
+    private const uint HolographicSecondaryColor = 16759788;
+    private const uint HolographicTertiaryColor = 16761760;
+
     /// <summary>
-    ///     Represents the full color configuration of a role.
+    ///     A holographic <see cref="RoleColors"/>.
     /// </summary>
-    public struct RoleColors : IEquatable<RoleColors>
-    {
-        /// <summary>
-        ///     Gets the primary color required by Discord for holographic role colors.
-        /// </summary>
-        public static Color HolographicPrimaryColor { get; } = new(11127295);
+    public static readonly RoleColors Holographic = new(
+        PrimaryColor: HolographicPrimaryColor,
+        SecondaryColor: HolographicSecondaryColor,
+        TertiaryColor: HolographicTertiaryColor
+    );
 
-        /// <summary>
-        ///     Gets the secondary color required by Discord for holographic role colors.
-        /// </summary>
-        public static Color HolographicSecondaryColor { get; } = new(16759788);
+    /// <summary>
+    ///     Gets whether this color is the <see cref="Holographic"/> color.
+    /// </summary>
+    public bool IsHolographic => this == Holographic;
 
-        /// <summary>
-        ///     Gets the tertiary color required by Discord for holographic role colors.
-        /// </summary>
-        public static Color HolographicTertiaryColor { get; } = new(16761760);
+    /// <summary>
+    ///     Gets whether this <see cref="RoleColors"/> is a gradient between 2 colors.
+    /// </summary>
+    public bool IsGradient => this is { SecondaryColor: not null, TertiaryColor: null };
 
-        /// <summary>
-        ///     Gets the primary color of this role.
-        /// </summary>
-        public Color? PrimaryColor { get; }
+    /// <summary>
+    ///     Gets whether this <see cref="RoleColors"/> is a single, solid color.
+    /// </summary>
+    public bool IsSolidColor => this is { SecondaryColor: null, TertiaryColor: null };
 
-        /// <summary>
-        ///     Gets the secondary color of this role.
-        /// </summary>
-        public Color? SecondaryColor { get; }
+    /// <summary>
+    ///     When sending <see cref="TertiaryColor"/>, the API enforces the role color to be a constant value,
+    ///     defined as <see cref="Holographic"/>.
+    /// </summary>
+    internal RoleColors Normalized
+        => TertiaryColor is not null ? Holographic : this;
 
-        /// <summary>
-        ///     Gets the tertiary color of this role.
-        /// </summary>
-        public Color? TertiaryColor { get; }
+    /// <summary>
+    ///     Creates a new <see cref="RoleColors"/> representing a single, solid color.
+    /// </summary>
+    /// <param name="color">The solid color to use to construct the new <see cref="RoleColors"/>.</param>
+    /// <returns>
+    ///     A new <see cref="RoleColors"/> representing the supplied color.
+    /// </returns>
+    public static RoleColors Solid(Color color)
+        => new(color);
 
-        /// <summary>
-        ///     Initializes a new <see cref="RoleColors"/> struct with the given role colors.
-        /// </summary>
-        public RoleColors(Color? primaryColor = null, Color? secondaryColor = null, Color? tertiaryColor = null)
-        {
-            PrimaryColor = primaryColor;
-            SecondaryColor = secondaryColor;
-            TertiaryColor = tertiaryColor;
-        }
+    /// <summary>
+    ///     Creates a new <see cref="RoleColors"/> representing a gradient between 2 colors.
+    /// </summary>
+    /// <param name="primary">The primary color of the gradient.</param>
+    /// <param name="secondary">The secondary color of the gradient.</param>
+    /// <returns>
+    ///     A new <see cref="RoleColors"/> representing the gradient between the 2 supplied colors.
+    /// </returns>
+    public static RoleColors Gradient(Color primary, Color secondary)
+        => new(primary, secondary);
 
-        /// <summary>
-        ///     Creates a <see cref="RoleColors"/> value from a single solid role color.
-        /// </summary>
-        public static RoleColors FromColor(Color color)
-            => new(color);
-
-        /// <summary>
-        ///     Returns the role colors normalized to Discord's API requirements.
-        /// </summary>
-        public RoleColors Normalize()
-            => TertiaryColor.HasValue
-                ? new(HolographicPrimaryColor, HolographicSecondaryColor, HolographicTertiaryColor)
-                : this;
-
-        public static bool operator ==(RoleColors left, RoleColors right)
-            => left.Equals(right);
-
-        public static bool operator !=(RoleColors left, RoleColors right)
-            => !left.Equals(right);
-
-        public bool Equals(RoleColors other)
-            => PrimaryColor == other.PrimaryColor
-            && SecondaryColor == other.SecondaryColor
-            && TertiaryColor == other.TertiaryColor;
-
-        public override bool Equals(object obj)
-            => obj is RoleColors other && Equals(other);
-
-        public override int GetHashCode()
-            => HashCode.Combine(PrimaryColor, SecondaryColor, TertiaryColor);
-
-        public override string ToString()
-            => $"{PrimaryColor} / {SecondaryColor?.ToString() ?? "null"} / {TertiaryColor?.ToString() ?? "null"}";
-    }
+    public static implicit operator RoleColors(Color color) => Solid(color);
+    public static implicit operator RoleColors?(Color? color) => color.HasValue ? Solid(color.Value) : null;
+    public static implicit operator RoleColors(uint color) => Solid(color);
+    public static implicit operator RoleColors?(uint? color) => color.HasValue ? Solid(color.Value) : null;
 }

--- a/src/Discord.Net.Core/Entities/Roles/RoleColors.cs
+++ b/src/Discord.Net.Core/Entities/Roles/RoleColors.cs
@@ -1,0 +1,84 @@
+using System;
+
+namespace Discord
+{
+    /// <summary>
+    ///     Represents the full color configuration of a role.
+    /// </summary>
+    public struct RoleColors : IEquatable<RoleColors>
+    {
+        /// <summary>
+        ///     Gets the primary color required by Discord for holographic role colors.
+        /// </summary>
+        public static Color HolographicPrimaryColor { get; } = new(11127295);
+
+        /// <summary>
+        ///     Gets the secondary color required by Discord for holographic role colors.
+        /// </summary>
+        public static Color HolographicSecondaryColor { get; } = new(16759788);
+
+        /// <summary>
+        ///     Gets the tertiary color required by Discord for holographic role colors.
+        /// </summary>
+        public static Color HolographicTertiaryColor { get; } = new(16761760);
+
+        /// <summary>
+        ///     Gets the primary color of this role.
+        /// </summary>
+        public Color? PrimaryColor { get; }
+
+        /// <summary>
+        ///     Gets the secondary color of this role.
+        /// </summary>
+        public Color? SecondaryColor { get; }
+
+        /// <summary>
+        ///     Gets the tertiary color of this role.
+        /// </summary>
+        public Color? TertiaryColor { get; }
+
+        /// <summary>
+        ///     Initializes a new <see cref="RoleColors"/> struct with the given role colors.
+        /// </summary>
+        public RoleColors(Color? primaryColor = null, Color? secondaryColor = null, Color? tertiaryColor = null)
+        {
+            PrimaryColor = primaryColor;
+            SecondaryColor = secondaryColor;
+            TertiaryColor = tertiaryColor;
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="RoleColors"/> value from a single solid role color.
+        /// </summary>
+        public static RoleColors FromColor(Color color)
+            => new(color);
+
+        /// <summary>
+        ///     Returns the role colors normalized to Discord's API requirements.
+        /// </summary>
+        public RoleColors Normalize()
+            => TertiaryColor.HasValue
+                ? new(HolographicPrimaryColor, HolographicSecondaryColor, HolographicTertiaryColor)
+                : this;
+
+        public static bool operator ==(RoleColors left, RoleColors right)
+            => left.Equals(right);
+
+        public static bool operator !=(RoleColors left, RoleColors right)
+            => !left.Equals(right);
+
+        public bool Equals(RoleColors other)
+            => PrimaryColor == other.PrimaryColor
+            && SecondaryColor == other.SecondaryColor
+            && TertiaryColor == other.TertiaryColor;
+
+        public override bool Equals(object obj)
+            => obj is RoleColors other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(PrimaryColor, SecondaryColor, TertiaryColor);
+
+        public override string ToString()
+            => $"{PrimaryColor} / {SecondaryColor?.ToString() ?? "null"} / {TertiaryColor?.ToString() ?? "null"}";
+    }
+}

--- a/src/Discord.Net.Core/Entities/Roles/RoleProperties.cs
+++ b/src/Discord.Net.Core/Entities/Roles/RoleProperties.cs
@@ -46,6 +46,13 @@ namespace Discord
         /// </remarks>
         public Optional<Color> Color { get; set; }
         /// <summary>
+        ///     Gets or sets the full color configuration of the role.
+        /// </summary>
+        /// <remarks>
+        ///     This value may not be set if the role is an @everyone role.
+        /// </remarks>
+        public Optional<RoleColors> Colors { get; set; }
+        /// <summary>
         ///     Gets or sets whether or not this role should be displayed independently in the user list.
         /// </summary>
         /// <remarks>

--- a/src/Discord.Net.Rest/API/AuditLogs/RoleInfoAuditLogModel.cs
+++ b/src/Discord.Net.Rest/API/AuditLogs/RoleInfoAuditLogModel.cs
@@ -10,6 +10,9 @@ internal class RoleInfoAuditLogModel : IAuditLogInfoModel
     [JsonField("color")]
     public uint? Color { get; set; }
 
+    [JsonField("colors")]
+    public RoleColors Colors { get; set; }
+
     [JsonField("hoist")]
     public bool? Hoist { get; set; }
 

--- a/src/Discord.Net.Rest/API/Common/Role.cs
+++ b/src/Discord.Net.Rest/API/Common/Role.cs
@@ -20,7 +20,7 @@ internal class Role
     public uint Color { get; set; }
 
     [JsonProperty("colors")]
-    public Optional<RoleColors> Colors { get; set; }
+    public RoleColors Colors { get; set; }
 
     [JsonProperty("hoist")]
     public bool Hoist { get; set; }

--- a/src/Discord.Net.Rest/API/Common/Role.cs
+++ b/src/Discord.Net.Rest/API/Common/Role.cs
@@ -19,6 +19,9 @@ internal class Role
     [JsonProperty("color")]
     public uint Color { get; set; }
 
+    [JsonProperty("colors")]
+    public Optional<RoleColors> Colors { get; set; }
+
     [JsonProperty("hoist")]
     public bool Hoist { get; set; }
 

--- a/src/Discord.Net.Rest/API/Common/RoleColors.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleColors.cs
@@ -5,12 +5,12 @@ namespace Discord.API
     internal class RoleColors
     {
         [JsonProperty("primary_color")]
-        public Optional<uint?> PrimaryColor { get; set; }
+        public uint PrimaryColor { get; set; }
 
         [JsonProperty("secondary_color")]
-        public Optional<uint?> SecondaryColor { get; set; }
+        public uint? SecondaryColor { get; set; }
 
         [JsonProperty("tertiary_color")]
-        public Optional<uint?> TertiaryColor { get; set; }
+        public uint? TertiaryColor { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/RoleColors.cs
+++ b/src/Discord.Net.Rest/API/Common/RoleColors.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Discord.API
+{
+    internal class RoleColors
+    {
+        [JsonProperty("primary_color")]
+        public Optional<uint?> PrimaryColor { get; set; }
+
+        [JsonProperty("secondary_color")]
+        public Optional<uint?> SecondaryColor { get; set; }
+
+        [JsonProperty("tertiary_color")]
+        public Optional<uint?> TertiaryColor { get; set; }
+    }
+}

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildRoleParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildRoleParams.cs
@@ -11,6 +11,8 @@ namespace Discord.API.Rest
         public Optional<string> Permissions { get; set; }
         [JsonProperty("color")]
         public Optional<uint> Color { get; set; }
+        [JsonProperty("colors")]
+        public Optional<API.RoleColors> Colors { get; set; }
         [JsonProperty("hoist")]
         public Optional<bool> Hoist { get; set; }
         [JsonProperty("icon")]

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using Model = Discord.API.AuditLogs.RoleInfoAuditLogModel;
 
 namespace Discord.Rest;
@@ -9,13 +10,7 @@ public struct RoleEditInfo
 {
     internal RoleEditInfo(Model model)
     {
-        if (model.Color is not null)
-            Color = new Color(model.Color.Value);
-        else
-            Color = null;
-
-        Colors = model.Colors?.ToEntity();
-
+        Colors = model.Colors?.ToEntity() ?? model.Color;
         Mentionable = model.IsMentionable;
         Hoist = model.Hoist;
         Name = model.Name;
@@ -35,7 +30,14 @@ public struct RoleEditInfo
     ///     A color object representing the color assigned to this role; <see langword="null" /> if this role does not have a
     ///     color.
     /// </returns>
-    public Color? Color { get; }
+    /// <remarks>
+    ///     This property is deprecated in the API, and its value will always be <see cref="Colors"/>.PrimaryColor
+    /// </remarks>
+    [Obsolete(
+        $"This property is deprecated in the API, and its value will always be {nameof(Colors)}.{nameof(RoleColors.PrimaryColor)}",
+        error: false
+    )]
+    public Color? Color => Colors?.PrimaryColor;
 
     /// <summary>
     ///     Gets the full color configuration of this role.
@@ -46,7 +48,7 @@ public struct RoleEditInfo
     ///     Gets a value that indicates whether this role is mentionable.
     /// </summary>
     /// <returns>
-    ///     <see langword="true" /> if other members can mention this role in a text channel; otherwise <see langword="false" />; 
+    ///     <see langword="true" /> if other members can mention this role in a text channel; otherwise <see langword="false" />;
     ///     <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? Mentionable { get; }
@@ -56,7 +58,7 @@ public struct RoleEditInfo
     ///     section on the user list).
     /// </summary>
     /// <returns>
-    ///     <see langword="true" /> if this role's members will appear in a separate section in the user list; otherwise 
+    ///     <see langword="true" /> if this role's members will appear in a separate section in the user list; otherwise
     ///     <see langword="false" />; <see langword="null" /> if this is not mentioned in this entry.
     /// </returns>
     public bool? Hoist { get; }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
@@ -14,9 +14,7 @@ public struct RoleEditInfo
         else
             Color = null;
 
-        Colors = model.Colors is not null
-            ? model.Colors.ToEntity()
-            : model.Color is not null && model.Color.Value != 0 ? RoleColors.FromColor(new Color(model.Color.Value)) : null;
+        Colors = model.Colors?.ToEntity();
 
         Mentionable = model.IsMentionable;
         Hoist = model.Hoist;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/RoleEditInfo.cs
@@ -14,6 +14,10 @@ public struct RoleEditInfo
         else
             Color = null;
 
+        Colors = model.Colors is not null
+            ? model.Colors.ToEntity()
+            : model.Color is not null && model.Color.Value != 0 ? RoleColors.FromColor(new Color(model.Color.Value)) : null;
+
         Mentionable = model.IsMentionable;
         Hoist = model.Hoist;
         Name = model.Name;
@@ -34,6 +38,11 @@ public struct RoleEditInfo
     ///     color.
     /// </returns>
     public Color? Color { get; }
+
+    /// <summary>
+    ///     Gets the full color configuration of this role.
+    /// </summary>
+    public RoleColors? Colors { get; }
 
     /// <summary>
     ///     Gets a value that indicates whether this role is mentionable.

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -645,6 +645,44 @@ namespace Discord.Rest
             return RestRole.Create(client, guild, model);
         }
 
+        public static async Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
+            string name, GuildPermissions? permissions, RoleColors? colors, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
+        {
+            if (name == null)
+                throw new ArgumentNullException(paramName: nameof(name));
+
+            if (icon is not null || emoji is not null)
+            {
+                guild.Features.EnsureFeature(GuildFeature.RoleIcons);
+
+                if (icon is not null && emoji is not null)
+                {
+                    throw new ArgumentException("Emoji and Icon properties cannot be present on a role at the same time.");
+                }
+            }
+
+            if (colors.HasValue && (colors.Value.SecondaryColor.HasValue || colors.Value.TertiaryColor.HasValue))
+                guild.Features.EnsureFeature(GuildFeature.EnhancedRoleColors);
+
+            var normalizedColors = colors?.Normalize();
+
+            var createGuildRoleParams = new API.Rest.ModifyGuildRoleParams
+            {
+                Color = normalizedColors.HasValue && normalizedColors.Value.PrimaryColor.HasValue ? normalizedColors.Value.PrimaryColor.Value.RawValue : Optional.Create<uint>(),
+                Colors = normalizedColors?.ToModel() ?? Optional<API.RoleColors>.Unspecified,
+                Hoist = isHoisted,
+                Mentionable = isMentionable,
+                Name = name,
+                Permissions = permissions?.RawValue.ToString() ?? Optional.Create<string>(),
+                Icon = icon?.ToModel(),
+                Emoji = emoji?.Name
+            };
+
+            var model = await client.ApiClient.CreateGuildRoleAsync(guild.Id, createGuildRoleParams, options).ConfigureAwait(false);
+
+            return RestRole.Create(client, guild, model);
+        }
+
         public static async Task<RestRole> GetRoleAsync(IGuild guild, BaseDiscordClient client, ulong roleId, RequestOptions options)
         {
             var model = await client.ApiClient.GetRoleAsync(guild.Id, roleId, options).ConfigureAwait(false);

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -613,37 +613,9 @@ namespace Discord.Rest
 
         #region Roles
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
-        public static async Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
+        public static Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
             string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
-        {
-            if (name == null)
-                throw new ArgumentNullException(paramName: nameof(name));
-
-            if (icon is not null || emoji is not null)
-            {
-                guild.Features.EnsureFeature(GuildFeature.RoleIcons);
-
-                if (icon is not null && emoji is not null)
-                {
-                    throw new ArgumentException("Emoji and Icon properties cannot be present on a role at the same time.");
-                }
-            }
-
-            var createGuildRoleParams = new API.Rest.ModifyGuildRoleParams
-            {
-                Color = color?.RawValue ?? Optional.Create<uint>(),
-                Hoist = isHoisted,
-                Mentionable = isMentionable,
-                Name = name,
-                Permissions = permissions?.RawValue.ToString() ?? Optional.Create<string>(),
-                Icon = icon?.ToModel(),
-                Emoji = emoji?.Name
-            };
-
-            var model = await client.ApiClient.CreateGuildRoleAsync(guild.Id, createGuildRoleParams, options).ConfigureAwait(false);
-
-            return RestRole.Create(client, guild, model);
-        }
+            => CreateRoleAsync(guild, client, name, permissions, color.HasValue ? RoleColors.FromColor(color.Value) : default(RoleColors?), isHoisted, isMentionable, options, icon, emoji);
 
         public static async Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
             string name, GuildPermissions? permissions, RoleColors? colors, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -612,13 +612,18 @@ namespace Discord.Rest
         #endregion
 
         #region Roles
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null" />.</exception>
-        public static Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
-            string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
-            => CreateRoleAsync(guild, client, name, permissions, color.HasValue ? RoleColors.FromColor(color.Value) : default(RoleColors?), isHoisted, isMentionable, options, icon, emoji);
-
-        public static async Task<RestRole> CreateRoleAsync(IGuild guild, BaseDiscordClient client,
-            string name, GuildPermissions? permissions, RoleColors? colors, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
+        public static async Task<RestRole> CreateRoleAsync(
+            IGuild guild,
+            BaseDiscordClient client,
+            string name,
+            GuildPermissions? permissions,
+            RoleColors? colors,
+            bool isHoisted,
+            bool isMentionable,
+            RequestOptions options,
+            Image? icon,
+            Emoji emoji
+        )
         {
             if (name == null)
                 throw new ArgumentNullException(paramName: nameof(name));
@@ -633,15 +638,12 @@ namespace Discord.Rest
                 }
             }
 
-            if (colors.HasValue && (colors.Value.SecondaryColor.HasValue || colors.Value.TertiaryColor.HasValue))
+            if(colors is {IsSolidColor: false})
                 guild.Features.EnsureFeature(GuildFeature.EnhancedRoleColors);
-
-            var normalizedColors = colors?.Normalize();
 
             var createGuildRoleParams = new API.Rest.ModifyGuildRoleParams
             {
-                Color = normalizedColors.HasValue && normalizedColors.Value.PrimaryColor.HasValue ? normalizedColors.Value.PrimaryColor.Value.RawValue : Optional.Create<uint>(),
-                Colors = normalizedColors?.ToModel() ?? Optional<API.RoleColors>.Unspecified,
+                Colors = colors?.Normalized.ToModel() ?? Optional<API.RoleColors>.Unspecified,
                 Hoist = isHoisted,
                 Mentionable = isMentionable,
                 Name = name,

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -910,6 +910,17 @@ namespace Discord.Rest
             _roles = _roles.Add(role.Id, role);
             return role;
         }
+
+        /// <summary>
+        ///     Creates a new role with the provided role colors.
+        /// </summary>
+        public async Task<RestRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = default(GuildPermissions?),
+            bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null)
+        {
+            var role = await GuildHelper.CreateRoleAsync(this, Discord, name, permissions, colors, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
+            _roles = _roles.Add(role.Id, role);
+            return role;
+        }
         #endregion
 
         #region Users
@@ -1624,8 +1635,14 @@ namespace Discord.Rest
         async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
             => await CreateRoleAsync(name, permissions, color, isHoisted, false, options).ConfigureAwait(false);
         /// <inheritdoc />
+        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, RequestOptions options)
+            => await CreateRoleAsync(name, colors, permissions, isHoisted, false, options).ConfigureAwait(false);
+        /// <inheritdoc />
         async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
             => await CreateRoleAsync(name, permissions, color, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
+            => await CreateRoleAsync(name, colors, permissions, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IGuildUser> IGuild.AddGuildUserAsync(ulong userId, string accessToken, Action<AddGuildUserProperties> func, RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -903,24 +903,15 @@ namespace Discord.Rest
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
-        public async Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
-            bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null)
+        public async Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = null,
+            RoleColors? color = null, bool isHoisted = false, bool isMentionable = false, RequestOptions options = null,
+            Image? icon = null, Emoji emoji = null)
         {
             var role = await GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
             _roles = _roles.Add(role.Id, role);
             return role;
         }
 
-        /// <summary>
-        ///     Creates a new role with the provided role colors.
-        /// </summary>
-        public async Task<RestRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = default(GuildPermissions?),
-            bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null)
-        {
-            var role = await GuildHelper.CreateRoleAsync(this, Discord, name, permissions, colors, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
-            _roles = _roles.Add(role.Id, role);
-            return role;
-        }
         #endregion
 
         #region Users
@@ -1632,17 +1623,12 @@ namespace Discord.Rest
             => await GetRoleAsync(id);
 
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, RoleColors? color, bool isHoisted, RequestOptions options)
             => await CreateRoleAsync(name, permissions, color, isHoisted, false, options).ConfigureAwait(false);
+
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, RequestOptions options)
-            => await CreateRoleAsync(name, colors, permissions, isHoisted, false, options).ConfigureAwait(false);
-        /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, RoleColors? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
             => await CreateRoleAsync(name, permissions, color, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
-        /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
-            => await CreateRoleAsync(name, colors, permissions, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IGuildUser> IGuild.AddGuildUserAsync(ulong userId, string accessToken, Action<AddGuildUserProperties> func, RequestOptions options)
@@ -1785,7 +1771,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         async Task<IAutoModRule> IGuild.CreateAutoModRuleAsync(Action<AutoModRuleProperties> props, RequestOptions options)
             => await CreateAutoModRuleAsync(props, options).ConfigureAwait(false);
-        
+
         /// <inheritdoc/>
         async Task<IGuildOnboarding> IGuild.GetOnboardingAsync(RequestOptions options)
             => await GetOnboardingAsync(options);

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -16,6 +16,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public Color Color { get; private set; }
         /// <inheritdoc />
+        public RoleColors? Colors { get; private set; }
+        /// <inheritdoc />
         public bool IsHoisted { get; private set; }
         /// <inheritdoc />
         public bool IsManaged { get; private set; }
@@ -65,6 +67,7 @@ namespace Discord.Rest
             IsMentionable = model.Mentionable;
             Position = model.Position;
             Color = new Color(model.Color);
+            Colors = model.Colors.IsSpecified ? model.Colors.Value?.ToEntity() : model.Color != 0 ? RoleColors.FromColor(Color) : null;
             Permissions = new GuildPermissions(model.Permissions);
             Flags = model.Flags;
 

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -67,7 +67,7 @@ namespace Discord.Rest
             IsMentionable = model.Mentionable;
             Position = model.Position;
             Color = new Color(model.Color);
-            Colors = model.Colors.IsSpecified ? model.Colors.Value?.ToEntity() : model.Color != 0 ? RoleColors.FromColor(Color) : null;
+            Colors = model.Colors?.ToEntity();
             Permissions = new GuildPermissions(model.Permissions);
             Flags = model.Flags;
 

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -13,10 +13,15 @@ namespace Discord.Rest
     {
         #region RestRole
         internal IGuild Guild { get; }
+
         /// <inheritdoc />
-        public Color Color { get; private set; }
+        [Obsolete(
+            $"This property is deprecated in the API, and its value will always be {nameof(Colors)}.{nameof(RoleColors.PrimaryColor)}",
+            error: false
+        )]
+        public Color Color => Colors.PrimaryColor;
         /// <inheritdoc />
-        public RoleColors? Colors { get; private set; }
+        public RoleColors Colors { get; private set; }
         /// <inheritdoc />
         public bool IsHoisted { get; private set; }
         /// <inheritdoc />
@@ -66,8 +71,7 @@ namespace Discord.Rest
             IsManaged = model.Managed;
             IsMentionable = model.Mentionable;
             Position = model.Position;
-            Color = new Color(model.Color);
-            Colors = model.Colors?.ToEntity();
+            Colors = model.Colors?.ToEntity() ?? model.Color;
             Permissions = new GuildPermissions(model.Permissions);
             Flags = model.Flags;
 

--- a/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
@@ -27,17 +27,18 @@ namespace Discord.Rest
                 }
             }
 
-            if (args.Colors.IsSpecified && (args.Colors.Value.SecondaryColor.HasValue || args.Colors.Value.TertiaryColor.HasValue))
-                role.Guild.Features.EnsureFeature(GuildFeature.EnhancedRoleColors);
+            var normalizedColors = args.Colors.IsSpecified
+                ? args.Colors.Value.Normalize()
+                : args.Color.IsSpecified
+                    ? RoleColors.FromColor(args.Color.Value)
+                    : default(RoleColors?);
 
-            var normalizedColors = args.Colors.IsSpecified ? args.Colors.Value.Normalize() : default(RoleColors);
+            if (normalizedColors.HasValue && (normalizedColors.Value.SecondaryColor.HasValue || normalizedColors.Value.TertiaryColor.HasValue))
+                role.Guild.Features.EnsureFeature(GuildFeature.EnhancedRoleColors);
 
             var apiArgs = new API.Rest.ModifyGuildRoleParams
             {
-                Color = args.Colors.IsSpecified
-                    ? normalizedColors.PrimaryColor.HasValue ? normalizedColors.PrimaryColor.Value.RawValue : Optional.Create<uint>()
-                    : args.Color.IsSpecified ? args.Color.Value.RawValue : Optional.Create<uint>(),
-                Colors = args.Colors.IsSpecified ? normalizedColors.ToModel() : Optional<API.RoleColors>.Unspecified,
+                Colors = normalizedColors.HasValue ? normalizedColors.Value.ToModel() : Optional<API.RoleColors>.Unspecified,
                 Hoist = args.Hoist,
                 Mentionable = args.Mentionable,
                 Name = args.Name,

--- a/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
@@ -27,18 +27,12 @@ namespace Discord.Rest
                 }
             }
 
-            var normalizedColors = args.Colors.IsSpecified
-                ? args.Colors.Value.Normalize()
-                : args.Color.IsSpecified
-                    ? RoleColors.FromColor(args.Color.Value)
-                    : default(RoleColors?);
-
-            if (normalizedColors.HasValue && (normalizedColors.Value.SecondaryColor.HasValue || normalizedColors.Value.TertiaryColor.HasValue))
+            if(args.Colors is { IsSpecified: true, Value.IsSolidColor: false })
                 role.Guild.Features.EnsureFeature(GuildFeature.EnhancedRoleColors);
 
             var apiArgs = new API.Rest.ModifyGuildRoleParams
             {
-                Colors = normalizedColors.HasValue ? normalizedColors.Value.ToModel() : Optional<API.RoleColors>.Unspecified,
+                Colors = args.Colors.IsSpecified ? args.Colors.Value.Normalized.ToModel() : Optional<API.RoleColors>.Unspecified,
                 Hoist = args.Hoist,
                 Mentionable = args.Mentionable,
                 Name = args.Name,

--- a/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RoleHelper.cs
@@ -27,9 +27,17 @@ namespace Discord.Rest
                 }
             }
 
+            if (args.Colors.IsSpecified && (args.Colors.Value.SecondaryColor.HasValue || args.Colors.Value.TertiaryColor.HasValue))
+                role.Guild.Features.EnsureFeature(GuildFeature.EnhancedRoleColors);
+
+            var normalizedColors = args.Colors.IsSpecified ? args.Colors.Value.Normalize() : default(RoleColors);
+
             var apiArgs = new API.Rest.ModifyGuildRoleParams
             {
-                Color = args.Color.IsSpecified ? args.Color.Value.RawValue : Optional.Create<uint>(),
+                Color = args.Colors.IsSpecified
+                    ? normalizedColors.PrimaryColor.HasValue ? normalizedColors.PrimaryColor.Value.RawValue : Optional.Create<uint>()
+                    : args.Color.IsSpecified ? args.Color.Value.RawValue : Optional.Create<uint>(),
+                Colors = args.Colors.IsSpecified ? normalizedColors.ToModel() : Optional<API.RoleColors>.Unspecified,
                 Hoist = args.Hoist,
                 Mentionable = args.Mentionable,
                 Name = args.Name,

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -54,6 +54,24 @@ namespace Discord.Rest
                 model.IsAvailableForPurchase.IsSpecified,
                 model.GuildConnections.IsSpecified);
         }
+        public static RoleColors ToEntity(this API.RoleColors model)
+            => new(
+                model.PrimaryColor.IsSpecified && model.PrimaryColor.Value.HasValue ? new Color(model.PrimaryColor.Value.Value) : (Color?)null,
+                model.SecondaryColor.IsSpecified && model.SecondaryColor.Value.HasValue ? new Color(model.SecondaryColor.Value.Value) : (Color?)null,
+                model.TertiaryColor.IsSpecified && model.TertiaryColor.Value.HasValue ? new Color(model.TertiaryColor.Value.Value) : (Color?)null);
+
+        public static API.RoleColors ToModel(this RoleColors entity)
+        {
+            var normalized = entity.Normalize();
+
+            return new()
+            {
+                PrimaryColor = normalized.PrimaryColor?.RawValue,
+                SecondaryColor = normalized.SecondaryColor?.RawValue,
+                TertiaryColor = normalized.TertiaryColor?.RawValue
+            };
+        }
+
         public static API.Embed ToModel(this Embed entity)
         {
             if (entity == null)

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -54,21 +54,23 @@ namespace Discord.Rest
                 model.IsAvailableForPurchase.IsSpecified,
                 model.GuildConnections.IsSpecified);
         }
+
         public static RoleColors ToEntity(this API.RoleColors model)
             => new(
-                new Color(model.PrimaryColor),
-                model.SecondaryColor.HasValue ? new Color(model.SecondaryColor.Value) : (Color?)null,
-                model.TertiaryColor.HasValue ? new Color(model.TertiaryColor.Value) : (Color?)null);
+                model.PrimaryColor,
+                model.SecondaryColor,
+                model.TertiaryColor
+            );
 
         public static API.RoleColors ToModel(this RoleColors entity)
         {
-            var normalized = entity.Normalize();
+            var normalized = entity.Normalized;
 
             return new()
             {
-                PrimaryColor = normalized.PrimaryColor?.RawValue ?? 0,
-                SecondaryColor = normalized.SecondaryColor?.RawValue,
-                TertiaryColor = normalized.TertiaryColor?.RawValue
+                PrimaryColor = normalized.PrimaryColor,
+                SecondaryColor = normalized.SecondaryColor,
+                TertiaryColor = normalized.TertiaryColor
             };
         }
 

--- a/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
+++ b/src/Discord.Net.Rest/Extensions/EntityExtensions.cs
@@ -56,9 +56,9 @@ namespace Discord.Rest
         }
         public static RoleColors ToEntity(this API.RoleColors model)
             => new(
-                model.PrimaryColor.IsSpecified && model.PrimaryColor.Value.HasValue ? new Color(model.PrimaryColor.Value.Value) : (Color?)null,
-                model.SecondaryColor.IsSpecified && model.SecondaryColor.Value.HasValue ? new Color(model.SecondaryColor.Value.Value) : (Color?)null,
-                model.TertiaryColor.IsSpecified && model.TertiaryColor.Value.HasValue ? new Color(model.TertiaryColor.Value.Value) : (Color?)null);
+                new Color(model.PrimaryColor),
+                model.SecondaryColor.HasValue ? new Color(model.SecondaryColor.Value) : (Color?)null,
+                model.TertiaryColor.HasValue ? new Color(model.TertiaryColor.Value) : (Color?)null);
 
         public static API.RoleColors ToModel(this RoleColors entity)
         {
@@ -66,7 +66,7 @@ namespace Discord.Rest
 
             return new()
             {
-                PrimaryColor = normalized.PrimaryColor?.RawValue,
+                PrimaryColor = normalized.PrimaryColor?.RawValue ?? 0,
                 SecondaryColor = normalized.SecondaryColor?.RawValue,
                 TertiaryColor = normalized.TertiaryColor?.RawValue
             };

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
@@ -1,4 +1,5 @@
 using Discord.Rest;
+using System;
 using Model = Discord.API.AuditLogs.RoleInfoAuditLogModel;
 
 namespace Discord.WebSocket;
@@ -10,13 +11,7 @@ public struct SocketRoleEditInfo
 {
     internal SocketRoleEditInfo(Model model)
     {
-        if (model.Color is not null)
-            Color = new Color(model.Color.Value);
-        else
-            Color = null;
-
-        Colors = model.Colors?.ToEntity();
-
+        Colors = model.Colors?.ToEntity() ?? model.Color;
         Mentionable = model.IsMentionable;
         Hoist = model.Hoist;
         Name = model.Name;
@@ -36,7 +31,14 @@ public struct SocketRoleEditInfo
     ///     A color object representing the color assigned to this role; <see langword="null" /> if this role does not have a
     ///     color.
     /// </returns>
-    public Color? Color { get; }
+    /// <remarks>
+    ///     This property is deprecated in the API, and its value will always be <see cref="Colors"/>.PrimaryColor
+    /// </remarks>
+    [Obsolete(
+        $"This property is deprecated in the API, and its value will always be {nameof(Colors)}.{nameof(RoleColors.PrimaryColor)}",
+        error: false
+    )]
+    public Color? Color => Colors?.PrimaryColor;
 
     /// <summary>
     ///     Gets the full color configuration of this role.

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
@@ -15,9 +15,7 @@ public struct SocketRoleEditInfo
         else
             Color = null;
 
-        Colors = model.Colors is not null
-            ? model.Colors.ToEntity()
-            : model.Color is not null && model.Color.Value != 0 ? RoleColors.FromColor(new Color(model.Color.Value)) : null;
+        Colors = model.Colors?.ToEntity();
 
         Mentionable = model.IsMentionable;
         Hoist = model.Hoist;

--- a/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
+++ b/src/Discord.Net.WebSocket/Entities/AuditLogs/DataTypes/SocketRoleEditInfo.cs
@@ -1,3 +1,4 @@
+using Discord.Rest;
 using Model = Discord.API.AuditLogs.RoleInfoAuditLogModel;
 
 namespace Discord.WebSocket;
@@ -13,6 +14,10 @@ public struct SocketRoleEditInfo
             Color = new Color(model.Color.Value);
         else
             Color = null;
+
+        Colors = model.Colors is not null
+            ? model.Colors.ToEntity()
+            : model.Color is not null && model.Color.Value != 0 ? RoleColors.FromColor(new Color(model.Color.Value)) : null;
 
         Mentionable = model.IsMentionable;
         Hoist = model.Hoist;
@@ -34,6 +39,11 @@ public struct SocketRoleEditInfo
     ///     color.
     /// </returns>
     public Color? Color { get; }
+
+    /// <summary>
+    ///     Gets the full color configuration of this role.
+    /// </summary>
+    public RoleColors? Colors { get; }
 
     /// <summary>
     ///     Gets a value that indicates whether this role is mentionable.

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1138,6 +1138,12 @@ namespace Discord.WebSocket
         public Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
             bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null)
             => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, isMentionable, options, icon, emoji);
+        /// <summary>
+        ///     Creates a new role with the provided role colors.
+        /// </summary>
+        public Task<RestRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = default(GuildPermissions?),
+            bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null)
+            => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, colors, isHoisted, isMentionable, options, icon, emoji);
         internal SocketRole AddRole(RoleModel model)
         {
             var role = SocketRole.Create(this, Discord.State, model);
@@ -2229,8 +2235,14 @@ namespace Discord.WebSocket
         async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
             => await CreateRoleAsync(name, permissions, color, isHoisted, false, options).ConfigureAwait(false);
         /// <inheritdoc />
+        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, RequestOptions options)
+            => await CreateRoleAsync(name, colors, permissions, isHoisted, false, options).ConfigureAwait(false);
+        /// <inheritdoc />
         async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
             => await CreateRoleAsync(name, permissions, color, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
+        /// <inheritdoc />
+        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
+            => await CreateRoleAsync(name, colors, permissions, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IGuildUser>> IGuild.GetUsersAsync(CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1135,15 +1135,10 @@ namespace Discord.WebSocket
         ///     A task that represents the asynchronous creation operation. The task result contains the newly created
         ///     role.
         /// </returns>
-        public Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = default(GuildPermissions?), Color? color = default(Color?),
+        public Task<RestRole> CreateRoleAsync(string name, GuildPermissions? permissions = null, RoleColors? color = null,
             bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null)
             => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, color, isHoisted, isMentionable, options, icon, emoji);
-        /// <summary>
-        ///     Creates a new role with the provided role colors.
-        /// </summary>
-        public Task<RestRole> CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions = default(GuildPermissions?),
-            bool isHoisted = false, bool isMentionable = false, RequestOptions options = null, Image? icon = null, Emoji emoji = null)
-            => GuildHelper.CreateRoleAsync(this, Discord, name, permissions, colors, isHoisted, isMentionable, options, icon, emoji);
+
         internal SocketRole AddRole(RoleModel model)
         {
             var role = SocketRole.Create(this, Discord.State, model);
@@ -1349,7 +1344,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public Task<MemberSearchResult> SearchUsersAsyncV2(int limit = DiscordConfig.MaxUsersPerBatch, MemberSearchPropertiesV2 args = null, RequestOptions options = null)
             => GuildHelper.SearchUsersAsyncV2(this, Discord, limit, args, options);
-        
+
         /// <inheritdoc />
         public Task ModifyCurrentUserAsync(Action<SelfGuildUserProperties> props, RequestOptions options = null)
         {
@@ -2232,17 +2227,12 @@ namespace Discord.WebSocket
             => await GetRoleAsync(id);
 
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, RequestOptions options)
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, RoleColors? color, bool isHoisted, RequestOptions options)
             => await CreateRoleAsync(name, permissions, color, isHoisted, false, options).ConfigureAwait(false);
+
         /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, RequestOptions options)
-            => await CreateRoleAsync(name, colors, permissions, isHoisted, false, options).ConfigureAwait(false);
-        /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, Color? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
+        async Task<IRole> IGuild.CreateRoleAsync(string name, GuildPermissions? permissions, RoleColors? color, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
             => await CreateRoleAsync(name, permissions, color, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
-        /// <inheritdoc />
-        async Task<IRole> IGuild.CreateRoleAsync(string name, RoleColors colors, GuildPermissions? permissions, bool isHoisted, bool isMentionable, RequestOptions options, Image? icon, Emoji emoji)
-            => await CreateRoleAsync(name, colors, permissions, isHoisted, isMentionable, options, icon, emoji).ConfigureAwait(false);
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IGuildUser>> IGuild.GetUsersAsync(CacheMode mode, RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -86,7 +86,7 @@ namespace Discord.WebSocket
             IsMentionable = model.Mentionable;
             Position = model.Position;
             Color = new Color(model.Color);
-            Colors = model.Colors.IsSpecified ? model.Colors.Value?.ToEntity() : model.Color != 0 ? RoleColors.FromColor(Color) : null;
+            Colors = model.Colors?.ToEntity();
             Permissions = new GuildPermissions(model.Permissions);
             Flags = model.Flags;
 

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -26,6 +26,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public Color Color { get; private set; }
         /// <inheritdoc />
+        public RoleColors? Colors { get; private set; }
+        /// <inheritdoc />
         public bool IsHoisted { get; private set; }
         /// <inheritdoc />
         public bool IsManaged { get; private set; }
@@ -84,6 +86,7 @@ namespace Discord.WebSocket
             IsMentionable = model.Mentionable;
             Position = model.Position;
             Color = new Color(model.Color);
+            Colors = model.Colors.IsSpecified ? model.Colors.Value?.ToEntity() : model.Color != 0 ? RoleColors.FromColor(Color) : null;
             Permissions = new GuildPermissions(model.Permissions);
             Flags = model.Flags;
 

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -24,9 +24,13 @@ namespace Discord.WebSocket
         public SocketGuild Guild { get; }
 
         /// <inheritdoc />
-        public Color Color { get; private set; }
+        [Obsolete(
+            $"This property is deprecated in the API, and its value will always be {nameof(Colors)}.{nameof(RoleColors.PrimaryColor)}",
+            error: false
+        )]
+        public Color Color => Colors.PrimaryColor;
         /// <inheritdoc />
-        public RoleColors? Colors { get; private set; }
+        public RoleColors Colors { get; private set; }
         /// <inheritdoc />
         public bool IsHoisted { get; private set; }
         /// <inheritdoc />
@@ -85,8 +89,7 @@ namespace Discord.WebSocket
             IsManaged = model.Managed;
             IsMentionable = model.Mentionable;
             Position = model.Position;
-            Color = new Color(model.Color);
-            Colors = model.Colors?.ToEntity();
+            Colors = model.Colors?.ToEntity() ?? model.Color;
             Permissions = new GuildPermissions(model.Permissions);
             Flags = model.Flags;
 


### PR DESCRIPTION
### Description
Until now, roles could only use the legacy `color` field, which only supports a single solid color. Discord's API exposes a `colors` object on roles, allowing enhanced role color configurations through `primary_color`, `secondary_color`, and `tertiary_color`.

This changeset introduces a dedicated `RoleColors` value type, exposes enhanced colors on role entities, adds support for sending and receiving the `colors` payload in REST and gateway models, and extends role creation/modification APIs in a way that remains backward-compatible with the existing `Color` API.

It also handles Discord's special tertiary color requirement: whenever `tertiary_color` is sent, the payload is normalized to Discord's required holographic color triplet.

### Changes
- Add a new `RoleColors` value type to represent enhanced role colors.
- Expose enhanced role colors through `IRole.Colors`.
- Add `RoleProperties.Colors` so roles can be modified with enhanced colors.
- Keep the existing `IRole.Color` and `RoleProperties.Color` behavior for backward compatibility.
- Extend role create APIs with new `CreateRoleAsync` overloads that accept `RoleColors`.
- Update REST role models to deserialize the API `colors` object.
- Update modify/create role REST payloads to serialize the API `colors` object.
- Add conversion helpers between API models and the new `RoleColors` entity type.
- Update `RestRole` and `SocketRole` to surface enhanced role colors.
- Add support for enhanced role colors in role audit log data.
- Add the `EnhancedRoleColors` guild feature and validate it before sending enhanced color payloads.
- Allow enhanced color payloads with nullable `primary_color`, matching Discord's API behavior.
- Normalize any payload containing `tertiary_color` to Discord's required holographic values:
  - `primary_color = 11127295`
  - `secondary_color = 16759788`
  - `tertiary_color = 16761760`
- Preserve existing single-color behavior by continuing to populate the legacy `color` field when appropriate.
- Add fallback handling so roles without a `colors` object still expose a compatible single-color representation where possible.