### PR TITLE
Add missing audit log action types

### DIFF
--- a/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
+++ b/src/Discord.Net.Core/Entities/AuditLogs/ActionType.cs
@@ -186,11 +186,11 @@ namespace Discord
         /// </summary>
         EventCreate = 100,
         /// <summary>
-        ///     A scheduled event was created.
+        ///     A scheduled event was updated.
         /// </summary>
         EventUpdate = 101,
         /// <summary>
-        ///     A scheduled event was created.
+        ///     A scheduled event was deleted.
         /// </summary>
         EventDelete = 102,
 
@@ -210,6 +210,19 @@ namespace Discord
         ///     Permissions were updated for a command.
         /// </summary>
         ApplicationCommandPermissionUpdate = 121,
+
+        /// <summary>
+        ///     A soundboard sound was created.
+        /// </summary>
+        SoundboardSoundCreate = 130,
+        /// <summary>
+        ///     A soundboard sound was updated.
+        /// </summary>
+        SoundboardSoundUpdate = 131,
+        /// <summary>
+        ///     A soundboard sound was deleted.
+        /// </summary>
+        SoundboardSoundDelete = 132,
 
         /// <summary>
         ///     Auto Moderation rule was created.
@@ -235,6 +248,19 @@ namespace Discord
         ///     Member was timed out by Auto Moderation.
         /// </summary>
         AutoModerationUserCommunicationDisabled = 145,
+        /// <summary>
+        ///     Member was quarantined by Auto Moderation.
+        /// </summary>
+        AutoModerationQuarantineUser = 146,
+
+        /// <summary>
+        ///     Creator monetization request was created.
+        /// </summary>
+        CreatorMonetizationRequestCreated = 150,
+        /// <summary>
+        ///     Creator monetization terms were accepted.
+        /// </summary>
+        CreatorMonetizationTermsAccepted = 151,
 
         /// <summary>
         ///     Guild Onboarding Question was created.
@@ -245,11 +271,28 @@ namespace Discord
         ///     Guild Onboarding Question was updated.
         /// </summary>
         OnboardingQuestionUpdated = 164,
+        /// <summary>
+        ///     Guild Onboarding Question was deleted.
+        /// </summary>
+        OnboardingQuestionDeleted = 165,
 
+        /// <summary>
+        ///     Guild Onboarding was created.
+        /// </summary>
+        OnboardingCreated = 166,
         /// <summary>
         ///     Guild Onboarding was updated.
         /// </summary>
         OnboardingUpdated = 167,
+
+        /// <summary>
+        ///     Guild Server Guide was created.
+        /// </summary>
+        HomeSettingsCreated = 190,
+        /// <summary>
+        ///     Guild Server Guide was updated.
+        /// </summary>
+        HomeSettingsUpdated = 191,
 
         /// <summary>
         ///     A voice channel status was updated by a user.


### PR DESCRIPTION
### Description
The `ActionType` enum is missing several audit log event types that are documented in the Discord API. This means events like soundboard changes, auto-mod quarantine actions, and server guide updates come through as raw integers instead of named enum values.

### Changes
- Add `SoundboardSoundCreate` (130), `SoundboardSoundUpdate` (131), `SoundboardSoundDelete` (132)
- Add `AutoModerationQuarantineUser` (146)
- Add `CreatorMonetizationRequestCreated` (150), `CreatorMonetizationTermsAccepted` (151)
- Add `OnboardingQuestionDeleted` (165), `OnboardingCreated` (166)
- Add `HomeSettingsCreated` (190), `HomeSettingsUpdated` (191)
- Fix doc comments on `EventUpdate` and `EventDelete` which both incorrectly said "A scheduled event was created"

### Related Issues
- Partially addresses #3019 (soundboard audit types)

Reference: https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events