### PR TITLE
Handle TaskCanceledException in TypingNotifier

### DIFF
--- a/src/Discord.Net.Rest/Utils/TypingNotifier.cs
+++ b/src/Discord.Net.Rest/Utils/TypingNotifier.cs
@@ -38,6 +38,7 @@ namespace Discord.Rest
                 }
             }
             catch (OperationCanceledException) { }
+            catch (TaskCanceledException) { }
         }
 
         public void Dispose()


### PR DESCRIPTION
<!--
Thanks in advance for your contribution to Discord.Net!
Before opening a pull request, please consider the following:
Does your changeset adhere to the Contributing Guidelines?
Does your changeset address a specific issue or idea? If not, please break your changes up into multiple requests.
Have your changes been previously discussed with other members of the community? We prefer new features to be vetted through an issue or a discussion in our Discord channel first; bug-fixes and other small changes are generally fine without prior vetting. 
-->

### Description
<!-- A brief explanation of changes made in this PR. -->
When typing is canceled by a Task Cancellation token, `TaskCanceledException` is thrown, not `OperationCanceledException`. Adding this as a swallow to the typing indicator.

### Changes
<!--
List things changed in this pull request.
Example:
- Add X entity
- Update Y method
-->
Added catch block to typing indicator to capture canceled tasks.

### Related Issues
<!--
List issues that are related to this PR.
Example:
- resolves #6969
-->
