### PR TITLE
[Docs] Replace obsolete ApplicationCommandException in the slash command guide

### DIFF
--- a/docs/guides/int_basics/application-commands/slash-commands/creating-slash-commands.md
+++ b/docs/guides/int_basics/application-commands/slash-commands/creating-slash-commands.md
@@ -80,9 +80,9 @@ public async Task Client_Ready()
         // Using the ready event is a simple implementation for the sake of the example. Suitable for testing and development.
         // For a production bot, it is recommended to only run the CreateGlobalApplicationCommandAsync() once for each command.
     }
-    catch(ApplicationCommandException exception)
+    catch(HttpException exception)
     {
-        // If our command was invalid, we should catch an ApplicationCommandException. This exception contains the path of the error as well as the error message. You can serialize the Error field in the exception to get a visual of where your error is.
+        // If our command was invalid, we should catch an HttpException. This exception contains the Discord error code, the request object that was sent, the reason of the exception and a list of of errors to explain what went wrong with the request. You can serialize the Error field in the exception to get a visual of where your error is.
         var json = JsonConvert.SerializeObject(exception.Errors, Formatting.Indented);
 
         // You can send this error somewhere or just print it to the console, for this example we're just going to print it.


### PR DESCRIPTION
### Description
<!-- A brief explanation of changes made in this PR. -->
Replace the deprecated ApplicationCommandException to HttpException as ApplicationCommandException is marked as obsolete as of version 3.19.0
### Changes
Rewrote a piece of the docs to use the non-obsolete exception  and added some context to what HttpException can give back after the exception was thrown
