### PR TITLE
fix: propagate parent module attributes to child commands

### DIFF
--- a/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleBuilder.cs
@@ -141,6 +141,18 @@ namespace Discord.Interactions.Builders
             _autocompleteCommands = new List<AutocompleteCommandBuilder>();
             _modalCommands = new List<ModalCommandBuilder>();
             _preconditions = new List<PreconditionAttribute>();
+
+            if (parent is not null)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                DefaultPermission = parent.DefaultPermission;
+                IsEnabledInDm = parent.IsEnabledInDm;
+#pragma warning restore CS0618 // Type or member is obsolete
+                IsNsfw = parent.IsNsfw;
+                DefaultMemberPermissions = parent.DefaultMemberPermissions;
+                ContextTypes = parent.ContextTypes;
+                IntegrationTypes = parent.IntegrationTypes;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2875

When attributes like `[EnabledInDm(false)]` are placed on a parent module class, child commands still allowed DM execution because the module builder never copied these values from the parent.

The internal `ModuleBuilder` constructor now inherits `DefaultPermission`, `IsEnabledInDm`, `IsNsfw`, `DefaultMemberPermissions`, `ContextTypes`, and `IntegrationTypes` from the parent builder when one is provided. Child modules can still override any of these via their own attributes since `BuildModule` processes attributes after construction.