### PR TITLE
[Docs] Fix reference to PreCompiledLambdas/UseCompiledLambda

### DIFF
--- a/docs/guides/int_framework/intro.md
+++ b/docs/guides/int_framework/intro.md
@@ -240,7 +240,7 @@ A Modal implementation would look like this:
 
 > [!NOTE]
 > If you are using Modals in the interaction service it is **highly
-> recommended** that you enable `PreCompiledLambdas` in your config
+> recommended** that you enable `InteractionServiceConfig.UseCompiledLambda`
 > to prevent performance issues.
 
 ## Interaction Context

--- a/docs/guides/int_framework/modals.md
+++ b/docs/guides/int_framework/modals.md
@@ -14,7 +14,7 @@ The title of the modal is set by implementing the `Title` property of the `IModa
 
 > [!NOTE]
 > If you are using Modals in the interaction service it is **highly
-> recommended** that you enable `PreCompiledLambdas` in your config
+> recommended** that you enable `InteractionServiceConfig.UseCompiledLambda`
 > to prevent performance issues.
 
 ## Responding with a modal


### PR DESCRIPTION
### Description
"UseCompiledLambda" config option was always called that since it was added.
Yet docs references a "PreCompiledLambdas" which does not exist.
Just fix the naming so that users reading the docs can actually find it