### PR TITLE
fix: user `global_name` description

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -99,7 +99,7 @@ namespace Discord
         UserProperties? PublicFlags { get; }
 
         /// <summary>
-        ///     Gets the user's display name, if it is set. For bots, this will get the application name.
+        ///     Gets the user's display name, if it is set.
         /// </summary>
         /// <remarks>
         ///     This property will be <see langword="null"/> if user has no display name set.


### PR DESCRIPTION
### Description
For bots, `global_name` is always `null`. This PR fixes the documentation for `GlobalName`.
Discord API Docs reference: https://github.com/discord/discord-api-docs/pull/8227

### Changes
Update documentation
