### PR TITLE
refactor(Core): rename JSON error code

### DIFF
--- a/src/Discord.Net.Core/DiscordErrorCode.cs
+++ b/src/Discord.Net.Core/DiscordErrorCode.cs
@@ -213,7 +213,7 @@ namespace Discord
         CannotSendVoiceMessageInThisChannel = 50173,
         TheUserAccountMustFirstBeVerified = 50178,
         ProvidedFileDoesNotHaveAValidDuration = 50192,
-        CannotSendMessageToThisUser_2 = 50278,
+        CannotSendMessagesToThisUserDueToHavingNoMutualGuilds = 50278,
         MissingPermissionToSendThisSticker = 50600,
         #endregion
 


### PR DESCRIPTION
### Description
Rename `CannotSendMessagesToThisUser_2` `DiscordErrorCode` enum to `CannotSendMessagesToThisUserDueToHavingNoMutualGuilds`

### Reference
- https://github.com/discord/discord-api-docs/pull/8244